### PR TITLE
Bump werkzeug lower bound, werkzeug-refresh-token script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 - Better interaction between `dbt init` and adapters. Avoid raising errors while initializing a project ([#2814](https://github.com/fishtown-analytics/dbt/pull/2814), [#3483](https://github.com/fishtown-analytics/dbt/pull/3483))
 - Update `create_adapter_plugins` script to include latest accessories, and stay up to date with latest dbt-core version ([#3002](https://github.com/fishtown-analytics/dbt/issues/3002), [#3509](https://github.com/fishtown-analytics/dbt/pull/3509))
 
+### Dependencies
+- Require `werkzeug>=1`
+
 Contributors:
 - [@kostek-pl](https://github.com/kostek-pl) ([#3236](https://github.com/fishtown-analytics/dbt/pull/3408))
 - [@tconbeer](https://github.com/tconbeer) [#3468](https://github.com/fishtown-analytics/dbt/pull/3468))

--- a/core/setup.py
+++ b/core/setup.py
@@ -65,7 +65,7 @@ setup(
         'sqlparse>=0.2.3,<0.4',
         'dbt-extractor==0.2.0',
         'typing-extensions>=3.7.4,<3.11',
-        'werkzeug>=0.15,<3.0',
+        'werkzeug>=1,<3',
         # the following are all to match snowflake-connector-python
         'requests<3.0.0',
         'idna>=2.5,<4',

--- a/scripts/werkzeug-refresh-token.py
+++ b/scripts/werkzeug-refresh-token.py
@@ -5,7 +5,7 @@ import textwrap
 from base64 import b64encode
 
 import requests
-from werkzeug import redirect
+from werkzeug.utils import redirect
 from werkzeug.middleware.dispatcher import DispatcherMiddleware
 from werkzeug.wrappers import Request, Response
 from werkzeug.serving import run_simple


### PR DESCRIPTION
- The `redirect` method moved from `werkzeug` (main) to `werkzeug.utils`, and direct import stopped being supported in `werkzeug==1.0.0` (I think)
- Bump `werkzeug` lower bound to `1.0.0`

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - ~This PR includes tests, or tests are not required/relevant for this PR~
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
