### PR TITLE
make experimental parser respect config merge behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Contributors:
 - Adds `install-prerelease` parameter to hub packages in `packages.yml`. When set to `True`, allows prerelease packages to be installed. By default, this parameter is False unless explicitly set to True.
 
 ### Fixes
+- Fix config merge behavior with experimental parser [3637](https://github.com/dbt-labs/dbt/pull/3637)
 - Fix `store_failures` config when defined as a modifier for `unique` and `not_null` tests ([#3575](https://github.com/fishtown-analytics/dbt/issues/3575), [#3577](https://github.com/fishtown-analytics/dbt/pull/3577))
 - Fix `where` config with `relationships` test by refactoring test SQL. Note: The default `relationships` test now includes CTEs, and may need reimplementing on adapters that don't support CTEs nested inside subqueries. ([#3579](https://github.com/fishtown-analytics/dbt/issues/3579), [#3583](https://github.com/fishtown-analytics/dbt/pull/3583))
 - Fix `dbt deps` version comparison logic which was causing incorrect pre-release package versions to be installed. ([#3578](https://github.com/dbt-labs/dbt/issues/3578), [#3609](https://github.com/dbt-labs/dbt/issues/3609))

--- a/core/dbt/parser/models.py
+++ b/core/dbt/parser/models.py
@@ -130,11 +130,12 @@ class ModelParser(SimpleSQLParser[ParsedModelNode]):
             # values from yaml files are in there already
             node.unrendered_config.update(dict(experimentally_parsed['configs']))
 
-            # set refs, sources, and configs on the node object
+            # set refs and sources on the node object
             node.refs += experimentally_parsed['refs']
             node.sources += experimentally_parsed['sources']
-            for configv in experimentally_parsed['configs']:
-                node.config[configv[0]] = configv[1]
+
+            # configs don't need to be merged into the node
+            # setting them in config._config_call_dict is sufficient
 
             self.manifest._parsing_info.static_analysis_parsed_path_count += 1
 

--- a/core/setup.py
+++ b/core/setup.py
@@ -63,7 +63,7 @@ setup(
         'networkx>=2.3,<3',
         'packaging~=20.9',
         'sqlparse>=0.2.3,<0.4',
-        'dbt-extractor==0.2.0',
+        'dbt-extractor==0.4.0',
         'typing-extensions>=3.7.4,<3.11',
         'werkzeug>=1,<3',
         # the following are all to match snowflake-connector-python

--- a/test/integration/072_experimental_parser_tests/models/model_a.sql
+++ b/test/integration/072_experimental_parser_tests/models/model_a.sql
@@ -1,0 +1,6 @@
+{{ config(tags='hello', x=False) }}
+{{ config(tags='world', x=True) }}
+
+select * from {{ ref('model_a') }}
+cross join {{ source('my_src', 'my_tbl') }}
+where false as boop

--- a/test/integration/072_experimental_parser_tests/models/schema.yml
+++ b/test/integration/072_experimental_parser_tests/models/schema.yml
@@ -1,0 +1,12 @@
+version: 2
+
+sources:
+  - name: my_src
+    schema: "{{ target.schema }}"
+    tables:
+      - name: my_tbl
+
+models:
+  - name: model_a
+    columns:
+      - name: fun

--- a/test/integration/072_experimental_parser_tests/test_all_experimental_parser.py
+++ b/test/integration/072_experimental_parser_tests/test_all_experimental_parser.py
@@ -1,0 +1,35 @@
+from dbt.contracts.graph.manifest import Manifest
+import os
+from test.integration.base import DBTIntegrationTest, use_profile
+
+
+def get_manifest():
+    path = './target/partial_parse.msgpack'
+    if os.path.exists(path):
+        with open(path, 'rb') as fp:
+            manifest_mp = fp.read()
+        manifest: Manifest = Manifest.from_msgpack(manifest_mp)
+        return manifest
+    else:
+        return None
+
+
+class TestAllExperimentalParser(DBTIntegrationTest):
+    @property
+    def schema(self):
+        return "072_experimental_parser"
+
+    @property
+    def models(self):
+        return "models"
+
+    @use_profile('postgres')
+    def test_postgres_experimental_parser(self):
+        results = self.run_dbt(['--use-experimental-parser', 'parse'])
+        manifest = get_manifest()
+        node = manifest.nodes['model.test.model_a']
+        self.assertEqual(node.refs, [['model_a']])
+        self.assertEqual(node.sources, [['my_src', 'my_tbl']])
+        self.assertEqual(node.config._extra, {'x': True})
+        self.assertEqual(node.config.tags, ['hello', 'world'])
+        


### PR DESCRIPTION
resolves #3640

### Description

Previously, the experimental parser was not respecting merge behavior for special config values, which was discovered by tracking data from 0.20.0. This fixes that by bumping `dbt-extractor` to `v0.4.0` which returns a list of unmerged key-value pairs for configs instead of a dictionary which allows merging to be done in `dbt-core`, and adds a very simple integration test to catch this and a few other simple problems in the future.

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
