### PR TITLE
Enable delete+insert incremental strategy for databricks

### DIFF
--- a/.changes/unreleased/Fixes-20260613-214400.yaml
+++ b/.changes/unreleased/Fixes-20260613-214400.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Allow Databricks incremental models to use the `delete+insert` strategy
+time: 2026-06-13T21:44:00.426007207+01:00
+custom:
+    author: Ewan-Keith
+    issue: "15250"
+    project: dbt-fusion

--- a/crates/dbt-adapter/src/adapter/adapter_impl.rs
+++ b/crates/dbt-adapter/src/adapter/adapter_impl.rs
@@ -502,7 +502,7 @@ impl AdapterImpl {
             Postgres | DuckDB => &[Append, DeleteInsert, Merge, Microbatch],
             Snowflake => &[Append, DeleteInsert, InsertOverwrite, Merge, Microbatch],
             Bigquery => &[Append],
-            Databricks => &[Append, Merge, InsertOverwrite, ReplaceWhere],
+            Databricks => &[Append, DeleteInsert, Merge, InsertOverwrite, ReplaceWhere],
             Redshift => &[Append, DeleteInsert, Merge, Microbatch],
             Fabric => &[Append, DeleteInsert, Merge, Microbatch],
             Salesforce => &[Append, Merge],

--- a/crates/dbt-adapter/src/adapter/tests.rs
+++ b/crates/dbt-adapter/src/adapter/tests.rs
@@ -415,17 +415,10 @@ fn test_get_relation_dispatch_spark_absent_database() {
 
 #[test]
 fn test_databricks_get_incremental_strategy_macro_accepts_delete_insert() {
-    let result = dispatch_test(
+    dispatch_test(
         &make_mock_adapter(AdapterType::Databricks),
         "get_incremental_strategy_macro",
-        &[
-            Value::from(BTreeMap::<String, Value>::new()),
-            Value::from("delete+insert"),
-        ],
-    );
-
-    assert!(
-        result.is_ok(),
-        "delete+insert should be a valid Databricks incremental strategy, got: {result:?}"
-    );
+        &[dict(&[]), Value::from("delete+insert")],
+    )
+    .unwrap();
 }

--- a/crates/dbt-adapter/src/adapter/tests.rs
+++ b/crates/dbt-adapter/src/adapter/tests.rs
@@ -412,3 +412,20 @@ fn test_get_relation_dispatch_spark_absent_database() {
         "unexpected error: {err}"
     );
 }
+
+#[test]
+fn test_databricks_get_incremental_strategy_macro_accepts_delete_insert() {
+    let result = dispatch_test(
+        &make_mock_adapter(AdapterType::Databricks),
+        "get_incremental_strategy_macro",
+        &[
+            Value::from(BTreeMap::<String, Value>::new()),
+            Value::from("delete+insert"),
+        ],
+    );
+
+    assert!(
+        result.is_ok(),
+        "delete+insert should be a valid Databricks incremental strategy, got: {result:?}"
+    );
+}

--- a/crates/dbt-loader/tests/materializations/incremental.rs
+++ b/crates/dbt-loader/tests/materializations/incremental.rs
@@ -5,8 +5,8 @@ use dbt_adapter::relation::RelationObject;
 use dbt_adapter_core::AdapterType;
 use dbt_jinja_utils::mock_object::MockJinjaObject;
 use dbt_schemas::dbt_types::RelationType;
-use minijinja::Value;
 use minijinja::dispatch_object::DispatchObject;
+use minijinja::Value;
 
 use crate::macro_test_harness::{
     MacroTestHarness, assert_executed_contains, default_mock_config, executed_sql,
@@ -78,11 +78,9 @@ fn delete_insert_config() -> Arc<MockJinjaObject> {
             _ => Ok(default),
         }
     });
-    mock.on("require", |args| {
-        match args.first().and_then(|v| v.as_str()) {
-            Some("unique_key") => Ok(Value::from("id")),
-            _ => Ok(Value::UNDEFINED),
-        }
+    mock.on("require", |args| match args.first().and_then(|v| v.as_str()) {
+        Some("unique_key") => Ok(Value::from("id")),
+        _ => Ok(Value::UNDEFINED),
     });
     mock
 }
@@ -262,17 +260,19 @@ mod databricks {
 
         harness.mock().on("get_columns_in_relation", |_| {
             Ok(Value::from_serialize(vec![
-                BTreeMap::from([("quoted", Value::from("`id`"))]),
-                BTreeMap::from([("quoted", Value::from("`name`"))]),
+                BTreeMap::from([("quoted", "`id`")]),
+                BTreeMap::from([("quoted", "`name`")]),
             ]))
         });
         harness.mock().on("get_incremental_strategy_macro", |args| {
             let strategy = args
                 .get(1)
                 .and_then(|v| v.as_str())
-                .expect("strategy argument should be passed");
+                .expect("strategy argument should be passed")
+                .replace('+', "_");
+            let macro_name = format!("get_incremental_{strategy}_sql");
             Ok(Value::from_object(DispatchObject {
-                macro_name: format!("get_incremental_{}_sql", strategy.replace('+', "_")),
+                macro_name,
                 package_name: None,
                 strict: false,
                 auto_execute: false,
@@ -292,25 +292,10 @@ mod databricks {
         render_incremental(&harness, ADAPTER, ctx)
             .unwrap_or_else(|e| panic!("incremental delete+insert failed: {e:?}"));
 
-        let sqls = executed_sql(harness.mock());
-        assert!(
-            sqls.iter().any(|sql| {
-                let lower = sql.to_lowercase();
-                lower.contains("delete from")
-                    && lower.contains("where")
-                    && sql.contains(".id IN (SELECT id FROM")
-            }),
-            "Expected delete+insert to execute a DELETE statement, got: {sqls:?}",
-        );
-        assert!(
-            sqls.iter().any(|sql| {
-                let lower = sql.to_lowercase();
-                lower.contains("insert into")
-                    && lower.contains("select `id`, `name`")
-                    && lower.contains("from")
-            }),
-            "Expected delete+insert to execute an INSERT statement, got: {sqls:?}",
-        );
+        assert_executed_contains(harness.mock(), "delete from");
+        assert_executed_contains(harness.mock(), ".id IN (SELECT id FROM");
+        assert_executed_contains(harness.mock(), "insert into");
+        assert_executed_contains(harness.mock(), "select `id`, `name`");
     }
 }
 

--- a/crates/dbt-loader/tests/materializations/incremental.rs
+++ b/crates/dbt-loader/tests/materializations/incremental.rs
@@ -6,6 +6,7 @@ use dbt_adapter_core::AdapterType;
 use dbt_jinja_utils::mock_object::MockJinjaObject;
 use dbt_schemas::dbt_types::RelationType;
 use minijinja::Value;
+use minijinja::dispatch_object::DispatchObject;
 
 use crate::macro_test_harness::{
     MacroTestHarness, assert_executed_contains, default_mock_config, executed_sql,
@@ -54,6 +55,33 @@ fn incremental_config() -> Arc<MockJinjaObject> {
             Some("full_refresh") => Ok(Value::from(false)),
             Some("on_schema_change") => Ok(Value::from("ignore")),
             _ => Ok(default),
+        }
+    });
+    mock
+}
+
+fn delete_insert_config() -> Arc<MockJinjaObject> {
+    let mock = incremental_config();
+    mock.on("get", |args| {
+        let key = args.first().and_then(|v| v.as_str());
+        let default = args.get(1).cloned().unwrap_or(Value::UNDEFINED);
+        match key {
+            Some("contract") => Ok(Value::from_serialize(BTreeMap::from([(
+                "enforced".to_string(),
+                Value::from(false),
+            )]))),
+            Some("full_refresh") => Ok(Value::from(false)),
+            Some("incremental_strategy") => Ok(Value::from("delete+insert")),
+            Some("incremental_predicates") | Some("predicates") => Ok(Value::from(())),
+            Some("unique_key") => Ok(Value::from("id")),
+            Some("on_schema_change") => Ok(Value::from("ignore")),
+            _ => Ok(default),
+        }
+    });
+    mock.on("require", |args| {
+        match args.first().and_then(|v| v.as_str()) {
+            Some("unique_key") => Ok(Value::from("id")),
+            _ => Ok(Value::UNDEFINED),
         }
     });
     mock
@@ -205,6 +233,83 @@ mod databricks {
         assert!(
             sqls.len() >= 2,
             "Expected at least 2 SQL statements (temp table + merge), got: {sqls:?}",
+        );
+    }
+
+    #[test]
+    fn existing_table_incremental_delete_insert_executes_delete_and_insert() {
+        let harness = build_harness();
+
+        let existing = harness.relation(
+            "TEST_DB",
+            "TEST_SCHEMA",
+            "my_incr",
+            Some(RelationType::Table),
+        );
+        harness.mock().on("get_relation", move |_| {
+            Ok(RelationObject::new(Arc::clone(&existing)).into_value())
+        });
+        harness
+            .mock()
+            .on("get_relation_config", |_| Ok(Value::UNDEFINED));
+
+        let model_config = Arc::new(MockJinjaObject::new());
+        model_config.on("get_changeset", |_| Ok(Value::from(())));
+        let model_config_val = Value::from_dyn_object(model_config);
+        harness.mock().on("get_config_from_model", move |_| {
+            Ok(model_config_val.clone())
+        });
+
+        harness.mock().on("get_columns_in_relation", |_| {
+            Ok(Value::from_serialize(vec![
+                BTreeMap::from([("quoted", Value::from("`id`"))]),
+                BTreeMap::from([("quoted", Value::from("`name`"))]),
+            ]))
+        });
+        harness.mock().on("get_incremental_strategy_macro", |args| {
+            let strategy = args
+                .get(1)
+                .and_then(|v| v.as_str())
+                .expect("strategy argument should be passed");
+            Ok(Value::from_object(DispatchObject {
+                macro_name: format!("get_incremental_{}_sql", strategy.replace('+', "_")),
+                package_name: None,
+                strict: false,
+                auto_execute: false,
+                context: None,
+            }))
+        });
+
+        let ctx = harness
+            .materialization_context("my_incr", "SELECT id, name FROM source")
+            .relation_type(RelationType::Table)
+            .config(Value::from_dyn_object(delete_insert_config()))
+            .with(
+                "model",
+                incremental_model("my_incr", "SELECT id, name FROM source"),
+            )
+            .build();
+        render_incremental(&harness, ADAPTER, ctx)
+            .unwrap_or_else(|e| panic!("incremental delete+insert failed: {e:?}"));
+
+        let sqls = executed_sql(harness.mock());
+        assert!(
+            sqls.iter().any(|sql| {
+                let lower = sql.to_lowercase();
+                lower.contains("delete from")
+                    && lower.contains("where")
+                    && sql.contains(".id IN (SELECT id FROM")
+            }),
+            "Expected delete+insert to execute a DELETE statement, got: {sqls:?}",
+        );
+        assert!(
+            sqls.iter().any(|sql| {
+                let lower = sql.to_lowercase();
+                lower.contains("insert into")
+                    && lower.contains("select `id`, `name`")
+                    && lower.contains("from")
+            }),
+            "Expected delete+insert to execute an INSERT statement, got: {sqls:?}",
         );
     }
 }


### PR DESCRIPTION
Resolves #15250

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

`dbt-fusion 2.0.0-preview.189` rejects Databricks incremental models configured with `incremental_strategy='delete+insert'` when the model enters the incremental path.

The same minimal project and model succeeds with dbt Core `1.11.6` and `dbt-databricks` `1.11.5`.

Fusion failure:

```text
The incremental strategy 'delete+insert' is not valid for this adapter
```

### Solution

Simply adds the `DeleteInsert` strategy for Databricks to the `valid_incremental_strategies()` function in `crates/dbt-adapter/src/adapter/adapter_impl.rs`. Also includes 2 new unit-tests validating that support is now added.

As well as the tests, I've ran a build with these changes on a project using delete+insert on databricks and have confirmed the run fails in the way described on the associated issue without these changes, and succeeds with this change.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions. [only making rust changes so this seems irrelevant).
