### PR TITLE
[#3567] Fix partial parsing error with version key if previous file is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Handle whitespace after a plus sign on the project config ([#3526](https://github.com/dbt-labs/dbt/pull/3526))
 - Partial parsing: don't reprocess SQL file already scheduled ([#3589](https://github.com/dbt-labs/dbt/issues/3589), [#3620](https://github.com/dbt-labs/dbt/pull/3620))
 - Handle interator functions in model config ([#3573](https://github.com/dbt-labs/dbt/issues/3573))
+- Partial parsing: fix error after changing empty yaml file ([#3567](https://gith7ub.com/dbt-labs/dbt/issues/3567), [#3618](https://github.com/dbt-labs/dbt/pull/3618))
 
 ### Under the hood
 - Improve default view and table materialization performance by checking relational cache before attempting to drop temp relations ([#3112](https://github.com/fishtown-analytics/dbt/issues/3112), [#3468](https://github.com/fishtown-analytics/dbt/pull/3468))

--- a/core/dbt/parser/partial.py
+++ b/core/dbt/parser/partial.py
@@ -445,7 +445,13 @@ class PartialParsing:
         new_schema_file = self.new_files[file_id]
         saved_yaml_dict = saved_schema_file.dict_from_yaml
         new_yaml_dict = new_schema_file.dict_from_yaml
-        saved_schema_file.pp_dict = {"version": saved_yaml_dict['version']}
+        if 'version' in new_yaml_dict:
+            # despite the fact that this goes in the saved_schema_file, it
+            # should represent the new yaml dictionary, and should produce
+            # an error if the updated yaml file doesn't have a version
+            saved_schema_file.pp_dict = {"version": new_yaml_dict['version']}
+        else:
+            saved_schema_file.pp_dict = {}
         self.handle_schema_file_changes(saved_schema_file, saved_yaml_dict, new_yaml_dict)
 
         # copy from new schema_file to saved_schema_file to preserve references

--- a/test/integration/068_partial_parsing_tests/extra-files/empty_schema_with_version.yml
+++ b/test/integration/068_partial_parsing_tests/extra-files/empty_schema_with_version.yml
@@ -1,0 +1,1 @@
+version: 2

--- a/test/integration/068_partial_parsing_tests/test_partial_parsing.py
+++ b/test/integration/068_partial_parsing_tests/test_partial_parsing.py
@@ -168,6 +168,16 @@ class TestModels(DBTIntegrationTest):
         results = self.run_dbt(["--partial-parse", "run"])
         self.assertEqual(len(results), 3)
 
+        # Add an empty schema file
+        shutil.copyfile('extra-files/empty_schema.yml', 'models-a/eschema.yml')
+        results = self.run_dbt(["--partial-parse", "run"])
+        self.assertEqual(len(results), 3)
+
+        # Add version to empty schema file
+        shutil.copyfile('extra-files/empty_schema_with_version.yml', 'models-a/eschema.yml')
+        results = self.run_dbt(["--partial-parse", "run"])
+        self.assertEqual(len(results), 3)
+
     def tearDown(self):
         if os.path.exists(normalize('models-a/model_two.sql')):
             os.remove(normalize('models-a/model_two.sql'))
@@ -181,6 +191,8 @@ class TestModels(DBTIntegrationTest):
             os.remove(normalize('target/partial_parse.msgpack'))
         if os.path.exists(normalize('macros/my_macro.sql')):
             os.remove(normalize('macros/my_macro.sql'))
+        if os.path.exists(normalize('models-a/eschema.yml')):
+            os.remove(normalize('models-a/eschema.yml'))
 
 
 class TestSources(DBTIntegrationTest):


### PR DESCRIPTION

resolves #3567


### Description

Fix handling of yaml file version in partial parsing. Also tweak partial parsing tests to avoid unnecessary changes when number of dbt files changes.

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
