### PR TITLE
Allow duplicated model names across packages

### DIFF
--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -381,6 +381,14 @@ class NameSearcher(Generic[N]):
                 return model
         return None
 
+    def search_many(self, haystack: Iterable[N]) -> List[N]:
+        """Find multiple entries in the given iterable by name."""
+        found = []
+        for model in haystack:
+            if self._matches(model):
+                found.append(model)
+        return found
+
 
 D = TypeVar('D')
 
@@ -514,6 +522,16 @@ class Manifest:
                 k: v.to_dict(omit_none=False) for k, v in self.sources.items()
             }
         }
+
+    def find_nodes_by_name(
+        self, name: str, package: Optional[str] = None
+    ) -> Optional[ManifestNode]:
+        searcher: NameSearcher = NameSearcher(
+            name, package, NodeType.refable()
+        )
+
+        result = searcher.search_many(self.nodes.values())
+        return result
 
     def find_disabled_by_name(
         self, name: str, package: Optional[str] = None

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -525,7 +525,7 @@ class Manifest:
 
     def find_nodes_by_name(
         self, name: str, package: Optional[str] = None
-    ) -> Optional[ManifestNode]:
+    ) -> List[ManifestNode]:
         searcher: NameSearcher = NameSearcher(
             name, package, NodeType.refable()
         )

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -769,7 +769,7 @@ def raise_ambiguous_ref(node_1, node_2):
         f'The reference {get_func} is ambiguous because there are two nodes '
         f'with the name "{duped_name}". To fix this, either change the name '
         'of one of these nodes, or use the two-argument version of ref() '
-        'to specify the package that contains the intended node. Found nodes:\n'
+        'to specify the package that contains the intended node. Found:\n'
         f'- {node_1.unique_id} ({node_1.original_file_path})\n'
         f'- {node_2.unique_id} ({node_2.original_file_path})\n\n'
         f'Example: {{{{ ref("{node_1.package_name}", "{node_1.name}") }}}}'

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -761,6 +761,21 @@ def raise_duplicate_macro_name(node_1, node_2, namespace) -> NoReturn:
     )
 
 
+def raise_ambiguous_ref(node_1, node_2):
+    duped_name = node_1.name
+    get_func = f'{{{{ ref("{duped_name}") }}}}'
+
+    raise_compiler_error(
+        f'The reference {get_func} is ambiguous because there are two nodes '
+        f'with the name "{duped_name}". To fix this, either change the name '
+        'of one of these nodes, or use the two-argument version of ref() '
+        'to specify the package that contains the intended node. Found nodes:\n'
+        f'- {node_1.unique_id} ({node_1.original_file_path})\n'
+        f'- {node_2.unique_id} ({node_2.original_file_path})\n\n'
+        f'Example: {{{{ ref("{node_1.package_name}", "{node_1.name}") }}}}'
+    )
+
+
 def raise_duplicate_resource_name(node_1, node_2):
     duped_name = node_1.name
 


### PR DESCRIPTION
resolves #1269 (partially?)

### Description

This PR makes it possible to have refable nodes (models, seeds, and snapshots) with duplicated names across different packages. Refable nodes with duplicated names continue to be disallowed within a specific package.

TODO:
 - [ ] determine if we're relying on model name uniqueness anywhere inside of Core (I didn't see anything, but need to think more about this)
 - [ ] determine if we're relying on model name uniqueness anywhere inside of the docs website? This sounds more likely....
 - [ ] add tests / maybe remove tests that depended on the previous behavior


### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [ ] I have run this code in development and it appears to resolve the stated issue
 - [ ] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
