### PR TITLE
[ClickHouse] Add support for the Dictionary materialization

### DIFF
--- a/.changes/unreleased/Features-20260710-114819.yaml
+++ b/.changes/unreleased/Features-20260710-114819.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Add support for ClickHouse Dictionary materialization
+time: 2026-07-10T11:48:19.246454+02:00
+custom:
+    author: koletzilla
+    issue: "14580"
+    project: dbt-core

--- a/crates/dbt-adapter/src/adapter/adapter_impl.rs
+++ b/crates/dbt-adapter/src/adapter/adapter_impl.rs
@@ -870,6 +870,75 @@ impl AdapterImpl {
         None
     }
 
+    /// ClickHouse `adapter.get_credentials(connection_overrides)` (impl.py):
+    /// connection parameters for dictionary SOURCE(CLICKHOUSE(...)) clauses.
+    /// Profile values merged with the model's `connection_overrides`; override
+    /// keys whose final value is falsy are removed.
+    pub fn get_credentials(&self, connection_overrides: &Value) -> Value {
+        let mut credentials: Vec<(String, Value)> = vec![
+            (
+                "user".to_string(),
+                Value::from(
+                    self.get_db_config("user")
+                        .map(|v| v.into_owned())
+                        .unwrap_or_else(|| "default".to_string()),
+                ),
+            ),
+            (
+                "password".to_string(),
+                Value::from(
+                    self.get_db_config("password")
+                        .map(|v| v.into_owned())
+                        .unwrap_or_default(),
+                ),
+            ),
+            (
+                "database".to_string(),
+                Value::from(
+                    self.get_db_config("database")
+                        .map(|v| v.into_owned())
+                        .unwrap_or_default(),
+                ),
+            ),
+            (
+                "host".to_string(),
+                Value::from(
+                    self.get_db_config("host")
+                        .map(|v| v.into_owned())
+                        .unwrap_or_else(|| "localhost".to_string()),
+                ),
+            ),
+            (
+                "port".to_string(),
+                Value::from(
+                    self.get_db_config("port")
+                        .map(|v| v.into_owned())
+                        .unwrap_or_default(),
+                ),
+            ),
+        ];
+
+        let mut override_keys: Vec<String> = Vec::new();
+        if let Ok(keys) = connection_overrides.try_iter() {
+            for key in keys {
+                let Some(name) = key.as_str() else { continue };
+                let Ok(value) = connection_overrides.get_item(&key) else {
+                    continue;
+                };
+                override_keys.push(name.to_string());
+                if let Some(entry) = credentials.iter_mut().find(|(k, _)| k == name) {
+                    entry.1 = value;
+                } else {
+                    credentials.push((name.to_string(), value));
+                }
+            }
+        }
+        // Python: overridden keys with falsy final values are dropped.
+        credentials.retain(|(k, v)| !override_keys.contains(k) || v.is_true());
+
+        Value::from(credentials.into_iter().collect::<BTreeMap<String, Value>>())
+    }
+
     /// Returns the table format string for `database` (e.g. `"ducklake"`, `"iceberg"`, `"default"`).
     ///
     /// Mirrors the Python reference implementation in dbt-duckdb:
@@ -5968,6 +6037,88 @@ mod tests {
     fn test_quote_for_bigquery() {
         let adapter = AdapterImpl::new(engine(Bigquery), None);
         assert_eq!(adapter.quote("abc"), "`abc`");
+    }
+
+    fn clickhouse_adapter(config: Mapping) -> AdapterImpl {
+        AdapterImpl::new(build_engine(ClickHouse, config), None)
+    }
+
+    #[test]
+    fn test_get_credentials_profile_values_and_defaults() {
+        // user/host fall back to impl.py defaults when absent from the profile;
+        // password/database/port default to empty strings.
+        let adapter = clickhouse_adapter(Mapping::from_iter([
+            ("password".into(), "secret".into()),
+            ("database".into(), "analytics".into()),
+        ]));
+        let creds = adapter.get_credentials(&Value::UNDEFINED);
+
+        assert_eq!(creds.get_attr("user").unwrap().as_str(), Some("default"));
+        assert_eq!(creds.get_attr("host").unwrap().as_str(), Some("localhost"));
+        assert_eq!(creds.get_attr("password").unwrap().as_str(), Some("secret"));
+        assert_eq!(
+            creds.get_attr("database").unwrap().as_str(),
+            Some("analytics")
+        );
+        assert_eq!(creds.get_attr("port").unwrap().as_str(), Some(""));
+    }
+
+    #[test]
+    fn test_get_credentials_overrides_replace_and_add_keys() {
+        let adapter = clickhouse_adapter(Mapping::from_iter([
+            ("user".into(), "profile_user".into()),
+            ("password".into(), "profile_pass".into()),
+            ("host".into(), "ch.example.com".into()),
+            ("port".into(), 8123.into()),
+        ]));
+        let overrides = Value::from(BTreeMap::from([
+            ("user".to_string(), Value::from("override_user")),
+            ("cluster".to_string(), Value::from("test_shard")),
+        ]));
+        let creds = adapter.get_credentials(&overrides);
+
+        // Overridden key replaced; unknown override key added.
+        assert_eq!(
+            creds.get_attr("user").unwrap().as_str(),
+            Some("override_user")
+        );
+        assert_eq!(
+            creds.get_attr("cluster").unwrap().as_str(),
+            Some("test_shard")
+        );
+        // Non-overridden profile values untouched (port stringified from the profile int).
+        assert_eq!(
+            creds.get_attr("password").unwrap().as_str(),
+            Some("profile_pass")
+        );
+        assert_eq!(
+            creds.get_attr("host").unwrap().as_str(),
+            Some("ch.example.com")
+        );
+        assert_eq!(creds.get_attr("port").unwrap().as_str(), Some("8123"));
+    }
+
+    #[test]
+    fn test_get_credentials_drops_falsy_overridden_keys() {
+        // impl.py parity: keys explicitly overridden to a falsy value are removed,
+        // while non-overridden keys keep their (possibly empty) profile values.
+        let adapter = clickhouse_adapter(Mapping::from_iter([
+            ("user".into(), "profile_user".into()),
+            ("password".into(), "profile_pass".into()),
+        ]));
+        let overrides = Value::from(BTreeMap::from([(
+            "password".to_string(),
+            Value::from(""),
+        )]));
+        let creds = adapter.get_credentials(&overrides);
+
+        assert!(creds.get_attr("password").unwrap().is_undefined());
+        assert_eq!(
+            creds.get_attr("user").unwrap().as_str(),
+            Some("profile_user")
+        );
+        // database was never configured nor overridden: present as empty string.
+        assert_eq!(creds.get_attr("database").unwrap().as_str(), Some(""));
     }
 
     #[test]

--- a/crates/dbt-adapter/src/adapter/adapter_impl.rs
+++ b/crates/dbt-adapter/src/adapter/adapter_impl.rs
@@ -870,6 +870,75 @@ impl AdapterImpl {
         None
     }
 
+    /// ClickHouse `adapter.get_credentials(connection_overrides)` (impl.py):
+    /// connection parameters for dictionary SOURCE(CLICKHOUSE(...)) clauses.
+    /// Profile values merged with the model's `connection_overrides`; override
+    /// keys whose final value is falsy are removed.
+    pub fn get_credentials(&self, connection_overrides: &Value) -> Value {
+        let mut credentials: Vec<(String, Value)> = vec![
+            (
+                "user".to_string(),
+                Value::from(
+                    self.get_db_config("user")
+                        .map(|v| v.into_owned())
+                        .unwrap_or_else(|| "default".to_string()),
+                ),
+            ),
+            (
+                "password".to_string(),
+                Value::from(
+                    self.get_db_config("password")
+                        .map(|v| v.into_owned())
+                        .unwrap_or_default(),
+                ),
+            ),
+            (
+                "database".to_string(),
+                Value::from(
+                    self.get_db_config("database")
+                        .map(|v| v.into_owned())
+                        .unwrap_or_default(),
+                ),
+            ),
+            (
+                "host".to_string(),
+                Value::from(
+                    self.get_db_config("host")
+                        .map(|v| v.into_owned())
+                        .unwrap_or_else(|| "localhost".to_string()),
+                ),
+            ),
+            (
+                "port".to_string(),
+                Value::from(
+                    self.get_db_config("port")
+                        .map(|v| v.into_owned())
+                        .unwrap_or_default(),
+                ),
+            ),
+        ];
+
+        let mut override_keys: Vec<String> = Vec::new();
+        if let Ok(keys) = connection_overrides.try_iter() {
+            for key in keys {
+                let Some(name) = key.as_str() else { continue };
+                let Ok(value) = connection_overrides.get_item(&key) else {
+                    continue;
+                };
+                override_keys.push(name.to_string());
+                if let Some(entry) = credentials.iter_mut().find(|(k, _)| k == name) {
+                    entry.1 = value;
+                } else {
+                    credentials.push((name.to_string(), value));
+                }
+            }
+        }
+        // Python: overridden keys with falsy final values are dropped.
+        credentials.retain(|(k, v)| !override_keys.contains(k) || v.is_true());
+
+        Value::from(credentials.into_iter().collect::<BTreeMap<String, Value>>())
+    }
+
     /// Returns the table format string for `database` (e.g. `"ducklake"`, `"iceberg"`, `"default"`).
     ///
     /// Mirrors the Python reference implementation in dbt-duckdb:
@@ -5949,6 +6018,88 @@ mod tests {
     fn test_quote_for_bigquery() {
         let adapter = AdapterImpl::new(engine(Bigquery), None);
         assert_eq!(adapter.quote("abc"), "`abc`");
+    }
+
+    fn clickhouse_adapter(config: Mapping) -> AdapterImpl {
+        AdapterImpl::new(build_engine(ClickHouse, config), None)
+    }
+
+    #[test]
+    fn test_get_credentials_profile_values_and_defaults() {
+        // user/host fall back to impl.py defaults when absent from the profile;
+        // password/database/port default to empty strings.
+        let adapter = clickhouse_adapter(Mapping::from_iter([
+            ("password".into(), "secret".into()),
+            ("database".into(), "analytics".into()),
+        ]));
+        let creds = adapter.get_credentials(&Value::UNDEFINED);
+
+        assert_eq!(creds.get_attr("user").unwrap().as_str(), Some("default"));
+        assert_eq!(creds.get_attr("host").unwrap().as_str(), Some("localhost"));
+        assert_eq!(creds.get_attr("password").unwrap().as_str(), Some("secret"));
+        assert_eq!(
+            creds.get_attr("database").unwrap().as_str(),
+            Some("analytics")
+        );
+        assert_eq!(creds.get_attr("port").unwrap().as_str(), Some(""));
+    }
+
+    #[test]
+    fn test_get_credentials_overrides_replace_and_add_keys() {
+        let adapter = clickhouse_adapter(Mapping::from_iter([
+            ("user".into(), "profile_user".into()),
+            ("password".into(), "profile_pass".into()),
+            ("host".into(), "ch.example.com".into()),
+            ("port".into(), 8123.into()),
+        ]));
+        let overrides = Value::from(BTreeMap::from([
+            ("user".to_string(), Value::from("override_user")),
+            ("cluster".to_string(), Value::from("test_shard")),
+        ]));
+        let creds = adapter.get_credentials(&overrides);
+
+        // Overridden key replaced; unknown override key added.
+        assert_eq!(
+            creds.get_attr("user").unwrap().as_str(),
+            Some("override_user")
+        );
+        assert_eq!(
+            creds.get_attr("cluster").unwrap().as_str(),
+            Some("test_shard")
+        );
+        // Non-overridden profile values untouched (port stringified from the profile int).
+        assert_eq!(
+            creds.get_attr("password").unwrap().as_str(),
+            Some("profile_pass")
+        );
+        assert_eq!(
+            creds.get_attr("host").unwrap().as_str(),
+            Some("ch.example.com")
+        );
+        assert_eq!(creds.get_attr("port").unwrap().as_str(), Some("8123"));
+    }
+
+    #[test]
+    fn test_get_credentials_drops_falsy_overridden_keys() {
+        // impl.py parity: keys explicitly overridden to a falsy value are removed,
+        // while non-overridden keys keep their (possibly empty) profile values.
+        let adapter = clickhouse_adapter(Mapping::from_iter([
+            ("user".into(), "profile_user".into()),
+            ("password".into(), "profile_pass".into()),
+        ]));
+        let overrides = Value::from(BTreeMap::from([(
+            "password".to_string(),
+            Value::from(""),
+        )]));
+        let creds = adapter.get_credentials(&overrides);
+
+        assert!(creds.get_attr("password").unwrap().is_undefined());
+        assert_eq!(
+            creds.get_attr("user").unwrap().as_str(),
+            Some("profile_user")
+        );
+        // database was never configured nor overridden: present as empty string.
+        assert_eq!(creds.get_attr("database").unwrap().as_str(), Some(""));
     }
 
     #[test]

--- a/crates/dbt-adapter/src/adapter/mod.rs
+++ b/crates/dbt-adapter/src/adapter/mod.rs
@@ -4076,6 +4076,7 @@ impl Adapter {
                     })?;
                 self.get_csv_data(table)
             }
+            "get_credentials" => self.get_credentials(args),
             "render_equals" => {
                 let iter = ArgsIter::new(name, &["expr1", "expr2"], args);
                 let expr1 = iter.next_arg::<&str>()?;
@@ -4087,6 +4088,20 @@ impl Adapter {
                 minijinja::ErrorKind::UnknownMethod,
                 format!("Unknown method on adapter object: '{name}'"),
             )),
+        }
+    }
+
+    /// ClickHouse: `adapter.get_credentials(connection_overrides)` — connection
+    /// parameters for dictionary SOURCE clauses. See [AdapterImpl::get_credentials].
+    pub fn get_credentials(&self, args: &[Value]) -> Result<Value, minijinja::Error> {
+        let iter = ArgsIter::new("get_credentials", &["connection_overrides"], args);
+        let overrides = iter.next_arg::<Option<&Value>>()?;
+        iter.finish()?;
+        match &self.inner {
+            Typed { adapter, .. } => {
+                Ok(adapter.get_credentials(overrides.unwrap_or(&Value::UNDEFINED)))
+            }
+            Parse(_) => Ok(empty_map_value()),
         }
     }
 

--- a/crates/dbt-adapter/src/adapter/mod.rs
+++ b/crates/dbt-adapter/src/adapter/mod.rs
@@ -4079,6 +4079,7 @@ impl Adapter {
                     })?;
                 self.get_csv_data(table)
             }
+            "get_credentials" => self.get_credentials(args),
             "render_equals" => {
                 let iter = ArgsIter::new(name, &["expr1", "expr2"], args);
                 let expr1 = iter.next_arg::<&str>()?;
@@ -4090,6 +4091,20 @@ impl Adapter {
                 minijinja::ErrorKind::UnknownMethod,
                 format!("Unknown method on adapter object: '{name}'"),
             )),
+        }
+    }
+
+    /// ClickHouse: `adapter.get_credentials(connection_overrides)` — connection
+    /// parameters for dictionary SOURCE clauses. See [AdapterImpl::get_credentials].
+    pub fn get_credentials(&self, args: &[Value]) -> Result<Value, minijinja::Error> {
+        let iter = ArgsIter::new("get_credentials", &["connection_overrides"], args);
+        let overrides = iter.next_arg::<Option<&Value>>()?;
+        iter.finish()?;
+        match &self.inner {
+            Typed { adapter, .. } => {
+                Ok(adapter.get_credentials(overrides.unwrap_or(&Value::UNDEFINED)))
+            }
+            Parse(_) => Ok(empty_map_value()),
         }
     }
 

--- a/crates/dbt-adapter/src/metadata/databricks/mod.rs
+++ b/crates/dbt-adapter/src/metadata/databricks/mod.rs
@@ -448,7 +448,8 @@ impl DatabricksMetadataAdapter {
             | RelationType::PointerTable
             | RelationType::DynamicTable
             | RelationType::MetricView
-            | RelationType::Function => {
+            | RelationType::Function
+            | RelationType::Dictionary => {
                 return Err(AdapterError::new(
                     AdapterErrorKind::NotSupported,
                     format!(

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-clickhouse/macros/materializations/table.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-clickhouse/macros/materializations/table.sql
@@ -90,6 +90,13 @@
 
 {% macro primary_key_clause(label) %}
   {%- set primary_key = config.get('primary_key', validator=validation.any[basestring]) -%}
+  {#- Fusion compatibility: Fusion's typed primary_key config arrives as a list
+      (scalar inputs are listified), so join it back into the raw string this
+      clause renders. No-op in Python, where the basestring validator raises
+      before a non-string value can reach this point. -#}
+  {%- if primary_key is not none and primary_key is not string -%}
+    {%- set primary_key = primary_key | join(', ') -%}
+  {%- endif %}
 
   {%- if primary_key is not none %}
     {{ label }} {{ primary_key }}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-clickhouse/macros/materializations/table.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-clickhouse/macros/materializations/table.sql
@@ -89,12 +89,12 @@
 {%- endmacro -%}
 
 {% macro primary_key_clause(label) %}
-  {%- set primary_key = config.get('primary_key', validator=validation.any[basestring]) -%}
+  {%- set primary_key = config.get('primary_key', validator=validation.any[list, basestring]) -%}
   {#- Fusion compatibility: Fusion's typed primary_key config arrives as a list
       (scalar inputs are listified), so join it back into the raw string this
-      clause renders. No-op in Python, where the basestring validator raises
-      before a non-string value can reach this point. -#}
-  {%- if primary_key is not none and primary_key is not string -%}
+      clause renders. Guarded like the incremental macros' unique_key handling.
+      No-op in Python, where a plain string passes through untouched. -#}
+  {%- if primary_key is not none and primary_key is iterable and (primary_key is not string and primary_key is not mapping) -%}
     {%- set primary_key = primary_key | join(', ') -%}
   {%- endif %}
 

--- a/crates/dbt-schemas/src/dbt_types.rs
+++ b/crates/dbt-schemas/src/dbt_types.rs
@@ -31,6 +31,8 @@ pub enum RelationType {
     MetricView,
     /// An enum for a warehouse function
     Function,
+    /// An enum for a ClickHouse dictionary
+    Dictionary,
 }
 
 impl RelationType {
@@ -88,6 +90,7 @@ impl fmt::Display for RelationType {
             RelationType::StreamingTable => "streaming_table",
             RelationType::MetricView => "metric_view",
             RelationType::Function => "function",
+            RelationType::Dictionary => "dictionary",
         };
         write!(f, "{s}")
     }
@@ -107,6 +110,7 @@ impl From<&str> for RelationType {
             "streaming_table" => RelationType::StreamingTable,
             "metric_view" => RelationType::MetricView,
             "function" => RelationType::Function,
+            "dictionary" => RelationType::Dictionary,
             _ => panic!("Invalid relation type: {s}"),
         }
     }
@@ -115,6 +119,13 @@ impl From<&str> for RelationType {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn dictionary_relation_type_round_trips() {
+        let rt = RelationType::from("dictionary");
+        assert_eq!(rt, RelationType::Dictionary);
+        assert_eq!(rt.to_string(), "dictionary");
+    }
 
     #[test]
     fn spark_real_types_resolve_to_table_or_view() {

--- a/crates/dbt-schemas/src/schemas/project/configs/common.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/common.rs
@@ -253,6 +253,18 @@ pub struct WarehouseSpecificNodeConfig {
     pub ttl: Option<String>,
     pub settings: Option<BTreeMap<String, YmlValue>>,
     pub query_settings: Option<BTreeMap<String, YmlValue>>,
+    // dictionary materialization
+    pub connection_overrides: Option<BTreeMap<String, YmlValue>>,
+    pub fields: Option<Vec<YmlValue>>,
+    pub source_type: Option<String>,
+    pub url: Option<String>,
+    pub format: Option<String>,
+    pub layout: Option<String>,
+    pub lifetime: Option<YmlValue>,
+    pub range: Option<YmlValue>,
+    pub table: Option<String>,
+    pub update_field: Option<String>,
+    pub update_lag: Option<YmlValue>,
 }
 
 impl ResolvedConfig for WarehouseSpecificNodeConfig {
@@ -460,6 +472,17 @@ pub fn same_warehouse_config(
     let ttl_eq = self_wh.ttl == other_wh.ttl;
     let settings_eq = self_wh.settings == other_wh.settings;
     let query_settings_eq = self_wh.query_settings == other_wh.query_settings;
+    let connection_overrides_eq = self_wh.connection_overrides == other_wh.connection_overrides;
+    let fields_eq = self_wh.fields == other_wh.fields;
+    let source_type_eq = self_wh.source_type == other_wh.source_type;
+    let url_eq = self_wh.url == other_wh.url;
+    let format_eq = self_wh.format == other_wh.format;
+    let layout_eq = self_wh.layout == other_wh.layout;
+    let lifetime_eq = self_wh.lifetime == other_wh.lifetime;
+    let range_eq = self_wh.range == other_wh.range;
+    let table_eq = self_wh.table == other_wh.table;
+    let update_field_eq = self_wh.update_field == other_wh.update_field;
+    let update_lag_eq = self_wh.update_lag == other_wh.update_lag;
 
     let result = partition_by_eq
         && cluster_by_eq
@@ -535,7 +558,18 @@ pub fn same_warehouse_config(
         && order_by_eq
         && ttl_eq
         && settings_eq
-        && query_settings_eq;
+        && query_settings_eq
+        && connection_overrides_eq
+        && fields_eq
+        && source_type_eq
+        && url_eq
+        && format_eq
+        && layout_eq
+        && lifetime_eq
+        && range_eq
+        && table_eq
+        && update_field_eq
+        && update_lag_eq;
 
     if !result {
         log_state_mod_diff(
@@ -1140,6 +1174,94 @@ pub fn same_warehouse_config(
                     Some((
                         format!("{:?}", &self_wh.query_settings),
                         format!("{:?}", &other_wh.query_settings),
+                    )),
+                ),
+                (
+                    "connection_overrides",
+                    connection_overrides_eq,
+                    Some((
+                        format!("{:?}", &self_wh.connection_overrides),
+                        format!("{:?}", &other_wh.connection_overrides),
+                    )),
+                ),
+                (
+                    "fields",
+                    fields_eq,
+                    Some((
+                        format!("{:?}", &self_wh.fields),
+                        format!("{:?}", &other_wh.fields),
+                    )),
+                ),
+                (
+                    "source_type",
+                    source_type_eq,
+                    Some((
+                        format!("{:?}", &self_wh.source_type),
+                        format!("{:?}", &other_wh.source_type),
+                    )),
+                ),
+                (
+                    "url",
+                    url_eq,
+                    Some((
+                        format!("{:?}", &self_wh.url),
+                        format!("{:?}", &other_wh.url),
+                    )),
+                ),
+                (
+                    "format",
+                    format_eq,
+                    Some((
+                        format!("{:?}", &self_wh.format),
+                        format!("{:?}", &other_wh.format),
+                    )),
+                ),
+                (
+                    "layout",
+                    layout_eq,
+                    Some((
+                        format!("{:?}", &self_wh.layout),
+                        format!("{:?}", &other_wh.layout),
+                    )),
+                ),
+                (
+                    "lifetime",
+                    lifetime_eq,
+                    Some((
+                        format!("{:?}", &self_wh.lifetime),
+                        format!("{:?}", &other_wh.lifetime),
+                    )),
+                ),
+                (
+                    "range",
+                    range_eq,
+                    Some((
+                        format!("{:?}", &self_wh.range),
+                        format!("{:?}", &other_wh.range),
+                    )),
+                ),
+                (
+                    "table",
+                    table_eq,
+                    Some((
+                        format!("{:?}", &self_wh.table),
+                        format!("{:?}", &other_wh.table),
+                    )),
+                ),
+                (
+                    "update_field",
+                    update_field_eq,
+                    Some((
+                        format!("{:?}", &self_wh.update_field),
+                        format!("{:?}", &other_wh.update_field),
+                    )),
+                ),
+                (
+                    "update_lag",
+                    update_lag_eq,
+                    Some((
+                        format!("{:?}", &self_wh.update_lag),
+                        format!("{:?}", &other_wh.update_lag),
                     )),
                 ),
             ],

--- a/crates/dbt-schemas/src/schemas/project/configs/common.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/common.rs
@@ -245,6 +245,20 @@ pub struct WarehouseSpecificNodeConfig {
     #[serde(default)]
     pub primary_key: PrimaryKeyConfig,
     pub category: Option<DataLakeObjectCategory>,
+
+    // ClickHouse
+    // dictionary materialization
+    pub connection_overrides: Option<BTreeMap<String, YmlValue>>,
+    pub fields: Option<Vec<YmlValue>>,
+    pub source_type: Option<String>,
+    pub url: Option<String>,
+    pub format: Option<String>,
+    pub layout: Option<String>,
+    pub lifetime: Option<YmlValue>,
+    pub range: Option<YmlValue>,
+    pub table: Option<String>,
+    pub update_field: Option<String>,
+    pub update_lag: Option<YmlValue>,
 }
 
 impl ResolvedConfig for WarehouseSpecificNodeConfig {
@@ -447,6 +461,17 @@ pub fn same_warehouse_config(
     let indexes_eq = self_wh.indexes == other_wh.indexes;
     let primary_key_eq = self_wh.primary_key == other_wh.primary_key;
     let category_eq = self_wh.category == other_wh.category;
+    let connection_overrides_eq = self_wh.connection_overrides == other_wh.connection_overrides;
+    let fields_eq = self_wh.fields == other_wh.fields;
+    let source_type_eq = self_wh.source_type == other_wh.source_type;
+    let url_eq = self_wh.url == other_wh.url;
+    let format_eq = self_wh.format == other_wh.format;
+    let layout_eq = self_wh.layout == other_wh.layout;
+    let lifetime_eq = self_wh.lifetime == other_wh.lifetime;
+    let range_eq = self_wh.range == other_wh.range;
+    let table_eq = self_wh.table == other_wh.table;
+    let update_field_eq = self_wh.update_field == other_wh.update_field;
+    let update_lag_eq = self_wh.update_lag == other_wh.update_lag;
 
     let result = partition_by_eq
         && cluster_by_eq
@@ -517,7 +542,18 @@ pub fn same_warehouse_config(
         && table_type_eq
         && indexes_eq
         && primary_key_eq
-        && category_eq;
+        && category_eq
+        && connection_overrides_eq
+        && fields_eq
+        && source_type_eq
+        && url_eq
+        && format_eq
+        && layout_eq
+        && lifetime_eq
+        && range_eq
+        && table_eq
+        && update_field_eq
+        && update_lag_eq;
 
     if !result {
         log_state_mod_diff(
@@ -1082,6 +1118,94 @@ pub fn same_warehouse_config(
                     Some((
                         format!("{:?}", &self_wh.category),
                         format!("{:?}", &other_wh.category),
+                    )),
+                ),
+                (
+                    "connection_overrides",
+                    connection_overrides_eq,
+                    Some((
+                        format!("{:?}", &self_wh.connection_overrides),
+                        format!("{:?}", &other_wh.connection_overrides),
+                    )),
+                ),
+                (
+                    "fields",
+                    fields_eq,
+                    Some((
+                        format!("{:?}", &self_wh.fields),
+                        format!("{:?}", &other_wh.fields),
+                    )),
+                ),
+                (
+                    "source_type",
+                    source_type_eq,
+                    Some((
+                        format!("{:?}", &self_wh.source_type),
+                        format!("{:?}", &other_wh.source_type),
+                    )),
+                ),
+                (
+                    "url",
+                    url_eq,
+                    Some((
+                        format!("{:?}", &self_wh.url),
+                        format!("{:?}", &other_wh.url),
+                    )),
+                ),
+                (
+                    "format",
+                    format_eq,
+                    Some((
+                        format!("{:?}", &self_wh.format),
+                        format!("{:?}", &other_wh.format),
+                    )),
+                ),
+                (
+                    "layout",
+                    layout_eq,
+                    Some((
+                        format!("{:?}", &self_wh.layout),
+                        format!("{:?}", &other_wh.layout),
+                    )),
+                ),
+                (
+                    "lifetime",
+                    lifetime_eq,
+                    Some((
+                        format!("{:?}", &self_wh.lifetime),
+                        format!("{:?}", &other_wh.lifetime),
+                    )),
+                ),
+                (
+                    "range",
+                    range_eq,
+                    Some((
+                        format!("{:?}", &self_wh.range),
+                        format!("{:?}", &other_wh.range),
+                    )),
+                ),
+                (
+                    "table",
+                    table_eq,
+                    Some((
+                        format!("{:?}", &self_wh.table),
+                        format!("{:?}", &other_wh.table),
+                    )),
+                ),
+                (
+                    "update_field",
+                    update_field_eq,
+                    Some((
+                        format!("{:?}", &self_wh.update_field),
+                        format!("{:?}", &other_wh.update_field),
+                    )),
+                ),
+                (
+                    "update_lag",
+                    update_lag_eq,
+                    Some((
+                        format!("{:?}", &self_wh.update_lag),
+                        format!("{:?}", &other_wh.update_lag),
                     )),
                 ),
             ],

--- a/crates/dbt-schemas/src/schemas/project/configs/config_merge.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/config_merge.rs
@@ -288,6 +288,9 @@ impl ReplaceIfNone for f64 {}
 
 // dbt_yaml types
 impl<T: Clone> ReplaceIfNone for Spanned<T> {}
+// Free-form YmlValue fields (e.g. ClickHouse dictionary `lifetime`/`range`/`update_lag`)
+// replace wholesale — no deep merge.
+impl ReplaceIfNone for YmlValue {}
 
 // std collections used as replace-if-none fields.
 // BTreeMap<String, YmlValue> (replace-if-none) is distinct from

--- a/crates/dbt-schemas/src/schemas/project/configs/data_test_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/data_test_config.rs
@@ -609,6 +609,17 @@ impl From<ProjectDataTestConfig> for DataTestConfig {
                 ttl: None,
                 settings: None,
                 query_settings: None,
+                connection_overrides: None,
+                fields: None,
+                source_type: None,
+                url: None,
+                format: None,
+                layout: None,
+                lifetime: None,
+                range: None,
+                table: None,
+                update_field: None,
+                update_lag: None,
             },
         }
     }

--- a/crates/dbt-schemas/src/schemas/project/configs/data_test_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/data_test_config.rs
@@ -508,6 +508,20 @@ impl From<ProjectDataTestConfig> for DataTestConfig {
                 // data test is unsupported for Salesforce yet
                 primary_key: PrimaryKeyConfig::default(),
                 category: None,
+
+                // ClickHouse 
+                // dictionary materialization
+                connection_overrides: None,
+                fields: None,
+                source_type: None,
+                url: None,
+                format: None,
+                layout: None,
+                lifetime: None,
+                range: None,
+                table: None,
+                update_field: None,
+                update_lag: None,
             },
         }
     }

--- a/crates/dbt-schemas/src/schemas/project/configs/model_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/model_config.rs
@@ -528,6 +528,29 @@ pub struct ProjectModelConfig {
     pub settings: Option<BTreeMap<String, YmlValue>>,
     #[serde(rename = "+query_settings")]
     pub query_settings: Option<BTreeMap<String, YmlValue>>,
+    // dictionary materialization
+    #[serde(rename = "+connection_overrides")]
+    pub connection_overrides: Option<BTreeMap<String, YmlValue>>,
+    #[serde(rename = "+fields")]
+    pub fields: Option<Vec<YmlValue>>,
+    #[serde(rename = "+source_type")]
+    pub source_type: Option<String>,
+    #[serde(rename = "+url")]
+    pub url: Option<String>,
+    #[serde(rename = "+format")]
+    pub format: Option<String>,
+    #[serde(rename = "+layout")]
+    pub layout: Option<String>,
+    #[serde(rename = "+lifetime")]
+    pub lifetime: Option<YmlValue>,
+    #[serde(rename = "+range")]
+    pub range: Option<YmlValue>,
+    #[serde(rename = "+table")]
+    pub table: Option<String>,
+    #[serde(rename = "+update_field")]
+    pub update_field: Option<String>,
+    #[serde(rename = "+update_lag")]
+    pub update_lag: Option<YmlValue>,
 
     // Flattened field:
     pub __additional_properties__: BTreeMap<String, ShouldBe<ProjectModelConfig>>,
@@ -992,6 +1015,17 @@ impl From<ProjectModelConfig> for ModelConfig {
                 ttl: config.ttl,
                 settings: config.settings,
                 query_settings: config.query_settings,
+                connection_overrides: config.connection_overrides,
+                fields: config.fields,
+                source_type: config.source_type,
+                url: config.url,
+                format: config.format,
+                layout: config.layout,
+                lifetime: config.lifetime,
+                range: config.range,
+                table: config.table,
+                update_field: config.update_field,
+                update_lag: config.update_lag,
             },
             // Python-specific fields - initialized to None here, set during Python AST analysis
             config_keys_used: None,
@@ -1188,6 +1222,17 @@ impl From<ModelConfig> for ProjectModelConfig {
             ttl: config.__warehouse_specific_config__.ttl,
             settings: config.__warehouse_specific_config__.settings,
             query_settings: config.__warehouse_specific_config__.query_settings,
+            connection_overrides: config.__warehouse_specific_config__.connection_overrides,
+            fields: config.__warehouse_specific_config__.fields,
+            source_type: config.__warehouse_specific_config__.source_type,
+            url: config.__warehouse_specific_config__.url,
+            format: config.__warehouse_specific_config__.format,
+            layout: config.__warehouse_specific_config__.layout,
+            lifetime: config.__warehouse_specific_config__.lifetime,
+            range: config.__warehouse_specific_config__.range,
+            table: config.__warehouse_specific_config__.table,
+            update_field: config.__warehouse_specific_config__.update_field,
+            update_lag: config.__warehouse_specific_config__.update_lag,
             __additional_properties__: BTreeMap::new(),
         }
     }

--- a/crates/dbt-schemas/src/schemas/project/configs/model_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/model_config.rs
@@ -516,6 +516,31 @@ pub struct ProjectModelConfig {
     #[serde(rename = "+sync")]
     pub sync: Option<SyncConfig>,
 
+    // ClickHouse
+    // dictionary materialization
+    #[serde(rename = "+connection_overrides")]
+    pub connection_overrides: Option<BTreeMap<String, YmlValue>>,
+    #[serde(rename = "+fields")]
+    pub fields: Option<Vec<YmlValue>>,
+    #[serde(rename = "+source_type")]
+    pub source_type: Option<String>,
+    #[serde(rename = "+url")]
+    pub url: Option<String>,
+    #[serde(rename = "+format")]
+    pub format: Option<String>,
+    #[serde(rename = "+layout")]
+    pub layout: Option<String>,
+    #[serde(rename = "+lifetime")]
+    pub lifetime: Option<YmlValue>,
+    #[serde(rename = "+range")]
+    pub range: Option<YmlValue>,
+    #[serde(rename = "+table")]
+    pub table: Option<String>,
+    #[serde(rename = "+update_field")]
+    pub update_field: Option<String>,
+    #[serde(rename = "+update_lag")]
+    pub update_lag: Option<YmlValue>,
+
     // Flattened field:
     pub __additional_properties__: BTreeMap<String, ShouldBe<ProjectModelConfig>>,
 }
@@ -821,6 +846,18 @@ impl From<ProjectModelConfig> for ModelConfig {
 
                 primary_key: config.primary_key,
                 category: config.category,
+
+                connection_overrides: config.connection_overrides,
+                fields: config.fields,
+                source_type: config.source_type,
+                url: config.url,
+                format: config.format,
+                layout: config.layout,
+                lifetime: config.lifetime,
+                range: config.range,
+                table: config.table,
+                update_field: config.update_field,
+                update_lag: config.update_lag,
             },
             // Python-specific fields - initialized to None here, set during Python AST analysis
             config_keys_used: None,
@@ -1012,6 +1049,17 @@ impl From<ModelConfig> for ProjectModelConfig {
             primary_key: config.__warehouse_specific_config__.primary_key,
             category: config.__warehouse_specific_config__.category,
             sync: config.sync,
+            connection_overrides: config.__warehouse_specific_config__.connection_overrides,
+            fields: config.__warehouse_specific_config__.fields,
+            source_type: config.__warehouse_specific_config__.source_type,
+            url: config.__warehouse_specific_config__.url,
+            format: config.__warehouse_specific_config__.format,
+            layout: config.__warehouse_specific_config__.layout,
+            lifetime: config.__warehouse_specific_config__.lifetime,
+            range: config.__warehouse_specific_config__.range,
+            table: config.__warehouse_specific_config__.table,
+            update_field: config.__warehouse_specific_config__.update_field,
+            update_lag: config.__warehouse_specific_config__.update_lag,
             __additional_properties__: BTreeMap::new(),
         }
     }

--- a/crates/dbt-schemas/src/schemas/project/configs/seed_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/seed_config.rs
@@ -570,6 +570,17 @@ impl From<ProjectSeedConfig> for SeedConfig {
                 ttl: None,
                 settings: None,
                 query_settings: None,
+                connection_overrides: None,
+                fields: None,
+                source_type: None,
+                url: None,
+                format: None,
+                layout: None,
+                lifetime: None,
+                range: None,
+                table: None,
+                update_field: None,
+                update_lag: None,
             },
         }
     }

--- a/crates/dbt-schemas/src/schemas/project/configs/seed_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/seed_config.rs
@@ -471,6 +471,18 @@ impl From<ProjectSeedConfig> for SeedConfig {
                 // seed is unsupported for Salesforce yet
                 primary_key: PrimaryKeyConfig::default(),
                 category: None,
+
+                connection_overrides: None,
+                fields: None,
+                source_type: None,
+                url: None,
+                format: None,
+                layout: None,
+                lifetime: None,
+                range: None,
+                table: None,
+                update_field: None,
+                update_lag: None,
             },
         }
     }

--- a/crates/dbt-schemas/src/schemas/project/configs/snapshot_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/snapshot_config.rs
@@ -789,6 +789,17 @@ impl From<ProjectSnapshotConfig> for SnapshotConfig {
                 ttl: None,
                 settings: None,
                 query_settings: None,
+                connection_overrides: None,
+                fields: None,
+                source_type: None,
+                url: None,
+                format: None,
+                layout: None,
+                lifetime: None,
+                range: None,
+                table: None,
+                update_field: None,
+                update_lag: None,
             },
         }
     }

--- a/crates/dbt-schemas/src/schemas/project/configs/snapshot_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/snapshot_config.rs
@@ -679,6 +679,18 @@ impl From<ProjectSnapshotConfig> for SnapshotConfig {
                 // snapshot is unsupported for Salesforce yet
                 primary_key: PrimaryKeyConfig::default(),
                 category: None,
+
+                connection_overrides: None,
+                fields: None,
+                source_type: None,
+                url: None,
+                format: None,
+                layout: None,
+                lifetime: None,
+                range: None,
+                table: None,
+                update_field: None,
+                update_lag: None,
             },
         }
     }

--- a/crates/dbt-schemas/src/schemas/project/configs/source_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/source_config.rs
@@ -457,6 +457,17 @@ impl From<ProjectSourceConfig> for SourceConfig {
                 ttl: None,
                 settings: None,
                 query_settings: None,
+                connection_overrides: None,
+                fields: None,
+                source_type: None,
+                url: None,
+                format: None,
+                layout: None,
+                lifetime: None,
+                range: None,
+                table: None,
+                update_field: None,
+                update_lag: None,
             },
         }
     }

--- a/crates/dbt-schemas/src/schemas/project/configs/source_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/source_config.rs
@@ -388,6 +388,18 @@ impl From<ProjectSourceConfig> for SourceConfig {
                 // sources doesn't need this field
                 primary_key: PrimaryKeyConfig::default(),
                 category: None,
+
+                connection_overrides: None,
+                fields: None,
+                source_type: None,
+                url: None,
+                format: None,
+                layout: None,
+                lifetime: None,
+                range: None,
+                table: None,
+                update_field: None,
+                update_lag: None,
             },
         }
     }

--- a/crates/dbt-schemas/src/schemas/project/configs/unit_test_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/unit_test_config.rs
@@ -492,6 +492,17 @@ impl From<ProjectUnitTestConfig> for UnitTestConfig {
                 ttl: None,
                 settings: None,
                 query_settings: None,
+                connection_overrides: None,
+                fields: None,
+                source_type: None,
+                url: None,
+                format: None,
+                layout: None,
+                lifetime: None,
+                range: None,
+                table: None,
+                update_field: None,
+                update_lag: None,
             },
         }
     }

--- a/crates/dbt-schemas/src/schemas/project/configs/unit_test_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/unit_test_config.rs
@@ -409,6 +409,18 @@ impl From<ProjectUnitTestConfig> for UnitTestConfig {
                 // unit test is unsupported for Salesforce yet
                 primary_key: PrimaryKeyConfig::default(),
                 category: None,
+
+                connection_overrides: None,
+                fields: None,
+                source_type: None,
+                url: None,
+                format: None,
+                layout: None,
+                lifetime: None,
+                range: None,
+                table: None,
+                update_field: None,
+                update_lag: None,
             },
         }
     }


### PR DESCRIPTION
Related to https://github.com/dbt-labs/dbt-core/issues/14580

- Add the dictionary materialization so they can be used as we use them in dbt-core v1: https://github.com/ClickHouse/dbt-clickhouse/blob/main/tests/integration/adapter/dictionary/test_dictionary.py
- Saw that Databricks has a list of unsuported materializations. Added it to that list.
- Include list of settings used in this materialization:  `fields`, `source_type`, `layout`, `lifetime`, `range`, `table`, `url`, `format`, `update_field`, `update_lag`, `connection_overrides`.

Out of scope things that will be included in next PRs:
- ON CLUSTER setting
- Persist grants/docs


### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.

