### PR TITLE
Allow no-launch-browser logins on BigQuery

### DIFF
--- a/core/dbt/clients/gcloud.py
+++ b/core/dbt/clients/gcloud.py
@@ -19,8 +19,11 @@ def gcloud_installed():
         return False
 
 
-def setup_default_credentials():
+def setup_default_credentials(credentials):
     if gcloud_installed():
-        run_cmd('.', ["gcloud", "auth", "application-default", "login"])
+        if credentials.launch_browser:
+            run_cmd('.', ["gcloud", "auth", "application-default", "login"])
+        else:
+            run_cmd('.', ["gcloud", "auth", "application-default", "login", "--no-launch-browser"])
     else:
         raise dbt.exceptions.RuntimeException(NOT_INSTALLED_MSG)

--- a/plugins/bigquery/dbt/adapters/bigquery/connections.py
+++ b/plugins/bigquery/dbt/adapters/bigquery/connections.py
@@ -90,6 +90,9 @@ class BigQueryCredentials(Credentials):
     maximum_bytes_billed: Optional[int] = None
     impersonate_service_account: Optional[str] = None
 
+    # oauth
+    launch_browser: Optional[bool] = True
+
     # Keyfile json creds
     keyfile: Optional[str] = None
     keyfile_json: Optional[Dict[str, Any]] = None
@@ -204,6 +207,7 @@ class BigQueryConnectionManager(BaseConnectionManager):
 
         if method == BigQueryConnectionMethod.OAUTH:
             credentials, _ = get_bigquery_defaults(scopes=cls.SCOPE)
+            import ipdb; ipdb.set_trace()
             return credentials
 
         elif method == BigQueryConnectionMethod.SERVICE_ACCOUNT:
@@ -266,7 +270,7 @@ class BigQueryConnectionManager(BaseConnectionManager):
 
         except google.auth.exceptions.DefaultCredentialsError:
             logger.info("Please log into GCP to continue")
-            gcloud.setup_default_credentials()
+            gcloud.setup_default_credentials(connection.credentials)
 
             handle = cls.get_bigquery_client(connection.credentials)
 

--- a/plugins/bigquery/dbt/adapters/bigquery/connections.py
+++ b/plugins/bigquery/dbt/adapters/bigquery/connections.py
@@ -207,7 +207,6 @@ class BigQueryConnectionManager(BaseConnectionManager):
 
         if method == BigQueryConnectionMethod.OAUTH:
             credentials, _ = get_bigquery_defaults(scopes=cls.SCOPE)
-            import ipdb; ipdb.set_trace()
             return credentials
 
         elif method == BigQueryConnectionMethod.SERVICE_ACCOUNT:


### PR DESCRIPTION
resolves `None`

### Description
When using dbt with BigQuery from a remote machine, the gcloud auth flow doesn't work since it tries to launch a browser on the remote machine.

One valid workaround is to instead auth first in the remote machine. The `--no-launch-browser` provides a convenient interface to allow you to visit the auth URL on your local machine, and then return the resulting token to your remote machine via the command line.
```
$ gcloud auth application-default login --no-launch-browser
Go to the following link in your browser :
    https://accounts.google.com/o/oauth2/auth/*********
Enter verification code: 4/1AY0e-g7ubzDXLQpxp4xYKk_L***
Credentials saved to file: [/home/ubuntu/.config/gcloud/application_default_credentials.json]
```
([GCloud docs](https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login#--launch-browser))

The idea here is to integrate this flow into dbt by first allowing a `launch_browser` key in a BQ `profiles.yml` (default=True), and then doing a simple check to see which version of the `gcloud auth` command to run — flag, or no flag.

Unfortunately, I could not get this to work on a local project. The `run_cmd` function doesn't seem to pipe the output of `gcloud auth application-default login --no-launch-browser` to the terminal (and even if it did print the URL, it probably won't accept an input from said terminal), so instead, dbt just hangs like this, when `launch_browser: False`
```
$ dbt seed
Running with dbt=0.19.0
Found 5 models, 20 tests, 0 snapshots, 0 analyses, 157 macros, 0 operations, 3 seed files, 0 sources, 0 exposures

Please log into GCP to continue
^Cctrl-c
```

I don't know enough python to debug the [run_cmd](https://github.com/fishtown-analytics/dbt/blob/develop/core/dbt/clients/system.py#L404) function here, and figure out what isn't working. Opening this PR as a draft in case someone sees it and goes "OH this is super ezpz", but really, we can probably close it since this is a very specific use case.

### Checklist
 - [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [ ] I have run this code in development and it appears to resolve the stated issue
 - [ ] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
