### PR TITLE
Handle exception from tracker.flush()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ Contributors:
 ### Docs
 - Fix docs site crash if `relationships` test has one dependency instead of two ([docs#207](https://github.com/dbt-labs/dbt-docs/issues/207), ([docs#208](https://github.com/dbt-labs/dbt-docs/issues/208)))
 
+### Under the hood
+- Handle exceptions from anonymous usage tracking for users of `dbt-snowflake` on Apple M1 chips ([#3162](https://github.com/dbt-labs/dbt/issues/3162), [#3661](https://github.com/dbt-labs/dbt/issues/3661))
+
 Contributors:
 - [@NiallRees](https://github.com/NiallRees) ([#3624](https://github.com/dbt-labs/dbt/pull/3624))
 

--- a/core/dbt/tracking.py
+++ b/core/dbt/tracking.py
@@ -454,7 +454,12 @@ def track_partial_parser(options):
 
 def flush():
     logger.debug("Flushing usage events")
-    tracker.flush()
+    try:
+        tracker.flush()
+    except Exception:
+        logger.debug(
+            "An error was encountered while trying to flush usage events"
+        )
 
 
 def disable_tracking():


### PR DESCRIPTION
resolves #3162

The specific details of this one are frustrating to me: M1 users of `dbt-snowflake` (or people who install `dbt-snowflake` incidentally via Homebrew) are encountering a wonky error because of how `snowflake-connector-python` monkey-patches `pyOpenSSL` into `urllib3`, and there's a bug with `pyOpenSSL` on M1 chips.

As a general rule, though, we shouldn't brick entire dbt runs because of a failure to send anonymous usage tracking.

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - ❓ I have run this code in development and it appears to resolve the stated issue — I don't have an M1 mac!
 - ~This PR includes tests, or tests are not required/relevant for this PR~
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
