### PR TITLE
Collab PR for macro detection integration tests

### DIFF
--- a/core/dbt/parser/models.py
+++ b/core/dbt/parser/models.py
@@ -1,7 +1,7 @@
 from dbt.context.context_config import ContextConfig
 from dbt.contracts.graph.parsed import ParsedModelNode
 import dbt.flags as flags
-import dbt.tracking
+from dbt.logger import GLOBAL_LOGGER as logger
 from dbt.node_types import NodeType
 from dbt.parser.base import SimpleSQLParser
 from dbt.parser.search import FileBlock
@@ -11,7 +11,7 @@ from dbt_extractor import ExtractionError, py_extract_from_source  # type: ignor
 from functools import reduce
 from itertools import chain
 import random
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, Iterator, List, Optional, Union
 
 
 class ModelParser(SimpleSQLParser[ParsedModelNode]):
@@ -28,6 +28,7 @@ class ModelParser(SimpleSQLParser[ParsedModelNode]):
     def get_compiled_path(cls, block: FileBlock):
         return block.path.relative_path
 
+    # TODO when this is turned on by default, simplify the nasty if/else tree inside this method.
     def render_update(
         self, node: ParsedModelNode, config: ContextConfig
     ) -> None:
@@ -35,13 +36,19 @@ class ModelParser(SimpleSQLParser[ParsedModelNode]):
         sample: bool = random.randint(1, 101) == 100
 
         # top-level declaration of variables
-        experimentally_parsed: Union[str, Dict[str, List[Any]]] = ""
+        experimentally_parsed: Optional[Union[str, Dict[str, List[Any]]]] = None
         config_call_dict: Dict[str, Any] = {}
         source_calls: List[List[str]] = []
 
         # run the experimental parser if the flag is on or if we're sampling
         if flags.USE_EXPERIMENTAL_PARSER or sample:
             if self._has_banned_macro(node):
+                # this log line is used for integration testing. If you change
+                # the code at the beginning of the line change the tests in
+                # test/integration/072_experimental_parser_tests/test_all_experimental_parser.py
+                logger.debug(
+                    f"1601: parser fallback to jinja because of macro override for {node.path}"
+                )
                 experimentally_parsed = "has_banned_macro"
             else:
                 # run the experimental parser and return the results
@@ -49,6 +56,7 @@ class ModelParser(SimpleSQLParser[ParsedModelNode]):
                     experimentally_parsed = py_extract_from_source(
                         node.raw_sql
                     )
+                    logger.debug(f"1699: statically parsed {node.path}")
                 # if we want information on what features are barring the experimental
                 # parser from reading model files, this is where we would add that
                 # since that information is stored in the `ExtractionError`.
@@ -84,7 +92,7 @@ class ModelParser(SimpleSQLParser[ParsedModelNode]):
                 # no false positives or misses, we can expect the number model
                 # files parseable by the experimental parser to match our internal
                 # testing.
-                if dbt.tracking.active_user is not None:  # None in some tests
+                if tracking.active_user is not None:  # None in some tests
                     tracking.track_experimental_parser_sample({
                         "project_id": self.root_project.hashed_name(),
                         "file_id": utils.get_hash(node),
@@ -116,11 +124,20 @@ class ModelParser(SimpleSQLParser[ParsedModelNode]):
 
             self.manifest._parsing_info.static_analysis_parsed_path_count += 1
 
-        # the experimental parser tried and failed on this model.
+        # the experimental parser didn't run on this model.
+        # fall back to python jinja rendering.
+        elif experimentally_parsed is None:
+            # not logging here since the reason should have been logged above
+            super().render_update(node, config)
+        # the experimental parser ran on this model and failed.
         # fall back to python jinja rendering.
         else:
+            logger.debug(
+                f"1602: parser fallback to jinja because of extractor failure for {node.path}"
+            )
             super().render_update(node, config)
 
+    # checks for banned macros
     def _has_banned_macro(
         self, node: ParsedModelNode
     ) -> bool:
@@ -129,7 +146,7 @@ class ModelParser(SimpleSQLParser[ParsedModelNode]):
         project_name = node.package_name
         banned_macros = ['ref', 'source', 'config']
 
-        all_banned_macro_keys = chain.from_iterable(
+        all_banned_macro_keys: Iterator[str] = chain.from_iterable(
             map(
                 lambda name: [
                     f"macro.{project_name}.{name}",
@@ -146,16 +163,20 @@ class ModelParser(SimpleSQLParser[ParsedModelNode]):
         )
 
 
+# returns a list of string codes to be sent as a tracking event
 def _get_sample_result(
-    sample_output: Union[str, Dict[str, Any]],
+    sample_output: Optional[Union[str, Dict[str, Any]]],
     config_call_dict: Dict[str, Any],
     source_calls: List[List[str]],
     node: ParsedModelNode,
     config: ContextConfig
 ) -> List[str]:
     result: List[str] = []
+    # experimental parser didn't run
+    if sample_output is None:
+        result += ["09_experimental_parser_skipped"]
     # experimental parser couldn't parse
-    if (isinstance(sample_output, str)):
+    elif (isinstance(sample_output, str)):
         if sample_output == "cannot_parse":
             result += ["01_experimental_parser_cannot_parse"]
         elif sample_output == "has_banned_macro":

--- a/test/integration/072_experimental_parser_tests/config_macro/macros/config.sql
+++ b/test/integration/072_experimental_parser_tests/config_macro/macros/config.sql
@@ -1,0 +1,3 @@
+{% macro config() %}
+
+{% endmacro %}

--- a/test/integration/072_experimental_parser_tests/config_macro/models/model_a.sql
+++ b/test/integration/072_experimental_parser_tests/config_macro/models/model_a.sql
@@ -1,0 +1,1 @@
+select 1 as id

--- a/test/integration/072_experimental_parser_tests/config_macro/schema.yml
+++ b/test/integration/072_experimental_parser_tests/config_macro/schema.yml
@@ -1,0 +1,1 @@
+version: 2

--- a/test/integration/072_experimental_parser_tests/ref_macro/macros/ref.sql
+++ b/test/integration/072_experimental_parser_tests/ref_macro/macros/ref.sql
@@ -1,0 +1,3 @@
+{% macro ref(model_name) %}
+
+{% endmacro %}

--- a/test/integration/072_experimental_parser_tests/ref_macro/models/model_a.sql
+++ b/test/integration/072_experimental_parser_tests/ref_macro/models/model_a.sql
@@ -1,0 +1,1 @@
+select 1 as id

--- a/test/integration/072_experimental_parser_tests/ref_macro/schema.yml
+++ b/test/integration/072_experimental_parser_tests/ref_macro/schema.yml
@@ -1,0 +1,1 @@
+version: 2

--- a/test/integration/072_experimental_parser_tests/source_macro/macros/source.sql
+++ b/test/integration/072_experimental_parser_tests/source_macro/macros/source.sql
@@ -1,0 +1,3 @@
+{% macro source(source_name, table_name) %}
+
+{% endmacro %}

--- a/test/integration/072_experimental_parser_tests/source_macro/models/model_a.sql
+++ b/test/integration/072_experimental_parser_tests/source_macro/models/model_a.sql
@@ -1,0 +1,1 @@
+select 1 as id

--- a/test/integration/072_experimental_parser_tests/source_macro/schema.yml
+++ b/test/integration/072_experimental_parser_tests/source_macro/schema.yml
@@ -1,0 +1,1 @@
+version: 2

--- a/test/integration/072_experimental_parser_tests/test_all_experimental_parser.py
+++ b/test/integration/072_experimental_parser_tests/test_all_experimental_parser.py
@@ -23,6 +23,7 @@ class TestBasicExperimentalParser(DBTIntegrationTest):
     def models(self):
         return "basic"
 
+    # test that the experimental parser extracts some basic ref, source, and config calls.
     @use_profile('postgres')
     def test_postgres_experimental_parser_basic(self):
         results = self.run_dbt(['--use-experimental-parser', 'parse'])
@@ -32,3 +33,93 @@ class TestBasicExperimentalParser(DBTIntegrationTest):
         self.assertEqual(node.sources, [['my_src', 'my_tbl']])
         self.assertEqual(node.config._extra, {'x': True})
         self.assertEqual(node.config.tags, ['hello', 'world'])
+
+class TestRefOverrideExperimentalParser(DBTIntegrationTest):
+    @property
+    def schema(self):
+        return "072_ref_macro"
+
+    @property
+    def models(self):
+        return "ref_macro"
+
+    @property
+    def project_config(self):
+        return {
+            'config-version': 2,
+            'macro-paths': ['ref_macro'],
+        }
+
+    # test that the experimental parser doesn't run if the ref built-in is overriden with a macro
+    @use_profile('postgres')
+    def test_postgres_experimental_parser_ref_override(self):
+        _, log_output = self.run_dbt_and_capture(['--debug', '--use-experimental-parser', 'parse'])
+        
+        print(log_output)
+
+        # successful static parsing
+        self.assertFalse("1699: " in log_output)
+        # ran static parser but failed
+        self.assertFalse("1602: " in log_output)
+        # didn't run static parser because dbt detected a built-in macro override
+        self.assertTrue("1601: " in log_output)
+
+class TestSourceOverrideExperimentalParser(DBTIntegrationTest):
+    @property
+    def schema(self):
+        return "072_source_macro"
+
+    @property
+    def models(self):
+        return "source_macro"
+
+    @property
+    def project_config(self):
+        return {
+            'config-version': 2,
+            'macro-paths': ['source_macro'],
+        }
+
+    # test that the experimental parser doesn't run if the source built-in is overriden with a macro
+    @use_profile('postgres')
+    def test_postgres_experimental_parser_source_override(self):
+        _, log_output = self.run_dbt_and_capture(['--debug', '--use-experimental-parser', 'parse'])
+        
+        print(log_output)
+
+        # successful static parsing
+        self.assertFalse("1699: " in log_output)
+        # ran static parser but failed
+        self.assertFalse("1602: " in log_output)
+        # didn't run static parser because dbt detected a built-in macro override
+        self.assertTrue("1601: " in log_output)
+
+class TestConfigOverrideExperimentalParser(DBTIntegrationTest):
+    @property
+    def schema(self):
+        return "072_config_macro"
+
+    @property
+    def models(self):
+        return "config_macro"
+
+    @property
+    def project_config(self):
+        return {
+            'config-version': 2,
+            'macro-paths': ['config_macro'],
+        }
+
+    # test that the experimental parser doesn't run if the config built-in is overriden with a macro
+    @use_profile('postgres')
+    def test_postgres_experimental_parser_config_override(self):
+        _, log_output = self.run_dbt_and_capture(['--debug', '--use-experimental-parser', 'parse'])
+        
+        print(log_output)
+
+        # successful static parsing
+        self.assertFalse("1699: " in log_output)
+        # ran static parser but failed
+        self.assertFalse("1602: " in log_output)
+        # didn't run static parser because dbt detected a built-in macro override
+        self.assertTrue("1601: " in log_output)

--- a/test/unit/test_parser.py
+++ b/test/unit/test_parser.py
@@ -521,7 +521,7 @@ class ModelParserTest(BaseParserTest):
             self.parser.parse_file(block)
 
 
-class ExperimentalModelParserTest(BaseParserTest):
+class StaticModelParserTest(BaseParserTest):
     def setUp(self):
         super().setUp()
         self.parser = ModelParser(
@@ -533,6 +533,9 @@ class ExperimentalModelParserTest(BaseParserTest):
     def file_block_for(self, data, filename):
         return super().file_block_for(data, filename, 'models')
 
+    # tests that when the ref built-in is overriden with a macro definition
+    # that the ModelParser can detect it. This does not test that the static
+    # parser does not run in this case. That test is in integration test suite 072
     def test_built_in_macro_override_detection(self):
         macro_unique_id = 'macro.root.ref'
         self.parser.manifest.macros[macro_unique_id] = ParsedMacro(


### PR DESCRIPTION
Run this test with the following command:
```
python3 -m pytest -m profile_postgres test/integration/072_experimental_parser_tests/test_all_experimental_parser.py::TestRefOverrideExperimentalParser
```

This is the print debug lines I see:
```
RENDER_UPDATE CALLED
FLAG ON
macros with ref in name:
['macro.dbt.should_full_refresh']
```

I expect to see `macro.test.ref` in the list of macros with ref in the name since it's defined in `macros/ref.sql` but I don't see it.

I verified that the macro detection does indeed work by making a dummy project locally and just running `dbt parse` on it, so I'm not sure why it's not working in this integration test setting.

I attempted to specify the macro path in the project config since that didn't seem to be set by default, but that didn't work either.

Let me know if you have any thoughts as to why this isn't detecting the macro!