### PR TITLE
Rename default installation directory for packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Enact deprecation for `adapter-macro` and replace deprecation warning with an exception. ([#3901](https://github.com/dbt-labs/dbt/issues/3901))
 - Add warning when trying to put a node under the wrong key.  ie. A seed under models in a `schema.yml` file. ([#3899](https://github.com/dbt-labs/dbt/issues/3899))
 - Plugins for `redshift`, `snowflake`, and `bigquery` have moved to separate repos: [`dbt-redshift`](https://github.com/dbt-labs/dbt-redshift), [`dbt-snowflake`](https://github.com/dbt-labs/dbt-snowflake), [`dbt-bigquery`](https://github.com/dbt-labs/dbt-bigquery)
+- Change the default dbt packages installation directory to `dbt_packages` from `dbt_modules`.  Also rename `module-path` to `packages-install-path` to allow default overrides of package install directory.  Deprecation warning added for projects using the old `dbt_modules` name without specifying a `packages-install-path`.  ([#3523](https://github.com/dbt-labs/dbt/issues/3523))
 
 Contributors:
 

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -166,7 +166,7 @@ class Compiler:
 
     def initialize(self):
         make_directory(self.config.target_path)
-        make_directory(self.config.modules_path)
+        make_directory(self.config.packages_install_path)
 
     # creates a ModelContext which is converted to
     # a dict for jinja rendering of SQL

--- a/core/dbt/config/project.py
+++ b/core/dbt/config/project.py
@@ -341,7 +341,7 @@ class PartialProject(RenderComponents):
         target_path: str = value_or(cfg.target_path, 'target')
         clean_targets: List[str] = value_or(cfg.clean_targets, [target_path])
         log_path: str = value_or(cfg.log_path, 'logs')
-        modules_path: str = value_or(cfg.modules_path, 'dbt_modules')
+        packages_install_path: str = value_or(cfg.packages_install_path, 'dbt_packages')
         # in the default case we'll populate this once we know the adapter type
         # It would be nice to just pass along a Quoting here, but that would
         # break many things
@@ -399,7 +399,7 @@ class PartialProject(RenderComponents):
             snapshot_paths=snapshot_paths,
             clean_targets=clean_targets,
             log_path=log_path,
-            modules_path=modules_path,
+            packages_install_path=packages_install_path,
             quoting=quoting,
             models=models,
             on_run_start=on_run_start,
@@ -511,7 +511,7 @@ class Project:
     snapshot_paths: List[str]
     clean_targets: List[str]
     log_path: str
-    modules_path: str
+    packages_install_path: str
     quoting: Dict[str, Any]
     models: Dict[str, Any]
     on_run_start: List[str]

--- a/core/dbt/config/runtime.py
+++ b/core/dbt/config/runtime.py
@@ -98,7 +98,7 @@ class RuntimeConfig(Project, Profile, AdapterRequiredConfig):
             snapshot_paths=project.snapshot_paths,
             clean_targets=project.clean_targets,
             log_path=project.log_path,
-            modules_path=project.modules_path,
+            packages_install_path=project.packages_install_path,
             quoting=quoting,
             models=project.models,
             on_run_start=project.on_run_start,
@@ -338,7 +338,7 @@ class RuntimeConfig(Project, Profile, AdapterRequiredConfig):
                     f'dbt found {count_packages_specified} package(s) '
                     f'specified in packages.yml, but only '
                     f'{count_packages_installed} package(s) installed '
-                    f'in {self.modules_path}. Run "dbt deps" to '
+                    f'in {self.packages_install_path}. Run "dbt deps" to '
                     f'install package dependencies.'
                 )
             project_paths = itertools.chain(
@@ -376,7 +376,7 @@ class RuntimeConfig(Project, Profile, AdapterRequiredConfig):
                 yield project.project_name, project
 
     def _get_project_directories(self) -> Iterator[Path]:
-        root = Path(self.project_root) / self.modules_path
+        root = Path(self.project_root) / self.packages_install_path
 
         if root.exists():
             for path in root.iterdir():
@@ -494,7 +494,7 @@ class UnsetProfileConfig(RuntimeConfig):
             snapshot_paths=project.snapshot_paths,
             clean_targets=project.clean_targets,
             log_path=project.log_path,
-            modules_path=project.modules_path,
+            packages_install_path=project.packages_install_path,
             quoting=project.quoting,  # we never use this anyway.
             models=project.models,
             on_run_start=project.on_run_start,

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -185,7 +185,7 @@ class Project(HyphenatedDbtClassMixin, Replaceable):
     clean_targets: Optional[List[str]] = None
     profile: Optional[str] = None
     log_path: Optional[str] = None
-    modules_path: Optional[str] = None
+    packages_install_path: Optional[str] = None
     quoting: Optional[Quoting] = None
     on_run_start: Optional[List[str]] = field(default_factory=list_str)
     on_run_end: Optional[List[str]] = field(default_factory=list_str)

--- a/core/dbt/deprecations.py
+++ b/core/dbt/deprecations.py
@@ -55,7 +55,7 @@ class PackageInstallPathDeprecation(DBTDeprecation):
     _name = 'install-packages-path'
     _description = '''\
     The default package install path has changed from `dbt_modules` to `dbt_packages`.
-    Please update `clean-targets` in `dbt_project.yml` and `.gitignore`.
+    Please update `clean-targets` in `dbt_project.yml` and check `.gitignore` as well.
     Or, set `packages-install-path: dbt_modules` if you'd like to keep the current value.
     '''
 

--- a/core/dbt/deprecations.py
+++ b/core/dbt/deprecations.py
@@ -51,6 +51,15 @@ class PackageRedirectDeprecation(DBTDeprecation):
     '''
 
 
+class PackageInstallPathDeprecation(DBTDeprecation):
+    _name = 'install-packages-path'
+    _description = '''\
+    The default package install path has changed from `dbt_modules` to `dbt_packages`.
+    Please update `clean-targets` in `dbt_project.yml` and `.gitignore`.
+    Or, set `packages-install-path: dbt_modules` if you'd like to keep the current value.
+    '''
+
+
 _adapter_renamed_description = """\
 The adapter function `adapter.{old_name}` is deprecated and will be removed in
 a future release of dbt. Please use `adapter.{new_name}` instead.
@@ -89,6 +98,7 @@ def warn(name, *args, **kwargs):
 active_deprecations: Set[str] = set()
 
 deprecations_list: List[DBTDeprecation] = [
+    PackageInstallPathDeprecation(),
     PackageRedirectDeprecation()
 ]
 

--- a/core/dbt/deps/base.py
+++ b/core/dbt/deps/base.py
@@ -91,7 +91,7 @@ class PinnedPackage(BasePackage):
 
     def get_installation_path(self, project, renderer):
         dest_dirname = self.get_project_name(project, renderer)
-        return os.path.join(project.modules_path, dest_dirname)
+        return os.path.join(project.packages_install_path, dest_dirname)
 
     def get_subdirectory(self):
         return None

--- a/core/dbt/deps/registry.py
+++ b/core/dbt/deps/registry.py
@@ -69,7 +69,7 @@ class RegistryPinnedPackage(RegistryPackageMixin, PinnedPackage):
 
         download_url = metadata.downloads.tarball
         system.download_with_retries(download_url, tar_path)
-        deps_path = project.modules_path
+        deps_path = project.packages_install_path
         package_name = self.get_project_name(project, renderer)
         system.untar_package(tar_path, deps_path, package_name)
 

--- a/core/dbt/include/starter_project/.gitignore
+++ b/core/dbt/include/starter_project/.gitignore
@@ -1,4 +1,4 @@
 
 target/
-dbt_modules/
+dbt_packages/
 logs/

--- a/core/dbt/include/starter_project/dbt_project.yml
+++ b/core/dbt/include/starter_project/dbt_project.yml
@@ -22,7 +22,7 @@ snapshot-paths: ["snapshots"]
 target-path: "target"  # directory which will store compiled SQL files
 clean-targets:         # directories to be removed by `dbt clean`
   - "target"
-  - "dbt_modules"
+  - "dbt_packages"
 
 
 # Configuring models

--- a/core/dbt/main.py
+++ b/core/dbt/main.py
@@ -431,7 +431,7 @@ def _build_clean_subparser(subparsers, base_subparser):
         parents=[base_subparser],
         help='''
         Delete all folders in the clean-targets list
-        (usually the dbt_modules and target directories.)
+        (usually the dbt_packages and target directories.)
         '''
     )
     sub.set_defaults(cls=clean_task.CleanTask, which='clean', rpc_method=None)

--- a/core/dbt/task/clean.py
+++ b/core/dbt/task/clean.py
@@ -2,6 +2,7 @@ import os.path
 import os
 import shutil
 
+from dbt import deprecations
 from dbt.task.base import BaseTask, move_to_nearest_project_dir
 from dbt.logger import GLOBAL_LOGGER as logger
 from dbt.config import UnsetProfileConfig
@@ -33,6 +34,9 @@ class CleanTask(BaseTask):
         and cleans the project paths that are not protected.
         """
         move_to_nearest_project_dir(self.args)
+        if ('dbt_modules' in self.config.clean_targets and
+           self.config.packages_install_path != 'dbt_modules'):
+            deprecations.warn('install-packages-path')
         for path in self.config.clean_targets:
             logger.info("Checking {}/*".format(path))
             if not self.__is_protected_path(path):

--- a/core/dbt/task/deps.py
+++ b/core/dbt/task/deps.py
@@ -43,7 +43,7 @@ class DepsTask(BaseTask):
         )
 
     def run(self):
-        system.make_directory(self.config.modules_path)
+        system.make_directory(self.config.packages_install_path)
         packages = self.config.packages.packages
         if not packages:
             logger.info('Warning: No packages were found in packages.yml')

--- a/core/dbt/task/rpc/deps.py
+++ b/core/dbt/task/rpc/deps.py
@@ -9,9 +9,9 @@ from dbt.task.deps import DepsTask
 
 
 def _clean_deps(config):
-    if os.path.exists(config.modules_path):
-        shutil.rmtree(config.modules_path)
-    os.makedirs(config.modules_path)
+    if os.path.exists(config.packages_install_path):
+        shutil.rmtree(config.packages_install_path)
+    os.makedirs(config.packages_install_path)
 
 
 class RemoteDepsTask(

--- a/performance/projects/01_2000_simple_models/dbt_project.yml
+++ b/performance/projects/01_2000_simple_models/dbt_project.yml
@@ -22,7 +22,7 @@ macro-paths: ["macros"]
 target-path: "target"  # directory which will store compiled SQL files
 clean-targets:         # directories to be removed by `dbt clean`
     - "target"
-    - "dbt_modules"
+    - "dbt_packages"
 
 # You can define configurations for models in the `source-paths` directory here.
 # Using these configurations, you can enable or disable models, change how they

--- a/test/integration/006_simple_dependency_test/local_dependency/dbt_project.yml
+++ b/test/integration/006_simple_dependency_test/local_dependency/dbt_project.yml
@@ -16,7 +16,7 @@ require-dbt-version: '>=0.1.0'
 target-path: "target"  # directory which will store compiled SQL files
 clean-targets:         # directories to be removed by `dbt clean`
     - "target"
-    - "dbt_modules"
+    - "dbt_packages"
 
 
 seeds:

--- a/test/integration/006_simple_dependency_test/test_local_dependency.py
+++ b/test/integration/006_simple_dependency_test/test_local_dependency.py
@@ -296,7 +296,7 @@ class TestSimpleDependencyDuplicateName(DBTIntegrationTest):
 
     @use_profile('postgres')
     def test_postgres_local_dependency_same_name_sneaky(self):
-        os.makedirs('dbt_modules')
-        shutil.copytree('./duplicate_dependency', './dbt_modules/duplicate_dependency')
+        os.makedirs('dbt_packages')
+        shutil.copytree('./duplicate_dependency', './dbt_packages/duplicate_dependency')
         with self.assertRaises(dbt.exceptions.CompilationException):
             self.run_dbt(['compile'], expect_pass=False)

--- a/test/integration/006_simple_dependency_test/test_simple_dependency.py
+++ b/test/integration/006_simple_dependency_test/test_simple_dependency.py
@@ -173,7 +173,7 @@ class TestRekeyedDependencyWithSubduplicates(DBTIntegrationTest):
     @use_profile('postgres')
     def test_postgres_simple_dependency_deps(self):
         self.run_dbt(["deps"])
-        self.assertEqual(len(os.listdir('dbt_modules')), 2)
+        self.assertEqual(len(os.listdir('dbt_packages')), 2)
 
 
 class TestSimpleDependencyBranch(DBTIntegrationTest):

--- a/test/integration/012_deprecation_tests/models-trivial/model.sql
+++ b/test/integration/012_deprecation_tests/models-trivial/model.sql
@@ -1,0 +1,1 @@
+select 1 as id

--- a/test/integration/012_deprecation_tests/test_deprecations.py
+++ b/test/integration/012_deprecation_tests/test_deprecations.py
@@ -35,6 +35,34 @@ class TestDeprecations(BaseTestDeprecations):
         self.assertEqual(expected, deprecations.active_deprecations)
 
 
+class TestPackageInstallPathDeprecation(BaseTestDeprecations):
+    @property
+    def models(self):
+        return self.dir('dispatch-models')
+
+    @property
+    def project_config(self):
+        return {
+            'config-version': 2,
+            "clean-targets": "dbt_modules"
+        }
+
+    @use_profile('postgres')
+    def test_postgres_adapter_macro(self):
+        self.assertEqual(deprecations.active_deprecations, set())
+        self.run_dbt(["clean"])
+        expected = {'install-packages-path'}
+        self.assertEqual(expected, deprecations.active_deprecations)
+
+    @use_profile('postgres')
+    def test_postgres_adapter_macro_fail(self):
+        self.assertEqual(deprecations.active_deprecations, set())
+        with self.assertRaises(dbt.exceptions.CompilationException) as exc:
+            self.run_dbt(['--warn-error', 'run'])
+        exc_str = ' '.join(str(exc.exception).split())  # flatten all whitespace
+        assert 'path has changed from `dbt_modules` to `dbt_packages`.' in exc_str
+
+
 class TestPackageRedirectDeprecation(BaseTestDeprecations):
     @property
     def models(self):

--- a/test/integration/012_deprecation_tests/test_deprecations.py
+++ b/test/integration/012_deprecation_tests/test_deprecations.py
@@ -38,27 +38,27 @@ class TestDeprecations(BaseTestDeprecations):
 class TestPackageInstallPathDeprecation(BaseTestDeprecations):
     @property
     def models(self):
-        return self.dir('dispatch-models')
+        return self.dir('models-trivial')
 
     @property
     def project_config(self):
         return {
             'config-version': 2,
-            "clean-targets": "dbt_modules"
+            "clean-targets": ["dbt_modules"]
         }
 
     @use_profile('postgres')
-    def test_postgres_adapter_macro(self):
+    def test_postgres_package_path(self):
         self.assertEqual(deprecations.active_deprecations, set())
         self.run_dbt(["clean"])
         expected = {'install-packages-path'}
         self.assertEqual(expected, deprecations.active_deprecations)
 
     @use_profile('postgres')
-    def test_postgres_adapter_macro_fail(self):
+    def test_postgres_package_path_not_set(self):
         self.assertEqual(deprecations.active_deprecations, set())
         with self.assertRaises(dbt.exceptions.CompilationException) as exc:
-            self.run_dbt(['--warn-error', 'run'])
+            self.run_dbt(['--warn-error', 'clean'])
         exc_str = ' '.join(str(exc.exception).split())  # flatten all whitespace
         assert 'path has changed from `dbt_modules` to `dbt_packages`.' in exc_str
 

--- a/test/integration/013_context_var_tests/first_dependency/dbt_project.yml
+++ b/test/integration/013_context_var_tests/first_dependency/dbt_project.yml
@@ -16,7 +16,7 @@ require-dbt-version: '>=0.1.0'
 target-path: "target"  # directory which will store compiled SQL files
 clean-targets:         # directories to be removed by `dbt clean`
     - "target"
-    - "dbt_modules"
+    - "dbt_packages"
 
 vars:
   first_dep:

--- a/test/integration/068_partial_parsing_tests/local_dependency/dbt_project.yml
+++ b/test/integration/068_partial_parsing_tests/local_dependency/dbt_project.yml
@@ -16,7 +16,7 @@ require-dbt-version: '>=0.1.0'
 target-path: "target"  # directory which will store compiled SQL files
 clean-targets:         # directories to be removed by `dbt clean`
     - "target"
-    - "dbt_modules"
+    - "dbt_packages"
 
 
 seeds:

--- a/test/integration/100_rpc_test/test_rpc.py
+++ b/test/integration/100_rpc_test/test_rpc.py
@@ -1121,12 +1121,12 @@ class TestRPCServerDeps(HasRPCServer):
 
     def setUp(self):
         super().setUp()
-        if os.path.exists('./dbt_modules'):
-            shutil.rmtree('./dbt_modules')
+        if os.path.exists('./dbt_packages'):
+            shutil.rmtree('./dbt_packages')
 
     def tearDown(self):
-        if os.path.exists('./dbt_modules'):
-            shutil.rmtree('./dbt_modules')
+        if os.path.exists('./dbt_packages'):
+            shutil.rmtree('./dbt_packages')
         self.adapter.cleanup_connections()
         super().tearDown()
 
@@ -1144,7 +1144,7 @@ class TestRPCServerDeps(HasRPCServer):
         return "deps_models"
 
     def _check_start_predeps(self):
-        self.assertFalse(os.path.exists('./dbt_modules'))
+        self.assertFalse(os.path.exists('./dbt_packages'))
         status = self.assertIsResult(self.query('status').json())
         # will return an error because defined dependency is missing
         self.assertEqual(status['state'], 'error')
@@ -1155,8 +1155,8 @@ class TestRPCServerDeps(HasRPCServer):
 
         self.wait_for_state('ready', timestamp=status['timestamp'])
 
-        self.assertTrue(os.path.exists('./dbt_modules'))
-        self.assertEqual(len(os.listdir('./dbt_modules')), 1)
+        self.assertTrue(os.path.exists('./dbt_packages'))
+        self.assertEqual(len(os.listdir('./dbt_packages')), 1)
         self.assertIsResult(self.async_query('compile').json())
 
     @mark.flaky(rerun_filter=addr_in_use, max_runs=3)

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -596,7 +596,7 @@ class TestProject(BaseConfigTest):
         self.assertEqual(project.target_path, 'target')
         self.assertEqual(project.clean_targets, ['target'])
         self.assertEqual(project.log_path, 'logs')
-        self.assertEqual(project.modules_path, 'dbt_modules')
+        self.assertEqual(project.packages_install_path, 'dbt_packages')
         self.assertEqual(project.quoting, {})
         self.assertEqual(project.models, {})
         self.assertEqual(project.on_run_start, [])
@@ -643,7 +643,7 @@ class TestProject(BaseConfigTest):
             'target-path': 'other-target',
             'clean-targets': ['another-target'],
             'log-path': 'other-logs',
-            'modules-path': 'other-dbt_modules',
+            'packages-install-path': 'other-dbt_packages',
             'quoting': {'identifier': False},
             'models': {
                 'pre-hook': ['{{ logging.log_model_start_event() }}'],
@@ -713,7 +713,7 @@ class TestProject(BaseConfigTest):
         self.assertEqual(project.target_path, 'other-target')
         self.assertEqual(project.clean_targets, ['another-target'])
         self.assertEqual(project.log_path, 'other-logs')
-        self.assertEqual(project.modules_path, 'other-dbt_modules')
+        self.assertEqual(project.packages_install_path, 'other-dbt_packages')
         self.assertEqual(project.quoting, {'identifier': False})
         self.assertEqual(project.models, {
             'pre-hook': ['{{ logging.log_model_start_event() }}'],
@@ -1208,7 +1208,7 @@ class TestRuntimeConfigFiles(BaseFileTest):
         self.assertEqual(config.target_path, 'target')
         self.assertEqual(config.clean_targets, ['target'])
         self.assertEqual(config.log_path, 'logs')
-        self.assertEqual(config.modules_path, 'dbt_modules')
+        self.assertEqual(config.packages_install_path, 'dbt_packages')
         self.assertEqual(config.quoting, {'database': True, 'identifier': True, 'schema': True})
         self.assertEqual(config.models, {})
         self.assertEqual(config.on_run_start, [])

--- a/test/unit/test_parser.py
+++ b/test/unit/test_parser.py
@@ -61,7 +61,7 @@ class BaseParserTest(unittest.TestCase):
                 unique_id=f'macro.root.{name}',
                 package_name='root',
                 original_file_path=normalize('macros/macro.sql'),
-                root_path=get_abs_os_path('./dbt_modules/root'),
+                root_path=get_abs_os_path('./dbt_packages/root'),
                 path=normalize('macros/macro.sql'),
                 macro_sql=sql,
             )
@@ -109,7 +109,7 @@ class BaseParserTest(unittest.TestCase):
             'name': 'snowplow',
             'version': '0.1',
             'profile': 'test',
-            'project-root': get_abs_os_path('./dbt_modules/snowplow'),
+            'project-root': get_abs_os_path('./dbt_packages/snowplow'),
             'config-version': 2,
         }
 
@@ -139,7 +139,7 @@ class BaseParserTest(unittest.TestCase):
         self.patcher.stop()
 
     def file_block_for(self, data: str, filename: str, searched: str):
-        root_dir = get_abs_os_path('./dbt_modules/snowplow')
+        root_dir = get_abs_os_path('./dbt_packages/snowplow')
         filename = normalize(filename)
         path = FilePath(
             searched_path=searched,
@@ -503,7 +503,7 @@ class ModelParserTest(BaseParserTest):
             fqn=['snowplow', 'nested', 'model_1'],
             package_name='snowplow',
             original_file_path=normalize('models/nested/model_1.sql'),
-            root_path=get_abs_os_path('./dbt_modules/snowplow'),
+            root_path=get_abs_os_path('./dbt_packages/snowplow'),
             config=NodeConfig(materialized='table'),
             path=normalize('nested/model_1.sql'),
             raw_sql=raw_sql,
@@ -544,7 +544,7 @@ class StaticModelParserTest(BaseParserTest):
             unique_id=macro_unique_id,
             package_name='root',
             original_file_path=normalize('macros/macro.sql'),
-            root_path=get_abs_os_path('./dbt_modules/root'),
+            root_path=get_abs_os_path('./dbt_packages/root'),
             path=normalize('macros/macro.sql'),
             macro_sql='{% macro ref(model_name) %}{% set x = raise("boom") %}{% endmacro %}',
         )
@@ -561,7 +561,7 @@ class StaticModelParserTest(BaseParserTest):
             fqn=['snowplow', 'nested', 'model_1'],
             package_name='snowplow',
             original_file_path=normalize('models/nested/model_1.sql'),
-            root_path=get_abs_os_path('./dbt_modules/snowplow'),
+            root_path=get_abs_os_path('./dbt_packages/snowplow'),
             config=NodeConfig(materialized='table'),
             path=normalize('nested/model_1.sql'),
             raw_sql=raw_sql,
@@ -615,7 +615,7 @@ class SnapshotParserTest(BaseParserTest):
             fqn=['snowplow', 'nested', 'snap_1', 'foo'],
             package_name='snowplow',
             original_file_path=normalize('snapshots/nested/snap_1.sql'),
-            root_path=get_abs_os_path('./dbt_modules/snowplow'),
+            root_path=get_abs_os_path('./dbt_packages/snowplow'),
             config=SnapshotConfig(
                 strategy='timestamp',
                 updated_at='last_update',
@@ -676,7 +676,7 @@ class SnapshotParserTest(BaseParserTest):
             fqn=['snowplow', 'nested', 'snap_1', 'foo'],
             package_name='snowplow',
             original_file_path=normalize('snapshots/nested/snap_1.sql'),
-            root_path=get_abs_os_path('./dbt_modules/snowplow'),
+            root_path=get_abs_os_path('./dbt_packages/snowplow'),
             config=SnapshotConfig(
                 strategy='timestamp',
                 updated_at='last_update',
@@ -706,7 +706,7 @@ class SnapshotParserTest(BaseParserTest):
             fqn=['snowplow', 'nested', 'snap_1', 'bar'],
             package_name='snowplow',
             original_file_path=normalize('snapshots/nested/snap_1.sql'),
-            root_path=get_abs_os_path('./dbt_modules/snowplow'),
+            root_path=get_abs_os_path('./dbt_packages/snowplow'),
             config=SnapshotConfig(
                 strategy='timestamp',
                 updated_at='last_update',
@@ -758,7 +758,7 @@ class MacroParserTest(BaseParserTest):
             unique_id='macro.snowplow.foo',
             package_name='snowplow',
             original_file_path=normalize('macros/macro.sql'),
-            root_path=get_abs_os_path('./dbt_modules/snowplow'),
+            root_path=get_abs_os_path('./dbt_packages/snowplow'),
             path=normalize('macros/macro.sql'),
             macro_sql=raw_sql,
         )
@@ -781,7 +781,7 @@ class MacroParserTest(BaseParserTest):
             unique_id='macro.snowplow.bar',
             package_name='snowplow',
             original_file_path=normalize('macros/macro.sql'),
-            root_path=get_abs_os_path('./dbt_modules/snowplow'),
+            root_path=get_abs_os_path('./dbt_packages/snowplow'),
             path=normalize('macros/macro.sql'),
             macro_sql='{% macro bar(c, d) %}c + d{% endmacro %}',
         )
@@ -791,7 +791,7 @@ class MacroParserTest(BaseParserTest):
             unique_id='macro.snowplow.foo',
             package_name='snowplow',
             original_file_path=normalize('macros/macro.sql'),
-            root_path=get_abs_os_path('./dbt_modules/snowplow'),
+            root_path=get_abs_os_path('./dbt_packages/snowplow'),
             path=normalize('macros/macro.sql'),
             macro_sql='{% macro foo(a, b) %}a ~ b{% endmacro %}',
         )
@@ -834,7 +834,7 @@ class SingularTestParserTest(BaseParserTest):
             fqn=['snowplow', 'test_1'],
             package_name='snowplow',
             original_file_path=normalize('tests/test_1.sql'),
-            root_path=get_abs_os_path('./dbt_modules/snowplow'),
+            root_path=get_abs_os_path('./dbt_packages/snowplow'),
             refs=[['blah']],
             config=TestConfig(severity='ERROR'),
             tags=[],
@@ -878,7 +878,7 @@ class AnalysisParserTest(BaseParserTest):
             fqn=['snowplow', 'analysis', 'nested', 'analysis_1'],
             package_name='snowplow',
             original_file_path=normalize('analyses/nested/analysis_1.sql'),
-            root_path=get_abs_os_path('./dbt_modules/snowplow'),
+            root_path=get_abs_os_path('./dbt_packages/snowplow'),
             depends_on=DependsOn(),
             config=NodeConfig(),
             path=normalize('analysis/nested/analysis_1.sql'),

--- a/test/unit/utils.py
+++ b/test/unit/utils.py
@@ -235,7 +235,7 @@ def generate_name_macros(package):
             unique_id=f'macro.{package}.{name}',
             package_name=package,
             original_file_path=normalize('macros/macro.sql'),
-            root_path='./dbt_modules/root',
+            root_path='./dbt_packages/root',
             path=normalize('macros/macro.sql'),
             macro_sql=sql,
         )


### PR DESCRIPTION
resolves #3523

### Description

- Change the default dbt packages installation directory to `dbt_packages` from `dbt_modules`.  
- Rename `module-path` to `packages-install-path` to make the purpose more clear. 
- Add deprecation warning for projects using the old `dbt_modules` name without specifying a `packages-install-path`.  Add related deprecation test.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
