### PR TITLE
Add colourful count of pass/fail tests in dbt debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 ## dbt 0.21.0 (Release TBD)
 
+### Fixes
+- `dbt debug` shows a summary of whether all checks passed or not ([3831](https://github.com/dbt-labs/dbt/issues/3831), [3832](https://github.com/dbt-labs/dbt/issues/3831))
+
 ### Under the hood
 
 - Use GitHub Actions for CI ([#3688](https://github.com/dbt-labs/dbt/issues/3688), [#3669](https://github.com/dbt-labs/dbt/pull/3669))
+
+Contributors: 
+- [@joellabes](https://github.com/joellabes) ([#3669](https://github.com/dbt-labs/dbt/pull/3669))
 
 ## dbt 0.21.0b2 (August 19, 2021)
 

--- a/core/dbt/task/debug.py
+++ b/core/dbt/task/debug.py
@@ -125,6 +125,10 @@ class DebugTask(BaseTask):
         self.test_dependencies()
         self.test_connection()
 
+        if self.any_failure:
+            print(red('{}/4 checks failed'.format(len(self.messages))))
+        else:
+            print(green('All checks passed!'))
         for message in self.messages:
             print(message)
             print('')
@@ -368,7 +372,7 @@ class DebugTask(BaseTask):
         print('Connection:')
         for k, v in self.profile.credentials.connection_info():
             print('  {}: {}'.format(k, v))
-        print('  Connection test: {}'.format(self._connection_result()))
+        print('  Connection test: [{}]'.format(self._connection_result()))
         print('')
 
     @classmethod

--- a/core/dbt/task/debug.py
+++ b/core/dbt/task/debug.py
@@ -130,7 +130,7 @@ class DebugTask(BaseTask):
             print(red(f"{(pluralize(len(self.messages), 'check'))} failed:"))
         else:
             print(green('All checks passed!'))
-        
+
         for message in self.messages:
             print(message)
             print('')
@@ -328,8 +328,8 @@ class DebugTask(BaseTask):
         if self.project_fail_details == FILE_NOT_FOUND:
             return
         msg = (
-            f'Project loading failed for the following reason: ' \
-            f'\n{self.project_fail_details} ' \
+            f'Project loading failed for the following reason:'
+            f'\n{self.project_fail_details}'
             f'\n'
         )
         self.messages.append(msg)
@@ -342,8 +342,8 @@ class DebugTask(BaseTask):
         if self.profile_fail_details == FILE_NOT_FOUND:
             return
         msg = (
-            f'Profile loading failed for the following reason: ' \
-            f'\n{self.profile_fail_details} ' \
+            f'Profile loading failed for the following reason:'
+            f'\n{self.profile_fail_details}'
             f'\n'
         )
         self.messages.append(msg)

--- a/core/dbt/task/debug.py
+++ b/core/dbt/task/debug.py
@@ -16,6 +16,7 @@ from dbt.context.target import generate_target_context
 from dbt.clients.yaml_helper import load_yaml_text
 from dbt.links import ProfileConfigDocs
 from dbt.ui import green, red
+from dbt.utils import pluralize
 from dbt.version import get_installed_version
 
 from dbt.task.base import BaseTask, get_nearest_project_dir
@@ -126,9 +127,10 @@ class DebugTask(BaseTask):
         self.test_connection()
 
         if self.any_failure:
-            print(red('{}/4 checks failed'.format(len(self.messages))))
+            print(red(f"{(pluralize(len(self.messages), 'check'))} failed:"))
         else:
             print(green('All checks passed!'))
+        
         for message in self.messages:
             print(message)
             print('')
@@ -325,9 +327,12 @@ class DebugTask(BaseTask):
         self.any_failure = True
         if self.project_fail_details == FILE_NOT_FOUND:
             return
-        print('Project loading failed for the following reason:')
-        print(self.project_fail_details)
-        print('')
+        msg = (
+            f'Project loading failed for the following reason: ' \
+            f'\n{self.project_fail_details} ' \
+            f'\n'
+        )
+        self.messages.append(msg)
 
     def _log_profile_fail(self):
         if not self.profile_fail_details:
@@ -336,9 +341,12 @@ class DebugTask(BaseTask):
         self.any_failure = True
         if self.profile_fail_details == FILE_NOT_FOUND:
             return
-        print('Profile loading failed for the following reason:')
-        print(self.profile_fail_details)
-        print('')
+        msg = (
+            f'Profile loading failed for the following reason: ' \
+            f'\n{self.profile_fail_details} ' \
+            f'\n'
+        )
+        self.messages.append(msg)
 
     @staticmethod
     def attempt_connection(profile):


### PR DESCRIPTION
resolves #3831 

### Description
With a failing check:
![image](https://user-images.githubusercontent.com/7335046/131309392-5015321a-8856-414c-b7fc-2c316c71eb7d.png)

With no failing checks:
![image](https://user-images.githubusercontent.com/7335046/131309327-00b7bd99-5bb3-4034-92d2-f743d6028e55.png)

### Style comment

That red is sorta hard to see. I would have preferred to use yellow, but that would be inconsistent. 
### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
