### PR TITLE
Warn when selector contains unaccompanied graph operator

### DIFF
--- a/.changes/unreleased/Under the Hood-20260405-040626.yaml
+++ b/.changes/unreleased/Under the Hood-20260405-040626.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Warn when a graph operator (+, @) is used without an accompanying model name in a selector (e.g. "+", "1+1", "@").
+time: 2026-04-05T04:06:26.000000Z
+custom:
+    Author: vinicius
+    Issue: "10388"

--- a/core/dbt/graph/selector_spec.py
+++ b/core/dbt/graph/selector_spec.py
@@ -4,9 +4,11 @@ from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Set, Tuple, Union
 
+from dbt.events.types import NoNodesForSelectionCriteria
 from dbt.exceptions import InvalidSelectorError
 from dbt.flags import get_flags
 from dbt_common.dataclass_schema import StrEnum, dbtClassMixin
+from dbt_common.events.functions import warn_or_error
 from dbt_common.exceptions import DbtRuntimeError
 
 from .graph import UniqueId
@@ -21,6 +23,35 @@ RAW_SELECTOR_PATTERN = re.compile(
     r"\Z"
 )
 SELECTOR_METHOD_SEPARATOR = "."
+
+
+def _has_graph_operator(groupdict: Dict[str, Any]) -> bool:
+    """Return True if the parsed selector groupdict contains any graph operator."""
+    return bool(
+        groupdict.get("childrens_parents")
+        or groupdict.get("parents")
+        or groupdict.get("children")
+    )
+
+
+def _is_unaccompanied_graph_operator(groupdict: Dict[str, Any]) -> bool:
+    """Return True when a graph operator is present but has no accompanying model name.
+
+    A valid selector must pair a graph operator with a "stringy" value (a model name, tag,
+    path, etc.).  When the value is absent or purely numeric the operator is unaccompanied:
+
+    - ``+``       parents flag set, value is empty string
+    - ``1+``      parents flag set with depth, value is empty string
+    - ``@``       childrens_parents flag set, value is empty string
+    - ``1+1``     parents flag set, value is ``"1"`` (numeric only — looks like a depth)
+    - ``+2``      parents flag set, value is ``"2"`` (numeric only)
+    """
+    if not _has_graph_operator(groupdict):
+        return False
+    value = groupdict.get("value") or ""
+    # An empty value or a value that is purely numeric (i.e. looks like a depth modifier
+    # rather than a real model name) means the operator has no accompanying target.
+    return not value or value.isdigit()
 
 
 class IndirectSelection(StrEnum):
@@ -164,7 +195,11 @@ class SelectionCriteria:
             # bad spec!
             raise DbtRuntimeError(f'Invalid selector spec "{raw}"')
 
-        return cls.selection_criteria_from_dict(raw, result.groupdict())
+        groupdict = result.groupdict()
+        if _is_unaccompanied_graph_operator(groupdict):
+            warn_or_error(NoNodesForSelectionCriteria(spec_raw=raw))
+
+        return cls.selection_criteria_from_dict(raw, groupdict)
 
 
 class BaseSelectionGroup(dbtClassMixin, Iterable[SelectionSpec], metaclass=ABCMeta):

--- a/tests/unit/graph/test_selector_spec.py
+++ b/tests/unit/graph/test_selector_spec.py
@@ -11,6 +11,8 @@ from dbt.graph.selector_spec import (
     SelectionDifference,
     SelectionIntersection,
     SelectionUnion,
+    _has_graph_operator,
+    _is_unaccompanied_graph_operator,
 )
 
 
@@ -219,3 +221,81 @@ def test_union():
         [{"model_a", "model_b"}, {"model_b", "model_c"}, {"model_d"}]
     )
     assert combined == {"model_a", "model_b", "model_c", "model_d"}
+
+
+# ── Unaccompanied graph operator detection ────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "groupdict,expected",
+    [
+        # No graph operator at all — not unaccompanied
+        ({"childrens_parents": None, "parents": None, "children": None, "value": ""}, False),
+        ({"childrens_parents": None, "parents": None, "children": None, "value": "mymodel"}, False),
+        # Has operator, empty value — unaccompanied
+        ({"childrens_parents": None, "parents": "+", "children": None, "value": ""}, True),
+        ({"childrens_parents": "@", "parents": None, "children": None, "value": ""}, True),
+        ({"childrens_parents": None, "parents": "1+", "children": None, "value": ""}, True),
+        # Has operator, numeric-only value — unaccompanied (looks like a depth modifier)
+        ({"childrens_parents": None, "parents": "1+", "children": None, "value": "1"}, True),
+        ({"childrens_parents": None, "parents": "+", "children": None, "value": "2"}, True),
+        # Has operator, real string value — NOT unaccompanied
+        ({"childrens_parents": None, "parents": "+", "children": None, "value": "mymodel"}, False),
+        ({"childrens_parents": "@", "parents": None, "children": None, "value": "mymodel"}, False),
+        ({"childrens_parents": None, "parents": "2+", "children": "+3", "value": "mymodel"}, False),
+        # Children-only with real value — not unaccompanied
+        ({"childrens_parents": None, "parents": None, "children": "+", "value": "mymodel"}, False),
+        # Children-only with numeric value — unaccompanied
+        ({"childrens_parents": None, "parents": None, "children": "+1", "value": "1"}, True),
+        # Alphanumeric value with operator — NOT unaccompanied (could be a model named "1abc")
+        ({"childrens_parents": None, "parents": "+", "children": None, "value": "1abc"}, False),
+    ],
+)
+def test_is_unaccompanied_graph_operator(groupdict, expected):
+    assert _is_unaccompanied_graph_operator(groupdict) == expected
+
+
+@pytest.mark.parametrize(
+    "raw_spec",
+    [
+        "+",
+        "@",
+        "1+",
+        "1+1",
+        "+2",
+        "2+3",
+    ],
+)
+def test_from_single_spec_warns_on_unaccompanied_operator(raw_spec):
+    """from_single_spec emits a NoNodesForSelectionCriteria warning for bare operators."""
+    with patch("dbt.graph.selector_spec.warn_or_error") as mock_warn:
+        SelectionCriteria.from_single_spec(raw_spec)
+        mock_warn.assert_called_once()
+        event = mock_warn.call_args[0][0]
+        assert type(event).__name__ == "NoNodesForSelectionCriteria"
+
+
+@pytest.mark.parametrize(
+    "raw_spec",
+    [
+        "mymodel",
+        "+mymodel",
+        "mymodel+",
+        "@mymodel",
+        "2+mymodel+3",
+        "tag:my_tag",
+        "+tag:my_tag",
+        "path/to/models",
+        "+path/to/models",
+        # model names that start with digits are valid if they contain letters too
+        "1abc",
+        "+1abc",
+    ],
+)
+def test_from_single_spec_no_warning_for_valid_selectors(raw_spec):
+    """from_single_spec does not warn when a graph operator accompanies a real model name."""
+    with patch("dbt.graph.selector_spec.warn_or_error") as mock_warn:
+        with patch("dbt.graph.selector_spec.get_flags") as patched_flags:
+            patched_flags.return_value.INDIRECT_SELECTION = IndirectSelection.Eager
+            SelectionCriteria.from_single_spec(raw_spec)
+        mock_warn.assert_not_called()


### PR DESCRIPTION
Resolves #10388

### Problem

If you run something like `dbt list --select +` or `dbt list --select 1+1`,
dbt just accepts it silently and gives you unexpected results. Usually nothing,
sometimes everything downstream. No warning, no hint that the selector is wrong.

The original report was from someone who put an accidental space in an intersection
selector: `model+,+ other_model`. That space caused `+ other_model` to be parsed
as just `+`.

### Solution

Added detection for these "unaccompanied" graph operators in
`SelectionCriteria.from_single_spec`. When one is found, it fires a
`NoNodesForSelectionCriteria` warning, the same warning dbt already uses when
a selector matches zero nodes. Felt like the right fit instead of creating a
whole new event type.

A graph operator counts as unaccompanied when:
- It has `+` or `@` but no actual value (`+`, `@`, `1+`)
- The value is purely numeric, so it looks like a depth modifier instead of
  a model name (`1+1`, `+2`, `2+3`)

Anything with letters, paths, or colons in the value passes through without
warning. So `+mymodel`, `tag:my_tag`, even `+1abc` are all fine.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.