### PR TITLE
Backport rm git backports for previous debian release, use git package

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,21 +5,18 @@ ARG BASE_REQUIREMENTS_SRC_PATH
 ARG WHEEL_REQUIREMENTS_SRC_PATH
 ARG DIST_PATH
 
-# We need backport packages to get a more recent version of git
-RUN printf "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports_git.list && \
-    apt-get update \
-    && apt-get dist-upgrade -y \
-    && apt-get install -y --no-install-recommends \
-    git-man/buster-backports \
-    git/buster-backports \
-    ssh-client \
-    software-properties-common \
-    make \
-    build-essential \
-    ca-certificates \
-    libpq-dev \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN apt-get update \
+  && apt-get dist-upgrade -y \
+  && apt-get install -y --no-install-recommends \
+  git \
+  ssh-client \
+  software-properties-common \
+  make \
+  build-essential \
+  ca-certificates \
+  libpq-dev \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN echo BASE_REQUIREMENTS_SRC_PATH=$BASE_REQUIREMENTS_SRC_PATH
 RUN echo WHEEL_REQUIREMENTS_SRC_PATH=$WHEEL_REQUIREMENTS_SRC_PATH


### PR DESCRIPTION
backport #3785 for #3784 

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue