### PR TITLE
feat(seeds): support .jsonl/.ndjson seed files

### DIFF
--- a/.changes/unreleased/Features-20260611-100000.yaml
+++ b/.changes/unreleased/Features-20260611-100000.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Support `.jsonl` and `.ndjson` seed files alongside `.csv`, `.json`, and `.parquet`
+time: 2026-06-11T10:00:00.000000-04:00
+custom:
+    author: jmmaloney4
+    issue: "2365"
+    project: dbt-fusion

--- a/crates/dbt-df-providers/src/seed_io.rs
+++ b/crates/dbt-df-providers/src/seed_io.rs
@@ -376,4 +376,34 @@ mod tests {
             assert_eq!(b.schema(), schema);
         }
     }
+
+    #[test]
+    fn read_jsonl_seed_full_read() {
+        let mut file = NamedTempFile::with_suffix(".jsonl").unwrap();
+        writeln!(file, r#"{{"id": 1, "name": "alpha"}}"#).unwrap();
+        writeln!(file, r#"{{"id": 2, "name": "beta"}}"#).unwrap();
+        file.flush().unwrap();
+
+        let (schema, batches) = read_json_seed(file.path(), true).expect("read jsonl");
+        let batches = batches.expect("batches");
+        let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total_rows, 2);
+        assert_eq!(schema.fields().len(), 2);
+    }
+
+    #[test]
+    fn read_ndjson_seed_full_read() {
+        let mut file = NamedTempFile::with_suffix(".ndjson").unwrap();
+        writeln!(file, r#"{{"x": 10, "y": "hello"}}"#).unwrap();
+        writeln!(file, r#"{{"x": 20, "y": "world"}}"#).unwrap();
+        writeln!(file).unwrap(); // blank line — Arrow JSON reader skips empty lines
+        writeln!(file, r#"{{"x": 30, "y": "!"}}"#).unwrap();
+        file.flush().unwrap();
+
+        let (schema, batches) = read_json_seed(file.path(), true).expect("read ndjson");
+        let batches = batches.expect("batches");
+        let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total_rows, 3);
+        assert_eq!(schema.fields().len(), 2);
+    }
 }

--- a/crates/dbt-df-providers/src/seed_io.rs
+++ b/crates/dbt-df-providers/src/seed_io.rs
@@ -377,33 +377,56 @@ mod tests {
         }
     }
 
-    #[test]
-    fn read_jsonl_seed_full_read() {
-        let mut file = NamedTempFile::with_suffix(".jsonl").unwrap();
-        writeln!(file, r#"{{"id": 1, "name": "alpha"}}"#).unwrap();
-        writeln!(file, r#"{{"id": 2, "name": "beta"}}"#).unwrap();
+    /// Helper: write newline-delimited JSON lines to a temp file and verify `read_json_seed`.
+    fn check_jsonl_variant(
+        suffix: &str,
+        lines: &[&str],
+        expect_rows: usize,
+        expect_fields: usize,
+    ) {
+        let mut file = NamedTempFile::with_suffix(suffix).unwrap();
+        for line in lines {
+            writeln!(file, "{line}").unwrap();
+        }
         file.flush().unwrap();
 
-        let (schema, batches) = read_json_seed(file.path(), true).expect("read jsonl");
+        let (schema, batches) = read_json_seed(file.path(), true)
+            .unwrap_or_else(|e| panic!("read {suffix}: {e}"));
         let batches = batches.expect("batches");
         let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
-        assert_eq!(total_rows, 2);
-        assert_eq!(schema.fields().len(), 2);
+        assert_eq!(total_rows, expect_rows, "row count for {suffix}");
+        assert_eq!(
+            schema.fields().len(),
+            expect_fields,
+            "field count for {suffix}"
+        );
+    }
+
+    #[test]
+    fn read_jsonl_seed_full_read() {
+        check_jsonl_variant(
+            ".jsonl",
+            &[
+                r#"{"id": 1, "name": "alpha"}"#,
+                r#"{"id": 2, "name": "beta"}"#,
+            ],
+            2,
+            2,
+        );
     }
 
     #[test]
     fn read_ndjson_seed_full_read() {
-        let mut file = NamedTempFile::with_suffix(".ndjson").unwrap();
-        writeln!(file, r#"{{"x": 10, "y": "hello"}}"#).unwrap();
-        writeln!(file, r#"{{"x": 20, "y": "world"}}"#).unwrap();
-        writeln!(file).unwrap(); // blank line — Arrow JSON reader skips empty lines
-        writeln!(file, r#"{{"x": 30, "y": "!"}}"#).unwrap();
-        file.flush().unwrap();
-
-        let (schema, batches) = read_json_seed(file.path(), true).expect("read ndjson");
-        let batches = batches.expect("batches");
-        let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
-        assert_eq!(total_rows, 3);
-        assert_eq!(schema.fields().len(), 2);
+        check_jsonl_variant(
+            ".ndjson",
+            &[
+                r#"{"x": 10, "y": "hello"}"#,
+                r#"{"x": 20, "y": "world"}"#,
+                "", // blank line — Arrow JSON reader skips empty lines
+                r#"{"x": 30, "y": "!"}"#,
+            ],
+            3,
+            2,
+        );
     }
 }

--- a/crates/dbt-loader/src/loader.rs
+++ b/crates/dbt-loader/src/loader.rs
@@ -376,7 +376,7 @@ pub async fn load(
                 in_dir,
                 pkg_name,
                 &ResourcePathKind::SeedPaths,
-                &["csv", "parquet", "json"],
+                &["csv", "parquet", "json", "jsonl", "ndjson"],
                 ap,
             );
             root.snapshot_files = find_files_by_kind_and_extension(
@@ -1059,7 +1059,7 @@ pub async fn load_inner(
         package_path,
         &dbt_project.name,
         &ResourcePathKind::SeedPaths,
-        &["csv", "parquet", "json"],
+        &["csv", "parquet", "json", "jsonl", "ndjson"],
         &all_files,
     );
     let docs_files = find_files_by_kind_and_extension(

--- a/crates/dbt-parser/src/resolve/resolve_seeds.rs
+++ b/crates/dbt-parser/src/resolve/resolve_seeds.rs
@@ -110,10 +110,15 @@ pub async fn resolve_seeds(
     // Track seed names seen so far (name → relative path) to detect duplicates across subdirs
     let mut seen_seed_names: HashMap<String, std::path::PathBuf> = HashMap::new();
     for seed_file in package.seed_files.iter() {
-        // Validate that path extension is one of csv, parquet, or json
+        // Validate that path extension is one of csv, parquet, json, jsonl, or ndjson
         let path = seed_file.path.clone();
         let path_extension = path.extension().unwrap_or_default().to_ascii_lowercase();
-        if path_extension != "csv" && path_extension != "parquet" && path_extension != "json" {
+        if path_extension != "csv"
+            && path_extension != "parquet"
+            && path_extension != "json"
+            && path_extension != "jsonl"
+            && path_extension != "ndjson"
+        {
             continue;
         }
 

--- a/crates/dbt-tasks-sa/src/register_seeds.rs
+++ b/crates/dbt-tasks-sa/src/register_seeds.rs
@@ -241,7 +241,7 @@ pub async fn pre_register_seeds(
         let format = match extension.as_deref() {
             Some("csv") => None,
             Some("parquet") => Some(TableFormat::Parquet),
-            Some("json") => Some(TableFormat::Json),
+            Some("json") | Some("jsonl") | Some("ndjson") => Some(TableFormat::Json),
             _ => {
                 // Silently skip — visit_render will detect missing schema and
                 // emit the error through normal task graph propagation.


### PR DESCRIPTION
## Summary

Adds support for seed files with `.jsonl` and `.ndjson` extensions, where each non-empty line is a JSON object. This addresses issue #2365.

Arrow's `infer_json_schema` already reads newline-delimited JSON natively, so no new I/O code is needed — only extension dispatch plumbing in the loader, resolver, and registrar.

### Example

```jsonl
{"id": 1, "name": "alpha", "metadata": {"source": "manual", "rank": 1}}
{"id": 2, "name": "beta", "metadata": {"source": "api", "flags": ["x", "y"]}, "active": true}
```

## Changes

- **`crates/dbt-loader/src/loader.rs`**: Added `"jsonl"`, `"ndjson"` to `find_files_by_kind_and_extension` at both seed discovery call sites (inline warm path + full walk).
- **`crates/dbt-parser/src/resolve/resolve_seeds.rs`**: Added `"jsonl"`, `"ndjson"` to the extension validation whitelist so the resolver accepts these files.
- **`crates/dbt-tasks-sa/src/register_seeds.rs`**: Added `Some("jsonl") | Some("ndjson")` to the match arm that dispatches to `TableFormat::Json`, reusing the existing `read_json_seed` path.
- **`crates/dbt-df-providers/src/seed_io.rs`**: Added 2 unit tests (`read_jsonl_seed_full_read`, `read_ndjson_seed_full_read`).
- **`.changes/unreleased/Features-20260611-100000.yaml`**: Changie entry.

## What is NOT changed

- Existing CSV, JSON, and Parquet seed parsing (completely unchanged).
- Seed selection, `ref()`, node naming, or materialization macros.
- `SeedConfig` data model (no new config fields).

## Test plan

- [x] `.jsonl` seed file is read correctly (unit test)
- [x] `.ndjson` seed file is read correctly with blank lines tolerated (unit test)
- [x] All existing `seed_io` tests still pass (6/6)
- [x] `cargo check` clean for all touched crates
- [ ] CI full validation

Closes #2365