### PR TITLE
Add adapter_unique_id to invocation tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Use GitHub Actions for CI ([#3688](https://github.com/dbt-labs/dbt/issues/3688), [#3669](https://github.com/dbt-labs/dbt/pull/3669))
 - Better dbt hub registry packages version logging that prompts the user for upgrades to relevant packages ([#3560](https://github.com/dbt-labs/dbt/issues/3560), [#3763](https://github.com/dbt-labs/dbt/issues/3763), [#3759](https://github.com/dbt-labs/dbt/pull/3759))
 - Allow the default seed macro's SQL parameter, `%s`, to be replaced by dispatching a new macro, `get_binding_char()`. This enables adapters with parameter marker characters such as `?` to not have to override `basic_load_csv_rows`.  ([#3622](https://github.com/fishtown-analytics/dbt/issues/3622), [#3623](https://github.com/fishtown-analytics/dbt/pull/3623))
+- Add `adapter_unique_id` to invocation context in anonymous usage tracking, to better understand dbt adoption ([#3713](https://github.com/dbt-labs/dbt/issues/3713), [#3796](https://github.com/dbt-labs/dbt/issues/3796))
 
 Contributors:
 - [@xemuliam](https://github.com/xemuliam) ([#3606](https://github.com/dbt-labs/dbt/pull/3606))

--- a/core/dbt/config/runtime.py
+++ b/core/dbt/config/runtime.py
@@ -391,6 +391,10 @@ class UnsetCredentials(Credentials):
     def type(self):
         return None
 
+    @property
+    def unique_field(self):
+        return None
+
     def connection_info(self, *args, **kwargs):
         return {}
 

--- a/core/dbt/contracts/connection.py
+++ b/core/dbt/contracts/connection.py
@@ -1,5 +1,6 @@
 import abc
 import itertools
+import hashlib
 from dataclasses import dataclass, field
 from typing import (
     Any, ClassVar, Dict, Tuple, Iterable, Optional, List, Callable,
@@ -126,6 +127,15 @@ class Credentials(
         raise NotImplementedError(
             'type not implemented for base credentials class'
         )
+        
+    @abc.abstractproperty
+    def unique_field(self) -> str:
+        raise NotImplementedError(
+            'type not implemented for base credentials class'
+        )
+        
+    def hashed_unique_field(self) -> str:
+        return hashlib.md5(self.unique_field.encode('utf-8')).hexdigest()
 
     def connection_info(
         self, *, with_aliases: bool = False

--- a/core/dbt/contracts/connection.py
+++ b/core/dbt/contracts/connection.py
@@ -127,13 +127,13 @@ class Credentials(
         raise NotImplementedError(
             'type not implemented for base credentials class'
         )
-        
+
     @abc.abstractproperty
     def unique_field(self) -> str:
         raise NotImplementedError(
             'type not implemented for base credentials class'
         )
-        
+
     def hashed_unique_field(self) -> str:
         return hashlib.md5(self.unique_field.encode('utf-8')).hexdigest()
 

--- a/core/dbt/tracking.py
+++ b/core/dbt/tracking.py
@@ -21,7 +21,7 @@ sp_logger.setLevel(100)
 COLLECTOR_URL = "fishtownanalytics.sinter-collect.com"
 COLLECTOR_PROTOCOL = "https"
 
-INVOCATION_SPEC = 'iglu:com.dbt/invocation/jsonschema/1-0-1'  # TODO bump to 1-0-2
+INVOCATION_SPEC = 'iglu:com.dbt/invocation/jsonschema/1-0-2'
 PLATFORM_SPEC = 'iglu:com.dbt/platform/jsonschema/1-0-0'
 RUN_MODEL_SPEC = 'iglu:com.dbt/run_model/jsonschema/1-0-1'
 INVOCATION_ENV_SPEC = 'iglu:com.dbt/invocation_env/jsonschema/1-0-0'
@@ -187,7 +187,7 @@ def get_invocation_context(user, config, args):
 
         "run_type": get_run_type(args),
         "adapter_type": adapter_type,
-        # "adapter_unique_id": adapter_id, TODO
+        "adapter_unique_id": adapter_unique_id,
     }
 
 

--- a/core/dbt/tracking.py
+++ b/core/dbt/tracking.py
@@ -21,7 +21,7 @@ sp_logger.setLevel(100)
 COLLECTOR_URL = "fishtownanalytics.sinter-collect.com"
 COLLECTOR_PROTOCOL = "https"
 
-INVOCATION_SPEC = 'iglu:com.dbt/invocation/jsonschema/1-0-1'
+INVOCATION_SPEC = 'iglu:com.dbt/invocation/jsonschema/1-0-1'  # TODO bump to 1-0-2
 PLATFORM_SPEC = 'iglu:com.dbt/platform/jsonschema/1-0-0'
 RUN_MODEL_SPEC = 'iglu:com.dbt/run_model/jsonschema/1-0-1'
 INVOCATION_ENV_SPEC = 'iglu:com.dbt/invocation_env/jsonschema/1-0-0'
@@ -166,10 +166,15 @@ def get_run_type(args):
 
 
 def get_invocation_context(user, config, args):
+    # this adapter might not have implemented the type or unique_field properties
     try:
         adapter_type = config.credentials.type
     except Exception:
         adapter_type = None
+    try:
+        adapter_unique_id = config.credentials.hashed_unique_field()
+    except Exception:
+        adapter_unique_id = None
 
     return {
         "project_id": None if config is None else config.hashed_name(),
@@ -182,6 +187,7 @@ def get_invocation_context(user, config, args):
 
         "run_type": get_run_type(args),
         "adapter_type": adapter_type,
+        # "adapter_unique_id": adapter_id, TODO
     }
 
 

--- a/plugins/bigquery/dbt/adapters/bigquery/connections.py
+++ b/plugins/bigquery/dbt/adapters/bigquery/connections.py
@@ -111,7 +111,7 @@ class BigQueryCredentials(Credentials):
     @property
     def type(self):
         return 'bigquery'
-        
+
     @property
     def unique_field(self):
         return self.database

--- a/plugins/bigquery/dbt/adapters/bigquery/connections.py
+++ b/plugins/bigquery/dbt/adapters/bigquery/connections.py
@@ -111,6 +111,10 @@ class BigQueryCredentials(Credentials):
     @property
     def type(self):
         return 'bigquery'
+        
+    @property
+    def unique_field(self):
+        return self.database
 
     def _connection_keys(self):
         return ('method', 'database', 'schema', 'location', 'priority',

--- a/plugins/postgres/dbt/adapters/postgres/connections.py
+++ b/plugins/postgres/dbt/adapters/postgres/connections.py
@@ -37,7 +37,7 @@ class PostgresCredentials(Credentials):
     @property
     def type(self):
         return 'postgres'
-        
+
     @property
     def unique_field(self):
         return self.host

--- a/plugins/postgres/dbt/adapters/postgres/connections.py
+++ b/plugins/postgres/dbt/adapters/postgres/connections.py
@@ -37,6 +37,10 @@ class PostgresCredentials(Credentials):
     @property
     def type(self):
         return 'postgres'
+        
+    @property
+    def unique_field(self):
+        return self.host
 
     def _connection_keys(self):
         return ('host', 'port', 'user', 'database', 'schema', 'search_path',

--- a/plugins/snowflake/dbt/adapters/snowflake/connections.py
+++ b/plugins/snowflake/dbt/adapters/snowflake/connections.py
@@ -57,7 +57,7 @@ class SnowflakeCredentials(Credentials):
     @property
     def type(self):
         return 'snowflake'
-        
+
     @property
     def unique_field(self):
         return self.account

--- a/plugins/snowflake/dbt/adapters/snowflake/connections.py
+++ b/plugins/snowflake/dbt/adapters/snowflake/connections.py
@@ -57,6 +57,10 @@ class SnowflakeCredentials(Credentials):
     @property
     def type(self):
         return 'snowflake'
+        
+    @property
+    def unique_field(self):
+        return self.account
 
     def _connection_keys(self):
         return (


### PR DESCRIPTION
resolves #3713

- Implemented an abstract property `unique_field` and a base method `hashed_unique_field`
- Each adapter need only define the `unique_field` property
- ~Waiting on addition of `adapter_unique_id` to `invocation` schema~

As far as the original four:
- Postgres: `host`
- Redshift (inherits from Postgres): `host`
- Snowflake: `account`
- BigQuery: `database`/`project`

We'll also want to add this for dbt-spark + dbt-presto. For community adapters, I'll add a comment to [this documentation](https://docs.getdbt.com/docs/contributing/building-a-new-adapter), and I can also open issues in the repos of the most popular known adapters.

cc @drewbanin @aescay

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
