### PR TITLE
Retry GitHub download failures

### DIFF
--- a/core/dbt/clients/registry.py
+++ b/core/dbt/clients/registry.py
@@ -1,5 +1,5 @@
 import requests
-from dbt.utils import memoized, _exception_retry as exception_retry
+from dbt.utils import memoized, _connection_exception_retry as connection_exception_retry
 from dbt.logger import GLOBAL_LOGGER as logger
 import os
 
@@ -16,7 +16,10 @@ def _get_url(url, registry_base_url=None):
     return '{}{}'.format(registry_base_url, url)
 
 
-@exception_retry
+def _get_with_retries(path, registry_base_url=None):
+    return connection_exception_retry(lambda: _get(path, registry_base_url), 5)
+
+
 def _get(path, registry_base_url=None):
     url = _get_url(path, registry_base_url)
     logger.debug('Making package registry request: GET {}'.format(url))
@@ -28,22 +31,22 @@ def _get(path, registry_base_url=None):
 
 
 def index(registry_base_url=None):
-    return _get('api/v1/index.json', registry_base_url)
+    return _get_with_retries('api/v1/index.json', registry_base_url)
 
 
 index_cached = memoized(index)
 
 
 def packages(registry_base_url=None):
-    return _get('api/v1/packages.json', registry_base_url)
+    return _get_with_retries('api/v1/packages.json', registry_base_url)
 
 
 def package(name, registry_base_url=None):
-    return _get('api/v1/{}.json'.format(name), registry_base_url)
+    return _get_with_retries('api/v1/{}.json'.format(name), registry_base_url)
 
 
 def package_version(name, version, registry_base_url=None):
-    return _get('api/v1/{}/{}.json'.format(name, version), registry_base_url)
+    return _get_with_retries('api/v1/{}/{}.json'.format(name, version), registry_base_url)
 
 
 def get_available_versions(name):

--- a/core/dbt/clients/registry.py
+++ b/core/dbt/clients/registry.py
@@ -1,3 +1,4 @@
+import functools
 import requests
 from dbt.utils import memoized, _connection_exception_retry as connection_exception_retry
 from dbt.logger import GLOBAL_LOGGER as logger
@@ -17,7 +18,8 @@ def _get_url(url, registry_base_url=None):
 
 
 def _get_with_retries(path, registry_base_url=None):
-    return connection_exception_retry(lambda: _get(path, registry_base_url), 5)
+    get_fn = functools.partial(_get, path, registry_base_url)
+    return connection_exception_retry(get_fn, 5)
 
 
 def _get(path, registry_base_url=None):

--- a/core/dbt/clients/system.py
+++ b/core/dbt/clients/system.py
@@ -15,9 +15,8 @@ from typing import (
 )
 
 import dbt.exceptions
-
 from dbt.logger import GLOBAL_LOGGER as logger
-from dbt.utils import _exception_retry as exception_retry
+from dbt.utils import _connection_exception_retry as connection_exception_retry
 
 if sys.platform == 'win32':
     from ctypes import WinDLL, c_bool
@@ -441,7 +440,12 @@ def run_cmd(
     return out, err
 
 
-@exception_retry
+def download_with_retries(
+    url: str, path: str, timeout: Optional[Union[float, tuple]] = None
+) -> None:
+    connection_exception_retry(lambda: download(url, path, timeout), 5)
+
+
 def download(
     url: str, path: str, timeout: Optional[Union[float, tuple]] = None
 ) -> None:

--- a/core/dbt/clients/system.py
+++ b/core/dbt/clients/system.py
@@ -15,9 +15,9 @@ from typing import (
 )
 
 import dbt.exceptions
-import dbt.utils
 
 from dbt.logger import GLOBAL_LOGGER as logger
+from dbt.utils import _exception_retry as exception_retry
 
 if sys.platform == 'win32':
     from ctypes import WinDLL, c_bool
@@ -441,6 +441,7 @@ def run_cmd(
     return out, err
 
 
+@exception_retry
 def download(
     url: str, path: str, timeout: Optional[Union[float, tuple]] = None
 ) -> None:

--- a/core/dbt/clients/system.py
+++ b/core/dbt/clients/system.py
@@ -1,4 +1,5 @@
 import errno
+import functools
 import fnmatch
 import json
 import os
@@ -443,7 +444,8 @@ def run_cmd(
 def download_with_retries(
     url: str, path: str, timeout: Optional[Union[float, tuple]] = None
 ) -> None:
-    connection_exception_retry(lambda: download(url, path, timeout), 5)
+    download_fn = functools.partial(download, url, path, timeout)
+    connection_exception_retry(download_fn, 5)
 
 
 def download(

--- a/core/dbt/deps/registry.py
+++ b/core/dbt/deps/registry.py
@@ -61,7 +61,7 @@ class RegistryPinnedPackage(RegistryPackageMixin, PinnedPackage):
         system.make_directory(os.path.dirname(tar_path))
 
         download_url = metadata.downloads.tarball
-        system.download(download_url, tar_path)
+        system.download_with_retries(download_url, tar_path)
         deps_path = project.modules_path
         package_name = self.get_project_name(project, renderer)
         system.untar_package(tar_path, deps_path, package_name)

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -714,7 +714,7 @@ def system_error(operation_name):
         .format(operation_name))
 
 
-class RegistryException(Exception):
+class ConnectionException(Exception):
     pass
 
 

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -607,11 +607,15 @@ class MultiDict(Mapping[str, Any]):
 
 
 def _connection_exception_retry(fn, max_attempts: int, attempt: int = 0):
+    """Attempts to run a function that makes an external call, if the call fails
+    on a connection error or timeout, it will be tried up to 5 more times.
+    """
     try:
         return fn()
     except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as exc:
         if attempt <= max_attempts - 1:
-            logger.debug("Retrying external call. Attempt: ", attempt, " Max attempts: " , max_attempts)
+            logger.debug('Retrying external call. Attempt: ' +
+                         f'{attempt} Max attempts: {max_attempts}')
             time.sleep(1)
             _connection_exception_retry(fn, max_attempts, attempt + 1)
         else:

--- a/test/unit/test_core_dbt_utils.py
+++ b/test/unit/test_core_dbt_utils.py
@@ -1,0 +1,41 @@
+import requests
+import unittest
+
+from dbt.exceptions import ConnectionException
+from dbt.utils import _connection_exception_retry as connection_exception_retry
+
+
+class testCoreDbtUtils(unittest.TestCase):
+    def test_connection_exception_retry_none(self):
+        Counter._reset()
+        connection_exception_retry(lambda: Counter._add(), 5)
+        self.assertEqual(1, counter)
+
+    def test_connection_exception_retry_max(self):
+        Counter._reset()
+        self.assertRaises(ConnectionException, connection_exception_retry(lambda: Counter._add_with_exception(), 5))
+        self.assertEqual(6, counter) # 6 = original attempt plus 5 retries
+
+    def test_connection_exception_retry_success(self):
+        Counter._reset()
+        connection_exception_retry(lambda: Counter._add_with_limited_exception(), 5)
+        self.assertEqual(2, counter) # 2 = original attempt plus 1 retry
+
+
+counter:int = 0 
+class Counter():
+    def _add():
+        global counter
+        counter+=1
+    def _add_with_exception():
+        global counter
+        counter+=1
+        raise requests.exceptions.ConnectionError
+    def _add_with_limited_exception():
+        global counter
+        counter+=1
+        if counter < 2:
+            raise requests.exceptions.ConnectionError
+    def _reset():
+        global counter
+        counter = 0

--- a/test/unit/test_core_dbt_utils.py
+++ b/test/unit/test_core_dbt_utils.py
@@ -5,7 +5,7 @@ from dbt.exceptions import ConnectionException
 from dbt.utils import _connection_exception_retry as connection_exception_retry
 
 
-class testCoreDbtUtils(unittest.TestCase):
+class TestCoreDbtUtils(unittest.TestCase):
     def test_connection_exception_retry_none(self):
         Counter._reset()
         connection_exception_retry(lambda: Counter._add(), 5)

--- a/test/unit/test_core_dbt_utils.py
+++ b/test/unit/test_core_dbt_utils.py
@@ -13,7 +13,8 @@ class testCoreDbtUtils(unittest.TestCase):
 
     def test_connection_exception_retry_max(self):
         Counter._reset()
-        self.assertRaises(ConnectionException, connection_exception_retry(lambda: Counter._add_with_exception(), 5))
+        with self.assertRaises(ConnectionException):
+            connection_exception_retry(lambda: Counter._add_with_exception(), 5)
         self.assertEqual(6, counter) # 6 = original attempt plus 5 retries
 
     def test_connection_exception_retry_success(self):

--- a/test/unit/test_registry_get_request_exception.py
+++ b/test/unit/test_registry_get_request_exception.py
@@ -1,9 +1,9 @@
 import unittest
 
-from dbt.exceptions import RegistryException
-from dbt.clients.registry import _get
+from dbt.exceptions import ConnectionException
+from dbt.clients.registry import _get_with_retries
 
 class testRegistryGetRequestException(unittest.TestCase):
     def test_registry_request_error_catching(self):
-        # using non routable IP to test connection error logic in the _get function
-        self.assertRaises(RegistryException, _get, '', 'http://0.0.0.0')
+        # using non routable IP to test connection error logic in the _get_with_retries function
+        self.assertRaises(ConnectionException, _get_with_retries, '', 'http://0.0.0.0')


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt/issues/3546

### Description

We are seeing `dbt deps` fail intermittently when trying to reach out to GitHub. We do retry logic for when we reach out to the registry hub so we want to try the same retry logic for GitHub to see if it improves the success rate of `dbt deps`.


### Checklist
 - [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [ ] I have run this code in development and it appears to resolve the stated issue
 - [ ] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
