### PR TITLE
[#3810] Skip partial parsing if certain macros have changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixes
 - Add generic tests defined on sources to the manifest once, not twice ([#3347](https://github.com/dbt-labs/dbt/issues/3347), [#3880](https://github.com/dbt-labs/dbt/pull/3880))
+- Skip partial parsing if certain macros have changed ([#3810](https://github.com/dbt-labs/dbt/issues/3810), [#3982](https://github.com/dbt-labs/dbt/pull/3892))
 
 ### Under the hood
 

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -29,7 +29,7 @@ from dbt.context.configured import generate_macro_context
 from dbt.context.providers import ParseProvider
 from dbt.contracts.files import FileHash, ParseFileType, SchemaSourceFile
 from dbt.parser.read_files import read_files, load_source_file
-from dbt.parser.partial import PartialParsing
+from dbt.parser.partial import PartialParsing, special_override_macros
 from dbt.contracts.graph.compiled import ManifestNode
 from dbt.contracts.graph.manifest import (
     Manifest, Disabled, MacroManifest, ManifestStateCheck, ParsingInfo
@@ -130,7 +130,9 @@ class ManifestLoader:
         self.root_project: RuntimeConfig = root_project
         self.all_projects: Mapping[str, Project] = all_projects
         self.manifest: Manifest = Manifest()
+        self.new_manifest = self.manifest
         self.manifest.metadata = root_project.get_metadata()
+        self.macro_resolver = None  # built after macros are loaded
         self.started_at = int(time.time())
         # This is a MacroQueryStringSetter callable, which is called
         # later after we set the MacroManifest in the adapter. It sets
@@ -149,6 +151,7 @@ class ManifestLoader:
         # We need to know if we're actually partially parsing. It could
         # have been enabled, but not happening because of some issue.
         self.partially_parsing = False
+        self.partial_parser = None
 
         # This is a saved manifest from a previous run that's used for partial parsing
         self.saved_manifest: Optional[Manifest] = self.read_manifest_for_partial_parse()
@@ -207,13 +210,14 @@ class ManifestLoader:
             saved_files = self.saved_manifest.files
         for project in self.all_projects.values():
             read_files(project, self.manifest.files, project_parser_files, saved_files)
+        orig_project_parser_files = project_parser_files
         self._perf_info.path_count = len(self.manifest.files)
         self._perf_info.read_files_elapsed = (time.perf_counter() - start_read_files)
 
         skip_parsing = False
         if self.saved_manifest is not None:
-            partial_parsing = PartialParsing(self.saved_manifest, self.manifest.files)
-            skip_parsing = partial_parsing.skip_parsing()
+            self.partial_parser = PartialParsing(self.saved_manifest, self.manifest.files)
+            skip_parsing = self.partial_parser.skip_parsing()
             if skip_parsing:
                 # nothing changed, so we don't need to generate project_parser_files
                 self.manifest = self.saved_manifest
@@ -223,7 +227,7 @@ class ManifestLoader:
                 # files are different, we need to create a new set of
                 # project_parser_files.
                 try:
-                    project_parser_files = partial_parsing.get_parsing_files()
+                    project_parser_files = self.partial_parser.get_parsing_files()
                     self.partially_parsing = True
                     self.manifest = self.saved_manifest
                 except Exception:
@@ -245,7 +249,7 @@ class ManifestLoader:
 
                     # get file info for local logs
                     parse_file_type = None
-                    file_id = partial_parsing.processing_file
+                    file_id = self.partial_parser.processing_file
                     if file_id and file_id in self.manifest.files:
                         old_file = self.manifest.files[file_id]
                         parse_file_type = old_file.parse_file_type
@@ -270,20 +274,19 @@ class ManifestLoader:
             # We need to parse the macros first, so they're resolvable when
             # the other files are loaded
             start_load_macros = time.perf_counter()
-            for project in self.all_projects.values():
-                if project.project_name not in project_parser_files:
-                    continue
-                parser_files = project_parser_files[project.project_name]
-                if 'MacroParser' not in parser_files:
-                    continue
-                parser = MacroParser(project, self.manifest)
-                for file_id in parser_files['MacroParser']:
-                    block = FileBlock(self.manifest.files[file_id])
-                    parser.parse_file(block)
-                    # increment parsed path count for performance tracking
-                    self._perf_info.parsed_path_count = self._perf_info.parsed_path_count + 1
-            # Look at changed macros and update the macro.depends_on.macros
-            self.macro_depends_on()
+            self.load_and_parse_macros(project_parser_files)
+
+            # If we're partially parsing check that certain macros have not been changed
+            if self.partially_parsing and self.skip_partial_parsing_because_of_macros():
+                logger.info(
+                    "Change detected to override macro used during parsing. Starting full parse."
+                )
+                # Get new Manifest with original file records and move over the macros
+                self.manifest = self.new_manifest  # contains newly read files
+                project_parser_files = orig_project_parser_files
+                self.partially_parsing = False
+                self.load_and_parse_macros(project_parser_files)
+
             self._perf_info.load_macros_elapsed = (time.perf_counter() - start_load_macros)
 
             # Now that the macros are parsed, parse the rest of the files.
@@ -370,6 +373,24 @@ class ManifestLoader:
 
         return self.manifest
 
+    def load_and_parse_macros(self, project_parser_files):
+        for project in self.all_projects.values():
+            if project.project_name not in project_parser_files:
+                continue
+            parser_files = project_parser_files[project.project_name]
+            if 'MacroParser' not in parser_files:
+                continue
+            parser = MacroParser(project, self.manifest)
+            for file_id in parser_files['MacroParser']:
+                block = FileBlock(self.manifest.files[file_id])
+                parser.parse_file(block)
+                # increment parsed path count for performance tracking
+                self._perf_info.parsed_path_count = self._perf_info.parsed_path_count + 1
+
+        self.build_macro_resolver()
+        # Look at changed macros and update the macro.depends_on.macros
+        self.macro_depends_on()
+
     # Parse the files in the 'parser_files' dictionary, for parsers listed in
     # 'parser_types'
     def parse_project(
@@ -440,20 +461,23 @@ class ManifestLoader:
             self._perf_info.parsed_path_count + total_parsed_path_count
         )
 
-    # Loop through macros in the manifest and statically parse
-    # the 'macro_sql' to find depends_on.macros
-    def macro_depends_on(self):
+    # This should only be called after the macros have been loaded
+    def build_macro_resolver(self):
         internal_package_names = get_adapter_package_names(
             self.root_project.credentials.type
         )
-        macro_resolver = MacroResolver(
+        self.macro_resolver = MacroResolver(
             self.manifest.macros,
             self.root_project.project_name,
             internal_package_names
         )
+
+    # Loop through macros in the manifest and statically parse
+    # the 'macro_sql' to find depends_on.macros
+    def macro_depends_on(self):
         macro_ctx = generate_macro_context(self.root_project)
         macro_namespace = TestMacroNamespace(
-            macro_resolver, {}, None, MacroStack(), []
+            self.macro_resolver, {}, None, MacroStack(), []
         )
         adapter = get_adapter(self.root_project)
         db_wrapper = ParseProvider().DatabaseWrapper(
@@ -472,7 +496,7 @@ class ManifestLoader:
                 package_name = macro.package_name
                 if '.' in macro_name:
                     package_name, macro_name = macro_name.split('.')
-                dep_macro_id = macro_resolver.get_macro_id(package_name, macro_name)
+                dep_macro_id = self.macro_resolver.get_macro_id(package_name, macro_name)
                 if dep_macro_id:
                     macro.depends_on.add_macro(dep_macro_id)  # will check for dupes
 
@@ -537,6 +561,21 @@ class ManifestLoader:
                     valid = False
                     reparse_reason = ReparseReason.project_config_changed
         return valid, reparse_reason
+
+    def skip_partial_parsing_because_of_macros(self):
+        if not self.partial_parser:
+            return False
+        if self.partial_parser.deleted_special_override_macro:
+            return True
+        # Check for custom versions of these special macros
+        for macro_name in special_override_macros:
+            macro = self.macro_resolver.get_macro(None, macro_name)
+            if macro and macro.package_name != 'dbt':
+                if (macro.file_id in self.partial_parser.file_diff['changed'] or
+                        macro.file_id in self.partial_parser.file_diff['added']):
+                    # The file with the macro in it has changed
+                    return True
+        return False
 
     def read_manifest_for_partial_parse(self) -> Optional[Manifest]:
         if not flags.PARTIAL_PARSE:

--- a/test/integration/068_partial_parsing_tests/extra-files/gsm_override.sql
+++ b/test/integration/068_partial_parsing_tests/extra-files/gsm_override.sql
@@ -1,0 +1,6 @@
+- custom macro
+{% macro generate_schema_name(schema_name, node) %}
+
+    {{ schema_name }}_{{ target.schema }}
+
+{% endmacro %}

--- a/test/integration/068_partial_parsing_tests/extra-files/gsm_override2.sql
+++ b/test/integration/068_partial_parsing_tests/extra-files/gsm_override2.sql
@@ -1,0 +1,6 @@
+- custom macro xxxx
+{% macro generate_schema_name(schema_name, node) %}
+
+    {{ schema_name }}_{{ target.schema }}
+
+{% endmacro %}

--- a/test/integration/068_partial_parsing_tests/extra-files/ref_override.sql
+++ b/test/integration/068_partial_parsing_tests/extra-files/ref_override.sql
@@ -1,0 +1,4 @@
+- Macro to override ref
+{% macro ref(modelname) %}
+{% do return(builtins.ref(modelname)) %}
+{% endmacro %}

--- a/test/integration/068_partial_parsing_tests/extra-files/ref_override2.sql
+++ b/test/integration/068_partial_parsing_tests/extra-files/ref_override2.sql
@@ -1,0 +1,4 @@
+- Macro to override ref xxxx
+{% macro ref(modelname) %}
+{% do return(builtins.ref(modelname)) %}
+{% endmacro %}


### PR DESCRIPTION
resolves #3810

### Description

Checks for changed or new macros for ref, config, source, and the generate_ macros, and switches to a full re-parse.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
