### PR TITLE
Serialize Undefined values to JSON for rpc requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fix type coercion issues when fetching query result sets ([#2984](https://github.com/fishtown-analytics/dbt/issues/2984), [#3499](https://github.com/fishtown-analytics/dbt/pull/3499))
 - Handle whitespace after a plus sign on the project config ([#3526](https://github.com/dbt-labs/dbt/pull/3526))
 - Fix table and view materialization issue when switching from one to the other ([#2161](https://github.com/dbt-labs/dbt/issues/2161)), [#3547](https://github.com/dbt-labs/dbt/pull/3547))
+- Fix for RPC requests that raise a RecursionError when serializing Undefined values as JSON ([#3464](https://github.com/dbt-labs/dbt/issues/3464), [#3687](https://github.com/dbt-labs/dbt/pull/3687))
 
 ### Under the hood
 - Improve default view and table materialization performance by checking relational cache before attempting to drop temp relations ([#3112](https://github.com/fishtown-analytics/dbt/issues/3112), [#3468](https://github.com/fishtown-analytics/dbt/pull/3468))

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -6,6 +6,7 @@ import decimal
 import functools
 import hashlib
 import itertools
+import jinja2
 import json
 import os
 from contextlib import contextmanager
@@ -306,14 +307,16 @@ def timestring() -> str:
 
 class JSONEncoder(json.JSONEncoder):
     """A 'custom' json encoder that does normal json encoder things, but also
-    handles `Decimal`s. Naturally, this can lose precision because they get
-    converted to floats.
+    handles `Decimal`s. and `Undefined`s. Decimals can lose precision because
+    they get converted to floats. Undefineds are serailized to an empty string.
     """
     def default(self, obj):
         if isinstance(obj, DECIMALS):
             return float(obj)
         if isinstance(obj, (datetime.datetime, datetime.date, datetime.time)):
             return obj.isoformat()
+        if isinstance(obj, jinja2.Undefined):
+            return ""
         if hasattr(obj, 'to_dict'):
             # if we have a to_dict we should try to serialize the result of
             # that!

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -308,7 +308,7 @@ def timestring() -> str:
 class JSONEncoder(json.JSONEncoder):
     """A 'custom' json encoder that does normal json encoder things, but also
     handles `Decimal`s. and `Undefined`s. Decimals can lose precision because
-    they get converted to floats. Undefineds are serailized to an empty string.
+    they get converted to floats. Undefined's are serialized to an empty string
     """
     def default(self, obj):
         if isinstance(obj, DECIMALS):

--- a/test/integration/100_rpc_test/rpc_serialize_test_models/test_serialize.sql
+++ b/test/integration/100_rpc_test/rpc_serialize_test_models/test_serialize.sql
@@ -1,0 +1,8 @@
+
+-- see https://github.com/dbt-labs/dbt/issues/3464
+-- Make sure that Undefined values are serialized correctly
+-- in RPC responses
+{{ log(none['foo']) }}
+
+select 1 as id
+

--- a/test/integration/100_rpc_test/test_execute_fetch_and_serialize.py
+++ b/test/integration/100_rpc_test/test_execute_fetch_and_serialize.py
@@ -17,6 +17,7 @@ class TestRpcExecuteReturnsResults(DBTIntegrationTest):
     def project_config(self):
         return {
             'config-version': 2,
+            'source-paths': ['rpc_serialize_test_models'],
             'macro-paths': ['macros'],
         }
 


### PR DESCRIPTION
resolves #3464

### Description
The rpc server uses a custom JSON encoder that doesn't know how to encode Undefined variables. As a result, the rpc server returns a 500 error w/ a `RecursionError` if an rpc response contains an Undefined object. See https://github.com/dbt-labs/dbt/issues/3464#issuecomment-892000312 for a full diagnosis of the issue.

This PR addresses the issue by teaching the dbt JSON Encoder how to serialize an Undefined object to JSON - specifically by serializing it out as an empty string.

Note: need to update the changelog on this one still...

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
