### PR TITLE
fix: bad argument passed in tracking _log_result

### DIFF
--- a/.changes/unreleased/Fixes-20240312-165522.yaml
+++ b/.changes/unreleased/Fixes-20240312-165522.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Change request type shown in tracking logs for POST request
+time: 2024-03-12T16:55:22.517958+01:00
+custom:
+  Author: pol-defont-reaulx
+  Issue: "9753"

--- a/core/dbt/tracking.py
+++ b/core/dbt/tracking.py
@@ -90,7 +90,7 @@ class TimeoutEmitter(Emitter):
             timeout=5.0,
         )
 
-        self._log_result("GET", r.status_code)
+        self._log_result("POST", r.status_code)
         return r
 
     def http_get(self, payload):


### PR DESCRIPTION
resolves #9753

### Problem

In tracking.py, the string argument sent to _log_result for http_post is not the right one. It's "GET" and should be "POST"

### Solution

Change "GET" to "POST"

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
