### PR TITLE
Fix integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ Contributors:
 
 - [@dave-connors-3](https://github.com/dave-connors-3) ([#3920](https://github.com/dbt-labs/dbt/issues/3920))
 
-
 ## dbt 0.21.0 (Release TBD)
 
 ### Fixes
@@ -22,6 +21,10 @@ Contributors:
 
 ### Under the hood
 - Bump artifact schema versions for 0.21.0 ([#3945](https://github.com/dbt-labs/dbt/pull/3945))
+
+Contributors:
+
+- [@kadero](https://github.com/kadero) ([#3952](https://github.com/dbt-labs/dbt/issues/3952))
 
 ## dbt 0.21.0rc1 (September 20, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Contributors:
 
 - [@dave-connors-3](https://github.com/dave-connors-3) ([#3920](https://github.com/dbt-labs/dbt/issues/3920))
 
+
 ## dbt 0.21.0 (Release TBD)
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 Contributors:
 
 - [@dave-connors-3](https://github.com/dave-connors-3) ([#3920](https://github.com/dbt-labs/dbt/issues/3920))
-
+- [@kadero](https://github.com/kadero) ([#3952](https://github.com/dbt-labs/dbt/issues/3952))
 
 ## dbt 0.21.0 (Release TBD)
 
@@ -22,10 +22,6 @@ Contributors:
 
 ### Under the hood
 - Bump artifact schema versions for 0.21.0 ([#3945](https://github.com/dbt-labs/dbt/pull/3945))
-
-Contributors:
-
-- [@kadero](https://github.com/kadero) ([#3952](https://github.com/dbt-labs/dbt/issues/3952))
 
 ## dbt 0.21.0rc1 (September 20, 2021)
 

--- a/test/integration/004_simple_snapshot_test/test_simple_snapshot.py
+++ b/test/integration/004_simple_snapshot_test/test_simple_snapshot.py
@@ -906,7 +906,7 @@ class TestSnapshotHardDelete(DBTIntegrationTest):
         for result in snapshotted[10:]:
             # result is a tuple, the dbt_valid_to column is the latest
             self.assertIsInstance(result[-1], datetime)
-            self.assertGreaterEqual(result[-1].astimezone(pytz.UTC), self._invalidated_snapshot_datetime)
+            self.assertGreaterEqual(result[-1].replace(tzinfo=pytz.UTC), self._invalidated_snapshot_datetime)
 
     def _revive_records(self):
         database = self.default_database
@@ -946,7 +946,7 @@ class TestSnapshotHardDelete(DBTIntegrationTest):
         for result in invalidated_records:
             # result is a tuple, the dbt_valid_to column is the latest
             self.assertIsInstance(result[1], datetime)
-            self.assertGreaterEqual(result[1].astimezone(pytz.UTC), self._invalidated_snapshot_datetime)
+            self.assertGreaterEqual(result[1].replace(tzinfo=pytz.UTC), self._invalidated_snapshot_datetime)
 
         # records which weren't revived (id != 10, 11)
         revived_records = self.run_sql(
@@ -968,5 +968,5 @@ class TestSnapshotHardDelete(DBTIntegrationTest):
             self.assertIsInstance(result[1], datetime)
             # there are milliseconds (part of microseconds in datetime objects) in the
             # invalidated_snapshot_datetime and not in result datetime so set the microseconds to 0
-            self.assertGreaterEqual(result[1].astimezone(pytz.UTC), self._invalidated_snapshot_datetime.replace(microsecond=0))
+            self.assertGreaterEqual(result[1].replace(tzinfo=pytz.UTC), self._invalidated_snapshot_datetime.replace(microsecond=0))
             self.assertIsNone(result[2])


### PR DESCRIPTION
resolves #3952

### Description
This PR aims to handle properly the datetime column in the integration test `TestSnapshotHardDelete.test__postgres__snapshot_hard_delete`.

The timestamp we extract from PG is in `UTC` and `offset naive`. We just need to make it `offset aware` to enable the comparaison.
`astimezone(pytz.UTC)` to `.replace(tzinfo=pytz.UTC)`


The fix was tested locally by launching the test under multiple Timezone:

```
# EDT
sudo timedatectl set-timezone America/New_York && timedatectl && python -m pytest -m profile_postgres test/integration/004_simple_snapshot_test/test_simple_snapshot.py::TestSnapshotHardDelete::test__postgres__snapshot_hard_delete

# PDT
sudo timedatectl set-timezone America/Los_Angeles && timedatectl && python -m pytest -m profile_postgres test/integration/004_simple_snapshot_test/test_simple_snapshot.py::TestSnapshotHardDelete::test__postgres__snapshot_hard_delete

# CEST
sudo timedatectl set-timezone Europe/Paris && timedatectl && python -m pytest -m profile_postgres test/integration/004_simple_snapshot_test/test_simple_snapshot.py::TestSnapshotHardDelete::test__postgres__snapshot_hard_delete

# NZDT
sudo timedatectl set-timezone Pacific/Auckland && timedatectl && python -m pytest -m profile_postgres test/integration/004_simple_snapshot_test/test_simple_snapshot.py::TestSnapshotHardDelete::test__postgres__snapshot_hard_delete

# IST
sudo timedatectl set-timezone Asia/Kolkata && timedatectl && python -m pytest -m profile_postgres test/integration/004_simple_snapshot_test/test_simple_snapshot.py::TestSnapshotHardDelete::test__postgres__snapshot_hard_delete
```


### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
