### PR TITLE
#3694 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,9 @@
 - Better dbt hub registry packages version logging that prompts the user for upgrades to relevant packages ([#3560](https://github.com/dbt-labs/dbt/issues/3560), [#3763](https://github.com/dbt-labs/dbt/issues/3763), [#3759](https://github.com/dbt-labs/dbt/pull/3759))
 
 Contributors:
-- [@sungchun12](https://github.com/sungchun12) ([#3759](https://github.com/dbt-labs/dbt/pull/3759))
 - [@xemuliam](https://github.com/xemuliam) ([#3606](https://github.com/dbt-labs/dbt/pull/3606))
+- [@sungchun12](https://github.com/sungchun12) ([#3759](https://github.com/dbt-labs/dbt/pull/3759))
+- [@dbrtly](https://github.com/dbrtly) ([#3834](https://github.com/dbt-labs/dbt/pull/3834))
 
 ## dbt 0.21.0b2 (August 19, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Fixes
 
-- Fix bigquery-specific synonyms for database and schema (project and dataset) for snapshots. ([#3694](https://github.com/dbt-labs/dbt/issues/3694), [#xxxx](https://github.com/dbt-labs/dbt/pull/xxxx tba))
+- Fix bigquery-specific synonym for schema (dataset) for snapshots. ([#3694](https://github.com/dbt-labs/dbt/issues/3694), [#xxxx](https://github.com/dbt-labs/dbt/pull/xxxx tba))
 
 ### Under the hood
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## dbt 0.21.0 (Release TBD)
 
+### Fixes
+
+- Fix bigquery-specific synonyms for database and schema (project and dataset) for snapshots. ([#3694](https://github.com/dbt-labs/dbt/issues/3694), [#xxxx](https://github.com/dbt-labs/dbt/pull/xxxx tba))
+
 ### Under the hood
 
 - Use GitHub Actions for CI ([#3688](https://github.com/dbt-labs/dbt/issues/3688), [#3669](https://github.com/dbt-labs/dbt/pull/3669))

--- a/plugins/bigquery/dbt/adapters/bigquery/connections.py
+++ b/plugins/bigquery/dbt/adapters/bigquery/connections.py
@@ -104,6 +104,8 @@ class BigQueryCredentials(Credentials):
     _ALIASES = {
         'project': 'database',
         'dataset': 'schema',
+        'target_project': 'target_database',
+        'target_dataset': 'target_schema',
     }
 
     @property

--- a/test/integration/004_simple_snapshot_test/test-check-col-snapshots-bq/snapshot.sql
+++ b/test/integration/004_simple_snapshot_test/test-check-col-snapshots-bq/snapshot.sql
@@ -1,10 +1,10 @@
 {% snapshot snapshot_actual %}
     {# this used to be check_cols=('email',), which ought to be totally valid,
-    but isn't because type systems are hard. #}
+    but is not because type systems are hard. #}
     {{
         config(
             target_database=var('target_database', database),
-            target_schema=schema,
+            target_schema=var('target_schema', schema),
             unique_key='concat(cast(id as string) , "-", first_name)',
             strategy='check',
             check_cols=['email'],
@@ -19,7 +19,7 @@
     {{
         config(
             target_database=var('target_database', database),
-            target_schema=schema,
+            target_schema=var('target_schema', schema),
             unique_key='concat(cast(id as string) , "-", first_name)',
             strategy='check',
             check_cols='all',

--- a/test/integration/004_simple_snapshot_test/test-check-col-snapshots-bq/snapshot.sql
+++ b/test/integration/004_simple_snapshot_test/test-check-col-snapshots-bq/snapshot.sql
@@ -3,8 +3,8 @@
     but is not because type systems are hard. #}
     {{
         config(
-            target_database=var('target_database', database),
-            target_schema=var('target_schema', schema),
+            target_project=var('target_database', database),
+            target_dataset=var('target_schema', schema),
             unique_key='concat(cast(id as string) , "-", first_name)',
             strategy='check',
             check_cols=['email'],
@@ -18,8 +18,8 @@
 {% snapshot snapshot_checkall %}
     {{
         config(
-            target_database=var('target_database', database),
-            target_schema=var('target_schema', schema),
+            target_project=var('target_database', database),
+            target_dataset=var('target_schema', schema),
             unique_key='concat(cast(id as string) , "-", first_name)',
             strategy='check',
             check_cols='all',

--- a/test/integration/004_simple_snapshot_test/test-snapshots-bq/snapshot.sql
+++ b/test/integration/004_simple_snapshot_test/test-snapshots-bq/snapshot.sql
@@ -3,7 +3,7 @@
     {{
         config(
             target_database=var('target_database', database),
-            target_schema=schema,
+            target_schema=var('target_schema', schema),
             unique_key='concat(cast(id as string) , "-", first_name)',
             strategy='timestamp',
             updated_at='updated_at',

--- a/test/integration/004_simple_snapshot_test/test-snapshots-bq/snapshot.sql
+++ b/test/integration/004_simple_snapshot_test/test-snapshots-bq/snapshot.sql
@@ -2,8 +2,8 @@
 
     {{
         config(
-            target_database=var('target_database', database),
-            target_schema=var('target_schema', schema),
+            target_project=var('target_database', database),
+            target_dataset=var('target_schema', schema),
             unique_key='concat(cast(id as string) , "-", first_name)',
             strategy='timestamp',
             updated_at='updated_at',

--- a/test/integration/004_simple_snapshot_test/test-snapshots-pg-custom-invalid/snapshot.sql
+++ b/test/integration/004_simple_snapshot_test/test-snapshots-pg-custom-invalid/snapshot.sql
@@ -1,5 +1,5 @@
 {% snapshot snapshot_actual %}
-    {# this custom strategy doesn't exist  in the 'dbt' package #}
+    {# this custom strategy does not exist  in the 'dbt' package #}
     {{
         config(
             target_database=var('target_database', database),


### PR DESCRIPTION
resolves #3694 

### Description

Normally for BigQuery connection profiles, dataset is a synonym for schema to reflect the BigQuery jargon but there was a bug for snapshots with this synonym.

Comments with conjunctions (eg. isn't, wasn't, aren't) do not play nicely with linting in vscode and were hard to read to used the slightly more verbose expressions for clearer syntax highlighting where I noticed it but avoided hunting for it across the entire repo.

### Checklist

- [X ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [X ] This PR includes tests, or tests are not required/relevant for this PR
- [X ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.

NB: 
As discussed I could not get the integration tests to run locally
I may have edited the change log incorrectly.