### PR TITLE
explicitly define __init__ for Profile class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Support BigQuery-specific aliases `target_dataset` and `target_project` in snapshot configs ([#3694](https://github.com/dbt-labs/dbt/issues/3694), [#3834](https://github.com/dbt-labs/dbt/pull/3834))
 - `dbt debug` shows a summary of whether all checks passed or not ([#3831](https://github.com/dbt-labs/dbt/issues/3831), [#3832](https://github.com/dbt-labs/dbt/issues/3831))
 - Fix issue when running the `deps` task after the `list` task in the RPC server ([#3846](https://github.com/dbt-labs/dbt/issues/3846), [#3848](https://github.com/dbt-labs/dbt/pull/3848))
+- Fix bug with initializing a dataclass that inherits from `typing.Protocol`, specifically for `dbt.config.profile.Profile` ([#3843](https://github.com/dbt-labs/dbt/issues/3843), [#3855](https://github.com/dbt-labs/dbt/pull/3855))
 
 ### Under the hood
 

--- a/core/dbt/config/profile.py
+++ b/core/dbt/config/profile.py
@@ -84,13 +84,31 @@ def read_user_config(directory: str) -> UserConfig:
 
 # The Profile class is included in RuntimeConfig, so any attribute
 # additions must also be set where the RuntimeConfig class is created
-@dataclass
+# `init=False` is a workaround for https://bugs.python.org/issue45081
+@dataclass(init=False)
 class Profile(HasCredentials):
     profile_name: str
     target_name: str
     config: UserConfig
     threads: int
     credentials: Credentials
+
+    def __init__(
+        self,
+        profile_name: str,
+        target_name: str,
+        config: UserConfig,
+        threads: int,
+        credentials: Credentials
+    ):
+        """Explicitly defining `__init__` to work around bug in Python 3.9.7
+        https://bugs.python.org/issue45081
+        """
+        self.profile_name = profile_name
+        self.target_name = target_name
+        self.config = config
+        self.threads = threads
+        self.credentials = credentials
 
     def to_profile_info(
         self, serialize_credentials: bool = False


### PR DESCRIPTION
resolves #3843 

### Description

This is a workaround for the bug described in https://bugs.python.org/issue45081. This workaround is the equivalent as below. It explicitly defines `__init__` on the dataclass to avoid issue when inheriting from `Protocol`

```python
from dataclasses import dataclass
from typing import Protocol

class P(Protocol):
    pass

@dataclass(init=False)
class B(P):
    value: str

    def __init__(self, value: str):
        self.value = value

print(B("test"))
```

Tested locally with
```console
$ python -VV
Python 3.9.7 (default, Sep  2 2021, 13:06:48) 
[Clang 12.0.5 (clang-1205.0.22.11)]
```

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
