### PR TITLE
Tweak function to return a value instead of asserting

### DIFF
--- a/test/integration/033_event_tracking_test/test_events.py
+++ b/test/integration/033_event_tracking_test/test_events.py
@@ -83,10 +83,7 @@ class TestEventTracking(DBTIntegrationTest):
             else:
                 populated_contexts.append(context)
 
-        self.assertEqual(
-            ordered_contexts,
-            populated_contexts
-        )
+        return ordered_contexts == populated_contexts
 
     def load_context(self):
 
@@ -277,11 +274,13 @@ class TestEventTrackingSuccess(TestEventTracking):
             self.build_context('compile', 'end', result_type='ok')
         ]
 
-        self.run_event_test(
+        test_result = self.run_event_test(
             ["compile", "--vars", "sensitive_thing: abc"],
             expected_calls,
             expected_contexts
         )
+
+        self.assertTrue(test_result)
 
     @use_profile("postgres")
     def test__postgres_event_tracking_deps(self):
@@ -337,7 +336,8 @@ class TestEventTrackingSuccess(TestEventTracking):
             self.build_context('deps', 'end', result_type='ok')
         ]
 
-        self.run_event_test(["deps"], expected_calls, expected_contexts)
+        test_result = self.run_event_test(["deps"], expected_calls, expected_contexts)
+        self.assertTrue(test_result)
 
     @use_profile("postgres")
     def test__postgres_event_tracking_seed(self):
@@ -405,7 +405,8 @@ class TestEventTrackingSuccess(TestEventTracking):
             self.build_context('seed', 'end', result_type='ok')
         ]
 
-        self.run_event_test(["seed"], expected_calls, expected_contexts)
+        test_result = self.run_event_test(["seed"], expected_calls, expected_contexts)
+        self.assertTrue(test_result)
 
     @use_profile("postgres")
     def test__postgres_event_tracking_models(self):
@@ -477,11 +478,13 @@ class TestEventTrackingSuccess(TestEventTracking):
             self.build_context('run', 'end', result_type='ok')
         ]
 
-        self.run_event_test(
+        test_result = self.run_event_test(
             ["run", "--model", "example", "example_2"],
             expected_calls,
             expected_contexts
         )
+
+        self.assertTrue(test_result)
 
     @use_profile("postgres")
     def test__postgres_event_tracking_model_error(self):
@@ -536,12 +539,14 @@ class TestEventTrackingSuccess(TestEventTracking):
             self.build_context('run', 'end', result_type='ok')
         ]
 
-        self.run_event_test(
+        test_result = self.run_event_test(
             ["run", "--model", "model_error"],
             expected_calls,
             expected_contexts,
             expect_pass=False
         )
+
+        self.assertTrue(test_result)
 
     @use_profile("postgres")
     def test__postgres_event_tracking_tests(self):
@@ -583,12 +588,14 @@ class TestEventTrackingSuccess(TestEventTracking):
             self.build_context('test', 'end', result_type='ok')
         ]
 
-        self.run_event_test(
+        test_result = self.run_event_test(
             ["test"],
             expected_calls,
             expected_contexts,
             expect_pass=False
         )
+
+        self.assertTrue(test_result)
 
 
 class TestEventTrackingCompilationError(TestEventTracking):
@@ -621,13 +628,15 @@ class TestEventTrackingCompilationError(TestEventTracking):
             self.build_context('compile', 'end', result_type='error')
         ]
 
-        self.run_event_test(
+        test_result = self.run_event_test(
             ["compile"],
             expected_calls,
             expected_contexts,
             expect_pass=False,
             expect_raise=True
         )
+
+        self.assertTrue(test_result)
 
 
 class TestEventTrackingUnableToConnect(TestEventTracking):
@@ -701,12 +710,14 @@ class TestEventTrackingUnableToConnect(TestEventTracking):
             self.build_context('run', 'end', result_type='error')
         ]
 
-        self.run_event_test(
+        test_result = self.run_event_test(
             ["run", "--target", "noaccess", "--models", "example"],
             expected_calls,
             expected_contexts,
             expect_pass=False
         )
+
+        self.assertTrue(test_result)
 
 
 class TestEventTrackingSnapshot(TestEventTracking):
@@ -770,11 +781,13 @@ class TestEventTrackingSnapshot(TestEventTracking):
             self.build_context('snapshot', 'end', result_type='ok')
         ]
 
-        self.run_event_test(
+        test_result = self.run_event_test(
             ["snapshot"],
             expected_calls,
             expected_contexts
         )
+
+        self.assertTrue(test_result)
 
 
 class TestEventTrackingCatalogGenerate(TestEventTracking):
@@ -817,8 +830,10 @@ class TestEventTrackingCatalogGenerate(TestEventTracking):
             self.build_context('generate', 'end', result_type='ok')
         ]
 
-        self.run_event_test(
+        test_result = self.run_event_test(
             ["docs", "generate"],
             expected_calls,
             expected_contexts
         )
+
+        self.assertTrue(test_result)


### PR DESCRIPTION
### Description

This looks like a very silly change. Why would we want this?

Well, when the helper function asserts, our tests are locked into the interface of the function itself. Our test _must fail_ if this equality check fails. However, with the addition of the new [experimental parser tracking event](https://github.com/dbt-labs/dbt/pull/3528), our tracking events are non-deterministic. This is a quick change for us to be able to assert that the set of fired events must be `A` or `B` (with or without the experimental parser sampling).

Although I do generally believe in pushing assert statements to the top-level test, this very simple change isn't a long term brilliant solution to efficiently testing non-deterministic tracking.

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
