### PR TITLE
dbt init: add gitignore, ignore pycache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Under the hood
 - Improve default view and table materialization performance by checking relational cache before attempting to drop temp relations ([#3112](https://github.com/fishtown-analytics/dbt/issues/3112), [#3468](https://github.com/fishtown-analytics/dbt/pull/3468))
 - Add optional `sslcert`, `sslkey`, and `sslrootcert` profile arguments to the Postgres connector. ([#3472](https://github.com/fishtown-analytics/dbt/pull/3472), [#3473](https://github.com/fishtown-analytics/dbt/pull/3473))
-- Move the example project used by `dbt init` into `dbt` repository, to avoid cloning an external repo ([#3005](https://github.com/fishtown-analytics/dbt/pull/3005), [#3474](https://github.com/fishtown-analytics/dbt/pull/3474))
+- Move the example project used by `dbt init` into `dbt` repository, to avoid cloning an external repo ([#3005](https://github.com/fishtown-analytics/dbt/pull/3005), [#3474](https://github.com/fishtown-analytics/dbt/pull/3474), [#3536](https://github.com/fishtown-analytics/dbt/pull/3536))
 - Better interaction between `dbt init` and adapters. Avoid raising errors while initializing a project ([#2814](https://github.com/fishtown-analytics/dbt/pull/2814), [#3483](https://github.com/fishtown-analytics/dbt/pull/3483))
 - Update project loading event data to include experimental parser information. ([#3438](https://github.com/fishtown-analytics/dbt/issues/3438), [#3495](https://github.com/fishtown-analytics/dbt/pull/3495))
 

--- a/core/MANIFEST.in
+++ b/core/MANIFEST.in
@@ -1,1 +1,1 @@
-recursive-include dbt/include *.py *.sql *.yml *.html *.md .gitkeep
+recursive-include dbt/include *.py *.sql *.yml *.html *.md .gitkeep .gitignore

--- a/core/dbt/include/starter_project/.gitignore
+++ b/core/dbt/include/starter_project/.gitignore
@@ -1,0 +1,4 @@
+
+target/
+dbt_modules/
+logs/

--- a/core/dbt/task/init.py
+++ b/core/dbt/task/init.py
@@ -16,7 +16,7 @@ DOCS_URL = 'https://docs.getdbt.com/docs/configure-your-profile'
 SLACK_URL = 'https://community.getdbt.com/'
 
 # This file is not needed for the starter project but exists for finding the resource path
-IGNORE_FILE = "__init__.py"
+IGNORE_FILES = ["__init__.py", "__pycache__"]
 
 ON_COMPLETE_MESSAGE = """
 Your new dbt project "{project_name}" was created! If this is your first time
@@ -44,7 +44,7 @@ class InitTask(BaseTask):
     def copy_starter_repo(self, project_name):
         logger.debug("Starter project path: " + starter_project_directory)
         shutil.copytree(starter_project_directory, project_name,
-                        ignore=shutil.ignore_patterns(IGNORE_FILE))
+                        ignore=shutil.ignore_patterns(*IGNORE_FILES))
 
     def create_profiles_dir(self, profiles_dir):
         if not os.path.exists(profiles_dir):


### PR DESCRIPTION
Follow-up to #3474, #3483

### Description

- Exclude `__pycache__` (if present, as it is for me) from `dbt init`
- Include `.gitignore` for starter dbt projects

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - ~This PR includes tests, or tests are not required/relevant for this PR~
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
