### PR TITLE
Fix: Drop audit schema tests in tearDown for test suite

### DIFF
--- a/test/integration/067_store_test_failures_tests/test_store_test_failures.py
+++ b/test/integration/067_store_test_failures_tests/test_store_test_failures.py
@@ -9,6 +9,13 @@ class TestStoreTestFailures(DBTIntegrationTest):
     def schema(self):
         return "test_store_test_failures_067"
 
+    def tearDown(self):
+        test_audit_schema = self.unique_schema() + "_dbt_test__audit"
+        with self.adapter.connection_named('__test'):
+            self._drop_schema_named(self.default_database, test_audit_schema)
+
+        super().tearDown()
+
     @property
     def models(self):
         return "models"


### PR DESCRIPTION
Related to (but does not completely resolve): https://github.com/dbt-labs/dbt/issues/3685

### Description

Added a step to the `067_store_test_failures_tests` integration test to drop the audit schemas at the end of the test invocation. This should keep our CI redshift instance a little cleaner going forwards :)

Does this one need a changelog entry?

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
