### PR TITLE
Speed up Snowflake column comments, while still avoiding errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Contributors:
 
 ## dbt 0.20.0 (Release TBD)
 
+### Fixes
+
+- Avoid slowdown in column-level `persist_docs` on Snowflake, while preserving the error-avoidance from [#3149](https://github.com/fishtown-analytics/dbt/issues/3149) ([#3541](https://github.com/fishtown-analytics/dbt/issues/3541), [#3543](https://github.com/fishtown-analytics/dbt/pull/3543))
+
 ## dbt 0.20.0rc2 (June 30, 2021)
 
 ### Fixes

--- a/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
+++ b/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
@@ -155,8 +155,10 @@
 
 
 {% macro snowflake__alter_column_comment(relation, column_dict) -%}
-    {% for column_name in column_dict %}
-        comment if exists on column {{ relation }}.{{ adapter.quote(column_name) if column_dict[column_name]['quote'] else column_name }} is $${{ column_dict[column_name]['description'] | replace('$', '[$]') }}$$;
+    {% set existing_columns = adapter.get_columns_in_relation(relation) | map(attribute="name") | list %}
+    alter {{ relation.type }} {{ relation }} alter
+    {% for column_name in column_dict if (column_name in existing_columns) or (column_name|upper in existing_columns) %}
+        {{ adapter.quote(column_name) if column_dict[column_name]['quote'] else column_name }} COMMENT $${{ column_dict[column_name]['description'] | replace('$', '[$]') }}$$ {{ ',' if not loop.last else ';' }}
     {% endfor %}
 {% endmacro %}
 


### PR DESCRIPTION
resolves #3541, [slack thread](https://getdbt.slack.com/archives/CJN7XRF1B/p1625643083492800)
see also: #3149, #3039

### Description

#3149 did a wonderful job of resolving the undesirable behavior (originally reported in #3039) whereby a column description, specified in yaml, would cause a model to fail building if the column doesn't actually exist in the model query. This "strictness" could be a feature, someday, but it's not how we think about properties (and especially descriptions) today.

Unfortunately, the approach taken in #3149 is resulting in much, much slower builds for models with many description-bearing columns—from seconds to minutes. This is because the Snowflake python connector requires running each semicolon-delineated query on its own, and so they run in sequence, hundreds of times. (Whereas `dbt-postgres`, which also uses per-column `comment on` statements, can run big batches of semicolon-delineated statements all at once.)

This PR takes an alternative approach—option 2 that I outlined in the original issue—by checking to see which columns exist in the just-created table, via `adapter.get_columns_in_relation`, and then comparing the result against the dictionary of columns with descriptions defined.

I'd like to sneak this into v0.20.0 final if possible :)

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR — Existing tests, including the one added by #3149
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
