### PR TITLE
Fix dbt deps sorting behavior for non-standard version semantics

### DIFF
--- a/core/dbt/semver.py
+++ b/core/dbt/semver.py
@@ -3,7 +3,6 @@ import re
 from typing import List
 
 from packaging import version as packaging_version
-from distutils.version import LooseVersion
 
 from dbt.exceptions import VersionsNotCompatibleException
 import dbt.utils
@@ -439,9 +438,14 @@ def filter_installable(
         install_prerelease: bool
 ) -> List[str]:
     installable = []
+    installable_dict = {}
     for version_string in versions:
         version = VersionSpecifier.from_version_string(version_string)
         if install_prerelease or not version.prerelease:
-            installable.append(version_string)
-    installable.sort(key=LooseVersion)
-    return installable
+            installable.append(version)
+            installable_dict[str(version)] = version_string
+    sorted_installable = sorted(installable)
+    sorted_installable_original_version_string = [
+        installable_dict.get(str(version)) for version in sorted_installable
+    ]
+    return sorted_installable_original_version_string

--- a/core/dbt/semver.py
+++ b/core/dbt/semver.py
@@ -445,7 +445,7 @@ def filter_installable(
             installable.append(version)
             installable_dict[str(version)] = version_string
     sorted_installable = sorted(installable)
-    sorted_installable_original_version_string = [
-        installable_dict.get(str(version)) for version in sorted_installable
+    sorted_installable_original_versions = [
+        str(installable_dict.get(str(version))) for version in sorted_installable
     ]
-    return sorted_installable_original_version_string
+    return sorted_installable_original_versions

--- a/test/unit/test_semver.py
+++ b/test/unit/test_semver.py
@@ -175,9 +175,9 @@ class TestSemver(unittest.TestCase):
 
     def test__filter_installable(self):
         assert filter_installable(
-            ['1.1.0',  '1.2.0a1', '1.0.0','2.1.0-alpha','2.2.0asdf','2.1.0','2.2.0','2.2.0-fishtown-beta'],
+            ['1.1.0',  '1.2.0a1', '1.0.0','2.1.0-alpha','2.2.0asdf','2.1.0','2.2.0','2.2.0-fishtown-beta','2.2.0-2'],
             install_prerelease=True
-        ) == ['1.0.0', '1.1.0', '1.2.0a1','2.1.0-alpha','2.1.0','2.2.0asdf','2.2.0-fishtown-beta','2.2.0']
+        ) == ['1.0.0', '1.1.0', '1.2.0a1','2.1.0-alpha','2.1.0','2.2.0asdf','2.2.0-fishtown-beta','2.2.0-2','2.2.0']
 
         assert filter_installable(
             ['1.1.0',  '1.2.0a1', '1.0.0','2.1.0-alpha','2.2.0asdf','2.1.0','2.2.0','2.2.0-fishtown-beta'],

--- a/test/unit/test_semver.py
+++ b/test/unit/test_semver.py
@@ -175,11 +175,11 @@ class TestSemver(unittest.TestCase):
 
     def test__filter_installable(self):
         assert filter_installable(
-            ['1.1.0',  '1.2.0a1', '1.0.0','2.1.0-alpha','2.2.0asdf'],
+            ['1.1.0',  '1.2.0a1', '1.0.0','2.1.0-alpha','2.2.0asdf','2.1.0','2.2.0','2.2.0-fishtown-beta'],
             install_prerelease=True
-        ) == ['1.0.0', '1.1.0', '1.2.0a1','2.1.0-alpha','2.2.0asdf']
+        ) == ['1.0.0', '1.1.0', '1.2.0a1','2.1.0-alpha','2.1.0','2.2.0asdf','2.2.0-fishtown-beta','2.2.0']
 
         assert filter_installable(
-            ['1.1.0',  '1.2.0a1', '1.0.0','2.1.0-alpha','2.2.0asdf'],
+            ['1.1.0',  '1.2.0a1', '1.0.0','2.1.0-alpha','2.2.0asdf','2.1.0','2.2.0','2.2.0-fishtown-beta'],
             install_prerelease=False
-        ) == ['1.0.0', '1.1.0']
+        ) == ['1.0.0', '1.1.0','2.1.0','2.2.0']


### PR DESCRIPTION
resolves bugs from #3852 #3759 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

### Description
When prereleases are included in the package versions list, it doesn't sort properly. The merged pull requests above had an issue with either being too strict or too loose when sorting version lists. It’s difficult to ensure this can capture all the unique ways people version their packages. [`StrictVersion`](https://www.python.org/dev/peps/pep-0386/#distutils) is too strict for packages and does not tolerate any deviation from the standard(think: `-` in the prerelease tag). [`LooseVersion`](https://www.python.org/dev/peps/pep-0386/#distutils)is too loose and not properly sorting prerelease versions BEFORE the latest stable version. 

This can apply to examples like this that exist in the [wild](https://hub.getdbt.com/mjirv/dbt_datamocktool/0.1.1-beta-fishtown/): `1.0.4-pre, 1.0.4-beta-fishtown`

This does NOT effect packages that aren't utilizing prereleases. 

With this solution, it iterates on the original `filter_installable` approach: https://github.com/dbt-labs/dbt/pull/3759#discussion_r697274347

However, this leverages a dictionary that sorts the formatted version strings first and then brings in the ORIGINAL version strings. If the ORIGINAL version string is not used, it can not properly download the package. Example: `0.5.0a1` will be interpreted as `0.5.0-a1` from dbt Hub and it will fail. (edit: example references how transforming a version number with [`from_version_string`](https://github.com/dbt-labs/dbt/blob/develop/core/dbt/semver.py#L94) using [`to_version_string`](https://github.com/dbt-labs/dbt/blob/develop/core/dbt/semver.py#L72) formats the version string in a way that isn't 1:1 with what exists in dbt Hub)
![image](https://user-images.githubusercontent.com/19176976/131927098-78b61f24-5748-4f5a-80fd-ad3dac59a2f6.png)

This solution also interprets the version number tag as a PRERELEASE and is lesser than a stable version.

Packages with known issues exemplifying current prerelease sorting behavior below. You'll notice the majority of these issues are with 3rd party packages. 
- [re-data/re_data](https://hub.getdbt.com/re-data/re_data/0.1.1-alpha/)
- [tailsdotcom/dbt_artifacts](https://hub.getdbt.com/tailsdotcom/dbt_artifacts/0.4.5a2/)
- [mjirv/dbt_datamocktool](https://hub.getdbt.com/mjirv/dbt_datamocktool/0.1.1-beta-fishtown/)
- [dbt-labs/adwords](https://hub.getdbt.com/dbt-labs/adwords/0.2.2a/)
- [Datavault-UK/dbtvault](https://hub.getdbt.com/datavault-uk/dbtvault/0.7.6-b1/)

**Example packages config**
![image](https://user-images.githubusercontent.com/19176976/131926810-1fbd81a6-420f-4f46-9f52-e8f87018712f.png)
**Current Behavior**
![image](https://user-images.githubusercontent.com/19176976/131927150-6de8df7e-3438-488f-8e96-b361908cf581.png)


**Expected Behavior**

![image](https://user-images.githubusercontent.com/19176976/131926824-ad5918df-881a-4761-b10c-5d04e7393d6c.png)


### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
