### PR TITLE
Build task arg parity

### DIFF
--- a/core/dbt/contracts/rpc.py
+++ b/core/dbt/contracts/rpc.py
@@ -121,6 +121,7 @@ class RPCDocsGenerateParameters(RPCParameters):
 
 @dataclass
 class RPCBuildParameters(RPCParameters):
+    resource_types: Optional[List[str]] = None
     threads: Optional[int] = None
     models: Union[None, str, List[str]] = None
     select: Union[None, str, List[str]] = None

--- a/core/dbt/main.py
+++ b/core/dbt/main.py
@@ -399,6 +399,13 @@ def _build_build_subparser(subparsers, base_subparser):
         Stop execution upon a first failure.
         '''
     )
+    sub.add_argument(
+        '--store-failures',
+        action='store_true',
+        help='''
+        Store test results (failing rows) in the database
+        '''
+    )
     resource_values: List[str] = [
         str(s) for s in build_task.BuildTask.ALL_RESOURCE_VALUES
     ] + ['all']

--- a/core/dbt/main.py
+++ b/core/dbt/main.py
@@ -414,18 +414,7 @@ def _build_build_subparser(subparsers, base_subparser):
                      action='append',
                      default=[],
                      dest='resource_types')
-    sub.add_argument(
-        '-m',
-        '--models',
-        dest='models',
-        nargs='+',
-        help='''
-        Specify the models to select and set the resource-type to 'model'.
-        Mutually exclusive with '--select' (or '-s') and '--resource-type'
-        ''',
-        metavar='SELECTOR',
-        required=False,
-    )
+    # explicity don't support --models
     sub.add_argument(
         '-s',
         '--select',
@@ -434,8 +423,6 @@ def _build_build_subparser(subparsers, base_subparser):
         help='''
             Specify the nodes to include.
         ''',
-        metavar='SELECTOR',
-        required=False,
     )
     _add_common_selector_arguments(sub)
     return sub

--- a/core/dbt/main.py
+++ b/core/dbt/main.py
@@ -10,23 +10,23 @@ from pathlib import Path
 
 import dbt.version
 import dbt.flags as flags
-import dbt.task.run as run_task
 import dbt.task.build as build_task
+import dbt.task.clean as clean_task
 import dbt.task.compile as compile_task
 import dbt.task.debug as debug_task
-import dbt.task.clean as clean_task
 import dbt.task.deps as deps_task
-import dbt.task.init as init_task
-import dbt.task.seed as seed_task
-import dbt.task.test as test_task
-import dbt.task.snapshot as snapshot_task
-import dbt.task.generate as generate_task
-import dbt.task.serve as serve_task
 import dbt.task.freshness as freshness_task
-import dbt.task.run_operation as run_operation_task
+import dbt.task.generate as generate_task
+import dbt.task.init as init_task
+import dbt.task.list as list_task
 import dbt.task.parse as parse_task
+import dbt.task.run as run_task
+import dbt.task.run_operation as run_operation_task
+import dbt.task.seed as seed_task
+import dbt.task.serve as serve_task
+import dbt.task.snapshot as snapshot_task
+import dbt.task.test as test_task
 from dbt.profiler import profiler
-from dbt.task.list import ListTask
 from dbt.task.rpc.server import RPCServerTask
 from dbt.adapters.factory import reset_adapters, cleanup_connections
 
@@ -400,8 +400,8 @@ def _build_build_subparser(subparsers, base_subparser):
         '''
     )
     resource_values: List[str] = [
-        str(s) for s in ListTask.ALL_RESOURCE_VALUES
-    ] + ['default', 'all']
+        str(s) for s in build_task.BuildTask.ALL_RESOURCE_VALUES
+    ] + ['all']
     sub.add_argument('--resource-type',
                      choices=resource_values,
                      action='append',
@@ -823,9 +823,9 @@ def _build_list_subparser(subparsers, base_subparser):
         ''',
         aliases=['ls'],
     )
-    sub.set_defaults(cls=ListTask, which='list', rpc_method=None)
+    sub.set_defaults(cls=list_task.ListTask, which='list', rpc_method=None)
     resource_values: List[str] = [
-        str(s) for s in ListTask.ALL_RESOURCE_VALUES
+        str(s) for s in list_task.ListTask.ALL_RESOURCE_VALUES
     ] + ['default', 'all']
     sub.add_argument('--resource-type',
                      choices=resource_values,
@@ -1070,7 +1070,8 @@ def parse_args(args, cls=DBTArgumentParser):
     # --select, --exclude
     # list_sub sets up its own arguments.
     _add_selection_arguments(
-        build_sub, run_sub, compile_sub, generate_sub, test_sub, snapshot_sub, seed_sub)
+        build_sub, run_sub, compile_sub, generate_sub,
+        test_sub, snapshot_sub, seed_sub)
     # --defer
     _add_defer_argument(run_sub, test_sub, build_sub)
     # --full-refresh

--- a/core/dbt/main.py
+++ b/core/dbt/main.py
@@ -407,6 +407,30 @@ def _build_build_subparser(subparsers, base_subparser):
                      action='append',
                      default=[],
                      dest='resource_types')
+    sub.add_argument(
+        '-m',
+        '--models',
+        dest='models',
+        nargs='+',
+        help='''
+        Specify the models to select and set the resource-type to 'model'.
+        Mutually exclusive with '--select' (or '-s') and '--resource-type'
+        ''',
+        metavar='SELECTOR',
+        required=False,
+    )
+    sub.add_argument(
+        '-s',
+        '--select',
+        dest='select',
+        nargs='+',
+        help='''
+            Specify the nodes to include.
+        ''',
+        metavar='SELECTOR',
+        required=False,
+    )
+    _add_common_selector_arguments(sub)
     return sub
 
 
@@ -1070,8 +1094,7 @@ def parse_args(args, cls=DBTArgumentParser):
     # --select, --exclude
     # list_sub sets up its own arguments.
     _add_selection_arguments(
-        build_sub, run_sub, compile_sub, generate_sub,
-        test_sub, snapshot_sub, seed_sub)
+        run_sub, compile_sub, generate_sub, test_sub, snapshot_sub, seed_sub)
     # --defer
     _add_defer_argument(run_sub, test_sub, build_sub)
     # --full-refresh

--- a/core/dbt/main.py
+++ b/core/dbt/main.py
@@ -399,6 +399,14 @@ def _build_build_subparser(subparsers, base_subparser):
         Stop execution upon a first failure.
         '''
     )
+    resource_values: List[str] = [
+        str(s) for s in ListTask.ALL_RESOURCE_VALUES
+    ] + ['default', 'all']
+    sub.add_argument('--resource-type',
+                     choices=resource_values,
+                     action='append',
+                     default=[],
+                     dest='resource_types')
     return sub
 
 

--- a/core/dbt/task/build.py
+++ b/core/dbt/task/build.py
@@ -5,18 +5,18 @@ from .test import TestRunner as test_runner
 
 from dbt.contracts.results import NodeStatus
 from dbt.graph import ResourceTypeSelector
-from dbt.exceptions import InternalException
+from dbt.exceptions import RuntimeException, InternalException
 from dbt.node_types import NodeType
+from dbt.task.test import TestSelector
 
 
 class BuildTask(RunTask):
-    """The Build task processes all assets of a given process and
-    attempts to 'build' them in an opinionated fashion. Every resource
-    type outlined in RUNNER_MAP will be processed by the mapped runner class.
+    """The Build task processes all assets of a given process and attempts to
+    'build' them in an opinionated fashion.  Every resource type outlined in
+    RUNNER_MAP will be processed by the mapped runner class.
 
     I.E. a resource of type Model is handled by the ModelRunner which is
-    imported as run_model_runner.
-    """
+    imported as run_model_runner. """
 
     RUNNER_MAP = {
         NodeType.Model: run_model_runner,
@@ -24,6 +24,15 @@ class BuildTask(RunTask):
         NodeType.Seed: seed_runner,
         NodeType.Test: test_runner,
     }
+    ALL_RESOURCE_VALUES = frozenset({x for x in RUNNER_MAP.keys()})
+
+    @property
+    def resource_types(self):
+        if not self.args.resource_types:
+            return list(self.ALL_RESOURCE_VALUES)
+
+        values = set(self.args.resource_types)
+        return list(values)
 
     MARK_DEPENDENT_ERRORS_STATUSES = [NodeStatus.Error, NodeStatus.Fail]
 
@@ -32,12 +41,19 @@ class BuildTask(RunTask):
             raise InternalException(
                 'manifest and graph must be set to get node selection'
             )
+        resource_types = self.resource_types
 
+        if resource_types == [NodeType.Test]:
+            return TestSelector(
+                graph=self.graph,
+                manifest=self.manifest,
+                previous_state=self.previous_state,
+            )
         return ResourceTypeSelector(
             graph=self.graph,
             manifest=self.manifest,
             previous_state=self.previous_state,
-            resource_types=[x for x in self.RUNNER_MAP.keys()],
+            resource_types=resource_types,
         )
 
     def get_runner_type(self, node):

--- a/core/dbt/task/build.py
+++ b/core/dbt/task/build.py
@@ -4,8 +4,12 @@ from .seed import SeedRunner as seed_runner
 from .test import TestRunner as test_runner
 
 from dbt.contracts.results import NodeStatus
-from dbt.exceptions import InternalException
-from dbt.graph import ResourceTypeSelector
+from dbt.exceptions import RuntimeException, InternalException
+from dbt.graph import (
+    parse_difference,
+    ResourceTypeSelector,
+    SelectionSpec,
+)
 from dbt.node_types import NodeType
 from dbt.task.test import TestSelector
 
@@ -28,8 +32,24 @@ class BuildTask(RunTask):
     }
     ALL_RESOURCE_VALUES = frozenset({x for x in RUNNER_MAP.keys()})
 
+    def __init__(self, args, config):
+        super().__init__(args, config)
+        if self.args.models:
+            if self.args.select:
+                raise RuntimeException(
+                    '"models" and "select" are mutually exclusive arguments'
+                )
+            if self.args.resource_types:
+                raise RuntimeException(
+                    '"models" and "resource_type" are mutually exclusive '
+                    'arguments'
+                )
+
     @property
     def resource_types(self):
+        if self.args.models:
+            return [NodeType.Model]
+
         if not self.args.resource_types:
             return list(self.ALL_RESOURCE_VALUES)
 
@@ -40,6 +60,20 @@ class BuildTask(RunTask):
             values.update(self.ALL_RESOURCE_VALUES)
 
         return list(values)
+
+    @property
+    def selector(self):
+        if self.args.models:
+            return self.args.models
+        else:
+            return self.args.select
+
+    def get_selection_spec(self) -> SelectionSpec:
+        if self.args.selector_name:
+            spec = self.config.get_selector(self.args.selector_name)
+        else:
+            spec = parse_difference(self.selector, self.args.exclude)
+        return spec
 
     def get_node_selector(self) -> ResourceTypeSelector:
         if self.manifest is None or self.graph is None:

--- a/core/dbt/task/list.py
+++ b/core/dbt/task/list.py
@@ -1,5 +1,4 @@
 import json
-from typing import Type
 
 from dbt.contracts.graph.parsed import (
     ParsedExposure,
@@ -186,7 +185,6 @@ class ListTask(GraphRunnableTask):
             raise InternalException(
                 'manifest and graph must be set to get perform node selection'
             )
-        cls: Type[ResourceTypeSelector]
         if self.resource_types == [NodeType.Test]:
             return TestSelector(
                 graph=self.graph,

--- a/core/dbt/task/rpc/project_commands.py
+++ b/core/dbt/task/rpc/project_commands.py
@@ -135,10 +135,7 @@ class RemoteTestProjectTask(RPCCommandTask[RPCTestParameters], TestTask):
     METHOD_NAME = 'test'
 
     def set_args(self, params: RPCTestParameters) -> None:
-        if params.models:
-            self.args.select = self._listify(params.models)
-        else:
-            self.args.select = self._listify(params.select)
+        self.args.select = self._listify(params.select)
         self.args.exclude = self._listify(params.exclude)
         self.args.selector_name = params.selector
         self.args.data = params.data
@@ -325,7 +322,6 @@ class RemoteBuildProjectTask(RPCCommandTask[RPCBuildParameters], BuildTask):
 
     def set_args(self, params: RPCBuildParameters) -> None:
         self.args.resource_types = self._listify(params.resource_types)
-        self.args.models = self._listify(params.models)
         self.args.select = self._listify(params.select)
         self.args.exclude = self._listify(params.exclude)
         self.args.selector_name = params.selector

--- a/core/dbt/task/rpc/project_commands.py
+++ b/core/dbt/task/rpc/project_commands.py
@@ -135,7 +135,10 @@ class RemoteTestProjectTask(RPCCommandTask[RPCTestParameters], TestTask):
     METHOD_NAME = 'test'
 
     def set_args(self, params: RPCTestParameters) -> None:
-        self.args.select = self._listify(params.select)
+        if params.models:
+            self.args.select = self._listify(params.models)
+        else:
+            self.args.select = self._listify(params.select)
         self.args.exclude = self._listify(params.exclude)
         self.args.selector_name = params.selector
         self.args.data = params.data

--- a/core/dbt/task/rpc/project_commands.py
+++ b/core/dbt/task/rpc/project_commands.py
@@ -325,10 +325,8 @@ class RemoteBuildProjectTask(RPCCommandTask[RPCBuildParameters], BuildTask):
 
     def set_args(self, params: RPCBuildParameters) -> None:
         self.args.resource_types = self._listify(params.resource_types)
-        if params.models:
-            self.args.select = self._listify(params.models)
-        else:
-            self.args.select = self._listify(params.select)
+        self.args.models = self._listify(params.models)
+        self.args.select = self._listify(params.select)
         self.args.exclude = self._listify(params.exclude)
         self.args.selector_name = params.selector
 

--- a/core/dbt/task/rpc/project_commands.py
+++ b/core/dbt/task/rpc/project_commands.py
@@ -320,9 +320,11 @@ class RemoteListTask(
 
 
 class RemoteBuildProjectTask(RPCCommandTask[RPCBuildParameters], BuildTask):
+
     METHOD_NAME = 'build'
 
     def set_args(self, params: RPCBuildParameters) -> None:
+        self.args.resource_types = self._listify(params.resource_types)
         if params.models:
             self.args.select = self._listify(params.models)
         else:

--- a/test/rpc/test_build.py
+++ b/test/rpc/test_build.py
@@ -120,14 +120,14 @@ def test_rpc_build_state(
         assert querier.wait_for_status('ready') is True
 
         results = querier.async_wait_for_result(
-            querier.build(state='./state', models=['state:modified'])
+            querier.build(state='./state', select=['state:modified'])
         )
         assert len(results['results']) == 3
 
         get_write_manifest(querier, os.path.join(state_dir, 'manifest.json'))
 
         results = querier.async_wait_for_result(
-            querier.build(state='./state', models=['state:modified']),
+            querier.build(state='./state', select=['state:modified']),
         )
         assert len(results['results']) == 0
 
@@ -135,7 +135,7 @@ def test_rpc_build_state(
         results = querier.async_wait_for_result(
             querier.build(
                 state='./state',
-                models=['state:modified'],
+                select=['state:modified'],
                 defer=True
             )
         )
@@ -185,20 +185,6 @@ def test_rpc_build_selectors(
         )
         assert len(results['results']) == 1
         assert results['results'][0]['node']['resource_type'] == 'seed'
-
-        # test simple models param
-        results = querier.async_wait_for_result(
-            querier.build(models=['my_model'])
-        )
-        assert len(results['results']) == 1
-        assert results['results'][0]['node']['resource_type'] == 'model'
-
-        # test simple models param
-        results = querier.async_wait_for_result(
-            querier.build(models=['my_model'])
-        )
-        assert len(results['results']) == 1
-        assert results['results'][0]['node']['resource_type'] == 'model'
 
         # test simple select param (should select tagged model and its tests)
         results = querier.async_wait_for_result(

--- a/test/rpc/test_build.py
+++ b/test/rpc/test_build.py
@@ -113,7 +113,8 @@ def test_rpc_build_state(
 
         get_write_manifest(querier, os.path.join(state_dir, 'manifest.json'))
 
-        project.models['my_model.sql'] = 'select * from {{ ref("data" )}} where id = 2'
+        project.models['my_model.sql'] =\
+            'select * from {{ ref("data" )}} where id = 2'
         project.write_models(project_root, remove=True)
         querier.sighup()
         assert querier.wait_for_status('ready') is True
@@ -129,9 +130,81 @@ def test_rpc_build_state(
             querier.build(state='./state', models=['state:modified']),
         )
         assert len(results['results']) == 0
-        
+
         # a better test of defer would require multiple targets
         results = querier.async_wait_for_result(
-            querier.build(state='./state', models=['state:modified'], defer=True)
+            querier.build(
+                state='./state',
+                models=['state:modified'],
+                defer=True
+            )
         )
         assert len(results['results']) == 0
+
+
+@pytest.mark.supported('postgres')
+def test_rpc_build_selectors(
+    project_root, profiles_root, dbt_profile, unique_schema
+):
+    schema_yaml = {
+        'version': 2,
+        'models': [{
+            'name': 'my_model',
+            'columns': [
+                {
+                    'name': 'id',
+                    'tests': ['not_null', 'unique'],
+                },
+            ],
+        }],
+    }
+    project = ProjectDefinition(
+        name='test',
+        project_data={
+            'seeds': {'+quote_columns': False},
+            'models': {'test': {'my_model': {'+tags': 'example_tag'}}}
+        },
+        models={
+            'my_model.sql': 'select * from {{ ref("data") }}',
+            'schema.yml': yaml.safe_dump(schema_yaml)
+        },
+        seeds={'data.csv': 'id,message\n1,hello\n2,goodbye'},
+        snapshots={'my_snapshots.sql': snapshot_data},
+    )
+    querier_ctx = get_querier(
+        project_def=project,
+        project_dir=project_root,
+        profiles_dir=profiles_root,
+        schema=unique_schema,
+        test_kwargs={},
+    )
+    with querier_ctx as querier:
+        # test simple resource_types param
+        results = querier.async_wait_for_result(
+            querier.build(resource_types=['seed'])
+        )
+        assert len(results['results']) == 1
+        assert results['results'][0]['node']['resource_type'] == 'seed'
+
+        # test simple models param
+        results = querier.async_wait_for_result(
+            querier.build(models=['my_model'])
+        )
+        assert len(results['results']) == 1
+        assert results['results'][0]['node']['resource_type'] == 'model'
+
+        # test simple models param
+        results = querier.async_wait_for_result(
+            querier.build(models=['my_model'])
+        )
+        assert len(results['results']) == 1
+        assert results['results'][0]['node']['resource_type'] == 'model'
+
+        # test simple select param (should select tagged model and its tests)
+        results = querier.async_wait_for_result(
+            querier.build(select=['tag:example_tag'])
+        )
+        assert len(results['results']) == 3
+        assert sorted(
+            [result['node']['resource_type'] for result in results['results']]
+        ) == ['model', 'test', 'test']

--- a/test/rpc/test_test.py
+++ b/test/rpc/test_test.py
@@ -105,7 +105,7 @@ def test_rpc_test_state(
             querier.test(state='./state', models=['state:modified']),
         )
         assert len(results['results']) == 0
-        
+
         # a better test of defer would require multiple targets
         results = querier.async_wait_for_result(
             querier.run(state='./state', models=['state:modified'], defer=True)

--- a/test/rpc/util.py
+++ b/test/rpc/util.py
@@ -384,7 +384,6 @@ class Querier:
 
     def build(
         self,
-        models: Optional[Union[str, List[str]]] = None,
         select: Optional[Union[str, List[str]]] = None,
         exclude: Optional[Union[str, List[str]]] = None,
         resource_types: Optional[Union[str, List[str]]] = None,
@@ -396,8 +395,6 @@ class Querier:
         params = {}
         if select is not None:
             params['select'] = select
-        if models is not None:
-            params['models'] = models
         if exclude is not None:
             params['exclude'] = exclude
         if resource_types is not None:

--- a/test/rpc/util.py
+++ b/test/rpc/util.py
@@ -260,10 +260,10 @@ class Querier:
     def run_operation(
         self,
         macro: str,
-        args: Optional[Dict[str, Any]],
+        args: Optional[Dict[str, Any]] = None,
         request_id: int = 1,
     ):
-        params = {'macro': macro}
+        params: Dict[str, Any] = {'macro': macro}
         if args is not None:
             params['args'] = args
         return self.request(
@@ -277,7 +277,7 @@ class Querier:
         show: bool = None,
         threads: Optional[int] = None,
         request_id: int = 1,
-        state: Optional[bool] = None,
+        state: Optional[str] = None,
     ):
         params = {}
         if select is not None:
@@ -300,7 +300,7 @@ class Querier:
         exclude: Optional[Union[str, List[str]]] = None,
         threads: Optional[int] = None,
         request_id: int = 1,
-        state: Optional[bool] = None,
+        state: Optional[str] = None,
     ):
         params = {}
         if select is not None:
@@ -337,7 +337,7 @@ class Querier:
         exclude: Optional[Union[str, List[str]]] = None,
         threads: Optional[int] = None,
         request_id: int = 1,
-        state: Optional[bool] = None,
+        state: Optional[str] = None,
     ):
         params = {}
         if select is not None:
@@ -361,7 +361,7 @@ class Querier:
         schema: bool = None,
         request_id: int = 1,
         defer: Optional[bool] = None,
-        state: Optional[bool] = None,
+        state: Optional[str] = None,
     ):
         params = {}
         if models is not None:
@@ -385,17 +385,23 @@ class Querier:
     def build(
         self,
         models: Optional[Union[str, List[str]]] = None,
+        select: Optional[Union[str, List[str]]] = None,
         exclude: Optional[Union[str, List[str]]] = None,
+        resource_types: Optional[Union[str, List[str]]] = None,
         threads: Optional[int] = None,
         request_id: int = 1,
         defer: Optional[bool] = None,
-        state: Optional[bool] = None,
+        state: Optional[str] = None,
     ):
         params = {}
+        if select is not None:
+            params['select'] = select
         if models is not None:
             params['models'] = models
         if exclude is not None:
             params['exclude'] = exclude
+        if resource_types is not None:
+            params['resource_types'] = resource_types
         if threads is not None:
             params['threads'] = threads
         if defer is not None:


### PR DESCRIPTION
resolves #3596 

### Description

Adds:
- `--resource-type` param to cli and rpc task
- ~ensures that `-models` and `--select` are mutually exclusive (aligns with `list` task behavior)~
	- ~additionally, `--models` will only select nodes of type `model` (again, to align with `list` task behavior)~
- adds `--store-failures` param to cli task

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
