### PR TITLE
fix: normalize function YAML name to lowercase to prevent silent no-op patch (#13022)

### DIFF
--- a/.changes/unreleased/Fixes-20260606-105136.yaml
+++ b/.changes/unreleased/Fixes-20260606-105136.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Normalize function YAML name to lowercase to prevent silent no-op patch when name casing doesn't match SQL filename
+time: 2026-06-06T10:51:36.822208+05:30
+custom:
+    author: AnuragRaut08
+    issue: "15203"
+    project: dbt-fusion

--- a/crates/dbt-error/src/codes.rs
+++ b/crates/dbt-error/src/codes.rs
@@ -171,6 +171,7 @@ pub enum ErrorCode {
     SemanticModelDeprecated = 1157,
     PackageMissingProjectFile = 1158,
     DbtYamlValidationError = 1159,
+    FunctionNameCaseMismatch = 1160,
 
     // Network/HTTP [1200–1249]
     NetworkError = 1200,

--- a/crates/dbt-parser/src/resolve/resolve_properties.rs
+++ b/crates/dbt-parser/src/resolve/resolve_properties.rs
@@ -875,3 +875,72 @@ fn pre_render_tables_field(
         }
     }
 }
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_function_yaml_value(name: &str) -> dbt_yaml::Value {
+        let yaml = format!("name: {name}\n");
+        dbt_yaml::from_str(&yaml).expect("valid yaml")
+    }
+
+    /// Inserting a function whose YAML `name:` is uppercase must store the
+    /// entry under the lowercase key so the renderer (which derives the node
+    /// name from the lowercase SQL filename) can find it.
+    #[test]
+    fn test_function_name_normalized_to_lowercase_on_insert() {
+        let mut props = MinimalProperties::default();
+
+        let uppercase_name = "RENAME_DATA_CLOUD_COLUMN";
+        let lowercase_name = "rename_data_cloud_column";
+
+        let normalized = uppercase_name.to_ascii_lowercase();
+        props.functions.insert(
+            normalized.clone(),
+            MinimalPropertiesEntry {
+                name: uppercase_name.to_string(),
+                name_span: Default::default(),
+                relative_path: std::path::PathBuf::from("schema.yml"),
+                schema_value: make_function_yaml_value(uppercase_name),
+                table_value: None,
+                version_info: None,
+                duplicate_paths: vec![],
+            },
+        );
+
+        // Must be reachable via lowercase key (how renderer looks it up)
+        assert!(
+            props.functions.contains_key(lowercase_name),
+            "expected key '{lowercase_name}' after inserting uppercase '{uppercase_name}'"
+        );
+
+        // Original casing preserved in the entry itself
+        let entry = props.functions.get(lowercase_name).unwrap();
+        assert_eq!(entry.name, uppercase_name);
+
+        // Uppercase key must NOT exist (that was the silent no-op bug)
+        assert!(!props.functions.contains_key(uppercase_name));
+    }
+
+    /// A function whose YAML `name:` is already lowercase is stored as-is.
+    #[test]
+    fn test_function_name_already_lowercase_unchanged() {
+        let mut props = MinimalProperties::default();
+        let name = "my_udf";
+
+        props.functions.insert(
+            name.to_string(),
+            MinimalPropertiesEntry {
+                name: name.to_string(),
+                name_span: Default::default(),
+                relative_path: std::path::PathBuf::from("schema.yml"),
+                schema_value: make_function_yaml_value(name),
+                table_value: None,
+                version_info: None,
+                duplicate_paths: vec![],
+            },
+        );
+
+        assert!(props.functions.contains_key(name));
+    }
+}

--- a/crates/dbt-parser/src/resolve/resolve_properties.rs
+++ b/crates/dbt-parser/src/resolve/resolve_properties.rs
@@ -301,13 +301,34 @@ impl MinimalProperties {
                     dependency_package_name_from_ctx(jinja_env, base_ctx),
                     true,
                 )?;
-                if let Some(existing_function) = self.functions.get_mut(&function.name) {
+                // Function node names are always derived as lowercase from the SQL
+                // filename. Normalize the YAML `name:` to lowercase so the lookup
+                // succeeds even when the author used a different case (e.g.
+                // `RENAME_DATA_CLOUD_COLUMN` vs `rename_data_cloud_column.sql`).
+                let normalized_name = function.name.to_ascii_lowercase();
+                if normalized_name != function.name {
+                    emit_warn_log_message(
+                        ErrorCode::FunctionNameCaseMismatch,
+                        format!(
+                            "Function name '{}' in '{}' does not match the expected lowercase \
+                             form '{}'. dbt derives the function node name from the SQL filename \
+                             (always lowercase), so the YAML entry will be matched \
+                             case-insensitively. Consider renaming it to '{}' to avoid ambiguity.",
+                            function.name,
+                            properties_path.display(),
+                            normalized_name,
+                            normalized_name,
+                        ),
+                        io_args.status_reporter.as_ref(),
+                    );
+                }
+                if let Some(existing_function) = self.functions.get_mut(&normalized_name) {
                     existing_function
                         .duplicate_paths
                         .push(properties_path.to_path_buf());
                 } else {
                     self.functions.insert(
-                        function.name.clone(),
+                        normalized_name,
                         MinimalPropertiesEntry {
                             name: validate_resource_name(&function.name)?,
                             name_span: Span::default(),


### PR DESCRIPTION
Fixes #13022

### Problem
When a `functions:` YAML schema entry uses a `name:` value with different 
casing than the SQL filename (e.g. `RENAME_DATA_CLOUD_COLUMN` in YAML vs 
`rename_data_cloud_column.sql` on disk), dbt silently no-ops the patch. 
The function compiles with empty arguments and `RETURNS INVALID_TYPE` — 
no warning or error is emitted, making this extremely difficult to debug.

The root cause is a case-sensitive map lookup mismatch. Function node names 
are always derived as lowercase from the SQL filename via `.file_stem()`. 
However, the YAML `name:` value was inserted into the `functions` BTreeMap 
as-is (preserving original casing). When the renderer later looks up the 
node by its lowercase filename-derived name, the key doesn't match and the 
patch is silently skipped.

### Solution
Two changes in `resolve_properties.rs`:

1. **Normalize the key to ASCII-lowercase** before inserting into the 
   `functions` BTreeMap, so it always matches the lowercase node name 
   derived from the SQL filename at render time.

2. **Emit a `FunctionNameCaseMismatch` warning** (new `ErrorCode 1160`) 
   whenever normalization was needed — consistent with how other YAML 
   mismatches are surfaced — so the user is clearly alerted and can fix 
   their YAML.

The `MinimalPropertiesEntry.name` field retains the original value from 
the YAML for display/diagnostic purposes; only the map key is normalized.

**Files changed:**
- `crates/dbt-error/src/codes.rs` — added `FunctionNameCaseMismatch = 1160`
- `crates/dbt-parser/src/resolve/resolve_properties.rs` — normalize function 
  name key to lowercase + emit warning on casing mismatch

### Checklist
- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.