### PR TITLE
Excluding Python 3.9.7 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ Contributors:
 
 - Better error handling for BigQuery job labels that are too long. ([#3612](https://github.com/dbt-labs/dbt/pull/3612), [#3703](https://github.com/dbt-labs/dbt/pull/3703))
 - Get more information on partial parsing version mismatches ([#3757](https://github.com/dbt-labs/dbt/issues/3757), [#3758](https://github.com/dbt-labs/dbt/pull/3758))
+- Removing Python 3.9.7 as supported by dbt ([#3853](https://github.com/dbt-labs/dbt/pull/3853))
 
 ### Fixes
 

--- a/core/setup.py
+++ b/core/setup.py
@@ -7,11 +7,6 @@ if sys.version_info < (3, 6):
     print('Please upgrade to Python 3.6 or higher.')
     sys.exit(1)
 
-if sys.version_info == (3, 9, 7):
-    print('Error: dbt does not support version 3.9.7 of Python.')
-    print('Please downgrade to Python 3.9.6.')
-    sys.exit(1)
-
 
 from setuptools import setup
 try:

--- a/core/setup.py
+++ b/core/setup.py
@@ -7,6 +7,11 @@ if sys.version_info < (3, 6):
     print('Please upgrade to Python 3.6 or higher.')
     sys.exit(1)
 
+if sys.version_info == (3, 9, 7):
+    print('Error: dbt does not support version 3.9.7 of Python.')
+    print('Please downgrade to Python 3.9.6.')
+    sys.exit(1)
+
 
 from setuptools import setup
 try:
@@ -86,5 +91,5 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
     ],
-    python_requires=">=3.6.3",
+    python_requires=">=3.6.3,!=3.9.7",
 )

--- a/plugins/bigquery/setup.py
+++ b/plugins/bigquery/setup.py
@@ -69,5 +69,5 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
     ],
-    python_requires=">=3.6.2",
+    python_requires=">=3.6.2,!=3.9.7",
 )

--- a/plugins/postgres/setup.py
+++ b/plugins/postgres/setup.py
@@ -87,5 +87,5 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
     ],
-    python_requires=">=3.6.2",
+    python_requires=">=3.6.2,!=3.9.7",
 )

--- a/plugins/redshift/setup.py
+++ b/plugins/redshift/setup.py
@@ -66,5 +66,5 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
     ],
-    python_requires=">=3.6.2",
+    python_requires=">=3.6.2,!=3.9.7",
 )

--- a/plugins/snowflake/setup.py
+++ b/plugins/snowflake/setup.py
@@ -66,5 +66,5 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
     ],
-    python_requires=">=3.6.2",
+    python_requires=">=3.6.2,!=3.9.7",
 )

--- a/setup.py
+++ b/setup.py
@@ -63,5 +63,5 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
     ],
-    python_requires=">=3.6.2",
+    python_requires=">=3.6.3,!=3.9.7",
 )

--- a/setup.py
+++ b/setup.py
@@ -63,5 +63,5 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
     ],
-    python_requires=">=3.6.3,!=3.9.7",
+    python_requires=">=3.6.2,!=3.9.7",
 )


### PR DESCRIPTION
resolves #3843 

### Description

Python 3.9.7 introduced a bug that breaks `dbt` so removing it from our list of supported Python versions. 
Pythons PR for the fix is here: https://github.com/python/cpython/pull/28121

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
