### PR TITLE
deps: surface descriptive error when Hub package omits version (#12649)

### DIFF
--- a/.changes/unreleased/Fixes-20260509-150005.yaml
+++ b/.changes/unreleased/Fixes-20260509-150005.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Surface descriptive ValidationError when a Hub package omits the `version` key, instead of a bare KeyError
+time: 2026-05-09T15:00:00.000000+02:00
+custom:
+    Author: jbbqqf
+    Issue: "12649"

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -138,7 +138,7 @@ class PackageConfig(dbtClassMixin):
                         "A git package is missing the value. It is a required property."
                     )
             if isinstance(package, dict) and package.get("package"):
-                if not package["version"]:
+                if not package.get("version"):
                     raise ValidationError(
                         f"{package['package']} is missing the version. When installing from the Hub "
                         "package index, version is a required property"

--- a/tests/unit/deps/test_deps.py
+++ b/tests/unit/deps/test_deps.py
@@ -885,6 +885,15 @@ class TestPackageSpec(unittest.TestCase):
         msg = "dbt-labs-test/b is missing the version. When installing from the Hub package index, version is a required property"
         assert msg in str(exc.exception)
 
+    def test_validation_error_when_version_key_absent_from_package_config(self):
+        # Regression test for #12649: when the `version` key is entirely
+        # absent (not just None), PackageConfig.validate should raise the
+        # descriptive ValidationError, not a bare KeyError.
+        packages_data = {"packages": [{"package": "dbt-labs-test/b"}]}
+
+        with self.assertRaisesRegex(ValidationError, r"is missing the version"):
+            PackageConfig.validate(data=packages_data)
+
     def test_validation_error_when_namespace_is_missing_from_package_config(self):
         packages_data = {"packages": [{"package": "dbt-labs", "version": "1.0.0"}]}
 


### PR DESCRIPTION
Resolves dbt-labs/dbt-core#12649

### Problem

When a `packages.yml` Hub entry omits the `version:` key entirely, `PackageConfig.validate` raises a bare `KeyError: 'version'` instead of the descriptive `ValidationError` that already exists at `core/dbt/contracts/project.py:140-145` ("`{package} is missing the version. When installing from the Hub package index, version is a required property`"). The guard is gated on `if not package["version"]:` — a direct subscript that throws `KeyError` before the descriptive message is built. The neighbouring fields (`package`, `local`, `git`) all use `.get()` for this exact reason.

### Solution

- `core/dbt/contracts/project.py`: `package["version"]` -> `package.get("version")`. One-line behavioural change that lets the existing `ValidationError` path handle both "key absent" and "value falsy".
- `tests/unit/deps/test_deps.py`: regression test `test_validation_error_when_version_key_absent_from_package_config` that validates a `{"package": "dbt-labs-test/b"}` dict (no `version` key at all) and asserts the descriptive `ValidationError` is raised — not `KeyError`. The pre-existing `test_validation_error_when_version_is_missing_from_package_config` only covered `version: None`.

### Reproduce BEFORE/AFTER yourself (copy-paste)

A reviewer can verify this fix end-to-end by pasting the block below.

```bash
# --- one-time setup ---
git clone https://github.com/dbt-labs/dbt-core.git /tmp/dbt-repro && cd /tmp/dbt-repro
python -m venv .venv && source .venv/bin/activate
pip install -e './core[test]'

git fetch https://github.com/jbbqqf/dbt-core.git feat/12649-hub-package-missing-version-error

# --- BEFORE: bare KeyError ---
git checkout origin/main && pip install -e './core[test]' --quiet
python -c "
from dbt.contracts.project import PackageConfig
try:
    PackageConfig.validate({'packages': [{'package': 'dbt-labs-test/b'}]})
    print('NO ERROR (unexpected)')
except KeyError as e:
    print(f'BEFORE → KeyError: {e!r}')
except Exception as e:
    print(f'BEFORE → {type(e).__name__}: {e}')
"
# Expected: BEFORE → KeyError: 'version'

# --- AFTER: descriptive ValidationError ---
git checkout FETCH_HEAD && pip install -e './core[test]' --quiet
python -c "
from dbt.contracts.project import PackageConfig
try:
    PackageConfig.validate({'packages': [{'package': 'dbt-labs-test/b'}]})
    print('NO ERROR (unexpected)')
except KeyError as e:
    print(f'AFTER → KeyError: {e!r}')
except Exception as e:
    print(f'AFTER → {type(e).__name__}: {e}')
"
# Expected: AFTER → ValidationError: dbt-labs-test/b is missing the version. When installing from the Hub package index, version is a required property
```

### What I ran locally

- `pytest tests/unit/deps/test_deps.py -k version` -> 6 passed (5 pre-existing + 1 new).

### Risk / blast radius

Strictly additive on the error-message side. `package.get("version")` returns `None` when the key is missing, and `not None` is `True`, so the behaviour for "key present and falsy" is unchanged. The only newly-handled case is "key absent" — which previously crashed with `KeyError` and now raises the same `ValidationError` already raised for `version: null`. **Interface note:** the exception type seen by callers in this case changes from `KeyError` to `dbt.exceptions.ValidationError`. Any caller catching `KeyError: 'version'` specifically would need to update — flagging for Product/DX review.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.

---

*PR drafted with assistance from Claude Code. The change was reviewed manually against `dbt-labs/dbt-core`'s source; the reproducer block above is the same one used during development.*
