### PR TITLE
Installing skills using `dbt deps`

### DIFF
--- a/.changes/unreleased/Features-20260423-125106.yaml
+++ b/.changes/unreleased/Features-20260423-125106.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Installing skills using `dbt deps`
+time: 2026-04-23T12:51:06.453813-06:00
+custom:
+    Author: dbeatty10
+    Issue: "12868"

--- a/core/dbt/config/project.py
+++ b/core/dbt/config/project.py
@@ -144,6 +144,9 @@ def package_and_project_data_from_root(project_root):
     if "projects" in packages_yml_dict:
         msg = "The 'projects' key cannot be specified in packages.yml"
         raise DbtProjectError(msg)
+    if "skills" in packages_yml_dict:
+        msg = "The 'skills' key cannot be specified in packages.yml"
+        raise DbtProjectError(msg)
 
     packages_specified_path = PACKAGES_FILE_NAME
     packages_dict = {}
@@ -258,7 +261,7 @@ def load_raw_project(project_root: str, validate: bool = False) -> Dict[str, Any
 
 
 def _query_comment_from_cfg(
-    cfg_query_comment: Union[QueryComment, NoValue, str, None]
+    cfg_query_comment: Union[QueryComment, NoValue, str, None],
 ) -> QueryComment:
     if not cfg_query_comment:
         return QueryComment(comment="")

--- a/core/dbt/deps/skills.py
+++ b/core/dbt/deps/skills.py
@@ -1,0 +1,170 @@
+import functools
+import shutil
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import dbt.exceptions
+from dbt.clients import git
+from dbt.config.project import load_yml_dict
+from dbt.config.renderer import PackageRenderer
+from dbt.constants import DEPENDENCIES_FILE_NAME
+from dbt.deps.base import downloads_directory, get_downloads_path
+from dbt.deps.registry import RegistryPinnedPackage
+from dbt.events.types import DepsInstallInfo, DepsStartPackageInstall
+from dbt_common.clients import system
+from dbt_common.events.functions import fire_event
+from dbt_common.utils.connection import connection_exception_retry
+
+
+def resolve_skill_paths(skill: Dict) -> List[str]:
+    """Build the list of install paths from the ``path`` field.
+
+    - If ``path`` is specified, use those paths.
+    - If ``path`` is not specified, default to .agents/skills/.
+    - Deduplicate while preserving order.
+    """
+    paths: List[str] = []
+
+    raw_paths = skill.get("path")
+    if raw_paths:
+        if isinstance(raw_paths, str):
+            raw_paths = [raw_paths]
+        for p in raw_paths:
+            if p not in paths:
+                paths.append(p)
+
+    if not paths:
+        paths = [".agents/skills"]
+
+    return paths
+
+
+def resolve_git(skill: Dict) -> Tuple[str, str]:
+    """Clone a git skill repo and return (source_path, version_name)."""
+    fire_event(DepsStartPackageInstall(package_name=skill["git"]))
+    dir_ = git.clone_and_checkout(
+        skill["git"],
+        get_downloads_path(),
+        revision=skill.get("revision"),
+    )
+    source = str(Path(get_downloads_path()) / dir_)
+    revision = skill.get("revision", "HEAD")
+    return source, f"revision {revision}"
+
+
+def resolve_local(skill: Dict, project_root: str) -> Tuple[str, str]:
+    """Resolve a local skill path and return (source_path, version_name)."""
+    local_path = Path(skill["local"]).expanduser()
+    if not local_path.is_absolute():
+        local_path = Path(project_root) / skill["local"]
+    fire_event(DepsStartPackageInstall(package_name=str(local_path)))
+    return str(local_path), f"local path {skill['local']}"
+
+
+def resolve_registry(skill: Dict, project, cli_vars) -> Tuple[str, str]:
+    """Download a registry package and return (source_path, version_name)."""
+    package_name = skill["package"]
+    version = str(skill["version"])
+    fire_event(DepsStartPackageInstall(package_name=package_name))
+    pkg = RegistryPinnedPackage(package=package_name, version=version, version_latest=version)
+    renderer = PackageRenderer(cli_vars)
+    try:
+        metadata = pkg._fetch_metadata(project, renderer)
+    except Exception:
+        raise dbt.exceptions.DbtProjectError(
+            f"Package {package_name} was not found in the package index. "
+            "Is the package name correct?"
+        )
+    # Use metadata.name (e.g. "dbt_utils") for the extraction directory,
+    # not the registry name (e.g. "dbt-labs/dbt-utils") which contains a slash.
+    project_name = metadata.name
+    tar_name = f"{project_name}.{version}.tar.gz"
+    tar_path = (Path(get_downloads_path()) / tar_name).resolve(strict=False)
+    system.make_directory(str(tar_path.parent))
+    download_untar_fn = functools.partial(
+        pkg.download_and_untar,
+        metadata.downloads.tarball,
+        str(tar_path),
+        get_downloads_path(),
+        project_name,
+    )
+    connection_exception_retry(download_untar_fn, 5)
+    source = str(Path(get_downloads_path()) / project_name)
+    return source, f"version {version}"
+
+
+def install_skills(project, cli_vars) -> None:
+    """Install skills defined under the ``skills`` key in dependencies.yml."""
+    deps_path = str(Path(project.project_root) / DEPENDENCIES_FILE_NAME)
+    if not system.path_exists(deps_path):
+        return
+
+    dependencies_dict = load_yml_dict(deps_path)
+    skills = dependencies_dict.get("skills", [])
+    if not skills:
+        return
+
+    with downloads_directory():
+        for skill in skills:
+            raw_paths = resolve_skill_paths(skill)
+
+            if "git" in skill:
+                source, version_name = resolve_git(skill)
+            elif "local" in skill:
+                source, version_name = resolve_local(skill, project.project_root)
+            elif "package" in skill:
+                source, version_name = resolve_registry(skill, project, cli_vars)
+            else:
+                continue
+
+            source_path = Path(source)
+
+            # Honor explicit subdirectory override
+            subdirectory = skill.get("subdirectory")
+            if subdirectory:
+                candidate = source_path / subdirectory
+                if candidate.is_dir():
+                    source_path = candidate
+
+            # Convention: if the source contains a skills/ subdirectory,
+            # install from there instead of the root.
+            skills_subdir = source_path / "skills"
+            if skills_subdir.is_dir():
+                source_path = skills_subdir
+
+            for install_path in raw_paths:
+                resolved = Path(install_path)
+                if resolved.is_absolute():
+                    dest = resolved
+                else:
+                    dest = Path(project.project_root) / install_path
+
+                system.make_directory(str(dest))
+
+                # Case 3: source itself is a single skill directory.
+                if (source_path / "SKILL.md").is_file():
+                    skill_name = source_path.name
+                    entry_dest = dest / skill_name
+                    if entry_dest.exists():
+                        system.rmtree(str(entry_dest))
+                    shutil.copytree(str(source_path), str(entry_dest))
+                else:
+                    # Cases 1 & 2: source contains skill subdirectories.
+                    # Install each skill folder individually (must contain SKILL.md).
+                    # This preserves existing skills in the destination that came
+                    # from other repos.
+                    allowed_skills = skill.get("skills")
+                    for entry in source_path.iterdir():
+                        if not entry.is_dir():
+                            continue
+                        if not (entry / "SKILL.md").is_file():
+                            continue
+                        if allowed_skills and entry.name not in allowed_skills:
+                            continue
+
+                        entry_dest = dest / entry.name
+                        if entry_dest.exists():
+                            system.rmtree(str(entry_dest))
+                        shutil.copytree(str(entry), str(entry_dest))
+
+                fire_event(DepsInstallInfo(version_name=f"{version_name} to {dest}"))

--- a/core/dbt/task/deps.py
+++ b/core/dbt/task/deps.py
@@ -1,7 +1,7 @@
 import json
 from hashlib import sha1
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import yaml
 
@@ -11,11 +11,16 @@ import dbt.utils
 from dbt.config import Project
 from dbt.config.project import load_yml_dict, package_config_from_data
 from dbt.config.renderer import PackageRenderer
-from dbt.constants import PACKAGE_LOCK_FILE_NAME, PACKAGE_LOCK_HASH_KEY
+from dbt.constants import (
+    DEPENDENCIES_FILE_NAME,
+    PACKAGE_LOCK_FILE_NAME,
+    PACKAGE_LOCK_HASH_KEY,
+)
 from dbt.contracts.project import PackageSpec
 from dbt.deps.base import downloads_directory
 from dbt.deps.registry import RegistryPinnedPackage
 from dbt.deps.resolver import resolve_lock_packages, resolve_packages
+from dbt.deps.skills import install_skills
 from dbt.events.types import (
     DepsAddPackage,
     DepsFoundDuplicatePackage,
@@ -315,6 +320,7 @@ class DepsTask(BaseTask):
 
         if not packages_lock_config:
             fire_event(DepsNoPackagesFound())
+            install_skills(self.project, self.cli_vars)
             return
 
         with downloads_directory():
@@ -352,3 +358,5 @@ class DepsTask(BaseTask):
             if packages_to_upgrade:
                 fire_event(Formatting(""))
                 fire_event(DepsNotifyUpdatesAvailable(packages=packages_to_upgrade))
+
+        install_skills(self.project, self.cli_vars)

--- a/core/dbt/task/deps.py
+++ b/core/dbt/task/deps.py
@@ -1,7 +1,7 @@
 import json
 from hashlib import sha1
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 import yaml
 
@@ -11,11 +11,7 @@ import dbt.utils
 from dbt.config import Project
 from dbt.config.project import load_yml_dict, package_config_from_data
 from dbt.config.renderer import PackageRenderer
-from dbt.constants import (
-    DEPENDENCIES_FILE_NAME,
-    PACKAGE_LOCK_FILE_NAME,
-    PACKAGE_LOCK_HASH_KEY,
-)
+from dbt.constants import PACKAGE_LOCK_FILE_NAME, PACKAGE_LOCK_HASH_KEY
 from dbt.contracts.project import PackageSpec
 from dbt.deps.base import downloads_directory
 from dbt.deps.registry import RegistryPinnedPackage

--- a/tests/functional/dependencies/test_skill_dependencies.py
+++ b/tests/functional/dependencies/test_skill_dependencies.py
@@ -1,0 +1,395 @@
+import os
+import shutil
+from unittest.mock import patch
+
+import pytest
+
+from dbt.tests.util import run_dbt
+
+SKILLS_GIT_URL = "https://github.com/dbt-labs/dbt-agent-skills.git"
+SKILLS_REVISION = "65d2e0b68e24b59e038e6deb14fa6624c63022fe"
+
+
+class TestSkillDependencies:
+    """Tests for skills installation via the `skills` key in dependencies.yml.
+
+    Target behavior: `dbt deps` should install skill entries to the path
+    specified by each skill's `path` field.
+    """
+
+    @pytest.fixture(scope="class")
+    def dependencies(self):
+        return {
+            "skills": [
+                {
+                    "git": SKILLS_GIT_URL,
+                    "revision": SKILLS_REVISION,
+                    # path omitted — should default to .agents/skills
+                }
+            ]
+        }
+
+    @pytest.fixture
+    def clean_start(self, project):
+        skills_dir = os.path.join(project.project_root, ".agents", "skills")
+        if os.path.exists(skills_dir):
+            shutil.rmtree(skills_dir)
+        if os.path.exists("package-lock.yml"):
+            os.remove("package-lock.yml")
+
+    def test_skills_not_present_before_deps(self, project, clean_start):
+        skills_dir = os.path.join(project.project_root, ".agents", "skills")
+        assert not os.path.exists(skills_dir)
+
+    def test_skills_installed_after_deps(self, project, clean_start):
+        skills_dir = os.path.join(project.project_root, ".agents", "skills")
+        assert not os.path.exists(skills_dir)
+
+        run_dbt(["deps"])
+
+        assert os.path.exists(skills_dir), (
+            "Expected .agents/skills/ to be created by `dbt deps` "
+            "when dependencies.yml contains a skills entry with path: '.agents/skills'"
+        )
+        skill_subdir = os.path.join(skills_dir, "adding-dbt-unit-test")
+        assert os.path.isdir(skill_subdir), (
+            "Expected .agents/skills/adding-dbt-unit-test/ to exist, "
+            f"but .agents/skills/ contains: {os.listdir(skills_dir)}"
+        )
+
+    def test_existing_skills_preserved_after_deps(self, project, clean_start):
+        """Existing skill folders in the destination should not be wiped out
+        when installing new skills from a different repo."""
+        skills_dir = os.path.join(project.project_root, ".agents", "skills")
+
+        # Pre-create an existing skill folder with a SKILL.md
+        existing_skill = os.path.join(skills_dir, "my-custom-skill")
+        os.makedirs(existing_skill, exist_ok=True)
+        with open(os.path.join(existing_skill, "SKILL.md"), "w") as f:
+            f.write("# My Custom Skill\n")
+
+        run_dbt(["deps"])
+
+        # The pre-existing skill should still be there
+        assert os.path.isdir(existing_skill), (
+            "Expected .agents/skills/my-custom-skill/ to survive `dbt deps`, "
+            f"but .agents/skills/ contains: {os.listdir(skills_dir)}"
+        )
+        assert os.path.isfile(os.path.join(existing_skill, "SKILL.md"))
+
+        # The newly installed skill should also be there
+        new_skill = os.path.join(skills_dir, "adding-dbt-unit-test")
+        assert os.path.isdir(new_skill), (
+            "Expected .agents/skills/adding-dbt-unit-test/ to exist alongside "
+            f"existing skills, but .agents/skills/ contains: {os.listdir(skills_dir)}"
+        )
+
+
+class TestSkillSubset:
+    """When a `skills` list is specified on an entry, only those skills
+    should be installed."""
+
+    @pytest.fixture(scope="class")
+    def dependencies(self):
+        return {
+            "skills": [
+                {
+                    "git": SKILLS_GIT_URL,
+                    "revision": SKILLS_REVISION,
+                    "path": ".agents/skills",
+                    "skills": [
+                        "adding-dbt-unit-test",
+                        "running-dbt-commands",
+                    ],
+                }
+            ]
+        }
+
+    @pytest.fixture
+    def clean_start(self, project):
+        skills_dir = os.path.join(project.project_root, ".agents", "skills")
+        if os.path.exists(skills_dir):
+            shutil.rmtree(skills_dir)
+        if os.path.exists("package-lock.yml"):
+            os.remove("package-lock.yml")
+
+    def test_only_listed_skills_installed(self, project, clean_start):
+        skills_dir = os.path.join(project.project_root, ".agents", "skills")
+
+        run_dbt(["deps"])
+
+        installed = set(os.listdir(skills_dir))
+        assert "adding-dbt-unit-test" in installed
+        assert "running-dbt-commands" in installed
+        # A skill that exists in the repo but was NOT listed should be absent
+        assert "fetching-dbt-docs" not in installed, (
+            "Expected only the listed skills to be installed, " f"but found: {installed}"
+        )
+
+
+class TestLocalSkillDependencies:
+    """Tests for installing skills from a local filesystem path."""
+
+    @pytest.fixture(scope="class")
+    def local_skills_dir(self, project_root):
+        """Create a local directory with skill folders to install from."""
+        local_src = os.path.join(project_root, "local_skills")
+        # Create a valid skill (has SKILL.md)
+        skill_a = os.path.join(local_src, "skill-alpha")
+        os.makedirs(skill_a)
+        with open(os.path.join(skill_a, "SKILL.md"), "w") as f:
+            f.write("# Skill Alpha\n")
+        with open(os.path.join(skill_a, "prompt.txt"), "w") as f:
+            f.write("Do something useful\n")
+
+        # Create another valid skill
+        skill_b = os.path.join(local_src, "skill-beta")
+        os.makedirs(skill_b)
+        with open(os.path.join(skill_b, "SKILL.md"), "w") as f:
+            f.write("# Skill Beta\n")
+
+        # Create an invalid folder (no SKILL.md) — should NOT be installed
+        not_a_skill = os.path.join(local_src, "not-a-skill")
+        os.makedirs(not_a_skill)
+        with open(os.path.join(not_a_skill, "README.md"), "w") as f:
+            f.write("# Not a skill\n")
+
+        return local_src
+
+    @pytest.fixture(scope="class")
+    def dependencies(self, local_skills_dir):
+        return {
+            "skills": [
+                {
+                    "local": "local_skills",
+                    "path": ".agents/skills",
+                }
+            ]
+        }
+
+    @pytest.fixture
+    def clean_start(self, project):
+        skills_dir = os.path.join(project.project_root, ".agents", "skills")
+        if os.path.exists(skills_dir):
+            shutil.rmtree(skills_dir)
+        if os.path.exists("package-lock.yml"):
+            os.remove("package-lock.yml")
+
+    def test_local_skills_installed(self, project, clean_start):
+        skills_dir = os.path.join(project.project_root, ".agents", "skills")
+
+        run_dbt(["deps"])
+
+        installed = set(os.listdir(skills_dir))
+        assert "skill-alpha" in installed
+        assert "skill-beta" in installed
+        # Folder without SKILL.md should not be installed
+        assert (
+            "not-a-skill" not in installed
+        ), f"Folder without SKILL.md should not be installed, but found: {installed}"
+        # Verify file contents survived the copy
+        assert os.path.isfile(os.path.join(skills_dir, "skill-alpha", "prompt.txt"))
+
+
+class TestLocalSkillWithSubdirectory:
+    """Tests for installing local skills using a subdirectory override."""
+
+    @pytest.fixture(scope="class")
+    def local_skills_dir(self, project_root):
+        """Create a local directory with skills nested in a subdirectory."""
+        local_src = os.path.join(project_root, "my_repo", "nunchuck-skills")
+        skill = os.path.join(local_src, "bo-staff")
+        os.makedirs(skill)
+        with open(os.path.join(skill, "SKILL.md"), "w") as f:
+            f.write("# Bo Staff\n")
+        return local_src
+
+    @pytest.fixture(scope="class")
+    def dependencies(self, local_skills_dir):
+        return {
+            "skills": [
+                {
+                    "local": "my_repo",
+                    "subdirectory": "nunchuck-skills",
+                    "path": ".agents/skills",
+                }
+            ]
+        }
+
+    @pytest.fixture
+    def clean_start(self, project):
+        skills_dir = os.path.join(project.project_root, ".agents", "skills")
+        if os.path.exists(skills_dir):
+            shutil.rmtree(skills_dir)
+        if os.path.exists("package-lock.yml"):
+            os.remove("package-lock.yml")
+
+    def test_subdirectory_skills_installed(self, project, clean_start):
+        skills_dir = os.path.join(project.project_root, ".agents", "skills")
+
+        run_dbt(["deps"])
+
+        assert os.path.isdir(
+            os.path.join(skills_dir, "bo-staff")
+        ), f".agents/skills/ contains: {os.listdir(skills_dir)}"
+
+
+class TestMultipleInstallPaths:
+    """The `path` field can be a list to install skills to multiple locations."""
+
+    @pytest.fixture(scope="class")
+    def local_skills_dir(self, project_root):
+        local_src = os.path.join(project_root, "local_skills")
+        skill = os.path.join(local_src, "my-skill")
+        os.makedirs(skill)
+        with open(os.path.join(skill, "SKILL.md"), "w") as f:
+            f.write("# My Skill\n")
+        return local_src
+
+    @pytest.fixture(scope="class")
+    def dependencies(self, local_skills_dir):
+        return {
+            "skills": [
+                {
+                    "local": "local_skills",
+                    "path": [
+                        ".agents/skills",
+                        ".claude/skills",
+                    ],
+                }
+            ]
+        }
+
+    @pytest.fixture
+    def clean_start(self, project):
+        for d in [".agents/skills", ".claude/skills"]:
+            full = os.path.join(project.project_root, d)
+            if os.path.exists(full):
+                shutil.rmtree(full)
+        if os.path.exists("package-lock.yml"):
+            os.remove("package-lock.yml")
+
+    def test_skills_installed_to_all_paths(self, project, clean_start):
+        run_dbt(["deps"])
+
+        for d in [".agents/skills", ".claude/skills"]:
+            skill_dir = os.path.join(project.project_root, d, "my-skill")
+            assert os.path.isdir(skill_dir), f"Expected {d}/my-skill/ to exist after `dbt deps`"
+            assert os.path.isfile(os.path.join(skill_dir, "SKILL.md"))
+
+
+class TestSingleSkillDirectory:
+    """Case 3: the source itself is a skill directory (contains SKILL.md at its root)."""
+
+    @pytest.fixture(scope="class")
+    def local_skills_dir(self, project_root):
+        # Create a single skill directory (not a parent containing skills)
+        skill = os.path.join(project_root, "my-single-skill")
+        os.makedirs(skill)
+        with open(os.path.join(skill, "SKILL.md"), "w") as f:
+            f.write("# My Single Skill\n")
+        with open(os.path.join(skill, "prompt.txt"), "w") as f:
+            f.write("Do something\n")
+        return skill
+
+    @pytest.fixture(scope="class")
+    def dependencies(self, local_skills_dir):
+        return {
+            "skills": [
+                {
+                    "local": "my-single-skill",
+                    "path": ".agents/skills",
+                }
+            ]
+        }
+
+    @pytest.fixture
+    def clean_start(self, project):
+        skills_dir = os.path.join(project.project_root, ".agents", "skills")
+        if os.path.exists(skills_dir):
+            shutil.rmtree(skills_dir)
+        if os.path.exists("package-lock.yml"):
+            os.remove("package-lock.yml")
+
+    def test_single_skill_installed(self, project, clean_start):
+        skills_dir = os.path.join(project.project_root, ".agents", "skills")
+
+        run_dbt(["deps"])
+
+        # The skill should be installed as a subdirectory named after the source
+        skill_dest = os.path.join(skills_dir, "my-single-skill")
+        assert os.path.isdir(skill_dest), (
+            f"Expected .agents/skills/my-single-skill/ but found: "
+            f"{os.listdir(skills_dir) if os.path.exists(skills_dir) else 'nothing'}"
+        )
+        assert os.path.isfile(os.path.join(skill_dest, "SKILL.md"))
+        assert os.path.isfile(os.path.join(skill_dest, "prompt.txt"))
+
+
+class TestSingleSkillTrailingSlash:
+    """A local path with a trailing slash should still use the directory name."""
+
+    @pytest.fixture(scope="class")
+    def local_skills_dir(self, project_root):
+        skill = os.path.join(project_root, "dinomight")
+        os.makedirs(skill)
+        with open(os.path.join(skill, "SKILL.md"), "w") as f:
+            f.write("# Dinomight\n")
+        return skill
+
+    @pytest.fixture(scope="class")
+    def dependencies(self, local_skills_dir):
+        return {
+            "skills": [
+                {
+                    "local": "dinomight/",
+                    "path": ".agents/skills",
+                }
+            ]
+        }
+
+    @pytest.fixture
+    def clean_start(self, project):
+        skills_dir = os.path.join(project.project_root, ".agents", "skills")
+        if os.path.exists(skills_dir):
+            shutil.rmtree(skills_dir)
+        if os.path.exists("package-lock.yml"):
+            os.remove("package-lock.yml")
+
+    def test_trailing_slash_preserves_name(self, project, clean_start):
+        skills_dir = os.path.join(project.project_root, ".agents", "skills")
+
+        run_dbt(["deps"])
+
+        skill_dest = os.path.join(skills_dir, "dinomight")
+        assert os.path.isdir(skill_dest), (
+            f"Expected .agents/skills/dinomight/ but found: "
+            f"{os.listdir(skills_dir) if os.path.exists(skills_dir) else 'nothing'}"
+        )
+        assert os.path.isfile(os.path.join(skill_dest, "SKILL.md"))
+
+
+class TestRegistrySkillPackageNotFound:
+    """A bad package name in skills should produce a clear 'not found' error,
+    not a raw ConnectionError with retry tracebacks."""
+
+    @pytest.fixture(scope="class")
+    def dependencies(self):
+        return {
+            "skills": [
+                {
+                    "package": "nonexistent-org/nonexistent-package",
+                    "version": "1.0.0",
+                }
+            ]
+        }
+
+    def test_bad_package_raises_friendly_error(self, project):
+        # Mock _fetch_metadata to simulate a registry 404, avoiding real
+        # network calls and the slow 5-retry cycle.
+        with patch(
+            "dbt.deps.registry.RegistryPinnedPackage._fetch_metadata",
+            side_effect=Exception("404 Client Error: Not Found"),
+        ):
+            with pytest.raises(Exception, match="not found in the package index"):
+                run_dbt(["deps"])

--- a/tests/unit/config/test_project.py
+++ b/tests/unit/config/test_project.py
@@ -6,6 +6,7 @@ from typing import Any, Dict
 from unittest import mock
 
 import pytest
+import yaml
 
 import dbt.config
 import dbt.exceptions
@@ -465,6 +466,22 @@ class TestProjectFile(BaseConfigTest):
         self.write_packages({"invalid": ["not a package of any kind"]})
         with self.assertRaises(dbt.exceptions.DbtProjectError):
             dbt.config.Project.from_project_root(self.project_dir, renderer)
+
+    def test_skills_not_allowed_in_packages_yml(self):
+        renderer = empty_project_renderer()
+        self.write_packages({"skills": [{"package": "dbt-labs/dbt-utils", "version": "1.2.3"}]})
+        with self.assertRaises(dbt.exceptions.DbtProjectError):
+            dbt.config.Project.from_project_root(self.project_dir, renderer)
+
+    def test_skills_allowed_in_dependencies_yml(self):
+        renderer = empty_project_renderer()
+        dependencies_data = {"skills": [{"package": "dbt-labs/dbt-utils", "version": "1.2.3"}]}
+        with open(self.project_path("dependencies.yml"), "w") as fp:
+            yaml.dump(dependencies_data, fp)
+        project = dbt.config.Project.from_project_root(self.project_dir, renderer)
+        # skills key is accepted without error; packages list is empty since
+        # the skills key is not yet functional
+        assert project.packages.packages == []
 
 
 class TestVariableProjectFile(BaseConfigTest):


### PR DESCRIPTION
Resolves #12868

### Problem

The idea is covered in this Discussion on GitHub:
- https://github.com/dbt-labs/dbt-core/discussions/12521

And in this issue:
- #12868

### Solution

Add a `skills:` top-level key to `dependencies.yml`. When a user runs `dbt deps`, dbt installs the declared skills into the project alongside packages.
                                                                                                                        
#### Simple example

`dependencies.yml`

```
skills: 
  - git: "https://github.com/dbt-labs/dbt-agent-skills.git"
    revision: 0.9.2                                                                                                     
 ```

After `dbt deps`:                                                                                                         
```
.agents/
└── skills/
    ├── adding-dbt-unit-test/
    │   └── SKILL.md
    └── running-dbt-commands/
        └── SKILL.md
```
#### Install behavior
- Runs as part of `dbt deps` (no new subcommand or flag)
- If it contains a top-level `skills/` directory, install from there                                              
- Otherwise, if the source itself contains a `SKILL.md` at its root, install it as a single skill
- Otherwise, install each subdirectory that contains a `SKILL.md` (skipping the rest)                                     
- Pre-existing skills in the destination that came from other sources are preserved (not wiped)                         
- Skills declared in `packages.yml` raise a clear error (because only allowed within `dependencies.yml`)

#### Breadth of examples

`dependencies.yml`

```yaml
skills:

  # dbt Hub
  - package: dbt-labs/dbt_utils
    version: 9.9.9

  # git URL
  - git: "https://github.com/dbt-labs/dbt-agent-skills.git"

  # Local path
  - local: /Users/dbeatty/jaffle-minis/minis/a244e_bare_minimum/nunchuck-skills

  # Private GitHub URL
  # TODO - not implemented yet -- see note below regarding using private repos with SSH
  - private: your-org/your-repo

  # explicit installation location - relative to the dbt project directory
  - git: "https://github.com/dbt-labs/dbt-agent-skills.git"
    revision: 65d2e0b68e24b59e038e6deb14fa6624c63022fe
    path: ".agentZ/skills"  # relative to the dbt project directory

  # explicit installation location - absolute path
  - git: "https://github.com/dbt-labs/dbt-agent-skills.git"
    revision: 65d2e0b68e24b59e038e6deb14fa6624c63022fe
    path: "~/.agents/skills"  # absolute path

  # multiple installation locations
  - git: "https://github.com/dbt-labs/dbt-agent-skills.git"
    path:
      - ".agents/skills"
      - ".codex/skills"

  # `revision` for git tag, branch name, or SHA (40-character hash)
  - git: "https://github.com/dbt-labs/dbt-agent-skills.git"
    revision: 0.1.0  # git tag  
    # revision: dbeatty/feature-branch  # branch name
    # revision: 65d2e0b68e24b59e038e6deb14fa6624c63022fe  # SHA (40-character hash)

  # `subdirectory` within the source directory
  - local: /Users/dbeatty/jaffle-minis/minis/a244e_bare_minimum
    subdirectory: "nunchuck-skills"  # name of subdirectory containing one or skills

  # skills to install (YAML list syntax 1)
  - git: "https://github.com/dbt-labs/dbt-agent-skills.git"
    skills:
      - building-dbt-semantic-layer

  # skills to install (YAML list syntax 2)
  - git: "https://github.com/dbt-labs/dbt-agent-skills.git"
    skills: ["troubleshooting-dbt-job-errors"]

  # Case 1: source is a Skill directory
  - local: /Users/dbeatty/jaffle-minis/minis/a244e_bare_minimum/skills/dinomight

  # Case 2: source contains one or more Skill directories
  - local: /Users/dbeatty/jaffle-minis/minis/a244e_bare_minimum/skills/

  # Case 3: source contains a `skills/` directory (that contains Skill subdirectories)
  - local: /Users/dbeatty/jaffle-minis/minis/a244e_bare_minimum/

  # Further testing  - with `subdirectory` 

  # Case 1 - with `subdirectory`
  - local: /Users/dbeatty/jaffle-minis/minis/a244e_bare_minimum/skills
    subdirectory: dinomight

  # Case 2 - with `subdirectory`
  - local: /Users/dbeatty/jaffle-minis/minis/a244e_bare_minimum/
    subdirectory: skills/

  # Case 3 - with `subdirectory`
  - local: /Users/dbeatty/jaffle-minis/minis/
    subdirectory: a244e_bare_minimum
```

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.