### PR TITLE
[BigQuery] add support for query reservation configuration

### DIFF
--- a/.changes/unreleased/Features-20260711-004954.yaml
+++ b/.changes/unreleased/Features-20260711-004954.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Add support for BigQuery query reservation configuration at model and connection levels
+time: 2026-07-11T00:49:54.355183+02:00
+custom:
+    author: max-ostapenko
+    issue: "15486"
+    project: dbt-core

--- a/crates/dbt-adapter/src/adapter/adapter_impl.rs
+++ b/crates/dbt-adapter/src/adapter/adapter_impl.rs
@@ -4546,16 +4546,22 @@ impl AdapterImpl {
     }
 }
 
-/// Reads `job_execution_timeout_seconds` from the BigQuery adapter attr of the current
-/// model or snapshot in the Jinja state. Returns `None` if the state has no model or the
-/// model has no BigQuery timeout configured.
+/// Reads the BigQuery adapter attributes (`bigquery_attr`) of the current model or snapshot
+/// in the Jinja state. Returns `None` if the state has no model or the model has no
+/// BigQuery attributes configured.
 ///
 /// The `bigquery_attr` field lives at the top level of the model value because
 /// `dbt-yaml`'s `flatten_dunder` serialization merges `__adapter_attr__` into the parent.
-fn bigquery_job_timeout_from_state(state: &State) -> Option<i64> {
+fn bigquery_attr_from_state(state: &State) -> Option<Value> {
     let model = state.lookup("model", &[])?;
-    let bq_attr = model.get_attr("bigquery_attr").ok()?;
-    bq_attr
+    model.get_attr("bigquery_attr").ok()
+}
+
+/// Reads `job_execution_timeout_seconds` from the BigQuery adapter attr of the current
+/// model or snapshot in the Jinja state. Returns `None` if the state has no model or the
+/// model has no BigQuery timeout configured.
+fn bigquery_job_timeout_from_state(state: &State) -> Option<i64> {
+    bigquery_attr_from_state(state)?
         .get_attr("job_execution_timeout_seconds")
         .ok()?
         .as_i64()
@@ -4564,13 +4570,8 @@ fn bigquery_job_timeout_from_state(state: &State) -> Option<i64> {
 /// Reads `reservation` from the BigQuery adapter attr of the current model or snapshot
 /// in the Jinja state. Returns `None` if the state has no model or the model has no
 /// BigQuery reservation configured.
-///
-/// The `bigquery_attr` field lives at the top level of the model value because
-/// `dbt-yaml`'s `flatten_dunder` serialization merges `__adapter_attr__` into the parent.
 fn bigquery_reservation_from_state(state: &State) -> Option<String> {
-    let model = state.lookup("model", &[])?;
-    let bq_attr = model.get_attr("bigquery_attr").ok()?;
-    bq_attr
+    bigquery_attr_from_state(state)?
         .get_attr("reservation")
         .ok()?
         .as_str()

--- a/crates/dbt-adapter/src/adapter/adapter_impl.rs
+++ b/crates/dbt-adapter/src/adapter/adapter_impl.rs
@@ -4531,6 +4531,14 @@ impl AdapterImpl {
                     options.push((QUERY_JOB_TIMEOUT.to_string(), OptionValue::Int(t * 1000)));
                 }
 
+                let reservation = bigquery_reservation_from_state(state).or_else(|| {
+                    self.get_db_config("reservation").map(|v| v.into_owned())
+                });
+
+                if let Some(r) = reservation {
+                    options.push((QUERY_RESERVATION.to_string(), OptionValue::String(r)));
+                }
+
                 options
             }
             _ => Vec::new(),
@@ -4551,6 +4559,22 @@ fn bigquery_job_timeout_from_state(state: &State) -> Option<i64> {
         .get_attr("job_execution_timeout_seconds")
         .ok()?
         .as_i64()
+}
+
+/// Reads `reservation` from the BigQuery adapter attr of the current model or snapshot
+/// in the Jinja state. Returns `None` if the state has no model or the model has no
+/// BigQuery reservation configured.
+///
+/// The `bigquery_attr` field lives at the top level of the model value because
+/// `dbt-yaml`'s `flatten_dunder` serialization merges `__adapter_attr__` into the parent.
+fn bigquery_reservation_from_state(state: &State) -> Option<String> {
+    let model = state.lookup("model", &[])?;
+    let bq_attr = model.get_attr("bigquery_attr").ok()?;
+    bq_attr
+        .get_attr("reservation")
+        .ok()?
+        .as_str()
+        .map(|s| s.to_owned())
 }
 
 /// List of possible builtin strategies for adapters.
@@ -5965,6 +5989,94 @@ mod tests {
         let state = State::new_for_env(&env);
         let options = adapter.get_adbc_execute_options(&state);
         assert!(find_job_timeout(&options).is_none());
+    }
+
+    // -- BigQuery reservation tests -------------------------------------------
+
+    fn make_bigquery_model_with_reservation(reservation: &str) -> Value {
+        use std::collections::BTreeMap;
+        let bq_attr = BTreeMap::from([("reservation", reservation)]);
+        let model = BTreeMap::from([("bigquery_attr", bq_attr)]);
+        Value::from_serialize(&model)
+    }
+
+    fn find_reservation(options: &[(String, OptionValue)]) -> Option<String> {
+        options.iter().find_map(|(k, v)| {
+            if k == QUERY_RESERVATION {
+                if let OptionValue::String(r) = v {
+                    Some(r.clone())
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        })
+    }
+
+    #[test]
+    fn test_bigquery_adbc_options_no_reservation_when_not_configured() {
+        let adapter = AdapterImpl::new(engine(Bigquery), None);
+        let env = Environment::new();
+        let state = State::new_for_env(&env);
+        let options = adapter.get_adbc_execute_options(&state);
+        assert!(find_reservation(&options).is_none());
+    }
+
+    #[test]
+    fn test_bigquery_adbc_options_model_level_reservation() {
+        let adapter = AdapterImpl::new(engine(Bigquery), None);
+        let mut env = Environment::new();
+        env.add_global(
+            "model",
+            make_bigquery_model_with_reservation(
+                "projects/project1/locations/US/reservations/my-reservation",
+            ),
+        );
+        let state = State::new_for_env(&env);
+        let options = adapter.get_adbc_execute_options(&state);
+        assert_eq!(
+            find_reservation(&options),
+            Some("projects/project1/locations/US/reservations/my-reservation".to_string())
+        );
+    }
+
+    #[test]
+    fn test_bigquery_adbc_options_connection_level_reservation_fallback() {
+        let config = Mapping::from_iter([(
+            "reservation".into(),
+            "projects/project1/locations/US/reservations/conn-reservation".into(),
+        )]);
+        let adapter = AdapterImpl::new(build_engine(Bigquery, config), None);
+        let env = Environment::new();
+        let state = State::new_for_env(&env);
+        let options = adapter.get_adbc_execute_options(&state);
+        assert_eq!(
+            find_reservation(&options),
+            Some("projects/project1/locations/US/reservations/conn-reservation".to_string())
+        );
+    }
+
+    #[test]
+    fn test_bigquery_adbc_options_model_level_overrides_connection_level_reservation() {
+        let config = Mapping::from_iter([(
+            "reservation".into(),
+            "projects/project1/locations/US/reservations/conn-reservation".into(),
+        )]);
+        let adapter = AdapterImpl::new(build_engine(Bigquery, config), None);
+        let mut env = Environment::new();
+        env.add_global(
+            "model",
+            make_bigquery_model_with_reservation(
+                "projects/project1/locations/US/reservations/model-reservation",
+            ),
+        );
+        let state = State::new_for_env(&env);
+        let options = adapter.get_adbc_execute_options(&state);
+        assert_eq!(
+            find_reservation(&options),
+            Some("projects/project1/locations/US/reservations/model-reservation".to_string())
+        );
     }
 
     // Regression test for https://github.com/dbt-labs/dbt-fusion/issues/1733:

--- a/crates/dbt-adbc/src/bigquery.rs
+++ b/crates/dbt-adbc/src/bigquery.rs
@@ -71,6 +71,8 @@ pub const QUERY_USE_LEGACY_SQL: &str = "adbc.bigquery.sql.query.use_legacy_sql";
 pub const QUERY_DRY_RUN: &str = "adbc.bigquery.sql.query.dry_run"; // bool
 pub const QUERY_CREATE_SESSION: &str = "adbc.bigquery.sql.query.create_session"; // bool
 pub const QUERY_JOB_TIMEOUT: &str = "adbc.bigquery.sql.query.job_timeout"; // i64
+pub const QUERY_RESERVATION: &str = "adbc.bigquery.sql.query.reservation"; // string
+
 
 pub const QUERY_RESULT_BUFFER_SIZE: &str = "adbc.bigquery.sql.query.result_buffer_size"; // i64
 pub const QUERY_PREFETCH_CONCURRENCY: &str = "adbc.bigquery.sql.query.prefetch_concurrency"; // i64


### PR DESCRIPTION
Resolves https://github.com/dbt-labs/dbt-core/issues/15486

### Problem

The `reservation` config value is not passed to BigQuery adbc driver.

### Solution

This pull request adds support for configuring BigQuery reservation assignments at both the model and connection levels in the `dbt-adapter`. The adapter now prioritizes model-level reservation settings, falling back to connection-level configuration if none is set on the model.

- Added a new option key `QUERY_RESERVATION` in `crates/dbt-adbc/src/bigquery.rs` to represent the reservation assignment for BigQuery jobs.
- Updated `AdapterImpl::get_adbc_execute_options` to read the reservation from the model's `bigquery_attr` in the Jinja state, with a fallback to the connection-level config if not set on the model.
- Introduced the helper function `bigquery_reservation_from_state` to extract the reservation from the current model in the state, handling the structure created by `dbt-yaml` serialization.

Driver-Level Support: https://github.com/dbt-labs/arrow-adbc/pull/133

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.