### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/.changes/unreleased/Under the Hood-20260709-225520.yaml
+++ b/.changes/unreleased/Under the Hood-20260709-225520.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: sync JSON schemas from dbt-fusion
+time: 2026-07-09T22:55:20.241010791Z
+custom:
+    Author: fa-assistant
+    Issue: N/A

--- a/core/dbt/jsonschemas/project/latest.json
+++ b/core/dbt/jsonschemas/project/latest.json
@@ -4750,6 +4750,15 @@
             "null"
           ]
         },
+        "+resource_tags": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "+row_access_policy": {
           "type": [
             "string",
@@ -5681,6 +5690,15 @@
             "string",
             "null"
           ]
+        },
+        "+resource_tags": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": "string"
+          }
         },
         "+row_access_policy": {
           "type": [


### PR DESCRIPTION
## Summary

This PR syncs the JSON schemas from the dbt-fusion repository.

### Files Updated
- `core/dbt/jsonschemas/project/latest.json`
- `core/dbt/jsonschemas/resources/latest.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Commit**: [`7d679eda580f8489e749edc3a9d516d66b098274`](https://github.com/dbt-labs/fs/commit/7d679eda580f8489e749edc3a9d516d66b098274)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/29054333891)