### PR TITLE
Fix error handling in `dbt build`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## dbt 0.21.0 (Release TBD)
 
 ### Features
-- Add `dbt build` command to run models, tests, seeds, and snapshots in DAG order. ([#2743] (https://github.com/dbt-labs/dbt/issues/2743), [#3490] (https://github.com/dbt-labs/dbt/issues/3490))
+- Add `dbt build` command to run models, tests, seeds, and snapshots in DAG order. ([#2743] (https://github.com/dbt-labs/dbt/issues/2743), [#3490] (https://github.com/dbt-labs/dbt/issues/3490), [#3608](https://github.com/dbt-labs/dbt/issues/3608))
 - Introduce `on_schema_change` config to detect and handle schema changes on incremental models ([#1132](https://github.com/fishtown-analytics/dbt/issues/1132), [#3387](https://github.com/fishtown-analytics/dbt/issues/3387))
 
 ### Breaking changes

--- a/core/dbt/task/build.py
+++ b/core/dbt/task/build.py
@@ -1,6 +1,4 @@
-from .compile import CompileTask
-
-from .run import ModelRunner as run_model_runner
+from .run import RunTask, ModelRunner as run_model_runner
 from .snapshot import SnapshotRunner as snapshot_model_runner
 from .seed import SeedRunner as seed_runner
 from .test import TestRunner as test_runner
@@ -10,7 +8,7 @@ from dbt.exceptions import InternalException
 from dbt.node_types import NodeType
 
 
-class BuildTask(CompileTask):
+class BuildTask(RunTask):
     """The Build task processes all assets of a given process and attempts to 'build'
     them in an opinionated fashion.  Every resource type outlined in RUNNER_MAP
     will be processed by the mapped runner class.

--- a/core/dbt/task/printer.py
+++ b/core/dbt/task/printer.py
@@ -87,9 +87,12 @@ def print_hook_end_line(
 
 
 def print_skip_line(
-    model, schema: str, relation: str, index: int, num_models: int
+    node, schema: str, relation: str, index: int, num_models: int
 ) -> None:
-    msg = 'SKIP relation {}.{}'.format(schema, relation)
+    if node.resource_type in NodeType.refable():
+        msg = f'SKIP relation {schema}.{relation}'
+    else:
+        msg = f'SKIP {node.resource_type} {node.name}'
     print_fancy_output_line(
         msg, ui.yellow('SKIP'), logger.info, index, num_models)
 

--- a/test/integration/069_build_test/models-failing/model_0.sql
+++ b/test/integration/069_build_test/models-failing/model_0.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+select * from {{ ref('countries') }}

--- a/test/integration/069_build_test/models-failing/model_1.sql
+++ b/test/integration/069_build_test/models-failing/model_1.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+select bad_column from {{ ref('snap_0') }}

--- a/test/integration/069_build_test/models-failing/model_2.sql
+++ b/test/integration/069_build_test/models-failing/model_2.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+select * from {{ ref('snap_1') }}

--- a/test/integration/069_build_test/models-failing/model_99.sql
+++ b/test/integration/069_build_test/models-failing/model_99.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+select '1' as "num"

--- a/test/integration/069_build_test/models-failing/test.yml
+++ b/test/integration/069_build_test/models-failing/test.yml
@@ -1,0 +1,15 @@
+version: 2
+
+models:
+  - name: model_0
+    columns:
+      - name: iso3
+        tests:
+          - unique
+          - not_null
+  - name: model_2
+    columns:
+      - name: iso3
+        tests:
+          - unique
+          - not_null

--- a/test/integration/069_build_test/test_build.py
+++ b/test/integration/069_build_test/test_build.py
@@ -17,7 +17,6 @@ class TestBuild(DBTIntegrationTest):
             "config-version": 2,
             "snapshot-paths": ["snapshots"],
             "data-paths": ["data"],
-            "source-paths": ["models"],
             "seeds": {
                 "quote_columns": False,
             },
@@ -35,3 +34,21 @@ class TestBuild(DBTIntegrationTest):
     @use_profile("postgres")
     def test__postgres_build_happy_path(self):
         self.build()
+
+
+class TestFailingBuild(TestBuild):
+    @property
+    def schema(self):
+        return "build_test_069"
+
+    @property
+    def models(self):
+        return "models-failing"
+        
+    @use_profile("postgres")
+    def test__postgres_build_happy_path(self):
+        results = self.build(expect_pass=False)
+        self.assertEqual(len(results), 12)
+        actual = [r.status for r in results]
+        expected = ['error']*1 + ['skipped']*4 + ['pass']*2 + ['success']*5
+        self.assertEqual(sorted(actual), sorted(expected))


### PR DESCRIPTION
resolves #3598

### Description

I saw that the `BuildTask` was inheriting from `CompileTask`, which sets:
https://github.com/dbt-labs/dbt/blob/9f716b31b3e0ca57a3722809f8c3405a7b5752f8/core/dbt/task/compile.py#L36-L38

That's the cause of the weird behavior I was seeing when reviewing #3490. We could just override that method for the BuildTask, but what I think we really want is for `dbt build` to operate at parity with `dbt run`, and take all of its cues—including how it handles hooks, deferral, etc, etc. I confirmed that `TestTask`, `SeedTask`, `SnapshotTask` also inherit from `RunTask`, so it feels appropriate that `BuildTask` would as well. Let me know if I'm totally off base here.

Tiny thing: I confirmed that a failed model will be handled and downstream resources will be skipped. Now that tests can be skipped, in addition to models/snapshots, I figured we should tweak the `SKIP` log message to be more inclusive of tests.

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
