### PR TITLE
Add support for loading secret env vars from file

### DIFF
--- a/core/dbt/config/renderer.py
+++ b/core/dbt/config/renderer.py
@@ -1,5 +1,6 @@
 import re
 from datetime import date
+from pathlib import Path
 from typing import Any, Callable, Dict, Optional, Tuple, Union
 
 from dbt.adapters.contracts.connection import HasCredentials
@@ -226,6 +227,9 @@ class SecretRenderer(BaseRenderer):
                 found = m.group(1)
                 value = get_invocation_context().env[found]
                 replace_this = SECRET_PLACEHOLDER.format(found)
+                # support for secret files
+                if found.lower().endswith("_file"):
+                    value = Path(value).read_text().rstrip()
                 return rendered.replace(replace_this, value)
         else:
             return rendered


### PR DESCRIPTION
This PR adds support for reading secrets from file, as an extension to the `DBT_ENV_SECRET_` prefix.

Because this is a feature that requires some consideration, this PR has the aim to open this discussion, and to demonstrate that the implementation is surprisingly simple.

This is my first PR to dbt, so any suggestions and input on points I missed are welcome.

### Why

Currently, it is difficult get secrets into dbt, if they are stored in a file.
Loading secrets from file is a common use-case in containerized setups or when using a secrets manager.

Although we currently support `DBT_ENV_SECRET_`, the secrets still have to be set as environment variables, which:
- might expose them to any process getting access to the environment
- requires users to pass from file before invoking dbt, requiring os/shell-dependent wrapping logic.
- is generally not considered good practice, see e.g. [here](https://blog.diogomonica.com/2017/03/27/why-you-shouldnt-use-env-variables-for-secret-data/)

### What

- Introduce a new convention for secret environment variables: `DBT_ENV_SECRET_XYZ_FILE`
- If prefix `DBT_ENV_SECRET_` and suffix `_FILE` are found, we assume that this env var does not hold the actual value, but a file path. The file is read to retrieve the actual value.
- This convention follows the one used in many projects, e.g. [postgres](https://github.com/docker-library/docs/blob/master/postgres/README.md#docker-secrets) or [authelia](https://www.authelia.com/configuration/methods/secrets/#environment-variables)


### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] Documentation reflects changes
