### PR TITLE
fix awkward exception being raised by a yml file with all comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add full node selection to source freshness command and align selection syntax with other tasks (`dbt source freshness --select source_name` --> `dbt source freshness --select source:souce_name`) and rename `dbt source snapshot-freshness` -> `dbt source freshness`. ([#2987](https://github.com/dbt-labs/dbt/issues/2987), [#3554](https://github.com/dbt-labs/dbt/pull/3554))
 
 ### Fixes
+- Fix exception on yml files with all comments [3568](https://github.com/dbt-labs/dbt/issues/3568)
 - Fix docs generation for cross-db sources in REDSHIFT RA3 node ([#3236](https://github.com/fishtown-analytics/dbt/issues/3236), [#3408](https://github.com/fishtown-analytics/dbt/pull/3408))
 - Fix type coercion issues when fetching query result sets ([#2984](https://github.com/fishtown-analytics/dbt/issues/2984), [#3499](https://github.com/fishtown-analytics/dbt/pull/3499))
 - Handle whitespace after a plus sign on the project config ([#3526](https://github.com/dbt-labs/dbt/pull/3526))

--- a/core/dbt/clients/yaml_helper.py
+++ b/core/dbt/clients/yaml_helper.py
@@ -1,5 +1,5 @@
 import dbt.exceptions
-
+from typing import Any, Dict, Optional
 import yaml
 import yaml.scanner
 
@@ -56,7 +56,7 @@ def contextualized_yaml_error(raw_contents, error):
                                      raw_error=error)
 
 
-def safe_load(contents):
+def safe_load(contents) -> Optional[Dict[str, Any]]:
     return yaml.load(contents, Loader=SafeLoader)
 
 

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -379,10 +379,10 @@ class ManifestLoader:
         if not self.partially_parsing and HookParser in parser_types:
             hook_parser = HookParser(project, self.manifest, self.root_project)
             path = hook_parser.get_path()
-            file_block = FileBlock(
-                load_source_file(path, ParseFileType.Hook, project.project_name)
-            )
-            hook_parser.parse_file(file_block)
+            file = load_source_file(path, ParseFileType.Hook, project.project_name)
+            if file:
+                file_block = FileBlock(file)
+                hook_parser.parse_file(file_block)
 
         # Store the performance info
         elapsed = time.perf_counter() - start_timer

--- a/test/integration/071_commented_yaml_regression_3568_test/models/schema.yml
+++ b/test/integration/071_commented_yaml_regression_3568_test/models/schema.yml
@@ -1,0 +1,3 @@
+# models/schema.yml
+# only comments here
+# https://github.com/dbt-labs/dbt/issues/3568

--- a/test/integration/071_commented_yaml_regression_3568_test/test_all_comment_yml_files.py
+++ b/test/integration/071_commented_yaml_regression_3568_test/test_all_comment_yml_files.py
@@ -1,0 +1,20 @@
+from test.integration.base import DBTIntegrationTest, use_profile
+
+
+class TestAllCommentYMLIsOk(DBTIntegrationTest):
+    @property
+    def schema(self):
+        return "071_commented_yaml"
+
+    @property
+    def models(self):
+        return "models"
+
+    @use_profile('postgres')
+    def test_postgres_parses_with_all_comment_yml(self):
+        try:
+            self.run_dbt(['parse'])
+        except TypeError:
+            assert False, '`dbt parse` failed with a yaml file that is all comments with the same exception as 3568'
+        except:
+            assert False, '`dbt parse` failed with a yaml file that is all comments'


### PR DESCRIPTION
resolves #3568

### Description

Adds handling for `None` response from yaml loader. Triggered in 0.20.0 by files with all comments.

### Requested Feedback

Are there more places I should be putting yml files with all comments in them? It looks like all the different file types go through the same pipeline, but if there's an exception to that we should test it too.

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
