### PR TITLE
[Backport] [#3764] Fix bug in applying patches to analyses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 ## dbt 0.20.2 (Release TBD)
 
 ### Under the hood
-- Better error handling for BigQuery job labels that are too long. ([#3612](https://github.com/dbt-labs/dbt/pull/3612), [#3703](https://github.com/dbt-labs/dbt/pull/3703))
 - Get more information on partial parsing version mismatches ([#3757](https://github.com/dbt-labs/dbt/issues/3757), [#3758](https://github.com/dbt-labs/dbt/pull/3758))
+
+### Fixes
+- Fix bug in finding analysis nodes when applying analysis patch ([#3764](https://github.com/dbt-labs/dbt/issues/3764), [#3767](https://github.com/dbt-labs/dbt/pull/3767))
 
 Contributors:
 - [@sungchun12](https://github.com/sungchun12) ([#3703](https://github.com/dbt-labs/dbt/pull/3703))
@@ -12,6 +14,10 @@ Contributors:
 
 ### Under the hood
 - Switch to full reparse on partial parsing exceptions. Log and report exception information. ([#3725](https://github.com/dbt-labs/dbt/issues/3725), [#3733](https://github.com/dbt-labs/dbt/pull/3733))
+- Check for existence of test node when removing. ([#3711](https://github.com/dbt-labs/dbt/issues/3711), [#3750](https://github.com/dbt-labs/dbt/pull/3750))
+- Better error handling for BigQuery job labels that are too long. [#3703](https://github.com/dbt-labs/dbt/pull/3703)
+
+### Fixes
 - Check for existence of test node when removing. ([#3711](https://github.com/dbt-labs/dbt/issues/3711), [#3750](https://github.com/dbt-labs/dbt/pull/3750))
 
 

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -172,7 +172,7 @@ class RefableLookup(dbtClassMixin):
 
 
 class AnalysisLookup(RefableLookup):
-    _lookup_types: ClassVar[set] = set(NodeType.Analysis)
+    _lookup_types: ClassVar[set] = set([NodeType.Analysis])
 
 
 def _search_packages(

--- a/test/integration/019_analysis_tests/analysis/schema.yml
+++ b/test/integration/019_analysis_tests/analysis/schema.yml
@@ -1,0 +1,5 @@
+version: 2
+
+analyses:
+  - name: analysis
+    description: "This is my analysis"

--- a/test/integration/019_analysis_tests/test_analyses.py
+++ b/test/integration/019_analysis_tests/test_analyses.py
@@ -1,4 +1,4 @@
-from test.integration.base import DBTIntegrationTest, use_profile
+from test.integration.base import DBTIntegrationTest, use_profile, get_manifest
 import os
 
 
@@ -36,6 +36,11 @@ class TestAnalyses(DBTIntegrationTest):
         self.assertFalse(os.path.exists(compiled_analysis_path))
         results = self.run_dbt(["compile"])
         self.assertEqual(len(results), 3)
+        manifest = get_manifest()
+        analysis_id = 'analysis.test.analysis'
+        self.assertIn(analysis_id, manifest.nodes)
+        node = manifest.nodes[analysis_id]
+        self.assertEqual(node.description, 'This is my analysis')
 
         self.assertTrue(os.path.exists(path_1))
         self.assertTrue(os.path.exists(path_2))

--- a/test/integration/base.py
+++ b/test/integration/base.py
@@ -23,6 +23,7 @@ from dbt.adapters.factory import get_adapter, reset_adapters, register_adapter
 from dbt.clients.jinja import template_cache
 from dbt.config import RuntimeConfig
 from dbt.context import providers
+from dbt.contracts.graph.manifest import Manifest
 from dbt.logger import GLOBAL_LOGGER as logger, log_manager
 
 
@@ -1230,3 +1231,15 @@ def bigquery_rate_limiter(err, *args):
         time.sleep(1)
         return True
     return False
+
+
+def get_manifest():
+    path = './target/partial_parse.msgpack'
+    if os.path.exists(path):
+        with open(path, 'rb') as fp:
+            manifest_mp = fp.read()
+        manifest: Manifest = Manifest.from_msgpack(manifest_mp)
+        return manifest
+    else:
+        return None
+


### PR DESCRIPTION
resolves #3764

### Description

Backport to version 20.2. Fix bug in looking up analysis node unique ids when applying patches.


### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
