### PR TITLE
Source freshness task node selection and cli command parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ### Features
 - Add `dbt build` command to run models, tests, seeds, and snapshots in DAG order. ([#2743] (https://github.com/dbt-labs/dbt/issues/2743), [#3490] (https://github.com/dbt-labs/dbt/issues/3490))
-- Add full node selection to source freshness command and align syntax with other tasks, rename `source snapshot-freshness` -> `source freshness` ([#2987](https://github.com/dbt-labs/dbt/issues/2987), [#3554](https://github.com/dbt-labs/dbt/pull/3554))
+
+### Breaking changes
+- Add full node selection to source freshness command and align selection syntax with other tasks (`dbt source freshness --select source_name` --> `dbt source freshness --select source:souce_name`) and rename `dbt source snapshot-freshness` -> `dbt source freshness`. ([#2987](https://github.com/dbt-labs/dbt/issues/2987), [#3554](https://github.com/dbt-labs/dbt/pull/3554))
 
 ### Fixes
 - Fix docs generation for cross-db sources in REDSHIFT RA3 node ([#3236](https://github.com/fishtown-analytics/dbt/issues/3236), [#3408](https://github.com/fishtown-analytics/dbt/pull/3408))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 - Add `dbt build` command to run models, tests, seeds, and snapshots in DAG order. ([#2743] (https://github.com/dbt-labs/dbt/issues/2743), [#3490] (https://github.com/dbt-labs/dbt/issues/3490))
+- Add full node selection to source freshness command and align syntax with other tasks, rename `source snapshot-freshness` -> `source freshness` ([#2987](https://github.com/dbt-labs/dbt/issues/2987), [#3554](https://github.com/dbt-labs/dbt/pull/3554))
 
 ### Fixes
 - Fix docs generation for cross-db sources in REDSHIFT RA3 node ([#3236](https://github.com/fishtown-analytics/dbt/issues/3236), [#3408](https://github.com/fishtown-analytics/dbt/pull/3408))

--- a/core/dbt/contracts/rpc.py
+++ b/core/dbt/contracts/rpc.py
@@ -186,6 +186,8 @@ class RPCRunOperationParameters(RPCParameters):
 class RPCSourceFreshnessParameters(RPCParameters):
     threads: Optional[int] = None
     select: Union[None, str, List[str]] = None
+    exclude: Union[None, str, List[str]] = None
+    selector: Optional[str] = None
 
 
 @dataclass

--- a/core/dbt/main.py
+++ b/core/dbt/main.py
@@ -41,6 +41,7 @@ class DBTVersion(argparse.Action):
     """This is very very similar to the builtin argparse._Version action,
     except it just calls dbt.version.get_version_information().
     """
+
     def __init__(self,
                  option_strings,
                  version=None,
@@ -764,16 +765,6 @@ def _build_source_snapshot_freshness_subparser(subparsers, base_subparser):
         ''',
     )
     sub.add_argument(
-        '-s',
-        '--select',
-        required=False,
-        nargs='+',
-        help='''
-        Specify the sources to snapshot freshness
-        ''',
-        dest='selected'
-    )
-    sub.add_argument(
         '-o',
         '--output',
         required=False,
@@ -795,6 +786,13 @@ def _build_source_snapshot_freshness_subparser(subparsers, base_subparser):
         which='snapshot-freshness',
         rpc_method='snapshot-freshness',
     )
+    _add_select_argument(
+        sub,
+        dest='select',
+        metavar='SELECTOR',
+        required=False,
+    )
+    _add_common_selector_arguments(sub)
     return sub
 
 

--- a/core/dbt/main.py
+++ b/core/dbt/main.py
@@ -756,13 +756,14 @@ def _build_test_subparser(subparsers, base_subparser):
     return sub
 
 
-def _build_source_snapshot_freshness_subparser(subparsers, base_subparser):
+def _build_source_freshness_subparser(subparsers, base_subparser):
     sub = subparsers.add_parser(
-        'snapshot-freshness',
+        'freshness',
         parents=[base_subparser],
         help='''
         Snapshots the current freshness of the project's sources
         ''',
+        aliases=['snapshot-freshness'],
     )
     sub.add_argument(
         '-o',
@@ -783,8 +784,8 @@ def _build_source_snapshot_freshness_subparser(subparsers, base_subparser):
     )
     sub.set_defaults(
         cls=freshness_task.FreshnessTask,
-        which='snapshot-freshness',
-        rpc_method='snapshot-freshness',
+        which='source-freshness',
+        rpc_method='source-freshness',
     )
     _add_select_argument(
         sub,
@@ -1082,7 +1083,7 @@ def parse_args(args, cls=DBTArgumentParser):
     _add_table_mutability_arguments(run_sub, compile_sub)
 
     _build_docs_serve_subparser(docs_subs, base_subparser)
-    _build_source_snapshot_freshness_subparser(source_subs, base_subparser)
+    _build_source_freshness_subparser(source_subs, base_subparser)
     _build_run_operation_subparser(subs, base_subparser)
 
     if len(args) == 0:

--- a/core/dbt/task/freshness.py
+++ b/core/dbt/task/freshness.py
@@ -137,9 +137,15 @@ class FreshnessTask(GraphRunnableTask):
         return False
 
     def get_selection_spec(self) -> SelectionSpec:
+        """Generates a selection spec from task arguments to use when processing
+        graph. A SelectionSpec describes what nodes to select when creating 
+        queue from graph of nodes.
+        """
         if self.args.selector_name:
+            # use pre-defined selector (--selector) to create selection spec
             spec = self.config.get_selector(self.args.selector_name)
         else:
+            # use --select and --exclude args to create selection spec
             spec = parse_difference(self.args.select, self.args.exclude)
         return spec
 

--- a/core/dbt/task/freshness.py
+++ b/core/dbt/task/freshness.py
@@ -137,9 +137,9 @@ class FreshnessTask(GraphRunnableTask):
         return False
 
     def get_selection_spec(self) -> SelectionSpec:
-        """Generates a selection spec from task arguments to use when processing
-        graph. A SelectionSpec describes what nodes to select when creating 
-        queue from graph of nodes.
+        """Generates a selection spec from task arguments to use when
+        processing graph. A SelectionSpec describes what nodes to select
+        when creating queue from graph of nodes.
         """
         if self.args.selector_name:
             # use pre-defined selector (--selector) to create selection spec

--- a/core/dbt/task/rpc/project_commands.py
+++ b/core/dbt/task/rpc/project_commands.py
@@ -231,7 +231,9 @@ class RemoteSourceFreshnessTask(
     METHOD_NAME = 'snapshot-freshness'
 
     def set_args(self, params: RPCSourceFreshnessParameters) -> None:
-        self.args.selected = self._listify(params.select)
+        self.args.select = self._listify(params.select)
+        self.args.exclude = self._listify(params.exclude)
+        self.args.selector_name = params.selector
         if params.threads is not None:
             self.args.threads = params.threads
         self.args.output = None

--- a/core/dbt/task/rpc/project_commands.py
+++ b/core/dbt/task/rpc/project_commands.py
@@ -228,7 +228,7 @@ class RemoteSourceFreshnessTask(
     RPCCommandTask[RPCSourceFreshnessParameters],
     FreshnessTask
 ):
-    METHOD_NAME = 'snapshot-freshness'
+    METHOD_NAME = 'source-freshness'
 
     def set_args(self, params: RPCSourceFreshnessParameters) -> None:
         self.args.select = self._listify(params.select)
@@ -237,6 +237,13 @@ class RemoteSourceFreshnessTask(
         if params.threads is not None:
             self.args.threads = params.threads
         self.args.output = None
+
+
+class RemoteSourceSnapshotFreshnessTask(
+    RemoteSourceFreshnessTask
+):
+    """ Deprecated task method name, aliases to `source-freshness` """
+    METHOD_NAME = 'snapshot-freshness'
 
 
 # this is a weird and special method.

--- a/test/integration/042_sources_test/test_sources.py
+++ b/test/integration/042_sources_test/test_sources.py
@@ -282,6 +282,41 @@ class TestSourceFreshness(SuccessfulSourcesTest):
         # by default, our data set is way out of date!
         self.freshness_start_time = datetime.utcnow()
         results = self.run_dbt_with_vars(
+            ['source', 'freshness', '-o', 'target/error_source.json'],
+            expect_pass=False
+        )
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].status, 'error')
+        self._assert_freshness_results('target/error_source.json', 'error')
+
+        self._set_updated_at_to(timedelta(hours=-12))
+        self.freshness_start_time = datetime.utcnow()
+        results = self.run_dbt_with_vars(
+            ['source', 'freshness', '-o', 'target/warn_source.json'],
+        )
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].status, 'warn')
+        self._assert_freshness_results('target/warn_source.json', 'warn')
+
+        self._set_updated_at_to(timedelta(hours=-2))
+        self.freshness_start_time = datetime.utcnow()
+        results = self.run_dbt_with_vars(
+            ['source', 'freshness', '-o', 'target/pass_source.json'],
+        )
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].status, 'pass')
+        self._assert_freshness_results('target/pass_source.json', 'pass')
+
+    @use_profile('postgres')
+    def test_postgres_source_freshness(self):
+        self._run_source_freshness()
+
+    @use_profile('postgres')
+    def test_postgres_source_snapshot_freshness(self):
+        """ Ensures that the deprecated command `source snapshot-freshness`
+        aliases to `source freshness` command """
+        self.freshness_start_time = datetime.utcnow()
+        results = self.run_dbt_with_vars(
             ['source', 'snapshot-freshness', '-o', 'target/error_source.json'],
             expect_pass=False
         )
@@ -307,10 +342,6 @@ class TestSourceFreshness(SuccessfulSourcesTest):
         self.assertEqual(results[0].status, 'pass')
         self._assert_freshness_results('target/pass_source.json', 'pass')
 
-    @use_profile('postgres')
-    def test_postgres_source_freshness(self):
-        self._run_source_freshness()
-
     @use_profile('snowflake')
     def test_snowflake_source_freshness(self):
         self._run_source_freshness()
@@ -323,6 +354,43 @@ class TestSourceFreshness(SuccessfulSourcesTest):
     def test_bigquery_source_freshness(self):
         self._run_source_freshness()
 
+    @use_profile('postgres')
+    def test_postgres_source_freshness_selection_select(self):
+        self._set_updated_at_to(timedelta(hours=-2))
+        self.freshness_start_time = datetime.utcnow()
+        # select source directly
+        results = self.run_dbt_with_vars(
+            ['source', 'freshness', '--select',
+                'source:test_source.test_table', '-o', 'target/pass_source.json'],
+        )
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].status, 'pass')
+        self._assert_freshness_results('target/pass_source.json', 'pass')
+
+    @use_profile('postgres')
+    def test_postgres_source_freshness_selection_exclude(self):
+        self._set_updated_at_to(timedelta(hours=-2))
+        self.freshness_start_time = datetime.utcnow()
+        # exclude source directly
+        results = self.run_dbt_with_vars(
+            ['source', 'freshness', '--exclude',
+                'source:test_source.test_table', '-o', 'target/exclude_source.json'],
+        )
+        self.assertEqual(len(results), 0)
+
+    @use_profile('postgres')
+    def test_postgres_source_freshness_selection_graph_operation(self):
+        self._set_updated_at_to(timedelta(hours=-2))
+        self.freshness_start_time = datetime.utcnow()
+        # select model ancestors
+        results = self.run_dbt_with_vars(
+            ['source', 'freshness', '--select',
+                '+descendant_model', '-o', 'target/ancestor_source.json']
+        )
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].status, 'pass')
+        self._assert_freshness_results('target/ancestor_source.json', 'pass')
+
 
 class TestSourceFreshnessErrors(SuccessfulSourcesTest):
     @property
@@ -332,7 +400,7 @@ class TestSourceFreshnessErrors(SuccessfulSourcesTest):
     @use_profile('postgres')
     def test_postgres_error(self):
         results = self.run_dbt_with_vars(
-            ['source', 'snapshot-freshness'],
+            ['source', 'freshness'],
             expect_pass=False
         )
         self.assertEqual(len(results), 1)
@@ -348,18 +416,18 @@ class TestSourceFreshnessFilter(SuccessfulSourcesTest):
     def test_postgres_all_records(self):
         # all records are filtered out
         self.run_dbt_with_vars(
-            ['source', 'snapshot-freshness'], expect_pass=False)
+            ['source', 'freshness'], expect_pass=False)
         # we should insert a record with #101 that's fresh, but will still fail
         # because the filter excludes it
         self._set_updated_at_to(timedelta(hours=-2))
         self.run_dbt_with_vars(
-            ['source', 'snapshot-freshness'], expect_pass=False)
+            ['source', 'freshness'], expect_pass=False)
 
         # we should now insert a record with #102 that's fresh, and the filter
         # includes it
         self._set_updated_at_to(timedelta(hours=-2))
         results = self.run_dbt_with_vars(
-            ['source', 'snapshot-freshness'], expect_pass=True)
+            ['source', 'freshness'], expect_pass=True)
 
 
 class TestMalformedSources(BaseSourcesTest):

--- a/test/integration/042_sources_test/test_sources.py
+++ b/test/integration/042_sources_test/test_sources.py
@@ -313,8 +313,9 @@ class TestSourceFreshness(SuccessfulSourcesTest):
 
     @use_profile('postgres')
     def test_postgres_source_snapshot_freshness(self):
-        """ Ensures that the deprecated command `source snapshot-freshness`
-        aliases to `source freshness` command """
+        """Ensures that the deprecated command `source snapshot-freshness`
+        aliases to `source freshness` command.
+        """
         self.freshness_start_time = datetime.utcnow()
         results = self.run_dbt_with_vars(
             ['source', 'snapshot-freshness', '-o', 'target/error_source.json'],
@@ -356,6 +357,7 @@ class TestSourceFreshness(SuccessfulSourcesTest):
 
     @use_profile('postgres')
     def test_postgres_source_freshness_selection_select(self):
+        """Tests node selection using the --select argument."""
         self._set_updated_at_to(timedelta(hours=-2))
         self.freshness_start_time = datetime.utcnow()
         # select source directly
@@ -369,6 +371,8 @@ class TestSourceFreshness(SuccessfulSourcesTest):
 
     @use_profile('postgres')
     def test_postgres_source_freshness_selection_exclude(self):
+        """Tests node selection using the --select argument. It 'excludes' the 
+        only source in the project so it should return no results."""
         self._set_updated_at_to(timedelta(hours=-2))
         self.freshness_start_time = datetime.utcnow()
         # exclude source directly
@@ -380,6 +384,10 @@ class TestSourceFreshness(SuccessfulSourcesTest):
 
     @use_profile('postgres')
     def test_postgres_source_freshness_selection_graph_operation(self):
+        """Tests node selection using the --select argument with graph
+        operations. `+descendant_model` == select all nodes `descendant_model`
+        depends on.
+        """
         self._set_updated_at_to(timedelta(hours=-2))
         self.freshness_start_time = datetime.utcnow()
         # select model ancestors

--- a/test/rpc/test_source_freshness.py
+++ b/test/rpc/test_source_freshness.py
@@ -65,10 +65,10 @@ def test_source_freshness(
         project.write_seeds(project_root, remove=True)
         querier.async_wait_for_result(querier.seed())
         # should warn
-        warn_results = querier.async_wait_for_result(querier.snapshot_freshness(select='test_source.test_table'))
+        warn_results = querier.async_wait_for_result(querier.snapshot_freshness(select='source:test_source.test_table'))
         assert len(warn_results['results']) == 1
         assert warn_results['results'][0]['status'] == 'warn'
-        warn_results = querier.async_wait_for_result(querier.cli_args('source snapshot-freshness -s test_source.test_table'))
+        warn_results = querier.async_wait_for_result(querier.cli_args('source snapshot-freshness -s source:test_source.test_table'))
         assert len(warn_results['results']) == 1
         assert warn_results['results'][0]['status'] == 'warn'
 
@@ -76,9 +76,9 @@ def test_source_freshness(
         project.write_seeds(project_root, remove=True)
         querier.async_wait_for_result(querier.seed())
         # should pass!
-        pass_results = querier.async_wait_for_result(querier.snapshot_freshness(select=['test_source.test_table']))
+        pass_results = querier.async_wait_for_result(querier.snapshot_freshness(select=['source:test_source.test_table']))
         assert len(pass_results['results']) == 1
         assert pass_results['results'][0]['status'] == 'pass'
-        pass_results = querier.async_wait_for_result(querier.cli_args('source snapshot-freshness --select test_source.test_table'))
+        pass_results = querier.async_wait_for_result(querier.cli_args('source snapshot-freshness --select source:test_source.test_table'))
         assert len(pass_results['results']) == 1
         assert pass_results['results'][0]['status'] == 'pass'

--- a/test/rpc/test_source_freshness.py
+++ b/test/rpc/test_source_freshness.py
@@ -21,9 +21,8 @@ sources:
         identifier: other_source
 '''
 
-
 @pytest.mark.supported('postgres')
-def test_source_freshness(
+def test_source_snapshot_freshness(
     project_root, profiles_root, dbt_profile, unique_schema
 ):
     start_time = datetime.utcnow()
@@ -80,5 +79,66 @@ def test_source_freshness(
         assert len(pass_results['results']) == 1
         assert pass_results['results'][0]['status'] == 'pass'
         pass_results = querier.async_wait_for_result(querier.cli_args('source snapshot-freshness --select source:test_source.test_table'))
+        assert len(pass_results['results']) == 1
+        assert pass_results['results'][0]['status'] == 'pass'
+
+@pytest.mark.supported('postgres')
+def test_source_freshness(
+    project_root, profiles_root, dbt_profile, unique_schema
+):
+    start_time = datetime.utcnow()
+    warn_me = start_time - timedelta(hours=18)
+    error_me = start_time - timedelta(days=2)
+    # this should trigger a 'warn'
+    project = ProjectDefinition(
+        project_data={'seeds': {'config': {'quote_columns': False}}},
+        seeds={
+            'source.csv': 'a,b\n1,{}\n'.format(error_me.strftime('%Y-%m-%d %H:%M:%S')),
+            'other_source.csv': 'a,b\n1,{}\n'.format(error_me.strftime('%Y-%m-%d %H:%M:%S'))
+        },
+        models={
+            'sources.yml': source_freshness_schema_yml.format(schema=unique_schema),
+        },
+    )
+    querier_ctx = get_querier(
+        project_def=project,
+        project_dir=project_root,
+        profiles_dir=profiles_root,
+        schema=unique_schema,
+        test_kwargs={},
+    )
+
+    with querier_ctx as querier:
+        seeds = querier.async_wait_for_result(querier.seed())
+        assert len(seeds['results']) == 2
+        # should error
+        error_results = querier.async_wait_for_result(querier.source_freshness(), state='failed')
+        assert len(error_results['results']) == 2
+        for result in error_results['results']:
+            assert result['status'] == 'error'
+        error_results = querier.async_wait_for_result(querier.cli_args('source freshness'), state='failed')
+        assert len(error_results['results']) == 2
+        for result in error_results['results']:
+            assert result['status'] == 'error'
+
+        project.seeds['source.csv'] += '2,{}\n'.format(warn_me.strftime('%Y-%m-%d %H:%M:%S'))
+        project.write_seeds(project_root, remove=True)
+        querier.async_wait_for_result(querier.seed())
+        # should warn
+        warn_results = querier.async_wait_for_result(querier.source_freshness(select='source:test_source.test_table'))
+        assert len(warn_results['results']) == 1
+        assert warn_results['results'][0]['status'] == 'warn'
+        warn_results = querier.async_wait_for_result(querier.cli_args('source freshness -s source:test_source.test_table'))
+        assert len(warn_results['results']) == 1
+        assert warn_results['results'][0]['status'] == 'warn'
+
+        project.seeds['source.csv'] += '3,{}\n'.format(start_time.strftime('%Y-%m-%d %H:%M:%S'))
+        project.write_seeds(project_root, remove=True)
+        querier.async_wait_for_result(querier.seed())
+        # should pass!
+        pass_results = querier.async_wait_for_result(querier.source_freshness(select=['source:test_source.test_table']))
+        assert len(pass_results['results']) == 1
+        assert pass_results['results'][0]['status'] == 'pass'
+        pass_results = querier.async_wait_for_result(querier.cli_args('source freshness --select source:test_source.test_table'))
         assert len(pass_results['results']) == 1
         assert pass_results['results'][0]['status'] == 'pass'

--- a/test/rpc/util.py
+++ b/test/rpc/util.py
@@ -318,6 +318,7 @@ class Querier:
         threads: Optional[int] = None,
         request_id: int = 1,
     ):
+        """ Deprecated rpc command `snapshot-freshness` -> `source-freshness` """
         params = {}
         if select is not None:
             params['select'] = select
@@ -325,6 +326,27 @@ class Querier:
             params['threads'] = threads
         return self.request(
             method='snapshot-freshness', params=params, request_id=request_id
+        )
+
+    def source_freshness(
+        self,
+        select: Optional[Union[str, List[str]]] = None,
+        exclude: Optional[Union[str, List[str]]] = None,
+        threads: Optional[int] = None,
+        request_id: int = 1,
+        state: Optional[bool] = None,
+    ):
+        params = {}
+        if select is not None:
+            params['select'] = select
+        if exclude is not None:
+            params['exclude'] = exclude
+        if threads is not None:
+            params['threads'] = threads
+        if state is not None:
+            params['state'] = state
+        return self.request(
+            method='source-freshness', params=params, request_id=request_id
         )
 
     def test(


### PR DESCRIPTION
resolves #2987 

### Description
- adds support for node selection (`--select`, `--exclude`, `--selector`)
- aligns selection syntax with other commands: `dbt source freshness --select raw_payments` -> `dbt source freshness --select source:raw_payments`
- rename cli and rpc command to `source freshness`
- continue to support `source snapshot-freshness` via cli and rpc

Note: There is no deprecation warning for using the old command name, it wasn't as simple as I initially thought (#3565)

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
