### PR TITLE
[#3563] Don't reload and validate schema files if they haven't changed

### DIFF
--- a/core/dbt/clients/system.py
+++ b/core/dbt/clients/system.py
@@ -30,7 +30,7 @@ def find_matching(
     root_path: str,
     relative_paths_to_search: List[str],
     file_pattern: str,
-) -> List[Dict[str, str]]:
+) -> List[Dict[str, Any]]:
     """
     Given an absolute `root_path`, a list of relative paths to that
     absolute root path (`relative_paths_to_search`), and a `file_pattern`
@@ -61,11 +61,19 @@ def find_matching(
                 relative_path = os.path.relpath(
                     absolute_path, absolute_path_to_search
                 )
+                modification_time = 0.0
+                try:
+                    modification_time = os.path.getmtime(absolute_path)
+                except OSError:
+                    logger.exception(
+                        f"Error retrieving modification time for file {absolute_path}"
+                    )
                 if reobj.match(local_file):
                     matching.append({
                         'searched_path': relative_path_to_search,
                         'absolute_path': absolute_path,
                         'relative_path': relative_path,
+                        'modification_time': modification_time,
                     })
 
     return matching

--- a/core/dbt/contracts/files.py
+++ b/core/dbt/contracts/files.py
@@ -42,6 +42,7 @@ parse_file_type_to_parser = {
 class FilePath(dbtClassMixin):
     searched_path: str
     relative_path: str
+    modification_time: float
     project_root: str
 
     @property
@@ -132,6 +133,10 @@ class RemoteFile(dbtClassMixin):
     def original_file_path(self):
         return 'from remote system'
 
+    @property
+    def modification_time(self):
+        return 'from remote system'
+
 
 @dataclass
 class BaseSourceFile(dbtClassMixin, SerializableType):
@@ -149,8 +154,6 @@ class BaseSourceFile(dbtClassMixin, SerializableType):
     @property
     def file_id(self):
         if isinstance(self.path, RemoteFile):
-            return None
-        if self.checksum.name == 'none':
             return None
         return f'{self.project_name}://{self.path.original_file_path}'
 

--- a/core/dbt/parser/hooks.py
+++ b/core/dbt/parser/hooks.py
@@ -72,10 +72,13 @@ class HookParser(SimpleParser[HookBlock, ParsedHookNode]):
 
     # Hooks are only in the dbt_project.yml file for the project
     def get_path(self) -> FilePath:
+        # There ought to be an existing file object for this, but
+        # until that is implemented use a dummy modification time
         path = FilePath(
             project_root=self.project.project_root,
             searched_path='.',
             relative_path='dbt_project.yml',
+            modification_time=0.0,
         )
         return path
 

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -203,8 +203,11 @@ class ManifestLoader:
         # used to get the SourceFiles from the manifest files.
         start_read_files = time.perf_counter()
         project_parser_files = {}
+        saved_files = {}
+        if self.saved_manifest:
+            saved_files = self.saved_manifest.files
         for project in self.all_projects.values():
-            read_files(project, self.manifest.files, project_parser_files)
+            read_files(project, self.manifest.files, project_parser_files, saved_files)
         self._perf_info.path_count = len(self.manifest.files)
         self._perf_info.read_files_elapsed = (time.perf_counter() - start_read_files)
 
@@ -423,7 +426,7 @@ class ManifestLoader:
         if not self.partially_parsing and HookParser in parser_types:
             hook_parser = HookParser(project, self.manifest, self.root_project)
             path = hook_parser.get_path()
-            file = load_source_file(path, ParseFileType.Hook, project.project_name)
+            file = load_source_file(path, ParseFileType.Hook, project.project_name, {})
             if file:
                 file_block = FileBlock(file)
                 hook_parser.parse_file(file_block)
@@ -648,7 +651,7 @@ class ManifestLoader:
             macro_parser = MacroParser(project, self.manifest)
             for path in macro_parser.get_paths():
                 source_file = load_source_file(
-                    path, ParseFileType.Macro, project.project_name)
+                    path, ParseFileType.Macro, project.project_name, {})
                 block = FileBlock(source_file)
                 # This does not add the file to the manifest.files,
                 # but that shouldn't be necessary here.

--- a/core/dbt/parser/search.py
+++ b/core/dbt/parser/search.py
@@ -84,6 +84,7 @@ class FilesystemSearcher(Iterable[FilePath]):
             file_match = FilePath(
                 searched_path=result['searched_path'],
                 relative_path=result['relative_path'],
+                modification_time=result['modification_time'],
                 project_root=root,
             )
             yield file_match

--- a/test/unit/test_docs_blocks.py
+++ b/test/unit/test_docs_blocks.py
@@ -136,6 +136,7 @@ class DocumentationParserTest(unittest.TestCase):
             relative_path=relative_path,
             project_root=self.root_path,
             searched_path=self.subdir_path,
+            modification_time=0.0,
         )
         source_file = SourceFile(path=match, checksum=FileHash.empty())
         source_file.contents = contents

--- a/test/unit/test_graph.py
+++ b/test/unit/test_graph.py
@@ -122,7 +122,7 @@ class GraphTest(unittest.TestCase):
         # Create the source file patcher
         self.load_source_file_patcher = patch('dbt.parser.read_files.load_source_file')
         self.mock_source_file = self.load_source_file_patcher.start()
-        def mock_load_source_file(path, parse_file_type, project_name):
+        def mock_load_source_file(path, parse_file_type, project_name, saved_files):
             for sf in self.mock_models:
                 if sf.path == path:
                     source_file = sf
@@ -137,6 +137,7 @@ class GraphTest(unittest.TestCase):
                 searched_path='.',
                 project_root=os.path.normcase(os.getcwd()),
                 relative_path='dbt_project.yml',
+                modification_time=0.0,
             )
             return path
 
@@ -165,6 +166,7 @@ class GraphTest(unittest.TestCase):
                 searched_path='models',
                 project_root=os.path.normcase(os.getcwd()),
                 relative_path='{}.sql'.format(k),
+                modification_time=0.0,
             )
             # FileHash can't be empty or 'search_key' will be None
             source_file = SourceFile(path=path, checksum=FileHash.from_contents('abc'))

--- a/test/unit/test_parser.py
+++ b/test/unit/test_parser.py
@@ -146,6 +146,7 @@ class BaseParserTest(unittest.TestCase):
             searched_path=searched,
             relative_path=filename,
             project_root=root_dir,
+            modification_time=0.0,
         )
         sf_cls = SchemaSourceFile if filename.endswith('.yml') else SourceFile
         source_file = sf_cls(

--- a/test/unit/test_partial_parsing.py
+++ b/test/unit/test_partial_parsing.py
@@ -1,5 +1,6 @@
 import unittest
 from unittest import mock
+import time
 
 import dbt.exceptions
 from dbt.parser.partial import PartialParsing
@@ -17,14 +18,14 @@ class TestPartialParsing(unittest.TestCase):
         project_name = 'my_test'
         project_root = '/users/root'
         model_file = SourceFile(
-            path=FilePath(project_root=project_root, searched_path='models', relative_path='my_model.sql'),
+            path=FilePath(project_root=project_root, searched_path='models', relative_path='my_model.sql', modification_time=time.time()),
             checksum=FileHash.from_contents('abcdef'),
             project_name=project_name,
             parse_file_type=ParseFileType.Model,
             nodes=['model.my_test.my_model'],
         )
         schema_file = SchemaSourceFile(
-            path=FilePath(project_root=project_root, searched_path='models', relative_path='schema.yml'),
+            path=FilePath(project_root=project_root, searched_path='models', relative_path='schema.yml', modification_time=time.time()),
             checksum=FileHash.from_contents('ghijkl'),
             project_name=project_name,
             parse_file_type=ParseFileType.Schema,

--- a/test/unit/test_system_client.py
+++ b/test/unit/test_system_client.py
@@ -153,7 +153,8 @@ class TestFindMatching(unittest.TestCase):
             expected_output = [{
                 'searched_path': relative_path,
                 'absolute_path': named_file.name,
-                'relative_path': os.path.basename(named_file.name)
+                'relative_path': os.path.basename(named_file.name),
+                'modification_time': out[0]['modification_time'],
             }]
             self.assertEqual(out, expected_output)
 
@@ -167,7 +168,8 @@ class TestFindMatching(unittest.TestCase):
             expected_output = [{
                 'searched_path': relative_path,
                 'absolute_path': named_file.name,
-                'relative_path': os.path.basename(named_file.name)
+                'relative_path': os.path.basename(named_file.name),
+                'modification_time': out[0]['modification_time'],
             }]
             self.assertEqual(out, expected_output)
 


### PR DESCRIPTION
resolves #3563


### Description

Store the modification time for files and for schema files compare the times and skip reloading if the files haven't changed. This only addresses schema files because we are already storing the dictionary representation in the saved files. If we wanted to do the same thing for SQL files we would have to store the contents.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
