### PR TITLE
Recognize Databricks adapter config keys in jsonschema validation

### DIFF
--- a/.changes/unreleased/Fixes-20260623-120000.yaml
+++ b/.changes/unreleased/Fixes-20260623-120000.yaml
@@ -1,0 +1,9 @@
+kind: Fixes
+body: 'Recognize Databricks adapter config keys (`query_tags`, `zorder`, `options`,
+  `unique_tmp_table_suffix`, `skip_optimize`) in jsonschema validation so they no
+  longer raise spurious `CustomKeyInConfigDeprecation` warnings (dbt-databricks#1540,
+  dbt-databricks#1302)'
+time: 2026-06-23T12:00:00.000000-05:00
+custom:
+    Author: sd-db
+    Issue: "N/A"

--- a/core/dbt/jsonschemas/jsonschemas.py
+++ b/core/dbt/jsonschemas/jsonschemas.py
@@ -37,8 +37,16 @@ _HIERARCHICAL_CONFIG_KEYS = {
     "unit_tests",
 }
 
-_ADAPTER_TO_CONFIG_ALIASES = {
+_ADAPTER_TO_EXTRA_KEYS = {
     "bigquery": ["dataset", "project"],
+    # databricks/dbt-databricks#1540, #1302
+    "databricks": [
+        "query_tags",
+        "zorder",
+        "options",
+        "unique_tmp_table_suffix",
+        "skip_optimize",
+    ],
 }
 
 
@@ -108,14 +116,14 @@ def _validate_with_schema(
     return validator.iter_errors(json)
 
 
-def _get_allowed_config_key_aliases() -> List[str]:
-    config_aliases = []
+def _get_allowed_config_extra_keys() -> List[str]:
+    extra_keys = []
     invocation_context = get_invocation_context()
     for adapter in invocation_context.adapter_types:
-        if adapter in _ADAPTER_TO_CONFIG_ALIASES:
-            config_aliases.extend(_ADAPTER_TO_CONFIG_ALIASES[adapter])
+        if adapter in _ADAPTER_TO_EXTRA_KEYS:
+            extra_keys.extend(_ADAPTER_TO_EXTRA_KEYS[adapter])
 
-    return config_aliases
+    return extra_keys
 
 
 def _get_allowed_config_fields_for_project_property(schema, property_field_name) -> List[str]:
@@ -132,7 +140,7 @@ def _get_allowed_config_fields_for_project_property(schema, property_field_name)
 
     allowed_config_fields = set(schema["definitions"][property_defn_name]["properties"])
     # in dbt_project.yml keys should have a + prefix
-    allowed_config_fields.update([f"+{key}" for key in _get_allowed_config_key_aliases()])
+    allowed_config_fields.update([f"+{key}" for key in _get_allowed_config_extra_keys()])
     return list(allowed_config_fields)
 
 
@@ -165,7 +173,7 @@ def _get_allowed_config_fields_from_error_path(
     ][0]["$ref"].split("/")[-1]
 
     allowed_config_fields = list(set(yml_schema["definitions"][config_field_name]["properties"]))
-    allowed_config_fields.extend(_get_allowed_config_key_aliases())
+    allowed_config_fields.extend(_get_allowed_config_extra_keys())
 
     return allowed_config_fields
 
@@ -207,7 +215,7 @@ def jsonschema_validate(schema: Dict[str, Any], json: Dict[str, Any], file_path:
                         len(error_path) == 2
                         and error_path[0] == "sources"
                         and isinstance(error_path[1], int)
-                        and key in _get_allowed_config_key_aliases()
+                        and key in _get_allowed_config_extra_keys()
                     ):
                         continue
 
@@ -247,7 +255,7 @@ def jsonschema_validate(schema: Dict[str, Any], json: Dict[str, Any], file_path:
                         keys = _additional_properties_violation_keys(sub_error)
                         key_path = error_path_to_string(error)
                         for key in keys:
-                            if key in _get_allowed_config_key_aliases():
+                            if key in _get_allowed_config_extra_keys():
                                 continue
 
                             deprecations.warn(
@@ -343,7 +351,7 @@ def validate_model_config(
                         continue
 
                     # Dont raise deprecation warnings for adapter specific config key aliases
-                    if key in _get_allowed_config_key_aliases():
+                    if key in _get_allowed_config_extra_keys():
                         continue
 
                     # For everything else, emit deprecation warning

--- a/tests/functional/deprecations/test_deprecations.py
+++ b/tests/functional/deprecations/test_deprecations.py
@@ -402,7 +402,7 @@ class TestCustomKeyInConfigSQLDeprecation:
 
     @mock.patch("dbt.jsonschemas.jsonschemas._JSONSCHEMA_SUPPORTED_ADAPTERS", {"postgres"})
     @mock.patch(
-        "dbt.jsonschemas.jsonschemas._get_allowed_config_key_aliases",
+        "dbt.jsonschemas.jsonschemas._get_allowed_config_extra_keys",
         return_value=["my_custom_key"],
     )
     def test_custom_key_in_config_sql_deprecation_adapter_specific_config_key_aliases(
@@ -1005,7 +1005,7 @@ class TestPropertyAliasesInConfig:
         return {"sources": {"test": {"+aliased_key": "value"}}}
 
     @mock.patch(
-        "dbt.jsonschemas.jsonschemas._ADAPTER_TO_CONFIG_ALIASES", {"postgres": ["aliased_key"]}
+        "dbt.jsonschemas.jsonschemas._ADAPTER_TO_EXTRA_KEYS", {"postgres": ["aliased_key"]}
     )
     @mock.patch("dbt.jsonschemas.jsonschemas._JSONSCHEMA_SUPPORTED_ADAPTERS", {"postgres"})
     def test_property_aliases_in_config(self, project):
@@ -1014,7 +1014,7 @@ class TestPropertyAliasesInConfig:
         assert len(event_catcher.caught_events) == 0
 
     @mock.patch(
-        "dbt.jsonschemas.jsonschemas._ADAPTER_TO_CONFIG_ALIASES", {"postgres": ["aliased_key"]}
+        "dbt.jsonschemas.jsonschemas._ADAPTER_TO_EXTRA_KEYS", {"postgres": ["aliased_key"]}
     )
     @mock.patch("dbt.jsonschemas.jsonschemas._JSONSCHEMA_SUPPORTED_ADAPTERS", {"postgres"})
     def test_deps_command_property_aliases_in_config(self, project):

--- a/tests/unit/test_jsonschemas.py
+++ b/tests/unit/test_jsonschemas.py
@@ -9,6 +9,7 @@ from dbt.deprecations import (
 )
 from dbt.jsonschemas.jsonschemas import (
     jsonschema_validate,
+    project_schema,
     resources_schema,
     validate_model_config,
 )
@@ -166,3 +167,46 @@ class TestSourceBigQueryAliases:
 
         jsonschema_validate(resources_schema(), source_with_dataset, "test.yml")
         assert active_deprecations == {"custom-key-in-object-deprecation": 1}
+
+
+class TestDatabricksConfigKeys:
+    DATABRICKS_CONFIG_KEYS = {
+        "query_tags": '{"team": "finance"}',
+        "view_update_via_alter": True,
+        "zorder": ["col_a", "col_b"],
+        "incremental_apply_config_changes": True,
+        "use_safer_relation_operations": True,
+        "unique_tmp_table_suffix": True,
+        "skip_optimize": True,
+    }
+
+    def test_model_config_no_warning(self):
+        reset_deprecations()
+
+        safe_set_invocation_context()
+        get_invocation_context().uses_adapter("databricks")
+
+        config = {
+            "materialized": "incremental",
+            "options": {"compression": "snappy"},
+            **self.DATABRICKS_CONFIG_KEYS,
+        }
+        validate_model_config(config, "test.yml")
+        assert active_deprecations == {}
+
+    def test_project_config_no_warning(self):
+        reset_deprecations()
+
+        safe_set_invocation_context()
+        get_invocation_context().uses_adapter("databricks")
+
+        project_dict = {
+            "name": "my_project",
+            "version": "1.0.0",
+            "profile": "my_project",
+            "models": {
+                "my_project": {f"+{k}": v for k, v in self.DATABRICKS_CONFIG_KEYS.items()}
+            },
+        }
+        jsonschema_validate(project_schema(), project_dict, "dbt_project.yml")
+        assert active_deprecations == {}

--- a/tests/unit/test_jsonschemas.py
+++ b/tests/unit/test_jsonschemas.py
@@ -204,9 +204,7 @@ class TestDatabricksConfigKeys:
             "name": "my_project",
             "version": "1.0.0",
             "profile": "my_project",
-            "models": {
-                "my_project": {f"+{k}": v for k, v in self.DATABRICKS_CONFIG_KEYS.items()}
-            },
+            "models": {"my_project": {f"+{k}": v for k, v in self.DATABRICKS_CONFIG_KEYS.items()}},
         }
         jsonschema_validate(project_schema(), project_dict, "dbt_project.yml")
         assert active_deprecations == {}


### PR DESCRIPTION
## Problem

dbt-core's jsonschema config validation flags valid dbt-databricks config keys as unknown, emitting a spurious `CustomKeyInConfigDeprecation` that tells users to move them into `config.meta`.

Reported in databricks/dbt-databricks#1540 (`query_tags`, `view_update_via_alter`) and databricks/dbt-databricks#1302 (`zorder`).

## Fix

Allow-list the databricks config keys that aren't in the bundled jsonschema — `query_tags`, `zorder`, `options`, `unique_tmp_table_suffix`, `skip_optimize` — via `_ADAPTER_TO_EXTRA_KEYS["databricks"]` in `jsonschemas.py`, so they bypass the deprecation without hand-editing the (Fusion-synced) schema files.

Also renames `_ADAPTER_TO_CONFIG_ALIASES` → `_ADAPTER_TO_EXTRA_KEYS` and `_get_allowed_config_key_aliases` → `_get_allowed_config_extra_keys` to reflect the broader use.

`view_update_via_alter` (also #1540), `incremental_apply_config_changes`, and `use_safer_relation_operations` already arrived via the dbt-fusion schema sync; this fills the remaining gap.

## Tests

New `TestDatabricksConfigKeys` covers both the model-config and `dbt_project.yml` paths; verified it fails when the allow-list entry is removed.
