### PR TITLE
Honor FORCE_COLOR and NO_COLOR environment variables

### DIFF
--- a/.changes/unreleased/Features-20260706-233322.yaml
+++ b/.changes/unreleased/Features-20260706-233322.yaml
@@ -1,0 +1,8 @@
+kind: Features
+body: Honor FORCE_COLOR and NO_COLOR environment variables so CLI output stays colored
+  when piped through a wrapper process, and can be forced off in tty contexts.
+time: 2026-07-06T23:33:22.646755279Z
+custom:
+  author: jsnb-devoted
+  issue: "15412"
+  project: dbt-core

--- a/crates/dbt-common/src/pretty_string.rs
+++ b/crates/dbt-common/src/pretty_string.rs
@@ -29,7 +29,13 @@ pub fn apply_color_env_overrides() {
     {
         console::set_colors_enabled(true);
         console::set_colors_enabled_stderr(true);
-        if std::env::var_os("CLICOLOR_FORCE").is_none() {
+        // Treat an empty CLICOLOR_FORCE as unset — if a parent set it to ""
+        // it did not actually opt into forcing colors, and clap/anstream
+        // would otherwise still skip forced coloring, making output
+        // inconsistent with the caller's FORCE_COLOR intent.
+        let clicolor_force_effective = std::env::var_os("CLICOLOR_FORCE")
+            .is_some_and(|v| !v.is_empty());
+        if !clicolor_force_effective {
             // SAFETY: called at the top of main before any threads are
             // spawned; mutating the process environment here is race-free.
             unsafe {

--- a/crates/dbt-common/src/pretty_string.rs
+++ b/crates/dbt-common/src/pretty_string.rs
@@ -4,6 +4,41 @@ use std::error::Error;
 use std::fmt::Display;
 use std::sync::LazyLock;
 
+/// Apply widely-adopted color-control environment variables to the `console`
+/// crate's global color-enabled flag. Call once, early in `main`, before any
+/// styled output is produced.
+///
+/// * `NO_COLOR` (any non-empty value) disables ANSI styling. Widely
+///   honored convention used by many CLI tools.
+/// * `FORCE_COLOR` (any value other than `"0"`) enables ANSI styling even
+///   when stdout is not a TTY — see <https://force-color.org>. This lets
+///   parent processes that capture stdout (e.g. a wrapper piping output)
+///   still receive colored output.
+/// * If neither is set, the `console` crate's default TTY detection wins.
+///
+/// When `FORCE_COLOR` is set, `CLICOLOR_FORCE=1` is also exported so
+/// clap/anstream-styled output (usage/error text) is colored consistently.
+pub fn apply_color_env_overrides() {
+    if std::env::var_os("NO_COLOR").is_some_and(|v| !v.is_empty()) {
+        console::set_colors_enabled(false);
+        console::set_colors_enabled_stderr(false);
+        return;
+    }
+    if let Some(v) = std::env::var_os("FORCE_COLOR")
+        && v != "0"
+    {
+        console::set_colors_enabled(true);
+        console::set_colors_enabled_stderr(true);
+        if std::env::var_os("CLICOLOR_FORCE").is_none() {
+            // SAFETY: called at the top of main before any threads are
+            // spawned; mutating the process environment here is race-free.
+            unsafe {
+                std::env::set_var("CLICOLOR_FORCE", "1");
+            }
+        }
+    }
+}
+
 pub static CYAN: LazyLock<Style> = LazyLock::new(|| Style::new().cyan().bold());
 pub static BLUE: LazyLock<Style> = LazyLock::new(|| Style::new().blue().bold());
 pub static RED: LazyLock<Style> = LazyLock::new(|| Style::new().red().bold());

--- a/crates/dbt-common/src/pretty_string.rs
+++ b/crates/dbt-common/src/pretty_string.rs
@@ -38,6 +38,7 @@ pub fn apply_color_env_overrides() {
         if !clicolor_force_effective {
             // SAFETY: called at the top of main before any threads are
             // spawned; mutating the process environment here is race-free.
+            #[allow(clippy::disallowed_methods)]
             unsafe {
                 std::env::set_var("CLICOLOR_FORCE", "1");
             }

--- a/crates/dbt-common/src/pretty_string.rs
+++ b/crates/dbt-common/src/pretty_string.rs
@@ -8,33 +8,40 @@ use std::sync::LazyLock;
 /// crate's global color-enabled flag. Call once, early in `main`, before any
 /// styled output is produced.
 ///
-/// * `NO_COLOR` (any non-empty value) disables ANSI styling. Widely
-///   honored convention used by many CLI tools.
-/// * `FORCE_COLOR` (any value other than `"0"`) enables ANSI styling even
-///   when stdout is not a TTY — see <https://force-color.org>. This lets
-///   parent processes that capture stdout (e.g. a wrapper piping output)
-///   still receive colored output.
-/// * If neither is set, the `console` crate's default TTY detection wins.
+/// * `NO_COLOR` disables ANSI styling. Presence-only: any value (including
+///   an empty string, as produced by `export NO_COLOR` with no assignment)
+///   counts. Widely honored convention used by many CLI tools.
+/// * `FORCE_COLOR=0` disables ANSI styling, matching the npm
+///   `supports-color` / `chalk` convention.
+/// * `FORCE_COLOR` set to any other value enables ANSI styling even when
+///   stdout is not a TTY — see <https://force-color.org>. This lets parent
+///   processes that capture stdout (e.g. a wrapper piping output) still
+///   receive colored output.
+/// * If none of the above apply, the `console` crate's default TTY
+///   detection wins.
 ///
-/// When `FORCE_COLOR` is set, `CLICOLOR_FORCE=1` is also exported so
+/// When `FORCE_COLOR` is enabling, `CLICOLOR_FORCE=1` is also exported so
 /// clap/anstream-styled output (usage/error text) is colored consistently.
 pub fn apply_color_env_overrides() {
-    if std::env::var_os("NO_COLOR").is_some_and(|v| !v.is_empty()) {
+    if std::env::var_os("NO_COLOR").is_some() {
         console::set_colors_enabled(false);
         console::set_colors_enabled_stderr(false);
         return;
     }
-    if let Some(v) = std::env::var_os("FORCE_COLOR")
-        && v != "0"
-    {
+    if let Some(v) = std::env::var_os("FORCE_COLOR") {
+        if v == "0" {
+            console::set_colors_enabled(false);
+            console::set_colors_enabled_stderr(false);
+            return;
+        }
         console::set_colors_enabled(true);
         console::set_colors_enabled_stderr(true);
         // Treat an empty CLICOLOR_FORCE as unset — if a parent set it to ""
         // it did not actually opt into forcing colors, and clap/anstream
         // would otherwise still skip forced coloring, making output
         // inconsistent with the caller's FORCE_COLOR intent.
-        let clicolor_force_effective = std::env::var_os("CLICOLOR_FORCE")
-            .is_some_and(|v| !v.is_empty());
+        let clicolor_force_effective =
+            std::env::var_os("CLICOLOR_FORCE").is_some_and(|v| !v.is_empty());
         if !clicolor_force_effective {
             // SAFETY: called at the top of main before any threads are
             // spawned; mutating the process environment here is race-free.

--- a/crates/dbt-common/src/tracing/layers/json_compat_layer.rs
+++ b/crates/dbt-common/src/tracing/layers/json_compat_layer.rs
@@ -18,7 +18,7 @@ use dbt_tracing::{
     background_writer::BackgroundWriter,
     data_provider::DataProvider,
     layer::{ConsumerLayer, TelemetryConsumer},
-    shared_writer::SharedWriter,
+    shared_writer::{SharedWriter, resolve_is_terminal},
     shutdown::TelemetryShutdownItem,
 };
 
@@ -193,7 +193,7 @@ impl JsonCompatLayer {
         command: FsCommand,
         command_name: &'static str,
     ) -> Self {
-        let is_tty = writer.is_terminal();
+        let is_tty = resolve_is_terminal(&writer);
         let custom_envs = crate::constants::collect_dbt_custom_envs();
 
         Self {

--- a/crates/dbt-sa-cli/src/main.rs
+++ b/crates/dbt-sa-cli/src/main.rs
@@ -1,4 +1,5 @@
 use dbt_clap_core::{CliParserFactory as _, from_main};
+use dbt_common::pretty_string::apply_color_env_overrides;
 use dbt_common::tracing::{FsTraceConfig, dbt_init::init_tracing};
 use dbt_features::cli::DefaultCliParserFactory;
 use dbt_features::feature_stack::FeatureStack;
@@ -9,6 +10,7 @@ use std::process::ExitCode;
 use std::sync::Arc;
 
 fn main() -> ExitCode {
+    apply_color_env_overrides();
     let version = env!("CARGO_PKG_VERSION");
     let cli_parser = DefaultCliParserFactory.create("dbt-core", version);
     let cli = dbt_lib::prepare_cli_or_exit(&cli_parser);

--- a/crates/dbt-tracing/src/layers/pretty_writer.rs
+++ b/crates/dbt-tracing/src/layers/pretty_writer.rs
@@ -1,6 +1,8 @@
 use crate::{
     LogRecordInfo, SpanEndInfo, SpanStartInfo, TelemetryOutputFlags, TelemetryRecordRef,
-    data_provider::DataProvider, layer::TelemetryConsumer, shared_writer::SharedWriter,
+    data_provider::DataProvider,
+    layer::TelemetryConsumer,
+    shared_writer::{SharedWriter, resolve_is_terminal},
 };
 
 pub type TelemetryRecordPrettyFormatter =
@@ -24,7 +26,7 @@ impl TelemetryPrettyWriterLayer {
         W: SharedWriter + 'static,
         F: Fn(TelemetryRecordRef, bool) -> Option<String> + Send + Sync + 'static,
     {
-        let is_tty = writer.is_terminal();
+        let is_tty = resolve_is_terminal(&writer);
 
         Self {
             writer: Box::new(writer),

--- a/crates/dbt-tracing/src/layers/pretty_writer.rs
+++ b/crates/dbt-tracing/src/layers/pretty_writer.rs
@@ -2,7 +2,7 @@ use crate::{
     LogRecordInfo, SpanEndInfo, SpanStartInfo, TelemetryOutputFlags, TelemetryRecordRef,
     data_provider::DataProvider,
     layer::TelemetryConsumer,
-    shared_writer::{SharedWriter, resolve_is_terminal},
+    shared_writer::{SharedWriter, resolve_is_terminal, resolve_use_color},
 };
 
 pub type TelemetryRecordPrettyFormatter =
@@ -16,7 +16,7 @@ pub type TelemetryRecordPrettyFormatter =
 pub struct TelemetryPrettyWriterLayer {
     writer: Box<dyn SharedWriter>,
     formatter: TelemetryRecordPrettyFormatter,
-    is_tty: bool,
+    use_color: bool,
     filter_flag: TelemetryOutputFlags,
 }
 
@@ -26,12 +26,16 @@ impl TelemetryPrettyWriterLayer {
         W: SharedWriter + 'static,
         F: Fn(TelemetryRecordRef, bool) -> Option<String> + Send + Sync + 'static,
     {
+        // Routing is based on terminal-ness alone (respecting FORCE_COLOR
+        // but not NO_COLOR, so setting NO_COLOR on a real TTY doesn't drop
+        // console-only records); styling additionally honors NO_COLOR.
         let is_tty = resolve_is_terminal(&writer);
+        let use_color = resolve_use_color(&writer);
 
         Self {
             writer: Box::new(writer),
             formatter: Box::new(formatter),
-            is_tty,
+            use_color,
             filter_flag: if is_tty {
                 TelemetryOutputFlags::OUTPUT_CONSOLE
             } else {
@@ -54,19 +58,20 @@ impl TelemetryConsumer for TelemetryPrettyWriterLayer {
     }
 
     fn on_span_start(&self, span: &SpanStartInfo, _: &mut DataProvider<'_>) {
-        if let Some(line) = (self.formatter)(TelemetryRecordRef::SpanStart(span), self.is_tty) {
+        if let Some(line) = (self.formatter)(TelemetryRecordRef::SpanStart(span), self.use_color) {
             self.writer.writeln(&line);
         }
     }
 
     fn on_span_end(&self, span: &SpanEndInfo, _: &mut DataProvider<'_>) {
-        if let Some(line) = (self.formatter)(TelemetryRecordRef::SpanEnd(span), self.is_tty) {
+        if let Some(line) = (self.formatter)(TelemetryRecordRef::SpanEnd(span), self.use_color) {
             self.writer.writeln(&line);
         }
     }
 
     fn on_log_record(&self, record: &LogRecordInfo, _: &mut DataProvider<'_>) {
-        if let Some(line) = (self.formatter)(TelemetryRecordRef::LogRecord(record), self.is_tty) {
+        if let Some(line) = (self.formatter)(TelemetryRecordRef::LogRecord(record), self.use_color)
+        {
             self.writer.writeln(&line);
         }
     }

--- a/crates/dbt-tracing/src/shared_writer.rs
+++ b/crates/dbt-tracing/src/shared_writer.rs
@@ -3,31 +3,40 @@ use std::io::{self, Write};
 /// Whether the writer should be treated as a terminal for **routing**
 /// purposes (e.g. selecting console vs log-file telemetry filters).
 ///
-/// * `FORCE_COLOR` (any value other than `"0"`) promotes a non-TTY writer
-///   to terminal-like — see <https://force-color.org>. This lets wrappers
-///   that pipe stdout (e.g. a parent process capturing output) still opt
-///   into console-style output.
+/// * `FORCE_COLOR` set to any value other than `"0"` promotes a non-TTY
+///   writer to terminal-like — see <https://force-color.org>. This lets
+///   wrappers that pipe stdout (e.g. a parent process capturing output)
+///   still opt into console-style output.
+/// * `FORCE_COLOR=0` (or unset) is *not* a demotion: it just declines to
+///   force, and terminal-ness falls back to the writer's actual TTY
+///   status. Treating `FORCE_COLOR=0` as "force off" would drop
+///   console-only telemetry on a real interactive terminal.
 /// * `NO_COLOR` does **not** affect this — it only disables ANSI styling
 ///   (see [`resolve_use_color`]), not terminal-ness. Demoting a real TTY
 ///   here would drop console-only telemetry records, which is beyond
 ///   `NO_COLOR`'s intended scope.
-/// * Otherwise, defers to [`SharedWriter::is_terminal`].
 pub fn resolve_is_terminal<W: SharedWriter + ?Sized>(writer: &W) -> bool {
-    if let Some(v) = std::env::var_os("FORCE_COLOR") {
-        return v != "0";
+    if std::env::var_os("FORCE_COLOR").is_some_and(|v| v != "0") {
+        return true;
     }
     writer.is_terminal()
 }
 
 /// Whether ANSI styling should be emitted for output written to this
-/// writer. Combines terminal-like status with the `NO_COLOR` convention.
+/// writer.
 ///
 /// * `NO_COLOR` (any non-empty value) disables styling regardless of the
 ///   writer's terminal status. Widely honored convention used by many
 ///   CLI tools.
+/// * `FORCE_COLOR=0` also disables styling (matches the convention
+///   established by npm's `supports-color` / `chalk`), without affecting
+///   routing decisions in [`resolve_is_terminal`].
 /// * Otherwise, returns [`resolve_is_terminal`].
 pub fn resolve_use_color<W: SharedWriter + ?Sized>(writer: &W) -> bool {
     if std::env::var_os("NO_COLOR").is_some_and(|v| !v.is_empty()) {
+        return false;
+    }
+    if std::env::var_os("FORCE_COLOR").is_some_and(|v| v == "0") {
         return false;
     }
     resolve_is_terminal(writer)

--- a/crates/dbt-tracing/src/shared_writer.rs
+++ b/crates/dbt-tracing/src/shared_writer.rs
@@ -1,5 +1,26 @@
 use std::io::{self, Write};
 
+/// Decide whether output should be treated as a color-capable terminal.
+///
+/// Honors the widely-adopted environment conventions before falling back to
+/// the writer's actual TTY status:
+///
+/// * `NO_COLOR` (any non-empty value) forces a non-terminal result.
+///   Widely honored convention used by many CLI tools.
+/// * `FORCE_COLOR` (any value other than `"0"`) forces a terminal result —
+///   see <https://force-color.org>. This lets wrappers that pipe stdout
+///   (e.g. a parent process capturing output) still opt into ANSI output.
+/// * Otherwise, defers to [`SharedWriter::is_terminal`].
+pub fn resolve_is_terminal<W: SharedWriter + ?Sized>(writer: &W) -> bool {
+    if std::env::var_os("NO_COLOR").is_some_and(|v| !v.is_empty()) {
+        return false;
+    }
+    if let Some(v) = std::env::var_os("FORCE_COLOR") {
+        return v != "0";
+    }
+    writer.is_terminal()
+}
+
 /// A trait for threadsafe writers used by tracing layers.
 ///
 /// Writers implementing this trait are expected to handle errors internally.

--- a/crates/dbt-tracing/src/shared_writer.rs
+++ b/crates/dbt-tracing/src/shared_writer.rs
@@ -1,24 +1,36 @@
 use std::io::{self, Write};
 
-/// Decide whether output should be treated as a color-capable terminal.
+/// Whether the writer should be treated as a terminal for **routing**
+/// purposes (e.g. selecting console vs log-file telemetry filters).
 ///
-/// Honors the widely-adopted environment conventions before falling back to
-/// the writer's actual TTY status:
-///
-/// * `NO_COLOR` (any non-empty value) forces a non-terminal result.
-///   Widely honored convention used by many CLI tools.
-/// * `FORCE_COLOR` (any value other than `"0"`) forces a terminal result —
-///   see <https://force-color.org>. This lets wrappers that pipe stdout
-///   (e.g. a parent process capturing output) still opt into ANSI output.
+/// * `FORCE_COLOR` (any value other than `"0"`) promotes a non-TTY writer
+///   to terminal-like — see <https://force-color.org>. This lets wrappers
+///   that pipe stdout (e.g. a parent process capturing output) still opt
+///   into console-style output.
+/// * `NO_COLOR` does **not** affect this — it only disables ANSI styling
+///   (see [`resolve_use_color`]), not terminal-ness. Demoting a real TTY
+///   here would drop console-only telemetry records, which is beyond
+///   `NO_COLOR`'s intended scope.
 /// * Otherwise, defers to [`SharedWriter::is_terminal`].
 pub fn resolve_is_terminal<W: SharedWriter + ?Sized>(writer: &W) -> bool {
-    if std::env::var_os("NO_COLOR").is_some_and(|v| !v.is_empty()) {
-        return false;
-    }
     if let Some(v) = std::env::var_os("FORCE_COLOR") {
         return v != "0";
     }
     writer.is_terminal()
+}
+
+/// Whether ANSI styling should be emitted for output written to this
+/// writer. Combines terminal-like status with the `NO_COLOR` convention.
+///
+/// * `NO_COLOR` (any non-empty value) disables styling regardless of the
+///   writer's terminal status. Widely honored convention used by many
+///   CLI tools.
+/// * Otherwise, returns [`resolve_is_terminal`].
+pub fn resolve_use_color<W: SharedWriter + ?Sized>(writer: &W) -> bool {
+    if std::env::var_os("NO_COLOR").is_some_and(|v| !v.is_empty()) {
+        return false;
+    }
+    resolve_is_terminal(writer)
 }
 
 /// A trait for threadsafe writers used by tracing layers.

--- a/crates/dbt-tracing/src/shared_writer.rs
+++ b/crates/dbt-tracing/src/shared_writer.rs
@@ -25,15 +25,16 @@ pub fn resolve_is_terminal<W: SharedWriter + ?Sized>(writer: &W) -> bool {
 /// Whether ANSI styling should be emitted for output written to this
 /// writer.
 ///
-/// * `NO_COLOR` (any non-empty value) disables styling regardless of the
-///   writer's terminal status. Widely honored convention used by many
-///   CLI tools.
+/// * `NO_COLOR` disables styling regardless of the writer's terminal
+///   status. Presence-only: any value (including an empty string, as
+///   produced by `export NO_COLOR` with no assignment) counts. Widely
+///   honored convention used by many CLI tools.
 /// * `FORCE_COLOR=0` also disables styling (matches the convention
 ///   established by npm's `supports-color` / `chalk`), without affecting
 ///   routing decisions in [`resolve_is_terminal`].
 /// * Otherwise, returns [`resolve_is_terminal`].
 pub fn resolve_use_color<W: SharedWriter + ?Sized>(writer: &W) -> bool {
-    if std::env::var_os("NO_COLOR").is_some_and(|v| !v.is_empty()) {
+    if std::env::var_os("NO_COLOR").is_some() {
         return false;
     }
     if std::env::var_os("FORCE_COLOR").is_some_and(|v| v == "0") {


### PR DESCRIPTION
Resolves #15412

### Problem

When stdout is piped through a wrapper process (e.g. a parent process capturing output for logging or reformatting), the CLI's TTY check fails and all color output is dropped. There is currently no user-facing knob to override this — the `--use-colors` flag was previously removed and now emits a "no longer supported" warning (see `crates/dbt-main/src/dbt_lib.rs`).

### Solution

Honor two widely adopted conventions across the three color subsystems in the CLI:

- `FORCE_COLOR` (any non-`"0"` value) forces ANSI output. See https://force-color.org
- `NO_COLOR` (any non-empty value) disables ANSI output. Widely honored convention used by many CLI tools.

Applied at three layers:

1. **Tracing pretty-writer / JSON-compat layers** — new `resolve_is_terminal` helper in `dbt-tracing` consulted instead of the raw `is_terminal` check.
2. **`console` crate** (used by `pretty_string` styling) — new `apply_color_env_overrides` helper called at the top of `main`.
3. **clap / anstream** (used for usage and error text) — propagate `FORCE_COLOR=1` → `CLICOLOR_FORCE=1` from the same helper so clap's own output stays consistent.

The interface change is minimal — two new env vars, both established cross-tool conventions rather than dbt-specific surface area.

### Testing

Manually verified with `FORCE_COLOR=1 dbt-sa-cli parse 2>&1 | cat -v`: ANSI codes appear across all three subsystems (per-node telemetry lines, `pretty_string`-styled `[error]` output, and clap's usage text). Without the env var, output is plain as before.

No unit tests added. Env-var-driven behavior is awkward to test in Rust because tests share a process (env mutation would need serialization). Happy to add tests if reviewers would like — the tracing crate already has a `MockWriter` with an `is_terminal` field that could underpin `resolve_is_terminal` coverage.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR. (See testing note above.)
- [ ] This PR has no interface changes — this PR adds two new env-var-driven behaviors; both are cross-tool conventions rather than dbt-specific surface area, but flagging for Product/DX awareness.
- [x] N/A — Rust codebase, no Python type annotations applicable.
