### PR TITLE
Partial parsing: check if a node has already been deleted [#3516]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Contributors:
 - Dispatch the core SQL statement of the new test materialization, to benefit adapter maintainers ([#3465](https://github.com/fishtown-analytics/dbt/pull/3465), [#3461](https://github.com/fishtown-analytics/dbt/pull/3461))
 - Minimal validation of yaml dictionaries prior to partial parsing ([#3246](https://github.com/fishtown-analytics/dbt/issues/3246), [#3460](https://github.com/fishtown-analytics/dbt/pull/3460))
 - Add partial parsing tests and improve partial parsing handling of macros ([#3449](https://github.com/fishtown-analytics/dbt/issues/3449), [#3505](https://github.com/fishtown-analytics/dbt/pull/3505))
+- Partial parsing: handle already deleted nodes when schema block also deleted ([#3516](http://github.com/fishown-analystics/dbt/issues/3516))
 
 Contributors:
 - [@swanderz](https://github.com/swanderz) ([#3461](https://github.com/fishtown-analytics/dbt/pull/3461))

--- a/core/dbt/parser/partial.py
+++ b/core/dbt/parser/partial.py
@@ -222,6 +222,10 @@ class PartialParsing:
         self.remove_node_in_saved(new_source_file, unique_id)
 
     def remove_node_in_saved(self, source_file, unique_id):
+        # Has already been deleted by another action
+        if unique_id not in self.saved_manifest.nodes:
+            return
+
         # delete node in saved
         node = self.saved_manifest.nodes.pop(unique_id)
         self.deleted_manifest.nodes[unique_id] = node

--- a/test/integration/068_partial_parsing_tests/test_partial_parsing.py
+++ b/test/integration/068_partial_parsing_tests/test_partial_parsing.py
@@ -90,12 +90,14 @@ class TestModels(DBTIntegrationTest):
         self.assertNotIn(unique_test_id, manifest.nodes.keys())
         self.assertEqual(len(results), 1)
 
-        # go back to previous version of schema file, removing patch and test for model three
+        # go back to previous version of schema file, removing patch, test, and model for model three
         shutil.copyfile('extra-files/models-schema1.yml', 'models-a/schema.yml')
+        os.remove(normalize('models-a/model_three.sql'))
         results = self.run_dbt(["--partial-parse", "run"])
-        self.assertEqual(len(results), 3)
+        self.assertEqual(len(results), 2)
 
         # remove schema file, still have 3 models
+        shutil.copyfile('extra-files/model_three.sql', 'models-a/model_three.sql')
         os.remove(normalize('models-a/schema.yml'))
         results = self.run_dbt(["--partial-parse", "run"])
         self.assertEqual(len(results), 3)


### PR DESCRIPTION
resolves #3516

### Description

When a model and a schema file section are deleted at the same time, check for existence of node before attempting to delete.

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
