### PR TITLE
Feature: state:modified.macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## dbt 0.21.0 (Release TBD)
 
+### Features
+- Capture changes to macros in `state:modified`. Introduce new `state:` sub-selectors: `modified.body`, `modified.configs`, `modified.persisted_descriptions`, `modified.relation`, `modified.macros` ([#2704](https://github.com/dbt-labs/dbt/issues/2704), [#3278](https://github.com/dbt-labs/dbt/issues/3278), [#3559](https://github.com/dbt-labs/dbt/issues/3559))
+
 ### Under the hood
 - Add `build` RPC method, and a subset of flags for `build` task ([#3595](https://github.com/dbt-labs/dbt/issues/3595), [#3674](https://github.com/dbt-labs/dbt/pull/3674))
 

--- a/core/dbt/contracts/graph/parsed.py
+++ b/core/dbt/contracts/graph/parsed.py
@@ -692,7 +692,7 @@ class ParsedSourceDefinition(
 
     @property
     def depends_on(self):
-        return {'nodes': []}
+        return DependsOn(macros=[], nodes=[])
 
     @property
     def refs(self):

--- a/core/dbt/graph/selector_methods.py
+++ b/core/dbt/graph/selector_methods.py
@@ -22,13 +22,11 @@ from dbt.contracts.graph.parsed import (
     ParsedSourceDefinition,
 )
 from dbt.contracts.state import PreviousState
-from dbt.logger import GLOBAL_LOGGER as logger
 from dbt.exceptions import (
     InternalException,
     RuntimeException,
 )
 from dbt.node_types import NodeType
-from dbt.ui import warning_tag
 
 
 SELECTOR_GLOB = '*'
@@ -426,26 +424,30 @@ class StateSelectorMethod(SelectorMethod):
         different_contents = not new.same_contents(old)
         upstream_macro_change = self.recursively_check_macros_modified(new)
         return different_contents or upstream_macro_change  # type: ignore
-        
+
     def check_modified_body(self, old: Optional[SelectorTarget], new: SelectorTarget) -> bool:
         if hasattr(new, "same_body"):
             return not new.same_body(old)
         else:
             return False
-        
+
     def check_modified_configs(self, old: Optional[SelectorTarget], new: SelectorTarget) -> bool:
         if hasattr(new, "same_config"):
             return not new.same_config(old)
         else:
             return False
-        
-    def check_modified_persisted_descriptions(self, old: Optional[SelectorTarget], new: SelectorTarget) -> bool:
+
+    def check_modified_persisted_descriptions(
+        self, old: Optional[SelectorTarget], new: SelectorTarget
+    ) -> bool:
         if hasattr(new, "same_persisted_description"):
             return not new.same_persisted_description(old)
         else:
             return False
-        
-    def check_modified_database_representations(self, old: Optional[SelectorTarget], new: SelectorTarget) -> bool:
+
+    def check_modified_database_representations(
+        self, old: Optional[SelectorTarget], new: SelectorTarget
+    ) -> bool:
         if hasattr(new, "same_database_representation"):
             return not new.same_database_representation(old)
         else:

--- a/core/dbt/graph/selector_methods.py
+++ b/core/dbt/graph/selector_methods.py
@@ -411,7 +411,7 @@ class StateSelectorMethod(SelectorMethod):
         # check if there are any changes in macros the first time
         if self.modified_macros is None:
             self.modified_macros = self._macros_modified()
-        
+
         for macro_uid in node.depends_on.macros:
             if macro_uid in self.modified_macros:
                 return True
@@ -427,17 +427,29 @@ class StateSelectorMethod(SelectorMethod):
         upstream_macro_change = self.recursively_check_macros_modified(new)
         return different_contents or upstream_macro_change  # type: ignore
         
-    def check_modified_contents(self, old: Optional[SelectorTarget], new: SelectorTarget) -> bool:
-        return not new.same_contents(old)
+    def check_modified_body(self, old: Optional[SelectorTarget], new: SelectorTarget) -> bool:
+        if hasattr(new, "same_body"):
+            return not new.same_body(old)
+        else:
+            return False
         
     def check_modified_configs(self, old: Optional[SelectorTarget], new: SelectorTarget) -> bool:
-        return not new.same_config(old)
+        if hasattr(new, "same_config"):
+            return not new.same_config(old)
+        else:
+            return False
         
     def check_modified_persisted_descriptions(self, old: Optional[SelectorTarget], new: SelectorTarget) -> bool:
-        return not new.same_persisted_description(old)
+        if hasattr(new, "same_persisted_description"):
+            return not new.same_persisted_description(old)
+        else:
+            return False
         
     def check_modified_database_representations(self, old: Optional[SelectorTarget], new: SelectorTarget) -> bool:
-        return not new.same_database_representation(old)
+        if hasattr(new, "same_database_representation"):
+            return not new.same_database_representation(old)
+        else:
+            return False
 
     def check_modified_macros(self, old: Optional[SelectorTarget], new: SelectorTarget) -> bool:
         return self.recursively_check_macros_modified(new)
@@ -456,7 +468,7 @@ class StateSelectorMethod(SelectorMethod):
         state_checks = {
             'new': self.check_new,
             'modified': self.check_modified,
-            'modified.contents': self.check_modified_contents,
+            'modified.body': self.check_modified_body,
             'modified.configs': self.check_modified_configs,
             'modified.persisted_descriptions': self.check_modified_persisted_descriptions,
             'modified.database_representations': self.check_modified_database_representations,

--- a/core/dbt/graph/selector_methods.py
+++ b/core/dbt/graph/selector_methods.py
@@ -421,19 +421,19 @@ class StateSelectorMethod(SelectorMethod):
         return False
 
     def check_modified(self, old: Optional[SelectorTarget], new: SelectorTarget) -> bool:
-        different_contents = not new.same_contents(old)
+        different_contents = not new.same_contents(old)  # type: ignore
         upstream_macro_change = self.recursively_check_macros_modified(new)
-        return different_contents or upstream_macro_change  # type: ignore
+        return different_contents or upstream_macro_change
 
     def check_modified_body(self, old: Optional[SelectorTarget], new: SelectorTarget) -> bool:
         if hasattr(new, "same_body"):
-            return not new.same_body(old)
+            return not new.same_body(old)  # type: ignore
         else:
             return False
 
     def check_modified_configs(self, old: Optional[SelectorTarget], new: SelectorTarget) -> bool:
         if hasattr(new, "same_config"):
-            return not new.same_config(old)
+            return not new.same_config(old)  # type: ignore
         else:
             return False
 
@@ -441,7 +441,7 @@ class StateSelectorMethod(SelectorMethod):
         self, old: Optional[SelectorTarget], new: SelectorTarget
     ) -> bool:
         if hasattr(new, "same_persisted_description"):
-            return not new.same_persisted_description(old)
+            return not new.same_persisted_description(old)  # type: ignore
         else:
             return False
 
@@ -449,7 +449,7 @@ class StateSelectorMethod(SelectorMethod):
         self, old: Optional[SelectorTarget], new: SelectorTarget
     ) -> bool:
         if hasattr(new, "same_database_representation"):
-            return not new.same_database_representation(old)
+            return not new.same_database_representation(old)  # type: ignore
         else:
             return False
 

--- a/test/integration/062_defer_state_test/changed_models/table_model.sql
+++ b/test/integration/062_defer_state_test/changed_models/table_model.sql
@@ -1,2 +1,3 @@
 {{ config(materialized='table') }}
 select * from {{ ref('ephemeral_model') }}
+-- {{ my_macro() }}

--- a/test/integration/062_defer_state_test/changed_models/table_model.sql
+++ b/test/integration/062_defer_state_test/changed_models/table_model.sql
@@ -1,3 +1,5 @@
 {{ config(materialized='table') }}
 select * from {{ ref('ephemeral_model') }}
--- {{ my_macro() }}
+
+-- establish a macro dependency to trigger state:modified.macros
+-- depends on: {{ my_macro() }}

--- a/test/integration/062_defer_state_test/changed_models_bad/table_model.sql
+++ b/test/integration/062_defer_state_test/changed_models_bad/table_model.sql
@@ -1,2 +1,3 @@
 {{ config(materialized='table') }}
 select * from {{ ref('ephemeral_model') }}
+-- {{ my_macro() }}

--- a/test/integration/062_defer_state_test/changed_models_bad/table_model.sql
+++ b/test/integration/062_defer_state_test/changed_models_bad/table_model.sql
@@ -1,3 +1,5 @@
 {{ config(materialized='table') }}
 select * from {{ ref('ephemeral_model') }}
--- {{ my_macro() }}
+
+-- establish a macro dependency to trigger state:modified.macros
+-- depends on: {{ my_macro() }}

--- a/test/integration/062_defer_state_test/models/table_model.sql
+++ b/test/integration/062_defer_state_test/models/table_model.sql
@@ -1,2 +1,3 @@
 {{ config(materialized='table') }}
 select * from {{ ref('ephemeral_model') }}
+-- {{ my_macro() }}

--- a/test/integration/062_defer_state_test/models/table_model.sql
+++ b/test/integration/062_defer_state_test/models/table_model.sql
@@ -1,3 +1,5 @@
 {{ config(materialized='table') }}
 select * from {{ ref('ephemeral_model') }}
--- {{ my_macro() }}
+
+-- establish a macro dependency to trigger state:modified.macros
+-- depends on: {{ my_macro() }}

--- a/test/integration/062_defer_state_test/test_modified_state.py
+++ b/test/integration/062_defer_state_test/test_modified_state.py
@@ -166,7 +166,6 @@ class TestModifiedState(DBTIntegrationTest):
 
         results, stdout = self.run_dbt_and_capture(['run', '--models', 'state:modified', '--state', './state'], strict=False)
         assert len(results) == 0
-        assert 'detected a change in macros' in stdout
 
         os.remove('macros/second_macro.sql')
         # add a new macro to the existing file
@@ -175,7 +174,6 @@ class TestModifiedState(DBTIntegrationTest):
 
         results, stdout = self.run_dbt_and_capture(['run', '--models', 'state:modified', '--state', './state'], strict=False)
         assert len(results) == 0
-        assert 'detected a change in macros' in stdout
 
     @use_profile('postgres')
     def test_postgres_changed_macro_contents(self):
@@ -192,9 +190,9 @@ class TestModifiedState(DBTIntegrationTest):
             fp.write('{% endmacro %}')
             fp.write(newline)
 
+        # table_model calls this macro
         results, stdout = self.run_dbt_and_capture(['run', '--models', 'state:modified', '--state', './state'], strict=False)
-        assert len(results) == 0
-        assert 'detected a change in macros' in stdout
+        assert len(results) == 1
 
     @use_profile('postgres')
     def test_postgres_changed_exposure(self):

--- a/test/unit/test_graph_selector_methods.py
+++ b/test/unit/test_graph_selector_methods.py
@@ -7,7 +7,9 @@ from pathlib import Path
 from dbt.contracts.files import FileHash
 from dbt.contracts.graph.parsed import (
     DependsOn,
+    MacroDependsOn,
     NodeConfig,
+    ParsedMacro,
     ParsedModelNode,
     ParsedExposure,
     ParsedSeedNode,
@@ -85,7 +87,7 @@ def make_model(pkg, name, sql, refs=None, sources=None, tags=None, path=None, al
         tags=tags,
         refs=ref_values,
         sources=source_values,
-        depends_on=DependsOn(nodes=depends_on_nodes),
+        depends_on=DependsOn(nodes=depends_on_nodes, macros=[]),
         resource_type=NodeType.Model,
         checksum=FileHash.from_contents(''),
     )
@@ -157,6 +159,27 @@ def make_source(pkg, source_name, table_name, path=None, loader=None, identifier
     )
 
 
+def make_macro(pkg, name, macro_sql, path=None, depends_on_macros=None):
+    if path is None:
+        path = 'macros/macros.sql'
+    
+    if depends_on_macros is None:
+        depends_on_macros = []
+    
+    return ParsedMacro(
+        name=name,
+        macro_sql=macro_sql,
+        unique_id=f'macro.{pkg}.{name}',
+        package_name=pkg,
+        root_path='/usr/dbt/some-project',
+        path=path,
+        original_file_path=path,
+        resource_type=NodeType.Macro,
+        tags=[],
+        depends_on=MacroDependsOn(macros=depends_on_macros),
+    )
+
+
 def make_unique_test(pkg, test_model, column_name, path=None, refs=None, sources=None, tags=None):
     return make_schema_test(pkg, 'unique', test_model, {}, column_name=column_name)
 
@@ -191,10 +214,10 @@ def make_schema_test(pkg, test_name, test_model, test_kwargs, path=None, refs=No
 
     if len(name_parts) == 2:
         namespace, test_name = name_parts
-        macro_depends = f'model.{namespace}.{test_name}'
+        macro_depends = f'macro.{namespace}.test_{test_name}'
     elif len(name_parts) == 1:
         namespace = None
-        macro_depends = f'model.dbt.{test_name}'
+        macro_depends = f'macro.dbt.test_{test_name}'
     else:
         assert False, f'invalid test name: {test_name}'
 
@@ -289,7 +312,7 @@ def make_data_test(pkg, name, sql, refs=None, sources=None, tags=None, path=None
         tags=tags,
         refs=ref_values,
         sources=source_values,
-        depends_on=DependsOn(nodes=depends_on_nodes),
+        depends_on=DependsOn(nodes=depends_on_nodes, macros=[]),
         resource_type=NodeType.Test,
         checksum=FileHash.from_contents(''),
     )
@@ -316,6 +339,45 @@ def make_exposure(pkg, name, path=None, fqn_extras=None, owner=None):
         root_path='/usr/src/app',
         original_file_path=path,
         owner=owner,
+    )
+
+
+
+@pytest.fixture
+def macro_test_unique():
+    return make_macro(
+        'dbt',
+        'test_unique',
+        'blablabla',
+        depends_on_macros=['macro.dbt.default__test_unique']
+    )
+
+
+@pytest.fixture
+def macro_default_test_unique():
+    return make_macro(
+        'dbt',
+        'default__test_unique',
+        'blablabla'
+    )
+
+
+@pytest.fixture
+def macro_test_not_null():
+    return make_macro(
+        'dbt',
+        'test_not_null',
+        'blablabla',
+        depends_on_macros=['macro.dbt.default__test_not_null']
+    )
+
+
+@pytest.fixture
+def macro_default_test_not_null():
+    return make_macro(
+        'dbt',
+        'default__test_not_null',
+        'blabla'
     )
 
 
@@ -494,16 +556,18 @@ def namespaced_union_model(seed, ext_source):
 @pytest.fixture
 def manifest(seed, source, ephemeral_model, view_model, table_model, ext_source, ext_model, union_model, ext_source_2, 
     ext_source_other, ext_source_other_2, table_id_unique, table_id_not_null, view_id_unique, ext_source_id_unique, 
-    view_test_nothing, namespaced_seed, namespace_model, namespaced_union_model):
+    view_test_nothing, namespaced_seed, namespace_model, namespaced_union_model, macro_test_unique, macro_default_test_unique,
+    macro_test_not_null, macro_default_test_not_null):
     nodes = [seed, ephemeral_model, view_model, table_model, union_model, ext_model,
              table_id_unique, table_id_not_null, view_id_unique, ext_source_id_unique, view_test_nothing,
              namespaced_seed, namespace_model, namespaced_union_model]
     sources = [source, ext_source, ext_source_2,
                ext_source_other, ext_source_other_2]
+    macros = [macro_test_unique, macro_default_test_unique, macro_test_not_null, macro_default_test_not_null]
     manifest = Manifest(
         nodes={n.unique_id: n for n in nodes},
         sources={s.unique_id: s for s in sources},
-        macros={},
+        macros={m.unique_id: m for m in macros},
         docs={},
         files={},
         exposures={},
@@ -696,6 +760,11 @@ def test_select_state_no_change(manifest, previous_state):
     method = statemethod(manifest, previous_state)
     assert not search_manifest_using_method(manifest, method, 'modified')
     assert not search_manifest_using_method(manifest, method, 'new')
+    assert not search_manifest_using_method(manifest, method, 'new')
+    assert not search_manifest_using_method(manifest, method, 'modified.configs')
+    assert not search_manifest_using_method(manifest, method, 'modified.persisted_descriptions')
+    assert not search_manifest_using_method(manifest, method, 'modified.database_representations')
+    assert not search_manifest_using_method(manifest, method, 'modified.macros')
 
 
 def test_select_state_nothing(manifest, previous_state):
@@ -722,9 +791,19 @@ def test_select_state_added_model(manifest, previous_state):
 def test_select_state_changed_model_sql(manifest, previous_state, view_model):
     change_node(manifest, view_model.replace(raw_sql='select 1 as id'))
     method = statemethod(manifest, previous_state)
+    
+    # both of these
     assert search_manifest_using_method(
         manifest, method, 'modified') == {'view_model'}
+    assert search_manifest_using_method(
+        manifest, method, 'modified.body') == {'view_model'}
+    
+    # none of these
     assert not search_manifest_using_method(manifest, method, 'new')
+    assert not search_manifest_using_method(manifest, method, 'modified.configs')
+    assert not search_manifest_using_method(manifest, method, 'modified.persisted_descriptions')
+    assert not search_manifest_using_method(manifest, method, 'modified.database_representations')
+    assert not search_manifest_using_method(manifest, method, 'modified.macros')
 
 
 def test_select_state_changed_model_fqn(manifest, previous_state, view_model):
@@ -813,7 +892,11 @@ def test_select_state_changed_seed_relation_documented(manifest, previous_state,
     method = statemethod(manifest, previous_state)
     assert search_manifest_using_method(
         manifest, method, 'modified') == {'seed'}
+    assert search_manifest_using_method(
+        manifest, method, 'modified.configs') == {'seed'}
     assert not search_manifest_using_method(manifest, method, 'new')
+    assert not search_manifest_using_method(manifest, method, 'modified.body')
+    assert not search_manifest_using_method(manifest, method, 'modified.persisted_descriptions')
 
 
 def test_select_state_changed_seed_relation_documented_nodocs(manifest, previous_state, seed):
@@ -825,7 +908,10 @@ def test_select_state_changed_seed_relation_documented_nodocs(manifest, previous
     method = statemethod(manifest, previous_state)
     assert search_manifest_using_method(
         manifest, method, 'modified') == {'seed'}
+    assert search_manifest_using_method(
+        manifest, method, 'modified.persisted_descriptions') == {'seed'}
     assert not search_manifest_using_method(manifest, method, 'new')
+    assert not search_manifest_using_method(manifest, method, 'modified.configs')
 
 
 def test_select_state_changed_seed_relation_documented_withdocs(manifest, previous_state, seed):
@@ -837,6 +923,8 @@ def test_select_state_changed_seed_relation_documented_withdocs(manifest, previo
     method = statemethod(manifest, previous_state)
     assert search_manifest_using_method(
         manifest, method, 'modified') == {'seed'}
+    assert search_manifest_using_method(
+        manifest, method, 'modified.persisted_descriptions') == {'seed'}
     assert not search_manifest_using_method(manifest, method, 'new')
 
 
@@ -847,7 +935,10 @@ def test_select_state_changed_seed_columns_documented(manifest, previous_state, 
     method = statemethod(manifest, previous_state)
     assert search_manifest_using_method(
         manifest, method, 'modified') == {'seed'}
+    assert search_manifest_using_method(
+        manifest, method, 'modified.configs') == {'seed'}
     assert not search_manifest_using_method(manifest, method, 'new')
+    assert not search_manifest_using_method(manifest, method, 'modified.persisted_descriptions')
 
 
 def test_select_state_changed_seed_columns_documented_nodocs(manifest, previous_state, seed):
@@ -862,7 +953,10 @@ def test_select_state_changed_seed_columns_documented_nodocs(manifest, previous_
     method = statemethod(manifest, previous_state)
     assert search_manifest_using_method(
         manifest, method, 'modified') == {'seed'}
+    assert search_manifest_using_method(
+        manifest, method, 'modified.persisted_descriptions') == {'seed'}
     assert not search_manifest_using_method(manifest, method, 'new')
+    assert not search_manifest_using_method(manifest, method, 'modified.configs')
 
 
 def test_select_state_changed_seed_columns_documented_withdocs(manifest, previous_state, seed):
@@ -877,4 +971,16 @@ def test_select_state_changed_seed_columns_documented_withdocs(manifest, previou
     method = statemethod(manifest, previous_state)
     assert search_manifest_using_method(
         manifest, method, 'modified') == {'seed'}
+    assert search_manifest_using_method(
+        manifest, method, 'modified.persisted_descriptions') == {'seed'}
+    assert not search_manifest_using_method(manifest, method, 'new')
+    assert not search_manifest_using_method(manifest, method, 'modified.configs')
+    
+def test_select_state_changed_test_macro_sql(manifest, previous_state, macro_default_test_not_null):
+    manifest.macros[macro_default_test_not_null.unique_id] = macro_default_test_not_null.replace(macro_sql='lalala')
+    method = statemethod(manifest, previous_state)
+    assert search_manifest_using_method(
+        manifest, method, 'modified') == {'not_null_table_model_id'}
+    assert search_manifest_using_method(
+        manifest, method, 'modified.macros') == {'not_null_table_model_id'}
     assert not search_manifest_using_method(manifest, method, 'new')

--- a/test/unit/test_graph_selector_methods.py
+++ b/test/unit/test_graph_selector_methods.py
@@ -763,7 +763,7 @@ def test_select_state_no_change(manifest, previous_state):
     assert not search_manifest_using_method(manifest, method, 'new')
     assert not search_manifest_using_method(manifest, method, 'modified.configs')
     assert not search_manifest_using_method(manifest, method, 'modified.persisted_descriptions')
-    assert not search_manifest_using_method(manifest, method, 'modified.database_representations')
+    assert not search_manifest_using_method(manifest, method, 'modified.relation')
     assert not search_manifest_using_method(manifest, method, 'modified.macros')
 
 
@@ -802,7 +802,7 @@ def test_select_state_changed_model_sql(manifest, previous_state, view_model):
     assert not search_manifest_using_method(manifest, method, 'new')
     assert not search_manifest_using_method(manifest, method, 'modified.configs')
     assert not search_manifest_using_method(manifest, method, 'modified.persisted_descriptions')
-    assert not search_manifest_using_method(manifest, method, 'modified.database_representations')
+    assert not search_manifest_using_method(manifest, method, 'modified.relation')
     assert not search_manifest_using_method(manifest, method, 'modified.macros')
 
 


### PR DESCRIPTION
resolves #2704
resolves #3278
resolves [this tweet](https://twitter.com/tjwaterman99/status/1420809652548296704)

### Description

If a macro's SQL is modified, mark any node that depends on it (or depends on a macro that depends on it) as modified.

While I was here, it was trivial to make sub-selectors (finally) happen:
- `state:modified.body`
- `state:modified.configs`
- `state:modified.persisted_descriptions`
- ~`state:modified.database_representations`~ `state:modified.relation`
- `state:modified.macros`

### For review
- I don't really know how to write recursive functions :)
- Let's revisit some of the nomenclature here (vs. the original proposal in #2704). Even though it's a mouthful, I prefer `persisted_descriptions` vs. just `descriptions`, to be clear it's the subset with `persist_docs` enabled. On the other hand, I'm not sure about `modified.database_representations` vs. something shorter & sweeter like `modified.relations`.
- There are a few more `same_x` checks (`same_fqn`, `same_quoting`, `same_external`) that are resource-specific and wouldn't have dedicated subselectors in this first round. I think that's ok—these aren't ones we've heard as much demand for, and they're still included in the `state:modified` superset—just worth calling out.

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
