### PR TITLE
fix: parse inline semantic models/metrics on versioned models (#15294)

### DIFF
--- a/.changes/unreleased/Fixes-20260618-173000.yaml
+++ b/.changes/unreleased/Fixes-20260618-173000.yaml
@@ -1,0 +1,8 @@
+kind: Fixes
+body: Parse inline (v2) semantic models and metrics declared on versioned models.
+  They were previously silently dropped from the manifest because the model-level
+  semantic constructs were not propagated to the latest version's patch.
+time: 2026-06-18T17:30:00.000000+00:00
+custom:
+    Author: pgoslatara
+    Issue: "15294"

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -1078,6 +1078,13 @@ class ModelPatchParser(NodePatchParser[UnparsedModelUpdate]):
                     block.target, unparsed_version.v
                 )
 
+                # Semantic constructs (the inline `semantic_model:` spec and
+                # `metrics:`) are declared at the model level and apply to the
+                # model as resolved by `ref()`, i.e. the latest version. Attach
+                # them to the latest version's patch only; otherwise they are
+                # silently dropped for versioned models (dbt-core#15294).
+                is_latest_version = unparsed_version.v == latest_version
+
                 versioned_model_patch = ParsedNodePatch(
                     name=target.name,
                     original_file_path=target.original_file_path,
@@ -1093,6 +1100,11 @@ class ModelPatchParser(NodePatchParser[UnparsedModelUpdate]):
                     latest_version=latest_version,
                     constraints=unparsed_version.constraints or target.constraints,
                     deprecation_date=unparsed_version.deprecation_date,
+                    semantic_model=target.semantic_model if is_latest_version else None,
+                    metrics=target.metrics if is_latest_version else None,
+                    derived_semantics=target.derived_semantics if is_latest_version else None,
+                    agg_time_dimension=target.agg_time_dimension if is_latest_version else None,
+                    primary_entity=target.primary_entity if is_latest_version else None,
                 )
                 # Node patched before config because config patching depends on model name,
                 # which may have been updated in the version patch

--- a/tests/functional/semantic_models/fixtures.py
+++ b/tests/functional/semantic_models/fixtures.py
@@ -1119,3 +1119,54 @@ semantic_model_schema_yml_v2_entity_without_name = """models:
         entity:
           type: foreign
 """
+
+# --- Regression fixtures for dbt-core#15294 -------------------------------
+# An inline (v2) semantic model declared on a *versioned* model. The columns
+# carrying the entity/dimension annotations live under versions[].columns.
+versioned_model_v1_sql = """select 1 as id, cast('2020-01-01' as date) as created_at"""
+
+versioned_model_v2_sql = """select 1 as id, cast('2020-01-01' as date) as created_at"""
+
+versioned_model_semantic_schema_yml_v2 = """models:
+  - name: metricflow_time_spine
+    time_spine:
+      standard_granularity_column: date_day
+    columns:
+      - name: date_day
+        granularity: day
+
+  - name: customers
+    description: A versioned model carrying an inline semantic model.
+    latest_version: 2
+    semantic_model:
+      enabled: true
+    agg_time_dimension: created_at
+    metrics:
+      - name: customers_count
+        description: Number of customers.
+        label: Customers Count
+        type: simple
+        agg: count
+        expr: id
+    versions:
+      - v: 1
+        columns:
+          - name: id
+            entity:
+              type: primary
+              name: customer
+          - name: created_at
+            granularity: day
+            dimension:
+              type: time
+      - v: 2
+        columns:
+          - name: id
+            entity:
+              type: primary
+              name: customer
+          - name: created_at
+            granularity: day
+            dimension:
+              type: time
+"""

--- a/tests/functional/semantic_models/test_semantic_model_v2_parsing.py
+++ b/tests/functional/semantic_models/test_semantic_model_v2_parsing.py
@@ -40,6 +40,10 @@ from tests.functional.semantic_models.fixtures import (
     semantic_model_schema_yml_v2_renamed,
     semantic_model_schema_yml_v2_with_primary_entity_only_on_column,
     semantic_model_test_groups_yml,
+    simple_metricflow_time_spine_sql,
+    versioned_model_semantic_schema_yml_v2,
+    versioned_model_v1_sql,
+    versioned_model_v2_sql,
 )
 
 
@@ -1095,3 +1099,47 @@ class TestSemanticModelEntityWithoutName:
 
 
 # TODO DI-4603: add enforcement and a test for a TIME type dimension and a column that has no granularity set
+
+
+class TestSemanticModelOnVersionedModel:
+    """Regression test for dbt-core#15294.
+
+    An inline (v2) semantic model declared on a *versioned* model — whose
+    columns live under versions[].columns — used to be silently dropped from
+    the manifest (no error, no warning). It should be parsed exactly once, for
+    the latest version (which `ref()` resolves to).
+    """
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "customers_v1.sql": versioned_model_v1_sql,
+            "customers_v2.sql": versioned_model_v2_sql,
+            "metricflow_time_spine.sql": simple_metricflow_time_spine_sql,
+            "schema.yml": versioned_model_semantic_schema_yml_v2,
+        }
+
+    def test_semantic_model_on_versioned_model(self, project) -> None:
+        runner = dbtTestRunner()
+        result = runner.invoke(["parse"])
+        assert result.success
+        assert isinstance(result.result, Manifest)
+        manifest = result.result
+
+        # Exactly one semantic model — not zero (the bug) and not one-per-version.
+        assert len(manifest.semantic_models) == 1
+        semantic_model = manifest.semantic_models["semantic_model.test.customers"]
+        assert semantic_model.name == "customers"
+        # The semantic model targets the model as resolved by ref() (latest version).
+        assert semantic_model.model == "ref('customers')"
+
+        # Entity + time dimension were resolved from the versioned columns.
+        entities = {entity.name: entity for entity in semantic_model.entities}
+        assert "customer" in entities
+        assert entities["customer"].type == EntityType.PRIMARY
+        dimensions = {dimension.name: dimension for dimension in semantic_model.dimensions}
+        assert "created_at" in dimensions
+        assert dimensions["created_at"].type == DimensionType.TIME
+
+        # The model-level metric is also produced (it was dropped by the same bug).
+        assert "metric.test.customers_count" in manifest.metrics


### PR DESCRIPTION
### Resolves #15294

### Problem

An inline (v2) semantic model — and any `metrics:` — declared at the model level on a **versioned** model is silently dropped from the manifest: no error, no warning, and no semantic model or metric is produced. The same definition on a non-versioned model works, and the dbt Fusion (2.0) engine handles the versioned case correctly.

### Root cause

In `PatchParser.parse_patch` (`core/dbt/parser/schemas.py`), the versioned-model branch builds a per-version `ParsedNodePatch` that includes the version's `columns` but omits the model-level semantic constructs (`semantic_model`, `metrics`, `derived_semantics`, `agg_time_dimension`, `primary_entity`) that the non-versioned path sets in `_get_node_patch`. As a result `patch.semantic_model` is always `None`, so `patch_node_properties` never enters the `semantic_model_enabled` branch and `parse_v2_semantic_model_from_dbt_model_patch` / `parse_v2_metrics_from_dbt_model_patch` are never called.

### Fix

Propagate the model-level semantic constructs onto the **latest** version's patch (the version `ref()` resolves to). Gating to the latest version produces exactly one semantic model, rather than zero (the bug) or one per version. Non-versioned parsing is untouched, and versioned models without semantic constructs are unaffected (all fields resolve to `None`, as before).

### How I verified

A minimal project (versioned `cust` + non-versioned `nonvers` control, each with the same inline `semantic_model:` + `metrics:`):

```
# dbt-core 1.12.0-b3 (before)         # with this fix
semantic_models: ['nonvers']          semantic_models: ['cust', 'nonvers']
metrics:         ['nonvers_count']    metrics:         ['cust_count', 'nonvers_count']
```

### Tests / changelog

- Added `TestSemanticModelOnVersionedModel` in `tests/functional/semantic_models/test_semantic_model_v2_parsing.py` (+ fixtures) asserting that a versioned model with an inline semantic model produces exactly one semantic model — with the entity/time-dimension resolved from `versions[].columns` — plus the model-level metric.
- Added a `Fixes` changie entry.

### Notes

- This targets **`1.12.latest`** because `main` is now the Rust/Fusion engine; the bug is specific to the Python 1.x parser (the Fusion engine already parses this correctly). Happy to retarget if there's a preferred branch/process.
- Scoped to the semantic constructs in the report; `time_spine` is intentionally not propagated (a versioned time-spine model isn't a meaningful combination).
- Related: #14600 (same YAML shape, different symptom — a Fusion-engine panic).
