### PR TITLE
Er/3899 models key mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Enact deprecation for default quoting to be True.  Override for the `dbt-snowflake` adapter so it stays `False`. ([#3898](https://github.com/dbt-labs/dbt/issues/3898))
 - Enact deprecation for object used as dictionaries when they should be dataclasses. Replace deprecation warning with an exception for the dunder methods of `__iter__` and `__len__` for all superclasses of FakeAPIObject. ([#3897](https://github.com/dbt-labs/dbt/issues/3897))
 - Enact deprecation for `adapter-macro` and replace deprecation warning with an exception. ([#3901](https://github.com/dbt-labs/dbt/issues/3901))
+- Add warning when trying to put a node under the wrong key.  ie. A seed under models in a `schema.yml` file. ([#3899](https://github.com/dbt-labs/dbt/issues/3899))
 
 Contributors:
 

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -1008,7 +1008,6 @@ class Manifest(MacroMethods, DataClassMessagePackMixin, dbtClassMixin):
     def add_disabled_nofile(self, node: CompileResultNode):
         self.disabled.append(node)
 
-
     def add_disabled(self, source_file: AnySourceFile, node: CompileResultNode, test_from=None):
         self.add_disabled_nofile(node)
         if isinstance(source_file, SchemaSourceFile):

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -567,7 +567,6 @@ class Manifest(MacroMethods, DataClassMessagePackMixin, dbtClassMixin):
     # Moved from the ParseResult object
     source_patches: MutableMapping[SourceKey, SourcePatch] = field(default_factory=dict)
     # following is from ParseResult
-    _disabled: MutableMapping[str, List[CompileResultNode]] = field(default_factory=dict)
     _doc_lookup: Optional[DocLookup] = field(
         default=None, metadata={'serialize': lambda x: None, 'deserialize': lambda x: None}
     )
@@ -1007,10 +1006,8 @@ class Manifest(MacroMethods, DataClassMessagePackMixin, dbtClassMixin):
         source_file.exposures.append(exposure.unique_id)
 
     def add_disabled_nofile(self, node: CompileResultNode):
-        if node.unique_id in self._disabled:
-            self._disabled[node.unique_id].append(node)
-        else:
-            self._disabled[node.unique_id] = [node]
+        self.disabled.append(node)
+
 
     def add_disabled(self, source_file: AnySourceFile, node: CompileResultNode, test_from=None):
         self.add_disabled_nofile(node)
@@ -1048,7 +1045,6 @@ class Manifest(MacroMethods, DataClassMessagePackMixin, dbtClassMixin):
             self.flat_graph,
             self.state_check,
             self.source_patches,
-            self._disabled,
             self._doc_lookup,
             self._source_lookup,
             self._ref_lookup,

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -404,7 +404,6 @@ class NameSearcher(Generic[N]):
 
     def search(self, haystack) -> Optional[N]:
         """Find an entry in the given iterable by name."""
-        # breakpoint()
         for model in haystack.values():
             if self._matches(model):
                 return model
@@ -738,7 +737,7 @@ class Manifest(MacroMethods, DataClassMessagePackMixin, dbtClassMixin):
             exposures={k: _deepcopy(v) for k, v in self.exposures.items()},
             selectors={k: _deepcopy(v) for k, v in self.selectors.items()},
             metadata=self.metadata,
-            disabled=[_deepcopy(n) for n in self.disabled],
+            disabled={k: _deepcopy(v) for k, v in self.disabled.items()},
             files={k: _deepcopy(v) for k, v in self.files.items()},
             state_check=_deepcopy(self.state_check),
         )
@@ -1042,12 +1041,12 @@ class Manifest(MacroMethods, DataClassMessagePackMixin, dbtClassMixin):
             self.docs,
             self.exposures,
             self.selectors,
-            self.disabled,
             self.files,
             self.metadata,
             self.flat_graph,
             self.state_check,
             self.source_patches,
+            self.disabled,
             self._doc_lookup,
             self._source_lookup,
             self._ref_lookup,

--- a/core/dbt/deprecations.py
+++ b/core/dbt/deprecations.py
@@ -61,12 +61,10 @@ class ModelsKeyNonModelDeprecation(DBTDeprecation):
     _name = 'models-key-mismatch'
 
     _description = '''\
-    "{node.name}" is a {node.resource_type} node, but it is specified in
+    "{patch.name}" is a {resource_type} node, but it is specified in
     the {patch.yaml_key} section of {patch.original_file_path}.
 
-
-
-    To fix this warning, place the `{node.name}` specification under
+    To fix this warning, place the `{patch.name}` specification under
     the {expected_key} key instead.
 
     This warning will become an error in a future release.

--- a/core/dbt/deprecations.py
+++ b/core/dbt/deprecations.py
@@ -57,20 +57,6 @@ class DispatchPackagesDeprecation(DBTDeprecation):
     '''
 
 
-class ModelsKeyNonModelDeprecation(DBTDeprecation):
-    _name = 'models-key-mismatch'
-
-    _description = '''\
-    "{patch.name}" is a {resource_type} node, but it is specified in
-    the {patch.yaml_key} section of {patch.original_file_path}.
-
-    To fix this warning, place the `{patch.name}` specification under
-    the {expected_key} key instead.
-
-    This warning will become an error in a future release.
-    '''
-
-
 class PackageRedirectDeprecation(DBTDeprecation):
     _name = 'package-redirect'
     _description = '''\
@@ -118,7 +104,6 @@ active_deprecations: Set[str] = set()
 
 deprecations_list: List[DBTDeprecation] = [
     DispatchPackagesDeprecation(),
-    ModelsKeyNonModelDeprecation(),
     PackageRedirectDeprecation()
 ]
 

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -5,7 +5,7 @@ from typing import NoReturn, Optional, Mapping, Any
 from dbt.logger import GLOBAL_LOGGER as logger
 from dbt.node_types import NodeType
 from dbt import flags
-from dbt.ui import line_wrap_message
+from dbt.ui import line_wrap_message, warning_tag
 
 import dbt.dataclass_schema
 
@@ -849,15 +849,6 @@ def raise_patch_targets_not_found(patches):
     )
 
 
-# todo: fix error message to be useful & add test
-def raise_no_unique_id(patch):
-    raise_compiler_error(
-        'No unique_id found for {} {}.'.format(
-            patch.yaml_key, patch.name
-        )
-    )
-
-
 def _fix_dupe_msg(path_1: str, path_2: str, name: str, type_name: str) -> str:
     if path_1 == path_2:
         return (
@@ -939,14 +930,11 @@ def warn_invalid_patch(patch, resource_type):
         '{patch.name}' is a {resource_type} node, but it is
         specified in the {patch.yaml_key} section of
         {patch.original_file_path}.
-
-
-
         To fix this error, place the `{patch.name}`
         specification under the {resource_type.pluralize()} key instead.
         '''
     )
-    warn_or_error(msg)
+    warn_or_error(msg, log_fmt=warning_tag('{}'))
 
 
 def raise_not_implemented(msg):
@@ -1014,7 +1002,6 @@ CONTEXT_EXPORTS = {
         raise_dep_not_found,
         raise_dependency_error,
         raise_duplicate_patch_name,
-        raise_no_unique_id,
         raise_duplicate_resource_name,
         raise_invalid_schema_yml_version,
         raise_not_implemented,

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -849,6 +849,7 @@ def raise_patch_targets_not_found(patches):
     )
 
 
+# todo: fix error message to be useful & add test
 def raise_no_unique_id(patch):
     raise_compiler_error(
         'No unique_id: {}'.format(

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -849,6 +849,14 @@ def raise_patch_targets_not_found(patches):
     )
 
 
+def raise_no_unique_id(patch, temp):
+    raise_compiler_error(
+        'No unique_id for {} {}. {}'.format(
+            patch.yaml_key, patch.name, temp
+        )
+    )
+
+
 def _fix_dupe_msg(path_1: str, path_2: str, name: str, type_name: str) -> str:
     if path_1 == path_2:
         return (
@@ -1007,6 +1015,7 @@ CONTEXT_EXPORTS = {
         raise_dep_not_found,
         raise_dependency_error,
         raise_duplicate_patch_name,
+        raise_no_unique_id,
         raise_duplicate_resource_name,
         raise_invalid_schema_yml_version,
         raise_not_implemented,

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -852,8 +852,8 @@ def raise_patch_targets_not_found(patches):
 # todo: fix error message to be useful & add test
 def raise_no_unique_id(patch):
     raise_compiler_error(
-        'No unique_id: {}'.format(
-            patch
+        'No unique_id found for {} {}.'.format(
+            patch.yaml_key, patch.name
         )
     )
 

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -849,10 +849,10 @@ def raise_patch_targets_not_found(patches):
     )
 
 
-def raise_no_unique_id(patch, temp):
+def raise_no_unique_id(patch):
     raise_compiler_error(
-        'No unique_id for {} {}. {}'.format(
-            patch.yaml_key, patch.name, temp
+        'No unique_id: {}'.format(
+            patch
         )
     )
 

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -933,22 +933,20 @@ def raise_unrecognized_credentials_type(typename, supported_types):
     )
 
 
-def raise_invalid_patch(
-    node, patch_section: str, patch_path: str,
-) -> NoReturn:
+def warn_invalid_patch(patch, resource_type):
     msg = line_wrap_message(
         f'''\
-        '{node.name}' is a {node.resource_type} node, but it is
-        specified in the {patch_section} section of
-        {patch_path}.
+        '{patch.name}' is a {resource_type} node, but it is
+        specified in the {patch.yaml_key} section of
+        {patch.original_file_path}.
 
 
 
-        To fix this error, place the `{node.name}`
-        specification under the {node.resource_type.pluralize()} key instead.
+        To fix this error, place the `{patch.name}`
+        specification under the {resource_type.pluralize()} key instead.
         '''
     )
-    raise_compiler_error(msg, node)
+    warn_or_error(msg)
 
 
 def raise_not_implemented(msg):

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -338,22 +338,12 @@ class ManifestLoader:
                 time.perf_counter() - start_patch
             )
 
-            # ParseResults had a 'disabled' attribute which was a dictionary
-            # which is now named '_disabled'. This used to copy from
-            # ParseResults to the Manifest.
-            # TODO: normalize to only one disabled
-            # todo: remove below?
-            # disabled = []
-            # for value in self.manifest..values():
-            #     disabled.extend(value)
-            # self.manifest.disabled = disabled
-
             # copy the selectors from the root_project to the manifest
             self.manifest.selectors = self.root_project.manifest_selectors
 
             # update the refs, sources, and docs
             # These check the created_at time on the nodes to
-            # determine whether they need processinga.
+            # determine whether they need processing.
             start_process = time.perf_counter()
             self.process_sources(self.root_project.project_name)
             self.process_refs(self.root_project.project_name)
@@ -903,7 +893,7 @@ def _warn_for_unused_resource_config_paths(
     manifest: Manifest, config: RuntimeConfig
 ) -> None:
     resource_fqns: Mapping[str, PathSet] = manifest.get_resource_fqns()
-    disabled_fqns: PathSet = frozenset(tuple(n.fqn) for n in manifest.disabled)
+    disabled_fqns: PathSet = frozenset(tuple(n.fqn) for n in manifest.disabled.values())
     config.warn_for_unused_resource_config_paths(resource_fqns, disabled_fqns)
 
 

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -342,10 +342,11 @@ class ManifestLoader:
             # which is now named '_disabled'. This used to copy from
             # ParseResults to the Manifest.
             # TODO: normalize to only one disabled
-            disabled = []
-            for value in self.manifest._disabled.values():
-                disabled.extend(value)
-            self.manifest.disabled = disabled
+            # todo: remove below?
+            # disabled = []
+            # for value in self.manifest..values():
+            #     disabled.extend(value)
+            # self.manifest.disabled = disabled
 
             # copy the selectors from the root_project to the manifest
             self.manifest.selectors = self.root_project.manifest_selectors

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -63,6 +63,8 @@ from dbt.utils import (
     get_pseudo_test_path, coerce_dict_str
 )
 
+from dbt import deprecations
+
 
 UnparsedSchemaYaml = Union[
     UnparsedSourceDefinition,
@@ -814,11 +816,17 @@ class NodePatchParser(
         source_file: SchemaSourceFile = self.yaml.file
         if patch.yaml_key in ['models', 'seeds', 'snapshots']:
             unique_id = self.manifest.ref_lookup.get_unique_id(patch.name, None)
-            if (unique_id is None and
-               not self.manifest.find_disabled_by_name(patch.name, None)):
-                # need to raise an exception when a refable node does not
-                # have a unique id and is not disabled
-                raise raise_no_unique_id(patch)
+            if unique_id:
+                if (unique_id.split('.')[0] + 's') != patch.yaml_key:
+                    deprecations.warn('models-key-mismatch',
+                                     patch=patch,
+                                     resource_type=unique_id.split('.')[0],
+                                     expected_key=patch.yaml_key)
+
+            elif self.manifest.find_disabled_by_name(patch.name, None):
+                    # need to raise an exception when a refable node does not
+                    # have a unique id and is not disabled
+                    raise raise_no_unique_id(patch)
         elif patch.yaml_key == 'analyses':
             unique_id = self.manifest.analysis_lookup.get_unique_id(patch.name, None)
         else:

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -49,7 +49,7 @@ from dbt.exceptions import (
     raise_invalid_schema_yml_version, ValidationException,
     CompilationException, raise_duplicate_patch_name,
     raise_duplicate_macro_patch_name, InternalException,
-    raise_duplicate_source_patch_name,
+    raise_duplicate_source_patch_name, raise_no_unique_id,
     warn_or_error,
 )
 from dbt.node_types import NodeType
@@ -822,8 +822,11 @@ class NodePatchParser(
                 f'file {source_file.path.original_file_path}'
             )
         if unique_id is None:
-            # This will usually happen when a node is disabled
-            return
+            # TODO: if node is not disabled raise exception
+            if self.manifest.find_disabled_by_name(patch.name, None):
+                breakpoint()
+                return
+            raise raise_no_unique_id(patch, patch.config)
 
         # patches can't be overwritten
         node = self.manifest.nodes.get(unique_id)

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -813,14 +813,13 @@ class NodePatchParser(
         assert isinstance(self.yaml.file, SchemaSourceFile)
         source_file: SchemaSourceFile = self.yaml.file
         if patch.yaml_key in ['models', 'seeds', 'snapshots']:
+            breakpoint()
             unique_id = self.manifest.ref_lookup.get_unique_id(patch.name, None)
             if (unique_id is None and
                not self.manifest.find_disabled_by_name(patch.name, None)):
-            # need to raise an exception when a refable node does not 
-            # have a unique id and is not disabled
-            # todo: fix error message to be useful & add test
+                # need to raise an exception when a refable node does not
+                # have a unique id and is not disabled
                 raise raise_no_unique_id(patch)
-                
         elif patch.yaml_key == 'analyses':
             unique_id = self.manifest.analysis_lookup.get_unique_id(patch.name, None)
         else:

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -45,12 +45,11 @@ from dbt.contracts.graph.unparsed import (
     UnparsedSourceDefinition,
 )
 from dbt.exceptions import (
-    validator_error_message, JSONValidationException,
+    warn_invalid_patch, validator_error_message, JSONValidationException,
     raise_invalid_schema_yml_version, ValidationException,
     CompilationException, raise_duplicate_patch_name,
     raise_duplicate_macro_patch_name, InternalException,
-    raise_duplicate_source_patch_name, raise_no_unique_id,
-    warn_or_error,
+    raise_duplicate_source_patch_name, warn_or_error,
 )
 from dbt.node_types import NodeType
 from dbt.parser.base import SimpleParser
@@ -815,23 +814,11 @@ class NodePatchParser(
         if patch.yaml_key in ['models', 'seeds', 'snapshots']:
             unique_id = self.manifest.ref_lookup.get_unique_id(patch.name, None)
             if unique_id:
-                resource_type = unique_id.split('.')[0]
-                if (unique_id.split('.')[0] + 's') != patch.yaml_key:
-                    warn_or_error(
-                        f"WARNING: {patch.name} is a {resource_type} node, "
-                        f"but it is specified in the {patch.yaml_key} section "
-                        f"of {patch.original_file_path}. "
-                        f"To fix this warning, place the `{patch.name}` specification "
-                        f"under the {resource_type} key instead.")
-
+                resource_type = NodeType(unique_id.split('.')[0])
+                if resource_type.pluralize() != patch.yaml_key:
+                    warn_invalid_patch(patch, resource_type)
                     return
 
-            else:
-                if not self.manifest.find_disabled_by_name(patch.name, None):
-                    # need to raise an exception when a refable node does not
-                    # have a unique id and is not disabled
-                    # todo: do we still want to do this?
-                    raise raise_no_unique_id(patch)
         elif patch.yaml_key == 'analyses':
             unique_id = self.manifest.analysis_lookup.get_unique_id(patch.name, None)
         else:

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -818,8 +818,9 @@ class NodePatchParser(
                not self.manifest.find_disabled_by_name(patch.name, None)):
             # need to raise an exception when a refable node does not 
             # have a unique id and is not disabled
-            # todo: fix error message to be useful
+            # todo: fix error message to be useful & add test
                 raise raise_no_unique_id(patch)
+                
         elif patch.yaml_key == 'analyses':
             unique_id = self.manifest.analysis_lookup.get_unique_id(patch.name, None)
         else:

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -813,7 +813,6 @@ class NodePatchParser(
         assert isinstance(self.yaml.file, SchemaSourceFile)
         source_file: SchemaSourceFile = self.yaml.file
         if patch.yaml_key in ['models', 'seeds', 'snapshots']:
-            breakpoint()
             unique_id = self.manifest.ref_lookup.get_unique_id(patch.name, None)
             if (unique_id is None and
                not self.manifest.find_disabled_by_name(patch.name, None)):

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -814,6 +814,12 @@ class NodePatchParser(
         source_file: SchemaSourceFile = self.yaml.file
         if patch.yaml_key in ['models', 'seeds', 'snapshots']:
             unique_id = self.manifest.ref_lookup.get_unique_id(patch.name, None)
+            if (unique_id is None and
+               not self.manifest.find_disabled_by_name(patch.name, None)):
+            # need to raise an exception when a refable node does not 
+            # have a unique id and is not disabled
+            # todo: fix error message to be useful
+                raise raise_no_unique_id(patch)
         elif patch.yaml_key == 'analyses':
             unique_id = self.manifest.analysis_lookup.get_unique_id(patch.name, None)
         else:
@@ -822,11 +828,8 @@ class NodePatchParser(
                 f'file {source_file.path.original_file_path}'
             )
         if unique_id is None:
-            # TODO: if node is not disabled raise exception
-            if self.manifest.find_disabled_by_name(patch.name, None):
-                breakpoint()
-                return
-            raise raise_no_unique_id(patch, patch.config)
+            # This will usually happen when a node is disabled
+            return
 
         # patches can't be overwritten
         node = self.manifest.nodes.get(unique_id)

--- a/test/integration/008_schema_tests_test/data/some_seed.csv
+++ b/test/integration/008_schema_tests_test/data/some_seed.csv
@@ -1,0 +1,3 @@
+col_int,col_str
+1,hello
+2,goodbye

--- a/test/integration/008_schema_tests_test/test_schema_v2_tests.py
+++ b/test/integration/008_schema_tests_test/test_schema_v2_tests.py
@@ -558,3 +558,21 @@ class TestInvalidSchema(DBTIntegrationTest):
             results = self.run_dbt()
         self.assertRegex(str(exc.exception), r"'models' is not a list")
 
+
+class TestWrongSpecificationBlock(DBTIntegrationTest):
+    @property
+    def schema(self):
+        return "schema_tests_008"
+
+    @property
+    def models(self):
+        return "wrong_specification_block"
+
+    @use_profile('postgres')
+    def test_postgres_wrong_specification_block(self):
+        with self.assertWarns(Warning):
+            results = self.run_dbt(['ls', '-s', 'some_seed', '--output', 'json', '--output-keys', 'name, description'])
+
+        assert len(results) == 1
+        assert results[0] == '{"name": "some_seed", "description": ""}'
+

--- a/test/integration/008_schema_tests_test/wrong_specification_block/schema.yml
+++ b/test/integration/008_schema_tests_test/wrong_specification_block/schema.yml
@@ -1,0 +1,4 @@
+version: 2
+models:
+  - name: some_seed
+    description: "This is my seed under a model"

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -1665,7 +1665,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                 'test.macro_info': ANY,
                 'test.macro_arg_info': ANY,
             },
-            'disabled': [],
+            'disabled': {},
         }
 
     def expected_postgres_references_manifest(self, model_database=None):
@@ -2162,7 +2162,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                 'snapshot.test.snapshot_seed': ['seed.test.seed'],
                 'source.test.my_source.my_table': [],
             },
-            'disabled': [],
+            'disabled': {},
             'macros': {
                 'macro.test.test_nothing': {
                     'name': 'test_nothing',
@@ -2652,7 +2652,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                 'test.macro_info': ANY,
                 'test.macro_arg_info': ANY,
             },
-            'disabled': [],
+            'disabled': {},
         }
 
     def _checksum_file(self, path):
@@ -2921,7 +2921,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                 'test.macro_info': ANY,
                 'test.macro_arg_info': ANY,
             },
-            'disabled': [],
+            'disabled': {},
         }
 
     def verify_metadata(self, metadata, dbt_schema_version):

--- a/test/unit/test_manifest.py
+++ b/test/unit/test_manifest.py
@@ -256,7 +256,7 @@ class ManifestTest(unittest.TestCase):
     @freezegun.freeze_time('2018-02-14T09:15:13Z')
     def test__no_nodes(self):
         manifest = Manifest(
-            nodes={}, sources={}, macros={}, docs={}, disabled=[], files={},
+            nodes={}, sources={}, macros={}, docs={}, disabled={}, files={},
             exposures={}, selectors={},
             metadata=ManifestMetadata(generated_at=datetime.utcnow()),
         )
@@ -278,7 +278,7 @@ class ManifestTest(unittest.TestCase):
                     # invocation_id is None, so it will not be present
                 },
                 'docs': {},
-                'disabled': [],
+                'disabled': {},
             }
         )
 
@@ -286,14 +286,14 @@ class ManifestTest(unittest.TestCase):
     def test__nested_nodes(self):
         nodes = copy.copy(self.nested_nodes)
         manifest = Manifest(
-            nodes=nodes, sources={}, macros={}, docs={}, disabled=[], files={},
+            nodes=nodes, sources={}, macros={}, docs={}, disabled={}, files={},
             exposures={}, selectors={},
             metadata=ManifestMetadata(generated_at=datetime.utcnow()),
         )
         serialized = manifest.writable_manifest().to_dict(omit_none=True)
         self.assertEqual(serialized['metadata']['generated_at'], '2018-02-14T09:15:13Z')
         self.assertEqual(serialized['docs'], {})
-        self.assertEqual(serialized['disabled'], [])
+        self.assertEqual(serialized['disabled'], {})
         parent_map = serialized['parent_map']
         child_map = serialized['child_map']
         # make sure there aren't any extra/missing keys.
@@ -355,7 +355,7 @@ class ManifestTest(unittest.TestCase):
         nodes = copy.copy(self.nested_nodes)
         sources = copy.copy(self.sources)
         manifest = Manifest(nodes=nodes, sources=sources, macros={}, docs={},
-                            disabled=[], files={}, exposures=exposures, selectors={})
+                            disabled={}, files={}, exposures=exposures, selectors={})
         manifest.build_flat_graph()
         flat_graph = manifest.flat_graph
         flat_exposures = flat_graph['exposures']
@@ -402,7 +402,7 @@ class ManifestTest(unittest.TestCase):
             generated_at=datetime.utcnow(),
         )
         manifest = Manifest(nodes={}, sources={}, macros={}, docs={},
-                            disabled=[], selectors={},
+                            disabled={}, selectors={},
                             metadata=metadata, files={}, exposures={})
 
         self.assertEqual(
@@ -427,13 +427,13 @@ class ManifestTest(unittest.TestCase):
                     'invocation_id': '01234567-0123-0123-0123-0123456789ab',
                     'env': {ENV_KEY_NAME: 'value'},
                 },
-                'disabled': [],
+                'disabled': {},
             }
         )
 
     def test_get_resource_fqns_empty(self):
         manifest = Manifest(nodes={}, sources={}, macros={}, docs={},
-                            disabled=[], files={}, exposures={}, selectors={})
+                            disabled={}, files={}, exposures={}, selectors={})
         self.assertEqual(manifest.get_resource_fqns(), {})
 
     def test_get_resource_fqns(self):
@@ -459,7 +459,7 @@ class ManifestTest(unittest.TestCase):
             checksum=FileHash.empty(),
         )
         manifest = Manifest(nodes=nodes, sources=self.sources, macros={}, docs={},
-                            disabled=[], files={}, exposures=self.exposures, selectors={})
+                            disabled={}, files={}, exposures=self.exposures, selectors={})
         expect = {
             'exposures': frozenset([
                 ('root', 'my_exposure')
@@ -646,7 +646,7 @@ class MixedManifestTest(unittest.TestCase):
     def test__no_nodes(self):
         metadata = ManifestMetadata(generated_at=datetime.utcnow(), invocation_id='01234567-0123-0123-0123-0123456789ab')
         manifest = Manifest(nodes={}, sources={}, macros={}, docs={}, selectors={},
-                            disabled=[], metadata=metadata, files={}, exposures={})
+                            disabled={}, metadata=metadata, files={}, exposures={})
         self.assertEqual(
             manifest.writable_manifest().to_dict(omit_none=True),
             {
@@ -665,7 +665,7 @@ class MixedManifestTest(unittest.TestCase):
                     'env': {ENV_KEY_NAME: 'value'},
                 },
                 'docs': {},
-                'disabled': [],
+                'disabled': {},
             }
         )
 
@@ -673,12 +673,12 @@ class MixedManifestTest(unittest.TestCase):
     def test__nested_nodes(self):
         nodes = copy.copy(self.nested_nodes)
         manifest = Manifest(nodes=nodes, sources={}, macros={}, docs={},
-                            disabled=[], selectors={},
+                            disabled={}, selectors={},
                             metadata=ManifestMetadata(generated_at=datetime.utcnow()),
                             files={}, exposures={})
         serialized = manifest.writable_manifest().to_dict(omit_none=True)
         self.assertEqual(serialized['metadata']['generated_at'], '2018-02-14T09:15:13Z')
-        self.assertEqual(serialized['disabled'], [])
+        self.assertEqual(serialized['disabled'], {})
         parent_map = serialized['parent_map']
         child_map = serialized['child_map']
         # make sure there aren't any extra/missing keys.
@@ -738,7 +738,7 @@ class MixedManifestTest(unittest.TestCase):
     def test__build_flat_graph(self):
         nodes = copy.copy(self.nested_nodes)
         manifest = Manifest(nodes=nodes, sources={}, macros={}, docs={},
-                            disabled=[], selectors={},
+                            disabled={}, selectors={},
                             files={}, exposures={})
         manifest.build_flat_graph()
         flat_graph = manifest.flat_graph
@@ -785,7 +785,7 @@ class TestManifestSearch(unittest.TestCase):
             docs={
                 d.unique_id: d for d in self.docs
             },
-            disabled=[],
+            disabled={},
             files={},
             exposures={},
             selectors={},
@@ -806,7 +806,7 @@ def make_manifest(nodes=[], sources=[], macros=[], docs=[]):
         docs={
             d.unique_id: d for d in docs
         },
-        disabled=[],
+        disabled={},
         files={},
         exposures={},
         selectors={},


### PR DESCRIPTION
resolves # 3899

### Description

Give a warning when a node is specified under the wrong type in `schema.yml` and don't continue processing.

Does this still need to be handled - I couldn't produce the behavior: Throw an exception for any model/seed/snapshot that has a `unique_id` of `None` and is not disabled.

As part of this change `manifest._disabled` was also removed in favor of the existing `manifest.disabled`.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
