### PR TITLE
sample exp parser more often

### DIFF
--- a/core/dbt/parser/models.py
+++ b/core/dbt/parser/models.py
@@ -32,8 +32,9 @@ class ModelParser(SimpleSQLParser[ParsedModelNode]):
     def render_update(
         self, node: ParsedModelNode, config: ContextConfig
     ) -> None:
-        # `True` roughly 1/100 times this function is called
-        sample: bool = random.randint(1, 101) == 100
+        # TODO go back to 1/100 when this is turned on by default.
+        # `True` roughly 1/50 times this function is called
+        sample: bool = random.randint(1, 51) == 50
 
         # top-level declaration of variables
         experimentally_parsed: Optional[Union[str, Dict[str, List[Any]]]] = None


### PR DESCRIPTION
### Description

We want to sample more model files from projects just for this minor version so we can increase our chances of running into any problems with user's projects. This is our last chance to collect data before turning on the static parser by default.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
