### PR TITLE
Fix logging for default selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Customize ls task JSON output by adding new flag `--output-keys` ([#3778](https://github.com/dbt-labs/dbt/issues/3778), [#3395](https://github.com/dbt-labs/dbt/issues/3395))
 - Add support for execution project on BigQuery through profile configuration ([#3707](https://github.com/dbt-labs/dbt/issues/3707), [#3708](https://github.com/dbt-labs/dbt/issues/3708))
 - Skip downstream nodes during the `build` task when a test fails. ([#3597](https://github.com/dbt-labs/dbt/issues/3597), [#3792](https://github.com/dbt-labs/dbt/pull/3792))
-- Added default field in the `selectors.yml` to allow user to define default selector ([#3448](https://github.com/dbt-labs/dbt/issues/3448#issuecomment-907611470))
+- Added default field in the `selectors.yml` to allow user to define default selector ([#3448](https://github.com/dbt-labs/dbt/issues/3448), [#3875](https://github.com/dbt-labs/dbt/issues/3875), [#3892](https://github.com/dbt-labs/dbt/issues/3892))
 
 ### Fixes
 

--- a/core/dbt/config/project.py
+++ b/core/dbt/config/project.py
@@ -653,7 +653,7 @@ class Project:
             )
         return self.selectors[name]["definition"]
 
-    def get_default_selector_name(self) -> Union[str, bool]:
+    def get_default_selector_name(self) -> Union[str, None]:
         """This function fetch the default selector to use on `dbt run` (if any)
         :return: either a selector if default is set or None
         :rtype: Union[SelectionSpec, None]

--- a/core/dbt/config/project.py
+++ b/core/dbt/config/project.py
@@ -38,7 +38,6 @@ from .selectors import (
     selector_data_from_root,
     SelectorConfig,
 )
-from dbt.logger import print_timestamped_line
 
 
 INVALID_VERSION_ERROR = """\
@@ -654,16 +653,14 @@ class Project:
             )
         return self.selectors[name]["definition"]
 
-    def get_default_selector(self) -> Union[SelectionSpec, bool, None]:
+    def get_default_selector_name(self) -> Union[str, bool]:
         """This function fetch the default selector to use on `dbt run` (if any)
         :return: either a selector if default is set or None
         :rtype: Union[SelectionSpec, None]
         """
         for selector_name, selector in self.selectors.items():
             if selector["default"] is True:
-                name = selector_name
-                print_timestamped_line(f'Using default selector {name}')
-                return self.get_selector(name)
+                return selector_name
 
         return None
 

--- a/core/dbt/task/compile.py
+++ b/core/dbt/task/compile.py
@@ -4,7 +4,7 @@ from .base import BaseRunner
 
 from dbt.contracts.results import RunStatus, RunResult
 from dbt.exceptions import InternalException
-from dbt.graph import ResourceTypeSelector, SelectionSpec, parse_difference
+from dbt.graph import ResourceTypeSelector
 from dbt.logger import print_timestamped_line
 from dbt.node_types import NodeType
 
@@ -36,16 +36,6 @@ class CompileRunner(BaseRunner):
 class CompileTask(GraphRunnableTask):
     def raise_on_first_error(self):
         return True
-
-    def get_selection_spec(self) -> SelectionSpec:
-        default_selector = self.config.get_default_selector()
-        if self.args.selector_name:
-            spec = self.config.get_selector(self.args.selector_name)
-        elif not (self.args.select or self.args.exclude) and default_selector:
-            spec = default_selector
-        else:
-            spec = parse_difference(self.args.select, self.args.exclude)
-        return spec
 
     def get_node_selector(self) -> ResourceTypeSelector:
         if self.manifest is None or self.graph is None:

--- a/core/dbt/task/freshness.py
+++ b/core/dbt/task/freshness.py
@@ -19,7 +19,7 @@ from dbt.exceptions import RuntimeException, InternalException
 from dbt.logger import print_timestamped_line
 from dbt.node_types import NodeType
 
-from dbt.graph import ResourceTypeSelector, SelectionSpec, parse_difference
+from dbt.graph import ResourceTypeSelector
 from dbt.contracts.graph.parsed import ParsedSourceDefinition
 
 
@@ -135,22 +135,6 @@ class FreshnessTask(GraphRunnableTask):
 
     def raise_on_first_error(self):
         return False
-
-    def get_selection_spec(self) -> SelectionSpec:
-        """Generates a selection spec from task arguments to use when
-        processing graph. A SelectionSpec describes what nodes to select
-        when creating queue from graph of nodes.
-        """
-        default_selector = self.config.get_default_selector()
-        if self.args.selector_name:
-            # use pre-defined selector (--selector) to create selection spec
-            spec = self.config.get_selector(self.args.selector_name)
-        elif not (self.args.select or self.args.exclude) and default_selector:
-            spec = default_selector
-        else:
-            # use --select and --exclude args to create selection spec
-            spec = parse_difference(self.args.select, self.args.exclude)
-        return spec
 
     def get_node_selector(self):
         if self.manifest is None or self.graph is None:

--- a/core/dbt/task/list.py
+++ b/core/dbt/task/list.py
@@ -5,11 +5,7 @@ from dbt.contracts.graph.parsed import (
     ParsedExposure,
     ParsedSourceDefinition
 )
-from dbt.graph import (
-    parse_difference,
-    ResourceTypeSelector,
-    SelectionSpec,
-)
+from dbt.graph import ResourceTypeSelector
 from dbt.task.runnable import GraphRunnableTask, ManifestTask
 from dbt.task.test import TestSelector
 from dbt.node_types import NodeType
@@ -165,21 +161,13 @@ class ListTask(GraphRunnableTask):
         return list(values)
 
     @property
-    def selector(self):
+    def selection_arg(self):
+        # for backwards compatibility, list accepts both --models and --select,
+        # with slightly different behavior: --models implies --resource-type model
         if self.args.models:
             return self.args.models
         else:
             return self.args.select
-
-    def get_selection_spec(self) -> SelectionSpec:
-        default_selector = self.config.get_default_selector()
-        if self.args.selector_name:
-            spec = self.config.get_selector(self.args.selector_name)
-        elif not (self.args.select or self.args.exclude) and default_selector:
-            spec = default_selector
-        else:
-            spec = parse_difference(self.selector, self.args.exclude)
-        return spec
 
     def get_node_selector(self):
         if self.manifest is None or self.graph is None:

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -115,7 +115,7 @@ class GraphRunnableTask(ManifestTask):
     @property
     def selection_arg(self):
         return self.args.select
-        
+
     @property
     def exclusion_arg(self):
         return self.args.exclude

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -41,7 +41,13 @@ from dbt.exceptions import (
     FailFastException,
 )
 
-from dbt.graph import GraphQueue, NodeSelector, SelectionSpec, Graph
+from dbt.graph import (
+    GraphQueue,
+    NodeSelector,
+    SelectionSpec,
+    parse_difference,
+    Graph
+)
 from dbt.parser.manifest import ManifestLoader
 
 import dbt.exceptions
@@ -106,11 +112,27 @@ class GraphRunnableTask(ManifestTask):
     def index_offset(self, value: int) -> int:
         return value
 
-    @abstractmethod
+    @property
+    def selection_arg(self):
+        return self.args.select
+        
+    @property
+    def exclusion_arg(self):
+        return self.args.exclude
+
     def get_selection_spec(self) -> SelectionSpec:
-        raise NotImplementedException(
-            f'get_selection_spec not implemented for task {type(self)}'
-        )
+        default_selector_name = self.config.get_default_selector_name()
+        if self.args.selector_name:
+            # use pre-defined selector (--selector)
+            spec = self.config.get_selector(self.args.selector_name)
+        elif not (self.selection_arg or self.exclusion_arg) and default_selector_name:
+            # use pre-defined selector (--selector) with default: true
+            logger.info(f"Using default selector {default_selector_name}")
+            spec = self.config.get_selector(default_selector_name)
+        else:
+            # use --select and --exclude args
+            spec = parse_difference(self.selection_arg, self.exclusion_arg)
+        return spec
 
     @abstractmethod
     def get_node_selector(self) -> NodeSelector:


### PR DESCRIPTION
Follow-on to #3875, the actual functionality of which I was eager to get into v0.21 :)

In particular, this fixes https://github.com/dbt-labs/dbt/pull/3875#discussion_r708094168. Only log "Using default selector" when the default selector is in fact being used, not every time one has been defined.

While we're here: Acknowledging that the `get_selection_spec` method is now 99% the same across the three tasks that implement it, move the method definition up to `GraphRunnableTask` (replacing the abstract method), and remove the duplicated code from the child tasks.

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.