### PR TITLE
fix: dbt unit tests feat without proper context

### DIFF
--- a/core/dbt/parser/unit_tests.py
+++ b/core/dbt/parser/unit_tests.py
@@ -100,19 +100,11 @@ class UnitTestManifestLoader:
 
         ctx = generate_parse_exposure(
             unit_test_node,  # type: ignore
-            self.root_project,
+            self.root_project,  # config
             self.manifest,
             test_case.package_name,
         )
 
-        # just to illustrate the issue in #..., but this change is obviously not
-        # the correct solution. I’ll wait for a discussion before writing any more
-        # advanced code.
-
-        if "var" not in ctx:
-            ctx["var"] = lambda var_name, default =None: default
-        if "env_var" not in ctx:
-            ctx["env_var"] = lambda var_name, default=None: default
         get_rendered(unit_test_node.raw_code, ctx, unit_test_node, capture_macros=True)
         # unit_test_node now has a populated refs/sources
 

--- a/core/dbt/parser/unit_tests.py
+++ b/core/dbt/parser/unit_tests.py
@@ -104,6 +104,15 @@ class UnitTestManifestLoader:
             self.manifest,
             test_case.package_name,
         )
+
+        # just to illustrate the issue in #..., but this change is obviously not
+        # the correct solution. I’ll wait for a discussion before writing any more
+        # advanced code.
+
+        if "var" not in ctx:
+            ctx["var"] = lambda var_name, default =None: default
+        if "env_var" not in ctx:
+            ctx["env_var"] = lambda var_name, default=None: default
         get_rendered(unit_test_node.raw_code, ctx, unit_test_node, capture_macros=True)
         # unit_test_node now has a populated refs/sources
 


### PR DESCRIPTION
Resolves #10539, resolves #10353 , resolves #10410

I made a very simple change to the code just to  solve a similar problem 10353, but this change is obviously not the correct solution. I’ll wait for a discussion before writing any more advanced code.

### Problem

absence of `env_var` and `var` in the `ctx` dictionary, which must be passed to the Jinja render method. 

### Solution

If a model has a unit test, the `get_rendered` method is called twice, each time with a different context. The issue arises with `build_unit_test_manifest_from_test`. When this method is called (https://github.com/dbt-labs/dbt-core/blob/f6088db25b4a386db49dfda5de613d1e70bb2445/core/dbt/parser/unit_tests.py#L116), the context doesn’t contain information about the `var` and environment variables (`env_var`).

Later, when the `get_rendered` method from `clients/jinja.py` calls `render_template` from `dbt_common/clients/jinja.py`, we encounter a compilation error due to the absence of `env_var` and `var` in the `ctx` dictionary, which must be passed to the Jinja render method. **The error will not appear if we don't have any kind of mixing with Nones, for example `select {{ var('something,1) }} as result` instead of `select {{ var('something,1)*2 }} as result`

Some questions:

Is this the expected behavior? Shouldn't the `ctx` used to render the string for the unit test include these variables?

Is there a reason why the same model is rendered more than once — once to build the model and again to render the unit test? Why is this string rendered a second time if it doesn’t seem to be used for any data manipulation?


models/_unit_tests.yml
```
version: 2

unit_tests:
  - name: test_unit_test
    model: test
    given: []
    expect:
      format: csv
      rows: |
        result
        10
```

models/test.sql
```
select {{ var('foo', 10) * 1 }} as result
```



This will only work for #10539 if ctx is constructed using `env_var`  and `var`,  but before coding any stuff I'll wait for the dbt-core team

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
