### PR TITLE
fixing typo in test

### DIFF
--- a/test/integration/033_event_tracking_test/test_events.py
+++ b/test/integration/033_event_tracking_test/test_events.py
@@ -445,7 +445,7 @@ class TestEventTrackingSuccess(TestEventTracking):
         ]
 
         test_result_A = self.run_event_test(["seed"], expected_calls_A, expected_contexts)
-        test_result_A = self.run_event_test(["seed"], expected_calls_B, expected_contexts)
+        test_result_B = self.run_event_test(["seed"], expected_calls_B, expected_contexts)
         
         self.assertTrue(test_result_A or test_result_B)
 


### PR DESCRIPTION
### Description

I got lucky when I originally merged this change. The events this is testing are non-deterministic so `test_result_A or test_result_B` resolved to `True or ____` and passed. However, in the event we fire a experimental parser sample, it would fail the assertion hence some flake. Thanks to @gshank and @iknox-fa for calling this out.

Just to clarify, this is not the only test that has been flaky in this file so I am still pro [PR#3604](https://github.com/dbt-labs/dbt/pull/3604).

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
