### PR TITLE
Make quotes consistent in dbt_project.yml after dbt init

### DIFF
--- a/core/dbt/include/starter_project/dbt_project.yml
+++ b/core/dbt/include/starter_project/dbt_project.yml
@@ -2,12 +2,12 @@
 # Name your project! Project names should contain only lowercase characters
 # and underscores. A good package name should reflect your organization's
 # name or the intended use of these models
-name: 'my_new_project'
-version: '1.0.0'
+name: "my_new_project"
+version: "1.0.0"
 config-version: 2
 
 # This setting configures which "profile" dbt uses for this project.
-profile: 'default'
+profile: "default"
 
 # These configurations specify where dbt should look for different types of files.
 # The `source-paths` config, for example, states that models in this project can be


### PR DESCRIPTION
Nitpick here, but `dbt init <project>` creates a `dbt_project.yml` with mixed quotes (single and double) so I figured might as well make those consistent.

(The PR template says an issue is required for any change, but I wanted to check if changes this small might be an exception.)