### PR TITLE
Porting back Changelog changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,9 @@ Contributors:
 - [@dave-connors-3](https://github.com/dave-connors-3) ([#3920](https://github.com/dbt-labs/dbt/issues/3920))
 - [@kadero](https://github.com/kadero) ([#3952](https://github.com/dbt-labs/dbt/issues/3952))
 
-## dbt 0.21.0 (Release TBD)
+## dbt 0.21.0 (October 04, 2021)
+
+## dbt 0.21.0rc2 (September 27, 2021)
 
 ### Fixes
 - Fix batching for large seeds on Snowflake ([#3941](https://github.com/dbt-labs/dbt/issues/3941), [#3942](https://github.com/dbt-labs/dbt/pull/3942))


### PR DESCRIPTION
Porting back Changelog changes from the last `0.21.0` releases