### PR TITLE
[#3210] Make --models and --select synonyms, except for 'ls'

### DIFF
--- a/core/dbt/contracts/rpc.py
+++ b/core/dbt/contracts/rpc.py
@@ -58,6 +58,7 @@ class RPCExecParameters(RPCParameters):
 class RPCCompileParameters(RPCParameters):
     threads: Optional[int] = None
     models: Union[None, str, List[str]] = None
+    select: Union[None, str, List[str]] = None
     exclude: Union[None, str, List[str]] = None
     selector: Optional[str] = None
     state: Optional[str] = None
@@ -77,6 +78,7 @@ class RPCListParameters(RPCParameters):
 class RPCRunParameters(RPCParameters):
     threads: Optional[int] = None
     models: Union[None, str, List[str]] = None
+    select: Union[None, str, List[str]] = None
     exclude: Union[None, str, List[str]] = None
     selector: Optional[str] = None
     state: Optional[str] = None
@@ -120,6 +122,7 @@ class RPCDocsGenerateParameters(RPCParameters):
 class RPCBuildParameters(RPCParameters):
     threads: Optional[int] = None
     models: Union[None, str, List[str]] = None
+    select: Union[None, str, List[str]] = None
     exclude: Union[None, str, List[str]] = None
     selector: Optional[str] = None
     state: Optional[str] = None

--- a/core/dbt/main.py
+++ b/core/dbt/main.py
@@ -615,17 +615,10 @@ def _add_common_selector_arguments(sub):
     )
 
 
-def _add_selection_arguments(*subparsers, **kwargs):
-    models_name = kwargs.get('models_name', 'models')
+def _add_selection_arguments(*subparsers):
     for sub in subparsers:
-        if models_name == 'models':
-            _add_models_argument(sub)
-        elif models_name == 'select':
-            # these still get stored in 'models', so they present the same
-            # interface to the task
-            _add_select_argument(sub)
-        else:
-            raise InternalException(f'Unknown models style {models_name}')
+        _add_models_argument(sub)
+        _add_select_argument(sub)
         _add_common_selector_arguments(sub)
 
 
@@ -1075,8 +1068,8 @@ def parse_args(args, cls=DBTArgumentParser):
                           rpc_sub, seed_sub, parse_sub, build_sub)
     # --models, --exclude
     # list_sub sets up its own arguments.
-    _add_selection_arguments(build_sub, run_sub, compile_sub, generate_sub, test_sub)
-    _add_selection_arguments(snapshot_sub, seed_sub, models_name='select')
+    _add_selection_arguments(
+        build_sub, run_sub, compile_sub, generate_sub, test_sub, snapshot_sub, seed_sub)
     # --defer
     _add_defer_argument(run_sub, test_sub, build_sub)
     # --full-refresh

--- a/core/dbt/main.py
+++ b/core/dbt/main.py
@@ -554,39 +554,6 @@ def _build_docs_generate_subparser(subparsers, base_subparser):
     return generate_sub
 
 
-def _add_models_argument(sub, help_override=None, **kwargs):
-    help_str = '''
-        Specify the models to include.
-    '''
-    if help_override is not None:
-        help_str = help_override
-    sub.add_argument(
-        '-m',
-        '--models',
-        dest='models',
-        nargs='+',
-        help=help_str,
-        **kwargs
-    )
-
-
-def _add_select_argument(sub, dest='models', help_override=None, **kwargs):
-    help_str = '''
-        Specify the nodes to include.
-    '''
-    if help_override is not None:
-        help_str = help_override
-
-    sub.add_argument(
-        '-s',
-        '--select',
-        dest=dest,
-        nargs='+',
-        help=help_str,
-        **kwargs
-    )
-
-
 def _add_common_selector_arguments(sub):
     sub.add_argument(
         '--exclude',
@@ -617,8 +584,24 @@ def _add_common_selector_arguments(sub):
 
 def _add_selection_arguments(*subparsers):
     for sub in subparsers:
-        _add_models_argument(sub)
-        _add_select_argument(sub)
+        sub.add_argument(
+            '-m',
+            '--models',
+            dest='select',
+            nargs='+',
+            help='''
+                Specify the nodes to include.
+            ''',
+        )
+        sub.add_argument(
+            '-s',
+            '--select',
+            dest='select',
+            nargs='+',
+            help='''
+                Specify the nodes to include.
+            ''',
+        )
         _add_common_selector_arguments(sub)
 
 
@@ -780,11 +763,14 @@ def _build_source_freshness_subparser(subparsers, base_subparser):
         which='source-freshness',
         rpc_method='source-freshness',
     )
-    _add_select_argument(
-        sub,
+    sub.add_argument(
+        '-s',
+        '--select',
         dest='select',
-        metavar='SELECTOR',
-        required=False,
+        nargs='+',
+        help='''
+            Specify the nodes to include.
+        ''',
     )
     _add_common_selector_arguments(sub)
     return sub
@@ -842,18 +828,26 @@ def _build_list_subparser(subparsers, base_subparser):
                      choices=['json', 'name', 'path', 'selector'],
                      default='selector')
 
-    _add_models_argument(
-        sub,
-        help_override='''
+    sub.add_argument(
+        '-m',
+        '--models',
+        dest='models',
+        nargs='+',
+        help='''
         Specify the models to select and set the resource-type to 'model'.
         Mutually exclusive with '--select' (or '-s') and '--resource-type'
         ''',
         metavar='SELECTOR',
-        required=False
+        required=False,
     )
-    _add_select_argument(
-        sub,
+    sub.add_argument(
+        '-s',
+        '--select',
         dest='select',
+        nargs='+',
+        help='''
+            Specify the nodes to include.
+        ''',
         metavar='SELECTOR',
         required=False,
     )
@@ -999,8 +993,6 @@ def parse_args(args, cls=DBTArgumentParser):
         enable_help='''
         Allow for partial parsing by looking for and writing to a pickle file
         in the target directory. This overrides the user configuration file.
-
-        WARNING: This can result in unexpected behavior if you use env_var()!
         ''',
         disable_help='''
         Disallow partial parsing. This overrides the user configuration file.
@@ -1066,7 +1058,7 @@ def parse_args(args, cls=DBTArgumentParser):
     # --threads, --no-version-check
     _add_common_arguments(run_sub, compile_sub, generate_sub, test_sub,
                           rpc_sub, seed_sub, parse_sub, build_sub)
-    # --models, --exclude
+    # --select, --exclude
     # list_sub sets up its own arguments.
     _add_selection_arguments(
         build_sub, run_sub, compile_sub, generate_sub, test_sub, snapshot_sub, seed_sub)

--- a/core/dbt/task/compile.py
+++ b/core/dbt/task/compile.py
@@ -41,7 +41,7 @@ class CompileTask(GraphRunnableTask):
         if self.args.selector_name:
             spec = self.config.get_selector(self.args.selector_name)
         else:
-            spec = parse_difference(self.args.models, self.args.exclude)
+            spec = parse_difference(self.args.select, self.args.exclude)
         return spec
 
     def get_node_selector(self) -> ResourceTypeSelector:

--- a/core/dbt/task/rpc/project_commands.py
+++ b/core/dbt/task/rpc/project_commands.py
@@ -79,7 +79,10 @@ class RemoteCompileProjectTask(
     METHOD_NAME = 'compile'
 
     def set_args(self, params: RPCCompileParameters) -> None:
-        self.args.models = self._listify(params.models)
+        if params.models:
+            self.args.select = self._listify(params.models)
+        else:
+            self.args.select = self._listify(params.select)
         self.args.exclude = self._listify(params.exclude)
         self.args.selector_name = params.selector
         if params.threads is not None:
@@ -94,7 +97,10 @@ class RemoteRunProjectTask(RPCCommandTask[RPCRunParameters], RunTask):
     METHOD_NAME = 'run'
 
     def set_args(self, params: RPCRunParameters) -> None:
-        self.args.models = self._listify(params.models)
+        if params.models:
+            self.args.select = self._listify(params.models)
+        else:
+            self.args.select = self._listify(params.select)
         self.args.exclude = self._listify(params.exclude)
         self.args.selector_name = params.selector
 
@@ -114,7 +120,7 @@ class RemoteSeedProjectTask(RPCCommandTask[RPCSeedParameters], SeedTask):
 
     def set_args(self, params: RPCSeedParameters) -> None:
         # select has an argparse `dest` value of `models`.
-        self.args.models = self._listify(params.select)
+        self.args.select = self._listify(params.select)
         self.args.exclude = self._listify(params.exclude)
         self.args.selector_name = params.selector
         if params.threads is not None:
@@ -129,7 +135,10 @@ class RemoteTestProjectTask(RPCCommandTask[RPCTestParameters], TestTask):
     METHOD_NAME = 'test'
 
     def set_args(self, params: RPCTestParameters) -> None:
-        self.args.models = self._listify(params.models)
+        if params.models:
+            self.args.select = self._listify(params.models)
+        else:
+            self.args.select = self._listify(params.select)
         self.args.exclude = self._listify(params.exclude)
         self.args.selector_name = params.selector
         self.args.data = params.data
@@ -152,7 +161,7 @@ class RemoteDocsGenerateProjectTask(
     METHOD_NAME = 'docs.generate'
 
     def set_args(self, params: RPCDocsGenerateParameters) -> None:
-        self.args.models = None
+        self.args.select = None
         self.args.exclude = None
         self.args.selector_name = None
         self.args.compile = params.compile
@@ -216,7 +225,7 @@ class RemoteSnapshotTask(RPCCommandTask[RPCSnapshotParameters], SnapshotTask):
 
     def set_args(self, params: RPCSnapshotParameters) -> None:
         # select has an argparse `dest` value of `models`.
-        self.args.models = self._listify(params.select)
+        self.args.select = self._listify(params.select)
         self.args.exclude = self._listify(params.exclude)
         self.args.selector_name = params.selector
         if params.threads is not None:
@@ -255,7 +264,7 @@ class GetManifest(
     METHOD_NAME = 'get-manifest'
 
     def set_args(self, params: GetManifestParameters) -> None:
-        self.args.models = None
+        self.args.select = None
         self.args.exclude = None
         self.args.selector_name = None
 
@@ -313,7 +322,10 @@ class RemoteBuildProjectTask(RPCCommandTask[RPCBuildParameters], BuildTask):
     METHOD_NAME = 'build'
 
     def set_args(self, params: RPCBuildParameters) -> None:
-        self.args.models = self._listify(params.models)
+        if params.models:
+            self.args.select = self._listify(params.models)
+        else:
+            self.args.select = self._listify(params.select)
         self.args.exclude = self._listify(params.exclude)
         self.args.selector_name = params.selector
 

--- a/test/integration/007_graph_selection_tests/test_graph_selection.py
+++ b/test/integration/007_graph_selection_tests/test_graph_selection.py
@@ -44,7 +44,7 @@ class TestGraphSelection(DBTIntegrationTest):
     def test__postgres__specific_model(self):
         self.run_sql_file("seed.sql")
 
-        results = self.run_dbt(['run', '--models', 'users'])
+        results = self.run_dbt(['run', '--select', 'users'])
         self.assertEqual(len(results), 1)
 
         self.assertTablesEqual("seed", "users")
@@ -80,7 +80,7 @@ class TestGraphSelection(DBTIntegrationTest):
     def test__postgres__tags_and_children(self):
         self.run_sql_file("seed.sql")
 
-        results = self.run_dbt(['run', '--models', 'tag:base+'])
+        results = self.run_dbt(['run', '--select', 'tag:base+'])
         self.assertEqual(len(results), 5)
 
         created_models = self.get_models_in_schema()
@@ -96,7 +96,7 @@ class TestGraphSelection(DBTIntegrationTest):
     def test__postgres__tags_and_children_limited(self):
         self.run_sql_file("seed.sql")
 
-        results = self.run_dbt(['run', '--models', 'tag:base+2'])
+        results = self.run_dbt(['run', '--select', 'tag:base+2'])
         self.assertEqual(len(results), 4)
 
         created_models = self.get_models_in_schema()
@@ -113,7 +113,7 @@ class TestGraphSelection(DBTIntegrationTest):
     def test__snowflake__specific_model(self):
         self.run_sql_file("seed.sql")
 
-        results = self.run_dbt(['run', '--models', 'users'])
+        results = self.run_dbt(['run', '--select', 'users'])
         self.assertEqual(len(results),  1)
 
         self.assertTablesEqual("SEED", "USERS")
@@ -127,7 +127,7 @@ class TestGraphSelection(DBTIntegrationTest):
     def test__postgres__specific_model_and_children(self):
         self.run_sql_file("seed.sql")
 
-        results = self.run_dbt(['run', '--models', 'users+'])
+        results = self.run_dbt(['run', '--select', 'users+'])
         self.assertEqual(len(results),  4)
 
         self.assertTablesEqual("seed", "users")
@@ -143,7 +143,7 @@ class TestGraphSelection(DBTIntegrationTest):
     def test__snowflake__specific_model_and_children(self):
         self.run_sql_file("seed.sql")
 
-        results = self.run_dbt(['run', '--models', 'users+'])
+        results = self.run_dbt(['run', '--select', 'users+'])
         self.assertEqual(len(results),  4)
 
         self.assertManyTablesEqual(
@@ -158,7 +158,7 @@ class TestGraphSelection(DBTIntegrationTest):
     def test__postgres__specific_model_and_children_limited(self):
         self.run_sql_file("seed.sql")
 
-        results = self.run_dbt(['run', '--models', 'users+1'])
+        results = self.run_dbt(['run', '--select', 'users+1'])
         self.assertEqual(len(results), 3)
 
         self.assertTablesEqual("seed", "users")
@@ -174,7 +174,7 @@ class TestGraphSelection(DBTIntegrationTest):
     def test__postgres__specific_model_and_parents(self):
         self.run_sql_file("seed.sql")
 
-        results = self.run_dbt(['run', '--models', '+users_rollup'])
+        results = self.run_dbt(['run', '--select', '+users_rollup'])
         self.assertEqual(len(results),  2)
 
         self.assertTablesEqual("seed", "users")
@@ -188,7 +188,7 @@ class TestGraphSelection(DBTIntegrationTest):
     def test__snowflake__specific_model_and_parents(self):
         self.run_sql_file("seed.sql")
 
-        results = self.run_dbt(['run', '--models', '+users_rollup'])
+        results = self.run_dbt(['run', '--select', '+users_rollup'])
         self.assertEqual(len(results),  2)
 
         self.assertManyTablesEqual(
@@ -204,7 +204,7 @@ class TestGraphSelection(DBTIntegrationTest):
     def test__postgres__specific_model_and_parents_limited(self):
         self.run_sql_file("seed.sql")
 
-        results = self.run_dbt(['run', '--models', '1+users_rollup'])
+        results = self.run_dbt(['run', '--select', '1+users_rollup'])
         self.assertEqual(len(results), 2)
 
         self.assertTablesEqual("seed", "users")
@@ -219,7 +219,7 @@ class TestGraphSelection(DBTIntegrationTest):
         self.run_sql_file("seed.sql")
 
         results = self.run_dbt(
-            ['run', '--models', '+users_rollup', '--exclude', 'models/users_rollup.sql']
+            ['run', '--select', '+users_rollup', '--exclude', 'models/users_rollup.sql']
         )
         self.assertEqual(len(results),  1)
 
@@ -235,7 +235,7 @@ class TestGraphSelection(DBTIntegrationTest):
         self.run_sql_file("seed.sql")
 
         results = self.run_dbt(
-            ['run', '--models', '+users_rollup', '--exclude', 'users_rollup']
+            ['run', '--select', '+users_rollup', '--exclude', 'users_rollup']
         )
         self.assertEqual(len(results),  1)
 
@@ -247,7 +247,7 @@ class TestGraphSelection(DBTIntegrationTest):
 
     @use_profile('postgres')
     def test__postgres__locally_qualified_name(self):
-        results = self.run_dbt(['run', '--models', 'test.subdir'])
+        results = self.run_dbt(['run', '--select', 'test.subdir'])
         self.assertEqual(len(results), 2)
 
         created_models = self.get_models_in_schema()
@@ -258,7 +258,7 @@ class TestGraphSelection(DBTIntegrationTest):
         self.assertIn('nested_users', created_models)
         self.assert_correct_schemas()
 
-        results = self.run_dbt(['run', '--models', 'models/test/subdir*'])
+        results = self.run_dbt(['run', '--select', 'models/test/subdir*'])
         self.assertEqual(len(results), 2)
 
         created_models = self.get_models_in_schema()
@@ -272,14 +272,14 @@ class TestGraphSelection(DBTIntegrationTest):
     @use_profile('postgres')
     def test__postgres__locally_qualified_name_model_with_dots(self):
         self.run_sql_file("seed.sql")
-        results = self.run_dbt(['run', '--models', 'alternative.users'])
+        results = self.run_dbt(['run', '--select', 'alternative.users'])
         self.assertEqual(len(results), 1)
 
         created_models = self.get_models_in_schema()
         self.assertIn('alternative.users', created_models)
         self.assert_correct_schemas()
 
-        results = self.run_dbt(['run', '--models', 'models/alternative.*'])
+        results = self.run_dbt(['run', '--select', 'models/alternative.*'])
         self.assertEqual(len(results), 1)
 
         created_models = self.get_models_in_schema()
@@ -289,7 +289,7 @@ class TestGraphSelection(DBTIntegrationTest):
     @use_profile('postgres')
     def test__postgres__childrens_parents(self):
         self.run_sql_file("seed.sql")
-        results = self.run_dbt(['run', '--models', '@base_users'])
+        results = self.run_dbt(['run', '--select', '@base_users'])
         self.assertEqual(len(results), 5)
 
         created_models = self.get_models_in_schema()
@@ -301,7 +301,7 @@ class TestGraphSelection(DBTIntegrationTest):
         self.assertNotIn('nested_users', created_models)
 
         results = self.run_dbt(
-            ['test', '--models', 'test_name:not_null'],
+            ['test', '--select', 'test_name:not_null'],
         )
         self.assertEqual(len(results), 1)
         assert results[0].node.name == 'not_null_emails_email'
@@ -309,7 +309,7 @@ class TestGraphSelection(DBTIntegrationTest):
     @use_profile('postgres')
     def test__postgres__more_childrens_parents(self):
         self.run_sql_file("seed.sql")
-        results = self.run_dbt(['run', '--models', '@users'])
+        results = self.run_dbt(['run', '--select', '@users'])
         # users, emails_alt, users_rollup, users_rollup_dependency, but not base_users (ephemeral)
         self.assertEqual(len(results), 4)
 
@@ -321,7 +321,7 @@ class TestGraphSelection(DBTIntegrationTest):
         self.assertNotIn('nested_users', created_models)
 
         results = self.run_dbt(
-            ['test', '--models', 'test_name:unique'],
+            ['test', '--select', 'test_name:unique'],
         )
         self.assertEqual(len(results), 2)
         assert sorted([r.node.name for r in results]) == ['unique_users_id', 'unique_users_rollup_gender']
@@ -330,12 +330,12 @@ class TestGraphSelection(DBTIntegrationTest):
     @use_profile('snowflake')
     def test__snowflake__skip_intermediate(self):
         self.run_sql_file("seed.sql")
-        results = self.run_dbt(['run', '--models', '@models/users.sql'])
+        results = self.run_dbt(['run', '--select', '@models/users.sql'])
         # base_users, emails, users_rollup, users_rollup_dependency
         self.assertEqual(len(results), 4)
 
         # now re-run, skipping users_rollup
-        results = self.run_dbt(['run', '--models', '@users', '--exclude', 'users_rollup'])
+        results = self.run_dbt(['run', '--select', '@users', '--exclude', 'users_rollup'])
         self.assertEqual(len(results), 3)
 
         # make sure that users_rollup_dependency and users don't interleave
@@ -351,7 +351,7 @@ class TestGraphSelection(DBTIntegrationTest):
     @use_profile('postgres')
     def test__postgres__concat(self):
         self.run_sql_file("seed.sql")
-        results = self.run_dbt(['run', '--models', '@emails_alt', 'users_rollup'])
+        results = self.run_dbt(['run', '--select', '@emails_alt', 'users_rollup'])
         # users, emails_alt, users_rollup
         self.assertEqual(len(results), 3)
 
@@ -365,7 +365,7 @@ class TestGraphSelection(DBTIntegrationTest):
     @use_profile('postgres')
     def test__postgres__concat_exclude(self):
         self.run_sql_file("seed.sql")
-        results = self.run_dbt(['run', '--models', '@emails_alt', 'users_rollup', '--exclude', 'emails_alt'])
+        results = self.run_dbt(['run', '--select', '@emails_alt', 'users_rollup', '--exclude', 'emails_alt'])
         # users, users_rollup
         self.assertEqual(len(results), 2)
 
@@ -380,7 +380,7 @@ class TestGraphSelection(DBTIntegrationTest):
     def test__postgres__concat_exclude_concat(self):
         self.run_sql_file("seed.sql")
         results = self.run_dbt(
-            ['run', '--models', '@emails_alt', 'users_rollup', '--exclude', 'emails_alt', 'users_rollup']
+            ['run', '--select', '@emails_alt', 'users_rollup', '--exclude', 'emails_alt', 'users_rollup']
         )
         # users
         self.assertEqual(len(results), 1)
@@ -394,7 +394,7 @@ class TestGraphSelection(DBTIntegrationTest):
         self.assertNotIn('nested_users', created_models)
 
         results = self.run_dbt(
-            ['test', '--models', '@emails_alt', 'users_rollup', '--exclude', 'emails_alt', 'users_rollup']
+            ['test', '--select', '@emails_alt', 'users_rollup', '--exclude', 'emails_alt', 'users_rollup']
         )
         self.assertEqual(len(results), 1)
         assert results[0].node.name == 'unique_users_id'

--- a/test/integration/007_graph_selection_tests/test_schema_test_graph_selection.py
+++ b/test/integration/007_graph_selection_tests/test_schema_test_graph_selection.py
@@ -31,7 +31,7 @@ class TestSchemaTestGraphSelection(DBTIntegrationTest):
         self.assertEqual(len(results), 10)
 
         args = FakeArgs()
-        args.models = include
+        args.select = include
         args.exclude = exclude
 
         test_task = TestTask(args, self.config)

--- a/test/integration/base.py
+++ b/test/integration/base.py
@@ -65,6 +65,7 @@ class FakeArgs:
         self.schema = True
         self.full_refresh = False
         self.models = None
+        self.select = None
         self.exclude = None
         self.single_threaded = False
         self.selector_name = None


### PR DESCRIPTION
resolves #3210


### Description

Some dbt commands used '--select' and some used '--models', but they worked the same under the covers. This makes the commands synonyms, although '--select' is preferred.  The 'ls' command has slightly different behavior for the two commands which is untouched.


### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
