### PR TITLE
[#3627] Improve findability of macro_patches, schedule right macro file for processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,9 @@
 - Fix table and view materialization issue when switching from one to the other ([#2161](https://github.com/dbt-labs/dbt/issues/2161)), [#3547](https://github.com/dbt-labs/dbt/pull/3547))
 - Partial parsing: don't reprocess SQL file already scheduled ([#3589](https://github.com/dbt-labs/dbt/issues/3589), [#3620](https://github.com/dbt-labs/dbt/pull/3620))
 - Handle interator functions in model config ([#3573](https://github.com/dbt-labs/dbt/issues/3573))
-- Partial parsing: fix error after changing empty yaml file ([#3567](https://gith7ub.com/dbt-labs/dbt/issues/3567), [#3618](https://github.com/dbt-labs/dbt/pull/3618))
+- Partial parsing: fix error after changing empty yaml file ([#3567](https://github.com/dbt-labs/dbt/issues/3567), [#3618](https://github.com/dbt-labs/dbt/pull/3618))
 - Partial parsing: handle source tests when changing test macro ([#3584](https://github.com/dbt-labs/dbt/issues/3584), [#3620](https://github.com/dbt-labs/dbt/pull/3620))
+- Partial parsing: schedule new macro file for parsing when macro patching ([#3627](https://github.com/dbt-labs/dbt/issues/3627), [#3627](https://github.com/dbt-labs/dbt/pull/3627))
 
 ### Under the hood
 - Improve default view and table materialization performance by checking relational cache before attempting to drop temp relations ([#3112](https://github.com/fishtown-analytics/dbt/issues/3112), [#3468](https://github.com/fishtown-analytics/dbt/pull/3468))

--- a/core/dbt/contracts/files.py
+++ b/core/dbt/contracts/files.py
@@ -220,7 +220,7 @@ class SchemaSourceFile(BaseSourceFile):
     # node patches contain models, seeds, snapshots, analyses
     ndp: List[str] = field(default_factory=list)
     # any macro patches in this file by macro unique_id.
-    mcp: List[str] = field(default_factory=list)
+    mcp: Dict[str, str] = field(default_factory=dict)
     # any source patches in this file. The entries are package, name pairs
     # Patches are only against external sources. Sources can be
     # created too, but those are in 'sources'

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -759,7 +759,7 @@ class Manifest(MacroMethods, DataClassMessagePackMixin, dbtClassMixin):
         if macro.patch_path:
             package_name, existing_file_path = macro.patch_path.split('://')
             raise_duplicate_macro_patch_name(patch, existing_file_path)
-        source_file.macro_patches.append(unique_id)
+        source_file.macro_patches[patch.name] = unique_id
         macro.patch(patch)
 
     def add_source_patch(

--- a/core/dbt/parser/partial.py
+++ b/core/dbt/parser/partial.py
@@ -668,19 +668,17 @@ class PartialParsing:
 
     def delete_schema_macro_patch(self, schema_file, macro):
         # This is just macro patches that need to be reapplied
-        for unique_id in schema_file.macro_patches:
-            parts = unique_id.split('.')
-            macro_name = parts[-1]
-            if macro_name == macro['name']:
-                macro_unique_id = unique_id
-                break
+        macro_unique_id = None
+        if macro['name'] in schema_file.macro_patches:
+            macro_unique_id = schema_file.macro_patches[macro['name']]
+            del schema_file.macro_patches[macro['name']]
         if macro_unique_id and macro_unique_id in self.saved_manifest.macros:
             macro = self.saved_manifest.macros.pop(macro_unique_id)
             self.deleted_manifest.macros[macro_unique_id] = macro
             macro_file_id = macro.file_id
-            self.add_to_pp_files(self.saved_files[macro_file_id])
-        if macro_unique_id in schema_file.macro_patches:
-            schema_file.macro_patches.remove(macro_unique_id)
+            if macro_file_id in self.new_files:
+                self.saved_files[macro_file_id] = self.new_files[macro_file_id]
+                self.add_to_pp_files(self.saved_files[macro_file_id])
 
     # exposures are created only from schema files, so just delete
     # the exposure.

--- a/test/integration/068_partial_parsing_tests/extra-files/macros.yml
+++ b/test/integration/068_partial_parsing_tests/extra-files/macros.yml
@@ -1,0 +1,4 @@
+version: 2
+macros:
+    - name: do_something
+      description: "This is a test macro"

--- a/test/integration/068_partial_parsing_tests/test_partial_parsing.py
+++ b/test/integration/068_partial_parsing_tests/test_partial_parsing.py
@@ -163,8 +163,17 @@ class TestModels(DBTIntegrationTest):
         with self.assertRaises(CompilationException):
             results = self.run_dbt(["--partial-parse", "run"])
 
-        # Remove the macro patch
+        # put back macro file, got back to schema file with no macro
+        # add separate macro patch schema file
         shutil.copyfile('extra-files/models-schema2.yml', 'models-a/schema.yml')
+        shutil.copyfile('extra-files/my_macro.sql', 'macros/my_macro.sql')
+        shutil.copyfile('extra-files/macros.yml', 'macros/macros.yml')
+        results = self.run_dbt(["--partial-parse", "run"])
+
+        # delete macro and schema file
+        print(f"\n\n*** remove macro and macro_patch\n\n")
+        os.remove(normalize('macros/my_macro.sql'))
+        os.remove(normalize('macros/macros.yml'))
         results = self.run_dbt(["--partial-parse", "run"])
         self.assertEqual(len(results), 3)
 
@@ -193,6 +202,8 @@ class TestModels(DBTIntegrationTest):
             os.remove(normalize('macros/my_macro.sql'))
         if os.path.exists(normalize('models-a/eschema.yml')):
             os.remove(normalize('models-a/eschema.yml'))
+        if os.path.exists(normalize('macros/macros.yml')):
+            os.remove(normalize('macros/macros.yml'))
 
 
 class TestSources(DBTIntegrationTest):


### PR DESCRIPTION

resolves #3627


### Description

When scheduling a changed or deleted macro_patch, the wrong macro file was scheduled for parsing. 

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
