### PR TITLE
Only try to create log directory if file logging is enabled

### DIFF
--- a/.changes/unreleased/Fixes-20241030-130239.yaml
+++ b/.changes/unreleased/Fixes-20241030-130239.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Don't try to create the log directory when file logging is disabled
+time: 2024-10-30T13:02:39.206813142-06:00
+custom:
+    Author: ericfreese
+    Issue: "10948"

--- a/core/dbt/events/logging.py
+++ b/core/dbt/events/logging.py
@@ -67,7 +67,6 @@ def _logfile_filter(log_cache_events: bool, line_format: LineFormat, msg: EventM
 
 def setup_event_logger(flags, callbacks: List[Callable[[EventMsg], None]] = []) -> None:
     cleanup_event_logger()
-    make_log_dir_if_missing(flags.LOG_PATH)
     event_manager = get_event_manager()
     event_manager.callbacks = callbacks.copy()
     add_callback_to_manager(track_behavior_change_warn)
@@ -93,6 +92,8 @@ def setup_event_logger(flags, callbacks: List[Callable[[EventMsg], None]] = []) 
         add_logger_to_manager(console_config)
 
     if flags.LOG_LEVEL_FILE != "none":
+        make_log_dir_if_missing(flags.LOG_PATH)
+
         # create and add the file logger to the event manager
         log_file = os.path.join(flags.LOG_PATH, "dbt.log")
         log_file_format = _line_format_from_str(flags.LOG_FORMAT_FILE, LineFormat.DebugText)


### PR DESCRIPTION
Resolves #10948

### Problem

I ran into this while deploying DBT core in an environment where dbt's current working directory is not writeable. I had set `DBT_LOG_PATH` to a separate writeable directory, but then realized recently that we actually want to entirely disable DBT's file logging because we store the stdout/stderr output separately.

After some digging through the source (because I couldn't find documentation of how to disable the file logging), I found this line:

https://github.com/dbt-labs/dbt-core/blob/dd77210756e6432ef2737ab59a65c238e3abfdda/core/dbt/events/logging.py#L95

A bit more digging and I found that I could set a `DBT_LOG_LEVEL_FILE=none` environment variable to effectively disable the file logging. I figured that after disabling file logging, I would no longer need to set `DBT_LOG_PATH` so I removed that environment variable.

Upon testing, I was surprised to see that `dbt debug` now provided no output and only exited with error code 2. I'd run into this issue before when it couldn't open the log file for writing, so I added `DBT_LOG_PATH=/tmp` back to the environment, and it ran successfully.

It seems to me that if file logging is disabled, dbt should not try to make the logging directory.

### Solution

As mentioned above, I can work around the problem for now by setting `DBT_LOG_PATH=/tmp` so that it will just create an empty directory in `/tmp` but that feels kind of silly.

I think it would be best to only try to make the logging directory if file logging is enabled, as the changes in my PR implement.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
