### PR TITLE
Secret scrubbing for env variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Move the example project used by `dbt init` into `dbt` repository, to avoid cloning an external repo ([#3005](https://github.com/fishtown-analytics/dbt/pull/3005), [#3474](https://github.com/fishtown-analytics/dbt/pull/3474), [#3536](https://github.com/fishtown-analytics/dbt/pull/3536))
 - Better interaction between `dbt init` and adapters. Avoid raising errors while initializing a project ([#2814](https://github.com/fishtown-analytics/dbt/pull/2814), [#3483](https://github.com/fishtown-analytics/dbt/pull/3483))
 - Update `create_adapter_plugins` script to include latest accessories, and stay up to date with latest dbt-core version ([#3002](https://github.com/fishtown-analytics/dbt/issues/3002), [#3509](https://github.com/fishtown-analytics/dbt/pull/3509))
+- Scrub environment secrets from logs and console output ([#3617](https://github.com/dbt-labs/dbt/pull/3617))
 
 Contributors:
 - [@kostek-pl](https://github.com/kostek-pl) ([#3236](https://github.com/fishtown-analytics/dbt/pull/3408))

--- a/core/dbt/logger.py
+++ b/core/dbt/logger.py
@@ -43,6 +43,14 @@ DEBUG_LOG_FORMAT = (
     '{record.message}'
 )
 
+SECRET_ENV_PREFIX = 'DBT_ENV_SECRET_'
+
+def get_secret_env() -> List[str]:
+    return [
+        v for k, v in os.environ.items()
+        if k.startswith(SECRET_ENV_PREFIX)
+    ]
+
 
 ExceptionInformation = str
 
@@ -333,6 +341,12 @@ class TimestampNamed(logbook.Processor):
         record.extra[self.name] = datetime.utcnow().isoformat()
 
 
+class ScrubSecrets(logbook.Processor):
+    def process(self, record):
+        for secret in get_secret_env():
+            record.message = record.message.replace(secret, "*****")
+
+
 logger = logbook.Logger('dbt')
 # provide this for the cache, disabled by default
 CACHE_LOGGER = logbook.Logger('dbt.cache')
@@ -473,7 +487,8 @@ class LogManager(logbook.NestedSetup):
         self._file_handler = DelayedFileHandler()
         self._relevel_processor = Relevel(allowed=['dbt', 'werkzeug'])
         self._state_processor = DbtProcessState('internal')
-        # keep track of wheter we've already entered to decide if we should
+        self._scrub_processor = ScrubSecrets()
+        # keep track of whether we've already entered to decide if we should
         # be actually pushing. This allows us to log in main() and also
         # support entering dbt execution via handle_and_check.
         self._stack_depth = 0
@@ -483,6 +498,7 @@ class LogManager(logbook.NestedSetup):
             self._file_handler,
             self._relevel_processor,
             self._state_processor,
+            self._scrub_processor
         ])
 
     def push_application(self):

--- a/core/dbt/logger.py
+++ b/core/dbt/logger.py
@@ -45,6 +45,7 @@ DEBUG_LOG_FORMAT = (
 
 SECRET_ENV_PREFIX = 'DBT_ENV_SECRET_'
 
+
 def get_secret_env() -> List[str]:
     return [
         v for k, v in os.environ.items()

--- a/test/integration/013_context_var_tests/models/context.sql
+++ b/test/integration/013_context_var_tests/models/context.sql
@@ -27,4 +27,6 @@ select
     '{{ run_started_at }}' as run_started_at,
     '{{ invocation_id }}'  as invocation_id,
 
-    '{{ env_var("DBT_TEST_013_ENV_VAR") }}' as env_var
+    '{{ env_var("DBT_TEST_013_ENV_VAR") }}' as env_var,
+    '{{ env_var("DBT_ENV_SECRET_013_SECRET") }}' as env_var_secret,
+    '{{ env_var("DBT_TEST_013_NOT_SECRET") }}' as env_var_not_secret

--- a/test/integration/013_context_var_tests/test_context_vars.py
+++ b/test/integration/013_context_var_tests/test_context_vars.py
@@ -1,3 +1,4 @@
+from dbt.logger import SECRET_ENV_PREFIX
 from test.integration.base import DBTIntegrationTest, use_profile
 
 import os
@@ -15,6 +16,8 @@ class TestContextVars(DBTIntegrationTest):
 
         os.environ["DBT_TEST_013_USER"] = "root"
         os.environ["DBT_TEST_013_PASS"] = "password"
+        os.environ[SECRET_ENV_PREFIX + "013_SECRET"] = "secret_variable"
+        os.environ["DBT_TEST_013_NOT_SECRET"] = "regular_variable"
 
         self.fields = [
             'this',
@@ -137,6 +140,13 @@ class TestContextVars(DBTIntegrationTest):
         self.assertEqual(ctx['target.user'], 'root')
         self.assertEqual(ctx['target.pass'], '')
         self.assertEqual(ctx['env_var'], '1')
+
+    @use_profile('postgres')
+    def test_postgres_env_vars_secrets(self):
+        _, log_output = self.run_dbt_and_capture(['--debug', 'run', '--target', 'prod'])
+
+        self.assertFalse("secret_variable" in log_output)
+        self.assertTrue("regular_variable" in log_output)
 
 
 class TestEmitWarning(DBTIntegrationTest):

--- a/test/integration/013_context_var_tests/test_context_vars.py
+++ b/test/integration/013_context_var_tests/test_context_vars.py
@@ -148,7 +148,6 @@ class TestContextVars(DBTIntegrationTest):
         self.assertFalse("secret_variable" in log_output)
         self.assertTrue("regular_variable" in log_output)
 
-
 class TestEmitWarning(DBTIntegrationTest):
     @property
     def schema(self):


### PR DESCRIPTION
resolves #3440 

### Description

This change allows users to prefix their environment variables with `DBT_ENV_SECRET_` which we will then treat as secrets and scrub them from the logs and console output.

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
