### PR TITLE
[#3711] Check that test unique_id exists in nodes when removing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Contributors:
 
 ### Under the hood
 - Switch to full reparse on partial parsing exceptions. Log and report exception information. ([#3725](https://github.com/dbt-labs/dbt/issues/3725), [#3733](https://github.com/dbt-labs/dbt/pull/3733))
+- Check for existence of test node when removing. ([#3711](https://github.com/dbt-labs/dbt/issues/3711), [#3750](https://github.com/dbt-labs/dbt/pull/3750))
 
 
 ## dbt 0.20.1 (August 11, 2021)

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -231,7 +231,7 @@ class ManifestLoader:
                                 "Switching to a full re-parse.")
 
                     # Get traceback info
-                    tb_info = traceback.format_exc(10)
+                    tb_info = traceback.format_exc()
                     formatted_lines = tb_info.splitlines()
                     (_, line, method) = formatted_lines[-3].split(', ')
                     exc_info = {

--- a/core/dbt/parser/partial.py
+++ b/core/dbt/parser/partial.py
@@ -654,8 +654,9 @@ class PartialParsing:
     def remove_tests(self, schema_file, dict_key, name):
         tests = schema_file.get_tests(dict_key, name)
         for test_unique_id in tests:
-            node = self.saved_manifest.nodes.pop(test_unique_id)
-            self.deleted_manifest.nodes[test_unique_id] = node
+            if test_unique_id in self.saved_manifest.nodes:
+                node = self.saved_manifest.nodes.pop(test_unique_id)
+                self.deleted_manifest.nodes[test_unique_id] = node
         schema_file.remove_tests(dict_key, name)
 
     def delete_schema_source(self, schema_file, source_dict):


### PR DESCRIPTION
resolves #3711

### Description

Check for existence of test unique_id in nodes before removing. Also remove limit on traceback.format_exc, because it was limiting from the start of the trace not the end as I imagined.


### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
