### PR TITLE
Handle failing tests for `build` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - to let copy several source tables into single target table at a time. ([Google doc reference](https://cloud.google.com/bigquery/docs/managing-tables#copying_multiple_source_tables))
 - Customize ls task JSON output by adding new flag `--output-keys` ([#3778](https://github.com/dbt-labs/dbt/issues/3778), [#3395](https://github.com/dbt-labs/dbt/issues/3395))
 - add support for execution project on BigQuery through profile configuration ([#3708](https://github.com/dbt-labs/dbt/issues/3708))
+- Skip downstream nodes during the `build` task when a test fails. ([#3597](https://github.com/dbt-labs/dbt/issues/3597), [#3792](https://github.com/dbt-labs/dbt/pull/3792))
 
 ### Fixes
 

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -395,15 +395,20 @@ class Compiler:
                 if node.resource_type != NodeType.Test:
                     test_dependencies = manifest.get_tests_for_node(dependency)
                     for test_dependency in test_dependencies:
-                        linker.dependency(
-                            node.unique_id,
-                            test_dependency
-                        )
+                        if (
+                           test_dependency not in node.depends_on_nodes and
+                           node.unique_id not in manifest.nodes[test_dependency].depends_on_nodes
+                        ):
+                            linker.dependency(
+                                node.unique_id,
+                                test_dependency
+                            )
 
                 linker.dependency(
                     node.unique_id,
                     (manifest.nodes[dependency].unique_id)
                 )
+
             elif dependency in manifest.sources:
                 linker.dependency(
                     node.unique_id,
@@ -421,6 +426,7 @@ class Compiler:
             self.link_node(linker, exposure, manifest)
 
         print(linker.graph.edges)
+
         cycle = linker.find_cycles()
 
         if cycle:

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -390,9 +390,16 @@ class Compiler:
         self, linker: Linker, node: GraphMemberNode, manifest: Manifest
     ):
         linker.add_node(node.unique_id)
-
         for dependency in node.depends_on_nodes:
             if dependency in manifest.nodes:
+                if node.resource_type != NodeType.Test:
+                    test_dependencies = manifest.get_tests_for_node(dependency)
+                    for test_dependency in test_dependencies:
+                        linker.dependency(
+                            node.unique_id,
+                            test_dependency
+                        )
+
                 linker.dependency(
                     node.unique_id,
                     (manifest.nodes[dependency].unique_id)
@@ -412,8 +419,8 @@ class Compiler:
             self.link_node(linker, node, manifest)
         for exposure in manifest.exposures.values():
             self.link_node(linker, exposure, manifest)
-            # linker.add_node(exposure.unique_id)
 
+        print(linker.graph.edges)
         cycle = linker.find_cycles()
 
         if cycle:

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -158,13 +158,23 @@ class Linker:
                 resolved_graph.add_edge(predecessor, node)
                 predecessor_tests = manifest.get_tests_for_node(predecessor)
                 for test in predecessor_tests:
-                    test_predecessors = set([
-                        n for n in nx.traversal.bfs_tree(self.graph, test, reverse=True)
-                        if n != test
-                    ])
+                    # test_predecessors = set([
+                    #     n for n in nx.traversal.bfs_tree(self.graph, test, reverse=True)
+                    #     if n != test
+                    # ])
+                    test_depends_on = set(manifest.nodes[test].depends_on_nodes)
+
+                    print(f"node: {node}")
+                    print(f"test: {test}")
+                    # print(f"test_predecessors: {test_predecessors}")
+                    print(f"test_depends_on: {test_depends_on}")
+                    print(f"node_predecessors: {node_predecessors}")
+                    print()
+
                     if (
-                        test_predecessors.issubset(node_predecessors)
-                        and not node_predecessors.issubset(test_predecessors)
+                        test_depends_on.issubset(node_predecessors)
+                        and not node_predecessors.issubset(test_depends_on)
+                        and test != node
                     ):
                         resolved_graph.add_edge(test, node)
 

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -150,9 +150,13 @@ class Linker:
     def resolve_test_deps(self, manifest: Manifest):
         resolved_graph = nx.DiGraph()
         for node_id in self.graph:
+            resolved_graph.add_node(node_id)
             for predecessor in self.graph.predecessors(node_id):
                 resolved_graph.add_edge(predecessor, node_id)
-            if manifest.nodes[node_id].resource_type != NodeType.Test:
+            if (
+                node_id in manifest.nodes and
+                manifest.nodes[node_id].resource_type != NodeType.Test
+            ):
                 all_upstream_nodes = nx.traversal.bfs_tree(
                     self.graph, node_id, reverse=True
                 )
@@ -170,7 +174,6 @@ class Linker:
                             and test != node_id
                         ):
                             resolved_graph.add_edge(test, node_id)
-
         # swap in new dependency graph
         self.graph = resolved_graph
 

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -2,7 +2,7 @@ import os
 from collections import defaultdict
 from typing import List, Dict, Any, Tuple, cast, Optional
 
-import networkx as nx
+import networkx as nx  # type: ignore
 import sqlparse
 
 from dbt import flags
@@ -169,9 +169,9 @@ class Linker:
                             manifest.nodes[test].depends_on_nodes
                         )
                         if (
-                            test_depends_on.issubset(upstream_nodes)
-                            and not upstream_nodes.issubset(test_depends_on)
-                            and test != node_id
+                            test_depends_on.issubset(upstream_nodes) and
+                            not upstream_nodes.issubset(test_depends_on) and
+                            test != node_id
                         ):
                             resolved_graph.add_edge(test, node_id)
         # swap in new dependency graph

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -207,7 +207,7 @@ class Linker:
                     # Get the set of all nodes that the test depends on
                     # including the upstream_node itself. This is necessary
                     # because tests can depend on multiple nodes (ex:
-                    # relationship tests). Test nodes do not distiquish
+                    # relationship tests). Test nodes do not distinguish
                     # between what node the test is "testing" and what
                     # node(s) it depends on.
                     test_depends_on = set(

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -159,7 +159,7 @@ class Linker:
             out_graph.add_node(node_id, **data)
         nx.write_gpickle(out_graph, outfile)
 
-    def resolve_graph(self, manifest: Manifest):
+    def resolve_graph(self, manifest: Manifest) -> None:
         """ This method adds additional edges to the DAG. For a given non-test
         executable node, add an edge from an upstream test to the given node if
         the set of nodes the test depends on is a proper/strict subset of the

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -1027,6 +1027,15 @@ class Manifest(MacroMethods, DataClassMessagePackMixin, dbtClassMixin):
         self.docs[doc.unique_id] = doc
         source_file.docs.append(doc.unique_id)
 
+    def get_tests_for_node(self, unique_id: UniqueID) -> List[UniqueID]:
+        """ return list of tests that depend on provided unique id """
+        return [
+            node.unique_id
+            for _, node in self.nodes.items()
+            if node.resource_type == NodeType.Test
+            and unique_id in node.depends_on_nodes
+        ]
+
     # end of methods formerly in ParseResult
 
     # Provide support for copy.deepcopy() - we just need to avoid the lock!

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -1028,7 +1028,9 @@ class Manifest(MacroMethods, DataClassMessagePackMixin, dbtClassMixin):
         source_file.docs.append(doc.unique_id)
 
     def get_tests_for_node(self, unique_id: UniqueID) -> List[UniqueID]:
-        """ return list of tests that depend on provided unique id """
+        """ Get a list of tests that depend on the node with the
+        provided unique id """
+
         return [
             node.unique_id
             for _, node in self.nodes.items()

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -1034,8 +1034,8 @@ class Manifest(MacroMethods, DataClassMessagePackMixin, dbtClassMixin):
         return [
             node.unique_id
             for _, node in self.nodes.items()
-            if node.resource_type == NodeType.Test
-            and unique_id in node.depends_on_nodes
+            if node.resource_type == NodeType.Test and
+            unique_id in node.depends_on_nodes
         ]
 
     # end of methods formerly in ParseResult

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -1027,17 +1027,6 @@ class Manifest(MacroMethods, DataClassMessagePackMixin, dbtClassMixin):
         self.docs[doc.unique_id] = doc
         source_file.docs.append(doc.unique_id)
 
-    def get_tests_for_node(self, unique_id: UniqueID) -> List[UniqueID]:
-        """ Get a list of tests that depend on the node with the
-        provided unique id """
-
-        return [
-            node.unique_id
-            for _, node in self.nodes.items()
-            if node.resource_type == NodeType.Test and
-            unique_id in node.depends_on_nodes
-        ]
-
     # end of methods formerly in ParseResult
 
     # Provide support for copy.deepcopy() - we just need to avoid the lock!

--- a/core/dbt/task/build.py
+++ b/core/dbt/task/build.py
@@ -3,6 +3,7 @@ from .snapshot import SnapshotRunner as snapshot_model_runner
 from .seed import SeedRunner as seed_runner
 from .test import TestRunner as test_runner
 
+from dbt.contracts.results import NodeStatus
 from dbt.graph import ResourceTypeSelector
 from dbt.exceptions import InternalException
 from dbt.node_types import NodeType
@@ -24,6 +25,8 @@ class BuildTask(RunTask):
         NodeType.Test: test_runner,
     }
 
+    MARK_DEPENDENT_ERRORS_STATUSES = [NodeStatus.Error, NodeStatus.Fail]
+
     def get_node_selector(self) -> ResourceTypeSelector:
         if self.manifest is None or self.graph is None:
             raise InternalException(
@@ -39,3 +42,4 @@ class BuildTask(RunTask):
 
     def get_runner_type(self, node):
         return self.RUNNER_MAP.get(node.resource_type)
+

--- a/core/dbt/task/build.py
+++ b/core/dbt/task/build.py
@@ -10,12 +10,12 @@ from dbt.node_types import NodeType
 
 
 class BuildTask(RunTask):
-    """The Build task processes all assets of a given process and attempts to 'build'
-    them in an opinionated fashion.  Every resource type outlined in RUNNER_MAP
-    will be processed by the mapped runner class.
+    """The Build task processes all assets of a given process and
+    attempts to 'build' them in an opinionated fashion. Every resource
+    type outlined in RUNNER_MAP will be processed by the mapped runner class.
 
-    I.E. a resource of type Model is handled by the ModelRunner which is imported
-    as run_model_runner.
+    I.E. a resource of type Model is handled by the ModelRunner which is
+    imported as run_model_runner.
     """
 
     RUNNER_MAP = {
@@ -42,4 +42,3 @@ class BuildTask(RunTask):
 
     def get_runner_type(self, node):
         return self.RUNNER_MAP.get(node.resource_type)
-

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -83,6 +83,9 @@ class ManifestTask(ConfiguredTask):
 
 
 class GraphRunnableTask(ManifestTask):
+
+    MARK_DEPENDENT_ERRORS_STATUSES = [NodeStatus.Error]
+
     def __init__(self, args, config):
         super().__init__(args, config)
         self.job_queue: Optional[GraphQueue] = None
@@ -289,7 +292,7 @@ class GraphRunnableTask(ManifestTask):
         else:
             self.manifest.update_node(node)
 
-        if result.status in (NodeStatus.Error, NodeStatus.Fail):
+        if result.status in self.MARK_DEPENDENT_ERRORS_STATUSES:
             if is_ephemeral:
                 cause = result
             else:

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -289,7 +289,7 @@ class GraphRunnableTask(ManifestTask):
         else:
             self.manifest.update_node(node)
 
-        if result.status == NodeStatus.Error:
+        if result.status in (NodeStatus.Error, NodeStatus.Fail):
             if is_ephemeral:
                 cause = result
             else:

--- a/test/integration/069_build_test/models-circular-relationship/model_0.sql
+++ b/test/integration/069_build_test/models-circular-relationship/model_0.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+select * from {{ ref('countries') }}

--- a/test/integration/069_build_test/models-circular-relationship/model_1.sql
+++ b/test/integration/069_build_test/models-circular-relationship/model_1.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+select * from {{ ref('model_0') }}

--- a/test/integration/069_build_test/models-circular-relationship/model_99.sql
+++ b/test/integration/069_build_test/models-circular-relationship/model_99.sql
@@ -1,0 +1,4 @@
+{{ config(materialized='table') }}
+
+select '1' as "num"
+

--- a/test/integration/069_build_test/models-circular-relationship/test.yml
+++ b/test/integration/069_build_test/models-circular-relationship/test.yml
@@ -1,0 +1,18 @@
+version: 2
+
+models:
+  - name: model_0
+    columns:
+      - name: iso3
+        tests:
+          - relationships:
+              to: ref('model_1')
+              field: iso3
+
+  - name: model_1
+    columns:
+      - name: iso3
+        tests:
+          - relationships:
+              to: ref('model_0')
+              field: iso3

--- a/test/integration/069_build_test/models-failing/model_3.sql
+++ b/test/integration/069_build_test/models-failing/model_3.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+select * from {{ ref('model_1') }}

--- a/test/integration/069_build_test/test_build.py
+++ b/test/integration/069_build_test/test_build.py
@@ -64,3 +64,18 @@ class TestFailingTestsBuild(TestBuildBase):
         actual = [str(r.status) for r in results]
         expected = ['fail'] + ['skipped']*6 + ['pass']*2 + ['success']*4
         self.assertEqual(sorted(actual), sorted(expected))
+
+
+class TestCircularRelationshipTestsBuild(TestBuildBase):
+    @property
+    def models(self):
+        return "models-circular-relationship"
+
+    @use_profile("postgres")
+    def test__postgres_circular_relationship_test_success(self):
+        """ Ensure that tests that refer to each other's model don't create
+        a circular dependency. """
+        results = self.build()
+        actual = [r.status for r in results]
+        expected = ['success']*7 + ['pass']*2
+        self.assertEqual(sorted(actual), sorted(expected))

--- a/test/integration/069_build_test/test_build.py
+++ b/test/integration/069_build_test/test_build.py
@@ -2,7 +2,7 @@ from test.integration.base import DBTIntegrationTest, use_profile
 import yaml
 
 
-class TestBuild(DBTIntegrationTest):
+class TestBuildBase(DBTIntegrationTest):
     @property
     def schema(self):
         return "build_test_069"
@@ -28,7 +28,7 @@ class TestBuild(DBTIntegrationTest):
         return self.run_dbt(args, expect_pass=expect_pass)
 
 
-class TestPassingBuild(TestBuild):
+class TestPassingBuild(TestBuildBase):
     @property
     def models(self):
         return "models"
@@ -38,11 +38,7 @@ class TestPassingBuild(TestBuild):
         self.build()
 
 
-class TestFailingBuild(TestBuild):
-    @property
-    def schema(self):
-        return "build_test_069"
-
+class TestFailingBuild(TestBuildBase):
     @property
     def models(self):
         return "models-failing"
@@ -56,11 +52,7 @@ class TestFailingBuild(TestBuild):
         self.assertEqual(sorted(actual), sorted(expected))
 
 
-class TestFailingTestsBuild(TestBuild):
-    @property
-    def schema(self):
-        return "build_test_069"
-
+class TestFailingTestsBuild(TestBuildBase):
     @property
     def models(self):
         return "tests-failing"

--- a/test/integration/069_build_test/tests-failing/model_0.sql
+++ b/test/integration/069_build_test/tests-failing/model_0.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+select * from {{ ref('countries') }}

--- a/test/integration/069_build_test/tests-failing/model_1.sql
+++ b/test/integration/069_build_test/tests-failing/model_1.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+select * from {{ ref('snap_0') }}

--- a/test/integration/069_build_test/tests-failing/model_2.sql
+++ b/test/integration/069_build_test/tests-failing/model_2.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+select * from {{ ref('snap_1') }}

--- a/test/integration/069_build_test/tests-failing/model_99.sql
+++ b/test/integration/069_build_test/tests-failing/model_99.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+select '1' as "num"

--- a/test/integration/069_build_test/tests-failing/test.yml
+++ b/test/integration/069_build_test/tests-failing/test.yml
@@ -1,0 +1,18 @@
+version: 2
+
+models:
+  - name: model_0
+    columns:
+      - name: iso3
+        tests:
+          - unique
+          - not_null
+      - name: historical_iso_numeric
+        tests:
+          - not_null
+  - name: model_2
+    columns:
+      - name: iso3
+        tests:
+          - unique
+          - not_null

--- a/test/rpc/test_build.py
+++ b/test/rpc/test_build.py
@@ -26,6 +26,7 @@ snapshot_data = '''
 {% endsnapshot %}
 '''
 
+
 @pytest.mark.supported('postgres')
 def test_rpc_build_threads(
     project_root, profiles_root, dbt_profile, unique_schema


### PR DESCRIPTION
resolves #3597 


### Description

This PR add additional edges to the DAG representation of node dependencies for a compiled project. It "just works" with how node selection is designed. The major takeaway here is we want a given node to depend on tests belonging to any upstream nodes. The caveat is that the test can only depend on nodes that are upstream of the given node in order to create this dependency, else this could open up the possibility of circular dependencies (ew, we love DAGs). This ensures that when running tasks that execute multiple different types of resources (`dbt build`), models will depend on all upstream dependencies having passing tests, else it will be skipped during execution.


### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
