### PR TITLE
add flag --no-skip-on-failure for command build, run, retry, seed

### DIFF
--- a/.changes/unreleased/Features-20231107-132842.yaml
+++ b/.changes/unreleased/Features-20231107-132842.yaml
@@ -1,5 +1,5 @@
 kind: Features
-body: add flag --no-skip-on-failture
+body: add flag --no-skip-on-failure
 time: 2023-11-07T13:28:42.420727773+01:00
 custom:
   Author: leo-schick

--- a/.changes/unreleased/Features-20231107-132842.yaml
+++ b/.changes/unreleased/Features-20231107-132842.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: add flag --no-skip-on-failture
+time: 2023-11-07T13:28:42.420727773+01:00
+custom:
+  Author: leo-schick
+  Issue: "2142"

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -174,7 +174,7 @@ def cli(ctx, **kwargs):
 @p.export_saved_queries
 @p.full_refresh
 @p.deprecated_include_saved_query
-@p.no_skip_on_failture
+@p.no_skip_on_failure
 @p.profiles_dir
 @p.project_dir
 @p.resource_type
@@ -542,7 +542,7 @@ def parse(ctx, **kwargs):
 @global_flags
 @p.exclude
 @p.full_refresh
-@p.no_skip_on_failture
+@p.no_skip_on_failure
 @p.profiles_dir
 @p.project_dir
 @p.empty
@@ -580,7 +580,7 @@ def run(ctx, **kwargs):
 @p.profiles_dir
 @p.vars
 @p.target_path
-@p.no_skip_on_failture
+@p.no_skip_on_failure
 @p.threads
 @p.full_refresh
 @requires.postflight
@@ -677,7 +677,7 @@ def run_operation(ctx, **kwargs):
 @global_flags
 @p.exclude
 @p.full_refresh
-@p.no_skip_on_failture
+@p.no_skip_on_failure
 @p.profiles_dir
 @p.project_dir
 @p.select

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -174,6 +174,7 @@ def cli(ctx, **kwargs):
 @p.export_saved_queries
 @p.full_refresh
 @p.deprecated_include_saved_query
+@p.no_skip_on_failture
 @p.profiles_dir
 @p.project_dir
 @p.resource_type
@@ -541,6 +542,7 @@ def parse(ctx, **kwargs):
 @global_flags
 @p.exclude
 @p.full_refresh
+@p.no_skip_on_failture
 @p.profiles_dir
 @p.project_dir
 @p.empty
@@ -578,6 +580,7 @@ def run(ctx, **kwargs):
 @p.profiles_dir
 @p.vars
 @p.target_path
+@p.no_skip_on_failture
 @p.threads
 @p.full_refresh
 @requires.postflight
@@ -674,6 +677,7 @@ def run_operation(ctx, **kwargs):
 @global_flags
 @p.exclude
 @p.full_refresh
+@p.no_skip_on_failture
 @p.profiles_dir
 @p.project_dir
 @p.select

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -609,6 +609,7 @@ def retry(ctx, **kwargs):
 @global_flags
 @p.exclude
 @p.full_refresh
+@p.no_skip_on_failure
 @p.profiles_dir
 @p.project_dir
 @p.resource_type

--- a/core/dbt/cli/params.py
+++ b/core/dbt/cli/params.py
@@ -120,6 +120,13 @@ fail_fast = click.option(
     help="Stop execution on first failure.",
 )
 
+no_skip_on_failture = click.option(
+    "--no-skip-on-failture",
+    envvar="DBT_NO_SKIP_ON_FAILTURE",
+    help="If specified, dbt will proceed with downstream models even the dependent model failed.",
+    is_flag=True,
+)
+
 favor_state = click.option(
     "--favor-state/--no-favor-state",
     envvar="DBT_FAVOR_STATE",

--- a/core/dbt/cli/params.py
+++ b/core/dbt/cli/params.py
@@ -120,9 +120,9 @@ fail_fast = click.option(
     help="Stop execution on first failure.",
 )
 
-no_skip_on_failture = click.option(
-    "--no-skip-on-failture",
-    envvar="DBT_NO_SKIP_ON_FAILTURE",
+no_skip_on_failure = click.option(
+    "--no-skip-on-failure",
+    envvar="DBT_NO_SKIP_ON_FAILURE",
     help="Proceed with downstream nodes even if an upstream node fails.",
     is_flag=True,
 )

--- a/core/dbt/cli/params.py
+++ b/core/dbt/cli/params.py
@@ -123,7 +123,7 @@ fail_fast = click.option(
 no_skip_on_failture = click.option(
     "--no-skip-on-failture",
     envvar="DBT_NO_SKIP_ON_FAILTURE",
-    help="If specified, dbt will proceed with downstream models even the dependent model failed.",
+    help="Proceed with downstream nodes even if an upstream node fails.",
     is_flag=True,
 )
 

--- a/core/dbt/flags.py
+++ b/core/dbt/flags.py
@@ -75,7 +75,7 @@ def get_flag_dict():
         "log_format",
         "version_check",
         "fail_fast",
-        "no_skip_on_failture",
+        "no_skip_on_failure",
         "send_anonymous_usage_stats",
         "printer_width",
         "indirect_selection",

--- a/core/dbt/flags.py
+++ b/core/dbt/flags.py
@@ -75,6 +75,7 @@ def get_flag_dict():
         "log_format",
         "version_check",
         "fail_fast",
+        "no_skip_on_failture",
         "send_anonymous_usage_stats",
         "printer_width",
         "indirect_selection",

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -450,8 +450,8 @@ class GraphRunnableTask(ConfiguredTask):
     ) -> None:
         if self.graph is None:
             raise DbtInternalError("graph is None in _mark_dependent_errors")
-        no_skip_on_failture = get_flags().NO_SKIP_ON_FAILTURE
-        if not no_skip_on_failture:
+        no_skip_on_failure = get_flags().NO_SKIP_ON_FAILURE
+        if not no_skip_on_failure:
             for dep_node_id in self.graph.get_dependent_nodes(UniqueId(node_id)):
                 self._skipped_children[dep_node_id] = cause
 

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -450,8 +450,10 @@ class GraphRunnableTask(ConfiguredTask):
     ) -> None:
         if self.graph is None:
             raise DbtInternalError("graph is None in _mark_dependent_errors")
-        for dep_node_id in self.graph.get_dependent_nodes(UniqueId(node_id)):
-            self._skipped_children[dep_node_id] = cause
+        no_skip_on_failture = get_flags().NO_SKIP_ON_FAILTURE
+        if not no_skip_on_failture:
+            for dep_node_id in self.graph.get_dependent_nodes(UniqueId(node_id)):
+                self._skipped_children[dep_node_id] = cause
 
     def populate_adapter_cache(
         self, adapter, required_schemas: Optional[Set[BaseRelation]] = None

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -350,6 +350,7 @@ def args_to_dict(args):
             "debug",
             "full_refresh",
             "fail_fast",
+            "no_skip_on_failture",
             "warn_error",
             "single_threaded",
             "log_cache_events",

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -350,7 +350,7 @@ def args_to_dict(args):
             "debug",
             "full_refresh",
             "fail_fast",
-            "no_skip_on_failture",
+            "no_skip_on_failure",
             "warn_error",
             "single_threaded",
             "log_cache_events",


### PR DESCRIPTION
resolves #2142

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

Downstream models are skipped. Sometimes e.g. when working in big data warehouses, it might be desirable to proceed with downstream models even a upstream model failed.


### Solution

Adds a new flag `--no-skip-on-failture` for the dbt commands `build`, `run`, `retry`, `clone` and `seed`. If set, the downstream models will not be added to `self._skipped_children` and therefore will not be skipped.

Note: user docs might need to be updated.

### Testing

I created a initial project with two additional models:
* `must_fail` - always fails
* `dependent_model` - uses the failing model

#### Test 1 - run without the new flag

![image](https://github.com/dbt-labs/dbt-core/assets/67712864/94237e52-64cf-4cfe-8453-7cdf179a31a8)

The model `dependent_model` is still skipped.

#### Test 2 - run with flag `--no-skip-on-failture`

![image](https://github.com/dbt-labs/dbt-core/assets/67712864/96394d70-e126-4b78-81f0-f6a3b9e8c3ea)

The model `dependent_model` is now executed, but fails since the table for `must_fail` does not exist. (This is expected behavior. In a real world scenario the failing model table might already exist from a previous execution and the model `dependent_model` would process successfully).

#### Test 3 - run retry with flag `--no-skip-on-failture`

![image](https://github.com/dbt-labs/dbt-core/assets/67712864/28bc6848-e3bd-410b-8b54-06a649b477f3)

The failing models are executed as expected.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR *(IMO not required; if wanted please assist how to build the tests)*
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions *(not required)*
