### PR TITLE
If SQL file already scheduled for parsing, don't reprocess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fix docs generation for cross-db sources in REDSHIFT RA3 node ([#3236](https://github.com/fishtown-analytics/dbt/issues/3236), [#3408](https://github.com/fishtown-analytics/dbt/pull/3408))
 - Fix type coercion issues when fetching query result sets ([#2984](https://github.com/fishtown-analytics/dbt/issues/2984), [#3499](https://github.com/fishtown-analytics/dbt/pull/3499))
 - Handle whitespace after a plus sign on the project config ([#3526](https://github.com/dbt-labs/dbt/pull/3526))
+- Partial parsing: don't reprocess SQL file already scheduled ([#3589](https://github.com/dbt-labs/dbt/issues/3589), [#3620](https://github.com/dbt-labs/dbt/pull/3620))
 
 ### Under the hood
 - Improve default view and table materialization performance by checking relational cache before attempting to drop temp relations ([#3112](https://github.com/fishtown-analytics/dbt/issues/3112), [#3468](https://github.com/fishtown-analytics/dbt/pull/3468))

--- a/test/integration/068_partial_parsing_tests/extra-files/model_four1.sql
+++ b/test/integration/068_partial_parsing_tests/extra-files/model_four1.sql
@@ -1,0 +1,1 @@
+select * from {{ ref('model_three') }}

--- a/test/integration/068_partial_parsing_tests/extra-files/model_four2.sql
+++ b/test/integration/068_partial_parsing_tests/extra-files/model_four2.sql
@@ -1,0 +1,1 @@
+select fun from {{ ref('model_one') }}


### PR DESCRIPTION
resolves #3589

### Description

Skip re-processing SQL file if already scheduled.

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
