### PR TITLE
[ClickHouse] Extend Materialized Views functionality: new settings and a few missing methods

### DIFF
--- a/.changes/unreleased/Features-20260710-172244.yaml
+++ b/.changes/unreleased/Features-20260710-172244.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: 'Clickhouse: Add more settings and missing internal methods'
+time: 2026-07-10T17:22:44.120442+02:00
+custom:
+    author: koletzilla
+    issue: "14587"
+    project: dbt-core

--- a/crates/dbt-adapter/src/relation/relation_object.rs
+++ b/crates/dbt-adapter/src/relation/relation_object.rs
@@ -215,6 +215,20 @@ impl Object for RelationObject {
                 self.get(&key, default)
             }
             "render" => Ok(render_without_filter(self)),
+            "derivative" => {
+                let iter = ArgsIter::new("derivative", &["suffix", "relation_type"], args);
+                let suffix = iter.next_arg::<&str>()?;
+                let relation_type = iter.next_arg::<Option<&str>>()?;
+                let interpret_suffix_as_full_identifier = iter
+                    .next_kwarg::<Option<bool>>("interpret_suffix_as_full_identifier")?
+                    .unwrap_or(false);
+                iter.finish()?;
+                let relation_type = relation_type
+                    .filter(|s| !s.is_empty())
+                    .map(RelationType::from);
+                self.derivative(suffix, relation_type, interpret_suffix_as_full_identifier)
+                    .map(|r| Value::from_object(RelationObject::new(r)))
+            }
             "without_identifier" => self
                 .without_identifier()
                 .map(|r| Value::from_object(RelationObject::new(r))),
@@ -890,5 +904,98 @@ mod tests {
 
         assert_eq!(relation.render_self_as_str(), "`analytics`.`events`");
         assert_eq!(relation.database(), Some(""));
+    }
+
+    #[test]
+    fn derivative_appends_suffix_and_overrides_type_for_clickhouse() {
+        let relation = do_create_relation(
+            AdapterType::ClickHouse,
+            "ignored".to_string(),
+            "analytics".to_string(),
+            Some("events".to_string()),
+            Some(RelationType::Table),
+            ResolvedQuoting {
+                database: true,
+                schema: true,
+                identifier: true,
+            },
+        )
+        .unwrap();
+
+        // suffix appended to identifier, type overridden, database stays empty
+        let mv = relation
+            .derivative("_mv", Some(RelationType::MaterializedView), false)
+            .unwrap();
+        assert_eq!(mv.render_self_as_str(), "`analytics`.`events_mv`");
+        assert_eq!(mv.database(), Some(""));
+        assert_eq!(mv.relation_type(), Some(RelationType::MaterializedView));
+
+        // interpret_suffix_as_full_identifier replaces the identifier entirely,
+        // and omitting relation_type inherits the source relation's type
+        let full = relation.derivative("custom_name", None, true).unwrap();
+        assert_eq!(full.render_self_as_str(), "`analytics`.`custom_name`");
+        assert_eq!(full.relation_type(), Some(RelationType::Table));
+    }
+
+    #[test]
+    fn derivative_via_call_method_accepts_single_argument() {
+        // The ClickHouse snapshot macro calls `target.derivative('__snapshot_upsert')`
+        // with a single positional argument (dbt-clickhouse snapshot.sql), so
+        // relation_type must be optional at the Jinja boundary and default to the
+        // source relation's type.
+        let relation = do_create_relation(
+            AdapterType::ClickHouse,
+            "ignored".to_string(),
+            "analytics".to_string(),
+            Some("events".to_string()),
+            Some(RelationType::Table),
+            ResolvedQuoting {
+                database: true,
+                schema: true,
+                identifier: true,
+            },
+        )
+        .unwrap();
+
+        let obj = Arc::new(RelationObject::from(relation));
+        let env = minijinja::Environment::new();
+        let state = State::new_for_env(&env);
+
+        let derived = obj
+            .call_method(
+                &state,
+                "derivative",
+                &[Value::from("__snapshot_upsert")],
+                &[],
+            )
+            .unwrap();
+        let derived = derived
+            .downcast_object_ref::<RelationObject>()
+            .expect("derivative should return a relation")
+            .inner();
+        assert_eq!(
+            derived.render_self_as_str(),
+            "`analytics`.`events__snapshot_upsert`"
+        );
+        assert_eq!(derived.relation_type(), Some(RelationType::Table));
+
+        // Two positional args still override the type
+        let derived = obj
+            .call_method(
+                &state,
+                "derivative",
+                &[Value::from("_mv"), Value::from("materialized_view")],
+                &[],
+            )
+            .unwrap();
+        let derived = derived
+            .downcast_object_ref::<RelationObject>()
+            .expect("derivative should return a relation")
+            .inner();
+        assert_eq!(derived.render_self_as_str(), "`analytics`.`events_mv`");
+        assert_eq!(
+            derived.relation_type(),
+            Some(RelationType::MaterializedView)
+        );
     }
 }

--- a/crates/dbt-adapter/src/relation/relation_object.rs
+++ b/crates/dbt-adapter/src/relation/relation_object.rs
@@ -203,6 +203,20 @@ impl Object for RelationObject {
                 self.get(&key, default)
             }
             "render" => Ok(render_without_filter(self)),
+            "derivative" => {
+                let iter = ArgsIter::new("derivative", &["suffix", "relation_type"], args);
+                let suffix = iter.next_arg::<&str>()?;
+                let relation_type = iter.next_arg::<Option<&str>>()?;
+                let interpret_suffix_as_full_identifier = iter
+                    .next_kwarg::<Option<bool>>("interpret_suffix_as_full_identifier")?
+                    .unwrap_or(false);
+                iter.finish()?;
+                let relation_type = relation_type
+                    .filter(|s| !s.is_empty())
+                    .map(RelationType::from);
+                self.derivative(suffix, relation_type, interpret_suffix_as_full_identifier)
+                    .map(|r| Value::from_object(RelationObject::new(r)))
+            }
             "without_identifier" => self
                 .without_identifier()
                 .map(|r| Value::from_object(RelationObject::new(r))),
@@ -871,5 +885,98 @@ mod tests {
 
         assert_eq!(relation.render_self_as_str(), "`analytics`.`events`");
         assert_eq!(relation.database(), Some(""));
+    }
+
+    #[test]
+    fn derivative_appends_suffix_and_overrides_type_for_clickhouse() {
+        let relation = do_create_relation(
+            AdapterType::ClickHouse,
+            "ignored".to_string(),
+            "analytics".to_string(),
+            Some("events".to_string()),
+            Some(RelationType::Table),
+            ResolvedQuoting {
+                database: true,
+                schema: true,
+                identifier: true,
+            },
+        )
+        .unwrap();
+
+        // suffix appended to identifier, type overridden, database stays empty
+        let mv = relation
+            .derivative("_mv", Some(RelationType::MaterializedView), false)
+            .unwrap();
+        assert_eq!(mv.render_self_as_str(), "`analytics`.`events_mv`");
+        assert_eq!(mv.database(), Some(""));
+        assert_eq!(mv.relation_type(), Some(RelationType::MaterializedView));
+
+        // interpret_suffix_as_full_identifier replaces the identifier entirely,
+        // and omitting relation_type inherits the source relation's type
+        let full = relation.derivative("custom_name", None, true).unwrap();
+        assert_eq!(full.render_self_as_str(), "`analytics`.`custom_name`");
+        assert_eq!(full.relation_type(), Some(RelationType::Table));
+    }
+
+    #[test]
+    fn derivative_via_call_method_accepts_single_argument() {
+        // The ClickHouse snapshot macro calls `target.derivative('__snapshot_upsert')`
+        // with a single positional argument (dbt-clickhouse snapshot.sql), so
+        // relation_type must be optional at the Jinja boundary and default to the
+        // source relation's type.
+        let relation = do_create_relation(
+            AdapterType::ClickHouse,
+            "ignored".to_string(),
+            "analytics".to_string(),
+            Some("events".to_string()),
+            Some(RelationType::Table),
+            ResolvedQuoting {
+                database: true,
+                schema: true,
+                identifier: true,
+            },
+        )
+        .unwrap();
+
+        let obj = Arc::new(RelationObject::from(relation));
+        let env = minijinja::Environment::new();
+        let state = State::new_for_env(&env);
+
+        let derived = obj
+            .call_method(
+                &state,
+                "derivative",
+                &[Value::from("__snapshot_upsert")],
+                &[],
+            )
+            .unwrap();
+        let derived = derived
+            .downcast_object_ref::<RelationObject>()
+            .expect("derivative should return a relation")
+            .inner();
+        assert_eq!(
+            derived.render_self_as_str(),
+            "`analytics`.`events__snapshot_upsert`"
+        );
+        assert_eq!(derived.relation_type(), Some(RelationType::Table));
+
+        // Two positional args still override the type
+        let derived = obj
+            .call_method(
+                &state,
+                "derivative",
+                &[Value::from("_mv"), Value::from("materialized_view")],
+                &[],
+            )
+            .unwrap();
+        let derived = derived
+            .downcast_object_ref::<RelationObject>()
+            .expect("derivative should return a relation")
+            .inner();
+        assert_eq!(derived.render_self_as_str(), "`analytics`.`events_mv`");
+        assert_eq!(
+            derived.relation_type(),
+            Some(RelationType::MaterializedView)
+        );
     }
 }

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-clickhouse/macros/materializations/materialized_view.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-clickhouse/macros/materializations/materialized_view.sql
@@ -323,7 +323,8 @@
 
 {% macro clickhouse__get_mv_current_target(mv_relation) %}
   {% set query %}
-    select replaceRegexpOne(create_table_query, '.*TO\\s+`?([^`\\s(]+)`?\\.`?([^`\\s(]+)`?.*', '\\1.\\2') as target_table
+    {#- '\x3F' is the ClickHouse string-literal escape for '?' (regex quantifier); the ADBC driver treats a literal '?' in query text as a bind parameter. To be fixed in https://github.com/ClickHouse/adbc_clickhouse/issues/53 -#}
+    select replaceRegexpOne(create_table_query, '.*TO\\s+`\x3F([^`\\s(]+)`\x3F\\.`\x3F([^`\\s(]+)`\x3F.*', '\\1.\\2') as target_table
     from system.tables
     where database = '{{ mv_relation.schema }}'
       and name = '{{ mv_relation.identifier }}'

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-clickhouse/macros/materializations/materialized_view.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-clickhouse/macros/materializations/materialized_view.sql
@@ -185,7 +185,7 @@
   {% set views = {} %}
   {% if view_names %}
     {% for view_name in view_names %}
-      {% set view_sql = modules.re.findall('--(?:\s)?' + view_name + ':begin(.*)--(?:\s)?' + view_name + ':end', sql, flags=modules.re.DOTALL)[0] %}
+      {% set view_sql = modules.re.findall('--(?:\s)?' + view_name + ':begin(.*)--(?:\s)?' + view_name + ':end', sql, modules.re.DOTALL)[0] %}
       {%- set _ = views.update({view_name: view_sql}) -%}
     {% endfor %}
   {% else %}

--- a/crates/dbt-schemas/src/schemas/project/configs/common.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/common.rs
@@ -265,6 +265,13 @@ pub struct WarehouseSpecificNodeConfig {
     pub table: Option<String>,
     pub update_field: Option<String>,
     pub update_lag: Option<YmlValue>,
+    // materialized-view materialization
+    pub refreshable: Option<BTreeMap<String, YmlValue>>,
+    #[serde(default, deserialize_with = "bool_or_string_bool")]
+    pub catchup: Option<bool>,
+    pub mv_on_schema_change: Option<String>,
+    #[serde(default, deserialize_with = "bool_or_string_bool")]
+    pub repopulate_from_mvs_on_full_refresh: Option<bool>,
 }
 
 impl ResolvedConfig for WarehouseSpecificNodeConfig {
@@ -483,6 +490,11 @@ pub fn same_warehouse_config(
     let table_eq = self_wh.table == other_wh.table;
     let update_field_eq = self_wh.update_field == other_wh.update_field;
     let update_lag_eq = self_wh.update_lag == other_wh.update_lag;
+    let refreshable_eq = self_wh.refreshable == other_wh.refreshable;
+    let catchup_eq = self_wh.catchup == other_wh.catchup;
+    let mv_on_schema_change_eq = self_wh.mv_on_schema_change == other_wh.mv_on_schema_change;
+    let repopulate_from_mvs_on_full_refresh_eq =
+        self_wh.repopulate_from_mvs_on_full_refresh == other_wh.repopulate_from_mvs_on_full_refresh;
 
     let result = partition_by_eq
         && cluster_by_eq
@@ -569,7 +581,11 @@ pub fn same_warehouse_config(
         && range_eq
         && table_eq
         && update_field_eq
-        && update_lag_eq;
+        && update_lag_eq
+        && refreshable_eq
+        && catchup_eq
+        && mv_on_schema_change_eq
+        && repopulate_from_mvs_on_full_refresh_eq;
 
     if !result {
         log_state_mod_diff(
@@ -1262,6 +1278,38 @@ pub fn same_warehouse_config(
                     Some((
                         format!("{:?}", &self_wh.update_lag),
                         format!("{:?}", &other_wh.update_lag),
+                    )),
+                ),
+                (
+                    "refreshable",
+                    refreshable_eq,
+                    Some((
+                        format!("{:?}", &self_wh.refreshable),
+                        format!("{:?}", &other_wh.refreshable),
+                    )),
+                ),
+                (
+                    "catchup",
+                    catchup_eq,
+                    Some((
+                        format!("{:?}", &self_wh.catchup),
+                        format!("{:?}", &other_wh.catchup),
+                    )),
+                ),
+                (
+                    "mv_on_schema_change",
+                    mv_on_schema_change_eq,
+                    Some((
+                        format!("{:?}", &self_wh.mv_on_schema_change),
+                        format!("{:?}", &other_wh.mv_on_schema_change),
+                    )),
+                ),
+                (
+                    "repopulate_from_mvs_on_full_refresh",
+                    repopulate_from_mvs_on_full_refresh_eq,
+                    Some((
+                        format!("{:?}", &self_wh.repopulate_from_mvs_on_full_refresh),
+                        format!("{:?}", &other_wh.repopulate_from_mvs_on_full_refresh),
                     )),
                 ),
             ],

--- a/crates/dbt-schemas/src/schemas/project/configs/common.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/common.rs
@@ -245,6 +245,15 @@ pub struct WarehouseSpecificNodeConfig {
     #[serde(default)]
     pub primary_key: PrimaryKeyConfig,
     pub category: Option<DataLakeObjectCategory>,
+
+    // ClickHouse
+    // materialized-view materialization
+    pub refreshable: Option<BTreeMap<String, YmlValue>>,
+    #[serde(default, deserialize_with = "bool_or_string_bool")]
+    pub catchup: Option<bool>,
+    pub mv_on_schema_change: Option<String>,
+    #[serde(default, deserialize_with = "bool_or_string_bool")]
+    pub repopulate_from_mvs_on_full_refresh: Option<bool>,
 }
 
 impl ResolvedConfig for WarehouseSpecificNodeConfig {
@@ -447,6 +456,11 @@ pub fn same_warehouse_config(
     let indexes_eq = self_wh.indexes == other_wh.indexes;
     let primary_key_eq = self_wh.primary_key == other_wh.primary_key;
     let category_eq = self_wh.category == other_wh.category;
+    let refreshable_eq = self_wh.refreshable == other_wh.refreshable;
+    let catchup_eq = self_wh.catchup == other_wh.catchup;
+    let mv_on_schema_change_eq = self_wh.mv_on_schema_change == other_wh.mv_on_schema_change;
+    let repopulate_from_mvs_on_full_refresh_eq =
+        self_wh.repopulate_from_mvs_on_full_refresh == other_wh.repopulate_from_mvs_on_full_refresh;
 
     let result = partition_by_eq
         && cluster_by_eq
@@ -517,7 +531,11 @@ pub fn same_warehouse_config(
         && table_type_eq
         && indexes_eq
         && primary_key_eq
-        && category_eq;
+        && category_eq
+        && refreshable_eq
+        && catchup_eq
+        && mv_on_schema_change_eq
+        && repopulate_from_mvs_on_full_refresh_eq;
 
     if !result {
         log_state_mod_diff(
@@ -1082,6 +1100,38 @@ pub fn same_warehouse_config(
                     Some((
                         format!("{:?}", &self_wh.category),
                         format!("{:?}", &other_wh.category),
+                    )),
+                ),
+                (
+                    "refreshable",
+                    refreshable_eq,
+                    Some((
+                        format!("{:?}", &self_wh.refreshable),
+                        format!("{:?}", &other_wh.refreshable),
+                    )),
+                ),
+                (
+                    "catchup",
+                    catchup_eq,
+                    Some((
+                        format!("{:?}", &self_wh.catchup),
+                        format!("{:?}", &other_wh.catchup),
+                    )),
+                ),
+                (
+                    "mv_on_schema_change",
+                    mv_on_schema_change_eq,
+                    Some((
+                        format!("{:?}", &self_wh.mv_on_schema_change),
+                        format!("{:?}", &other_wh.mv_on_schema_change),
+                    )),
+                ),
+                (
+                    "repopulate_from_mvs_on_full_refresh",
+                    repopulate_from_mvs_on_full_refresh_eq,
+                    Some((
+                        format!("{:?}", &self_wh.repopulate_from_mvs_on_full_refresh),
+                        format!("{:?}", &other_wh.repopulate_from_mvs_on_full_refresh),
                     )),
                 ),
             ],

--- a/crates/dbt-schemas/src/schemas/project/configs/data_test_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/data_test_config.rs
@@ -620,6 +620,10 @@ impl From<ProjectDataTestConfig> for DataTestConfig {
                 table: None,
                 update_field: None,
                 update_lag: None,
+                refreshable: None,
+                catchup: None,
+                mv_on_schema_change: None,
+                repopulate_from_mvs_on_full_refresh: None,
             },
         }
     }

--- a/crates/dbt-schemas/src/schemas/project/configs/data_test_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/data_test_config.rs
@@ -508,6 +508,11 @@ impl From<ProjectDataTestConfig> for DataTestConfig {
                 // data test is unsupported for Salesforce yet
                 primary_key: PrimaryKeyConfig::default(),
                 category: None,
+
+                refreshable: None,
+                catchup: None,
+                mv_on_schema_change: None,
+                repopulate_from_mvs_on_full_refresh: None,
             },
         }
     }

--- a/crates/dbt-schemas/src/schemas/project/configs/model_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/model_config.rs
@@ -516,6 +516,21 @@ pub struct ProjectModelConfig {
     #[serde(rename = "+sync")]
     pub sync: Option<SyncConfig>,
 
+    // ClickHouse
+    // materialized-view materialization
+    #[serde(rename = "+refreshable")]
+    pub refreshable: Option<BTreeMap<String, YmlValue>>,
+    #[serde(default, rename = "+catchup", deserialize_with = "bool_or_string_bool")]
+    pub catchup: Option<bool>,
+    #[serde(rename = "+mv_on_schema_change")]
+    pub mv_on_schema_change: Option<String>,
+    #[serde(
+        default,
+        rename = "+repopulate_from_mvs_on_full_refresh",
+        deserialize_with = "bool_or_string_bool"
+    )]
+    pub repopulate_from_mvs_on_full_refresh: Option<bool>,
+
     // Flattened field:
     pub __additional_properties__: BTreeMap<String, ShouldBe<ProjectModelConfig>>,
 }
@@ -821,6 +836,11 @@ impl From<ProjectModelConfig> for ModelConfig {
 
                 primary_key: config.primary_key,
                 category: config.category,
+
+                refreshable: config.refreshable,
+                catchup: config.catchup,
+                mv_on_schema_change: config.mv_on_schema_change,
+                repopulate_from_mvs_on_full_refresh: config.repopulate_from_mvs_on_full_refresh,
             },
             // Python-specific fields - initialized to None here, set during Python AST analysis
             config_keys_used: None,
@@ -1012,6 +1032,12 @@ impl From<ModelConfig> for ProjectModelConfig {
             primary_key: config.__warehouse_specific_config__.primary_key,
             category: config.__warehouse_specific_config__.category,
             sync: config.sync,
+            refreshable: config.__warehouse_specific_config__.refreshable,
+            catchup: config.__warehouse_specific_config__.catchup,
+            mv_on_schema_change: config.__warehouse_specific_config__.mv_on_schema_change,
+            repopulate_from_mvs_on_full_refresh: config
+                .__warehouse_specific_config__
+                .repopulate_from_mvs_on_full_refresh,
             __additional_properties__: BTreeMap::new(),
         }
     }
@@ -2007,6 +2033,82 @@ __additional_properties__: {}
                 "numpy".to_string(),
                 "matplotlib".to_string(),
             ])))
+        );
+    }
+
+    #[test]
+    fn test_clickhouse_mv_project_config_keys_parse_with_plus_prefix() {
+        let config: ProjectModelConfig = dbt_yaml::from_str(
+            r#"
++refreshable:
+  interval: EVERY 1 MINUTE
++catchup: false
++mv_on_schema_change: append_new_columns
++repopulate_from_mvs_on_full_refresh: true
+__additional_properties__: {}
+"#,
+        )
+        .unwrap();
+
+        let refreshable = config.refreshable.as_ref().expect("+refreshable should parse");
+        assert_eq!(
+            refreshable.get("interval").and_then(|v| v.as_str()),
+            Some("EVERY 1 MINUTE")
+        );
+        assert_eq!(config.catchup, Some(false));
+        assert_eq!(
+            config.mv_on_schema_change.as_deref(),
+            Some("append_new_columns")
+        );
+        assert_eq!(config.repopulate_from_mvs_on_full_refresh, Some(true));
+
+        // bool_or_string_bool accepts string booleans for the bool-typed keys
+        let config: ProjectModelConfig = dbt_yaml::from_str(
+            r#"
++catchup: "true"
++repopulate_from_mvs_on_full_refresh: "false"
+__additional_properties__: {}
+"#,
+        )
+        .unwrap();
+        assert_eq!(config.catchup, Some(true));
+        assert_eq!(config.repopulate_from_mvs_on_full_refresh, Some(false));
+    }
+
+    #[test]
+    fn test_clickhouse_mv_config_keys_roundtrip_through_model_config() {
+        let project_config: ProjectModelConfig = dbt_yaml::from_str(
+            r#"
++refreshable:
+  interval: EVERY 10 MINUTE
+  randomize: 5 MINUTE
++catchup: true
++mv_on_schema_change: fail
++repopulate_from_mvs_on_full_refresh: false
+__additional_properties__: {}
+"#,
+        )
+        .unwrap();
+
+        // ProjectModelConfig -> ModelConfig lands the keys in the warehouse config
+        let model_config: ModelConfig = project_config.clone().into();
+        let wh = &model_config.__warehouse_specific_config__;
+        assert_eq!(wh.refreshable, project_config.refreshable);
+        assert_eq!(wh.catchup, Some(true));
+        assert_eq!(wh.mv_on_schema_change.as_deref(), Some("fail"));
+        assert_eq!(wh.repopulate_from_mvs_on_full_refresh, Some(false));
+
+        // ModelConfig -> ProjectModelConfig restores them
+        let roundtripped: ProjectModelConfig = model_config.into();
+        assert_eq!(roundtripped.refreshable, project_config.refreshable);
+        assert_eq!(roundtripped.catchup, project_config.catchup);
+        assert_eq!(
+            roundtripped.mv_on_schema_change,
+            project_config.mv_on_schema_change
+        );
+        assert_eq!(
+            roundtripped.repopulate_from_mvs_on_full_refresh,
+            project_config.repopulate_from_mvs_on_full_refresh
         );
     }
 }

--- a/crates/dbt-schemas/src/schemas/project/configs/model_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/model_config.rs
@@ -551,6 +551,19 @@ pub struct ProjectModelConfig {
     pub update_field: Option<String>,
     #[serde(rename = "+update_lag")]
     pub update_lag: Option<YmlValue>,
+    // materialized-view materialization
+    #[serde(rename = "+refreshable")]
+    pub refreshable: Option<BTreeMap<String, YmlValue>>,
+    #[serde(default, rename = "+catchup", deserialize_with = "bool_or_string_bool")]
+    pub catchup: Option<bool>,
+    #[serde(rename = "+mv_on_schema_change")]
+    pub mv_on_schema_change: Option<String>,
+    #[serde(
+        default,
+        rename = "+repopulate_from_mvs_on_full_refresh",
+        deserialize_with = "bool_or_string_bool"
+    )]
+    pub repopulate_from_mvs_on_full_refresh: Option<bool>,
 
     // Flattened field:
     pub __additional_properties__: BTreeMap<String, ShouldBe<ProjectModelConfig>>,
@@ -1026,6 +1039,10 @@ impl From<ProjectModelConfig> for ModelConfig {
                 table: config.table,
                 update_field: config.update_field,
                 update_lag: config.update_lag,
+                refreshable: config.refreshable,
+                catchup: config.catchup,
+                mv_on_schema_change: config.mv_on_schema_change,
+                repopulate_from_mvs_on_full_refresh: config.repopulate_from_mvs_on_full_refresh,
             },
             // Python-specific fields - initialized to None here, set during Python AST analysis
             config_keys_used: None,
@@ -1233,6 +1250,12 @@ impl From<ModelConfig> for ProjectModelConfig {
             table: config.__warehouse_specific_config__.table,
             update_field: config.__warehouse_specific_config__.update_field,
             update_lag: config.__warehouse_specific_config__.update_lag,
+            refreshable: config.__warehouse_specific_config__.refreshable,
+            catchup: config.__warehouse_specific_config__.catchup,
+            mv_on_schema_change: config.__warehouse_specific_config__.mv_on_schema_change,
+            repopulate_from_mvs_on_full_refresh: config
+                .__warehouse_specific_config__
+                .repopulate_from_mvs_on_full_refresh,
             __additional_properties__: BTreeMap::new(),
         }
     }
@@ -2314,5 +2337,81 @@ __additional_properties__: {}
         assert_eq!(roundtripped.ttl, project_config.ttl);
         assert_eq!(roundtripped.settings, project_config.settings);
         assert_eq!(roundtripped.query_settings, project_config.query_settings);
+    }
+
+    #[test]
+    fn test_clickhouse_mv_project_config_keys_parse_with_plus_prefix() {
+        let config: ProjectModelConfig = dbt_yaml::from_str(
+            r#"
++refreshable:
+  interval: EVERY 1 MINUTE
++catchup: false
++mv_on_schema_change: append_new_columns
++repopulate_from_mvs_on_full_refresh: true
+__additional_properties__: {}
+"#,
+        )
+        .unwrap();
+
+        let refreshable = config.refreshable.as_ref().expect("+refreshable should parse");
+        assert_eq!(
+            refreshable.get("interval").and_then(|v| v.as_str()),
+            Some("EVERY 1 MINUTE")
+        );
+        assert_eq!(config.catchup, Some(false));
+        assert_eq!(
+            config.mv_on_schema_change.as_deref(),
+            Some("append_new_columns")
+        );
+        assert_eq!(config.repopulate_from_mvs_on_full_refresh, Some(true));
+
+        // bool_or_string_bool accepts string booleans for the bool-typed keys
+        let config: ProjectModelConfig = dbt_yaml::from_str(
+            r#"
++catchup: "true"
++repopulate_from_mvs_on_full_refresh: "false"
+__additional_properties__: {}
+"#,
+        )
+        .unwrap();
+        assert_eq!(config.catchup, Some(true));
+        assert_eq!(config.repopulate_from_mvs_on_full_refresh, Some(false));
+    }
+
+    #[test]
+    fn test_clickhouse_mv_config_keys_roundtrip_through_model_config() {
+        let project_config: ProjectModelConfig = dbt_yaml::from_str(
+            r#"
++refreshable:
+  interval: EVERY 10 MINUTE
+  randomize: 5 MINUTE
++catchup: true
++mv_on_schema_change: fail
++repopulate_from_mvs_on_full_refresh: false
+__additional_properties__: {}
+"#,
+        )
+        .unwrap();
+
+        // ProjectModelConfig -> ModelConfig lands the keys in the warehouse config
+        let model_config: ModelConfig = project_config.clone().into();
+        let wh = &model_config.__warehouse_specific_config__;
+        assert_eq!(wh.refreshable, project_config.refreshable);
+        assert_eq!(wh.catchup, Some(true));
+        assert_eq!(wh.mv_on_schema_change.as_deref(), Some("fail"));
+        assert_eq!(wh.repopulate_from_mvs_on_full_refresh, Some(false));
+
+        // ModelConfig -> ProjectModelConfig restores them
+        let roundtripped: ProjectModelConfig = model_config.into();
+        assert_eq!(roundtripped.refreshable, project_config.refreshable);
+        assert_eq!(roundtripped.catchup, project_config.catchup);
+        assert_eq!(
+            roundtripped.mv_on_schema_change,
+            project_config.mv_on_schema_change
+        );
+        assert_eq!(
+            roundtripped.repopulate_from_mvs_on_full_refresh,
+            project_config.repopulate_from_mvs_on_full_refresh
+        );
     }
 }

--- a/crates/dbt-schemas/src/schemas/project/configs/seed_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/seed_config.rs
@@ -581,6 +581,10 @@ impl From<ProjectSeedConfig> for SeedConfig {
                 table: None,
                 update_field: None,
                 update_lag: None,
+                refreshable: None,
+                catchup: None,
+                mv_on_schema_change: None,
+                repopulate_from_mvs_on_full_refresh: None,
             },
         }
     }

--- a/crates/dbt-schemas/src/schemas/project/configs/seed_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/seed_config.rs
@@ -471,6 +471,11 @@ impl From<ProjectSeedConfig> for SeedConfig {
                 // seed is unsupported for Salesforce yet
                 primary_key: PrimaryKeyConfig::default(),
                 category: None,
+
+                refreshable: None,
+                catchup: None,
+                mv_on_schema_change: None,
+                repopulate_from_mvs_on_full_refresh: None,
             },
         }
     }

--- a/crates/dbt-schemas/src/schemas/project/configs/snapshot_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/snapshot_config.rs
@@ -800,6 +800,10 @@ impl From<ProjectSnapshotConfig> for SnapshotConfig {
                 table: None,
                 update_field: None,
                 update_lag: None,
+                refreshable: None,
+                catchup: None,
+                mv_on_schema_change: None,
+                repopulate_from_mvs_on_full_refresh: None,
             },
         }
     }

--- a/crates/dbt-schemas/src/schemas/project/configs/snapshot_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/snapshot_config.rs
@@ -679,6 +679,11 @@ impl From<ProjectSnapshotConfig> for SnapshotConfig {
                 // snapshot is unsupported for Salesforce yet
                 primary_key: PrimaryKeyConfig::default(),
                 category: None,
+
+                refreshable: None,
+                catchup: None,
+                mv_on_schema_change: None,
+                repopulate_from_mvs_on_full_refresh: None,
             },
         }
     }

--- a/crates/dbt-schemas/src/schemas/project/configs/source_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/source_config.rs
@@ -468,6 +468,10 @@ impl From<ProjectSourceConfig> for SourceConfig {
                 table: None,
                 update_field: None,
                 update_lag: None,
+                refreshable: None,
+                catchup: None,
+                mv_on_schema_change: None,
+                repopulate_from_mvs_on_full_refresh: None,
             },
         }
     }

--- a/crates/dbt-schemas/src/schemas/project/configs/source_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/source_config.rs
@@ -388,6 +388,11 @@ impl From<ProjectSourceConfig> for SourceConfig {
                 // sources doesn't need this field
                 primary_key: PrimaryKeyConfig::default(),
                 category: None,
+
+                refreshable: None,
+                catchup: None,
+                mv_on_schema_change: None,
+                repopulate_from_mvs_on_full_refresh: None,
             },
         }
     }

--- a/crates/dbt-schemas/src/schemas/project/configs/unit_test_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/unit_test_config.rs
@@ -503,6 +503,10 @@ impl From<ProjectUnitTestConfig> for UnitTestConfig {
                 table: None,
                 update_field: None,
                 update_lag: None,
+                refreshable: None,
+                catchup: None,
+                mv_on_schema_change: None,
+                repopulate_from_mvs_on_full_refresh: None,
             },
         }
     }

--- a/crates/dbt-schemas/src/schemas/project/configs/unit_test_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/unit_test_config.rs
@@ -409,6 +409,11 @@ impl From<ProjectUnitTestConfig> for UnitTestConfig {
                 // unit test is unsupported for Salesforce yet
                 primary_key: PrimaryKeyConfig::default(),
                 category: None,
+
+                refreshable: None,
+                catchup: None,
+                mv_on_schema_change: None,
+                repopulate_from_mvs_on_full_refresh: None,
             },
         }
     }

--- a/crates/dbt-schemas/src/schemas/relations/base.rs
+++ b/crates/dbt-schemas/src/schemas/relations/base.rs
@@ -730,6 +730,34 @@ pub trait BaseRelation: BaseRelationProperties + Any + Send + Sync + fmt::Debug 
         Ok(self.to_owned())
     }
 
+    /// Derive a new relation from this one by appending `suffix` to the identifier
+    /// (or, when `interpret_suffix_as_full_identifier` is set, using `suffix` as the
+    /// whole identifier), keeping the same schema and optionally overriding the type.
+    ///
+    /// Called from the ClickHouse materialized-view and snapshot macros, e.g.
+    /// `target_relation.derivative('_mv', 'materialized_view')`.
+    /// Ref: dbt-clickhouse `relation.py::ClickHouseRelation.derivative`.
+    fn derivative(
+        &self,
+        suffix: &str,
+        relation_type: Option<RelationType>,
+        interpret_suffix_as_full_identifier: bool,
+    ) -> Result<Arc<dyn BaseRelation>, MinijinjaError> {
+        let new_identifier = if interpret_suffix_as_full_identifier {
+            suffix.to_string()
+        } else {
+            format!("{}{}", self.identifier_as_str()?, suffix)
+        };
+        let relation_type = relation_type.or_else(|| self.relation_type());
+        self.create_relation(
+            self.database().map(|s| s.to_string()),
+            Some(self.schema_as_str()?),
+            Some(new_identifier),
+            relation_type,
+            self.quote_policy(),
+        )
+    }
+
     /// Create a new relation with the specified components and policies.
     ///
     /// This method is used to create a new relation instance with the given database, schema,


### PR DESCRIPTION
Related to #14587

- Fix error when using MVs with implicit target as the `derivative` method didn't exists. Now it exists.
- New settings configured: `refreshable`, `catchup`, `mv_on_schema_change`, `repopulate_from_mvs_on_full_refresh`.
- clickhouse__get_mv_current_target fixed until https://github.com/ClickHouse/adbc_clickhouse/issues/53 is fixed: instead of using `?` we now use `\x3F`

Not included, pending for future PRs:
 - `mv_on_schema_change`, `repopulate_from_mvs_on_full_refresh` are not functional yet. They depend on `relation.mvs_pointing_to_it` which will be added in future PRs.
-  on_schema_change upgrade for MVs.
- cluster/exchange relation statue

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
