### PR TITLE
Bump minimum performance runs to 20

### DIFF
--- a/performance/runner/src/measure.rs
+++ b/performance/runner/src/measure.rs
@@ -74,6 +74,9 @@ pub fn measure<'a>(
                 // alternatively we could clear them before each run
                 .arg("--warmup")
                 .arg("1")
+                // --min-runs defaults to 10
+                .arg("--min-runs")
+                .arg("20")
                 .arg("--prepare")
                 .arg(metric.prepare)
                 .arg([metric.cmd, " --profiles-dir ", "../../project_config/"].join(""))


### PR DESCRIPTION
### Description

Looking at the last few runs of the performance action, `dbt parse` has pretty high variance in its run times. Running it 20 times instead of 10 may get us a better median value to compare.


### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
