### PR TITLE
Refactor relationships test to support where config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ Contributors:
 - [@JLDLaughlin](https://github.com/JLDLaughlin) ([#3473](https://github.com/fishtown-analytics/dbt/pull/3473))
 - [@jmriego](https://github.com/jmriego) ([#3526](https://github.com/dbt-labs/dbt/pull/3526))
 
+## dbt 0.20.1 (Release TBD)
+
+### Fixes
+- Fix `where` config with `relationships` test by refactoring test SQL ([#3579](https://github.com/fishtown-analytics/dbt/issues/3579), [#3579](https://github.com/fishtown-analytics/dbt/pull/3579))
+
 ## dbt 0.20.0 (July 12, 2021)
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Contributors:
 ## dbt 0.20.1 (Release TBD)
 
 ### Fixes
-- Fix `where` config with `relationships` test by refactoring test SQL ([#3579](https://github.com/fishtown-analytics/dbt/issues/3579), [#3579](https://github.com/fishtown-analytics/dbt/pull/3579))
+- Fix `where` config with `relationships` test by refactoring test SQL ([#3579](https://github.com/fishtown-analytics/dbt/issues/3579), [#3583](https://github.com/fishtown-analytics/dbt/pull/3583))
 
 ## dbt 0.20.0 (July 12, 2021)
 

--- a/core/dbt/include/global_project/macros/schema_tests/relationships.sql
+++ b/core/dbt/include/global_project/macros/schema_tests/relationships.sql
@@ -1,16 +1,23 @@
 
 {% macro default__test_relationships(model, column_name, to, field) %}
 
+with child as (
+    select * from {{ model }}
+    where {{ column_name }} is not null
+),
+
+parent as (
+    select * from {{ to }}
+)
+
 select
     child.{{ column_name }}
 
-from {{ model }} as child
-
-left join {{ to }} as parent
+from child
+left join parent
     on child.{{ column_name }} = parent.{{ field }}
 
-where child.{{ column_name }} is not null
-  and parent.{{ field }} is null
+where parent.{{ field }} is null
 
 {% endmacro %}
 

--- a/test/integration/008_schema_tests_test/models-v2/custom-configs/schema.yml
+++ b/test/integration/008_schema_tests_test/models-v2/custom-configs/schema.yml
@@ -12,3 +12,11 @@ models:
       - fail_calc
       - where:  # test override + weird quoting
           where: "\"favorite_color\" = 'red'"
+    columns:
+      - name: id
+        tests:
+          # relationships with where
+          - relationships:
+              to: ref('table_copy')  # itself
+              field: id
+              where: 1=1

--- a/test/integration/008_schema_tests_test/test_schema_v2_tests.py
+++ b/test/integration/008_schema_tests_test/test_schema_v2_tests.py
@@ -152,7 +152,7 @@ class TestCustomConfigSchemaTests(DBTIntegrationTest):
         results = self.run_dbt()
         results = self.run_dbt(['test'], strict=False)
 
-        self.assertEqual(len(results), 5)
+        self.assertEqual(len(results), 6)
         for result in results:
             self.assertFalse(result.skipped)
             self.assertEqual(


### PR DESCRIPTION
resolves #3579

@jaypeedevlin Does this make sense to you?

Any tests that alias `{{ model }}` themselves will run into this issue with the `where` config. A better way of doing this might be to give the option of providing a custom alias when templating `{{ model }}`, though I'm not sure how exactly we'd go about pulling that off.

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
