### PR TITLE
Microsoft Fabric Lakehouse support as a spark platform flavor

### DIFF
--- a/.changes/unreleased/Features-20260723-210000.yaml
+++ b/.changes/unreleased/Features-20260723-210000.yaml
@@ -1,0 +1,8 @@
+kind: Features
+body: Microsoft Fabric Lakehouse support as a platform flavor of the spark adapter
+  (Livy API with Microsoft Entra ID auth), covering classic and schema-enabled
+  lakehouses; 'type: fabricspark' profiles work unchanged as an alias
+time: 2026-07-23T21:00:00.000000+12:00
+custom:
+    author: arkin-nz
+    project: dbt-fusion

--- a/crates/dbt-adapter/src/adapter/adapter_impl.rs
+++ b/crates/dbt-adapter/src/adapter/adapter_impl.rs
@@ -3688,8 +3688,14 @@ impl AdapterImpl {
             Impl(Bigquery, engine) => {
                 bigquery::list_relations(engine.as_ref(), query_ctx, conn, db_schema, token)
             }
-            Impl(Databricks | Spark, engine) => {
+            Impl(Databricks, engine) => {
                 databricks::list_relations(engine.as_ref(), query_ctx, conn, db_schema, token)
+            }
+            // Spark has no `system.information_schema` outside Databricks
+            // Unity Catalog; SHOW TABLE EXTENDED exists on every backend,
+            // including Microsoft Fabric Lakehouses.
+            Impl(Spark, engine) => {
+                spark::list_relations(engine.as_ref(), query_ctx, conn, db_schema, token)
             }
             Impl(Redshift, engine) => {
                 redshift::list_relations(engine.as_ref(), query_ctx, conn, db_schema, token)

--- a/crates/dbt-adapter/src/metadata/databricks/mod.rs
+++ b/crates/dbt-adapter/src/metadata/databricks/mod.rs
@@ -922,13 +922,13 @@ impl MetadataAdapter for DatabricksMetadataAdapter {
             };
 
             let fqn = match adapter.adapter_type() {
-                AdapterType::Spark => {
-                    debug_assert!(
-                        database.is_empty(),
-                        "Spark database should be empty but got '{database}'"
-                    );
+                // Schema-enabled Fabric lakehouses carry the lakehouse name in
+                // `database` (3-part naming); classic lakehouses and plain
+                // Spark leave it empty.
+                AdapterType::Spark if database.is_empty() => {
                     format!("{schema}.{identifier}")
                 }
+                AdapterType::Spark => format!("{database}.{schema}.{identifier}"),
                 AdapterType::Databricks => format!("{database}.{schema}.{identifier}"),
                 _ => unreachable!(),
             };

--- a/crates/dbt-adapter/src/metadata/get_relation.rs
+++ b/crates/dbt-adapter/src/metadata/get_relation.rs
@@ -64,9 +64,9 @@ pub fn get_relation(
         AdapterType::Salesforce => {
             salesforce_get_relation(adapter, state, ctx, conn, database, schema, identifier)
         }
-        AdapterType::Spark => {
-            spark_get_relation(adapter, state, ctx, conn, schema, identifier, token)
-        }
+        AdapterType::Spark => spark_get_relation(
+            adapter, state, ctx, conn, database, schema, identifier, token,
+        ),
         AdapterType::DuckDB => duckdb_get_relation(
             adapter, state, ctx, conn, database, schema, identifier, token,
         ),
@@ -401,11 +401,13 @@ fn parse_describe_table_extended(
     Ok((relation_type, is_delta, metadata_map))
 }
 
+#[allow(clippy::too_many_arguments)]
 fn spark_get_relation(
     adapter: &AdapterImpl,
     state: &State,
     ctx: &QueryCtx,
     conn: &mut dyn Connection,
+    database: &str,
     schema: &str,
     identifier: &str,
     token: CancellationToken,
@@ -420,9 +422,18 @@ fn spark_get_relation(
     } else {
         identifier.to_string()
     };
+    // Spark relations are usually 2-part, but schema-enabled Fabric
+    // lakehouses carry the lakehouse name in `database` (3-part).
+    let query_prefix = if database.is_empty() {
+        String::new()
+    } else if adapter.quoting().database {
+        format!("{}.", adapter.quote(database))
+    } else {
+        format!("{database}.")
+    };
 
     // Spark 3.5 does not support AS JSON
-    let sql = format!("DESCRIBE TABLE EXTENDED {query_schema}.{query_identifier}");
+    let sql = format!("DESCRIBE TABLE EXTENDED {query_prefix}{query_schema}.{query_identifier}");
     let batch = adapter
         .engine()
         .execute(Some(state), conn, ctx, &sql, token);
@@ -444,7 +455,7 @@ fn spark_get_relation(
     Ok(Some(Box::new(
         Relation::new(
             AdapterType::Spark,
-            None::<String>,
+            (!database.is_empty()).then(|| database.to_string()),
             schema.to_string(),
             identifier.to_string(),
         )

--- a/crates/dbt-adapter/src/metadata/spark/mod.rs
+++ b/crates/dbt-adapter/src/metadata/spark/mod.rs
@@ -1,3 +1,257 @@
+//! Spark metadata queries.
+//!
+//! Relation listing is based on `SHOW TABLE EXTENDED`, which reports the
+//! relation type and storage provider for every relation in a schema in one
+//! query. Unlike `system.information_schema` (a Databricks Unity Catalog
+//! feature) it exists on every Spark backend, including Microsoft Fabric
+//! Lakehouses, where it works for both classic lakehouses (2-part
+//! `schema.table` naming) and schema-enabled lakehouses (3-part
+//! `lakehouse.schema.table`, with the lakehouse in the catalog slot).
+
+use std::sync::Arc;
+
+use arrow_array::*;
+use dbt_adapter_core::AdapterType;
+use dbt_common::cancellation::CancellationToken;
+use dbt_schemas::dbt_types::RelationType;
+use dbt_schemas::schemas::common::ResolvedQuoting;
+use dbt_schemas::schemas::relations::base::BaseRelation;
+
+use crate::AdapterEngine;
+use crate::errors::AdapterResult;
+use crate::metadata::CatalogAndSchema;
+use crate::record_batch::RecordBatchExt;
+use crate::relation::Relation;
+use dbt_adbc::{Connection, QueryCtx};
+
+/// Extracts the value of a `Key: value` line from `SHOW TABLE EXTENDED`'s
+/// `information` column.
+fn information_value<'a>(information: &'a str, key: &str) -> Option<&'a str> {
+    information.lines().find_map(|line| {
+        line.strip_prefix(key)
+            .and_then(|rest| rest.strip_prefix(": "))
+            .map(str::trim)
+    })
+}
+
+/// Returns true when a query error reports that the target schema does not
+/// exist, in which case it has no relations (dbt will create it).
+///
+/// The Livy driver surfaces Spark's error class in the message text; Spark's
+/// class for this condition is `SCHEMA_NOT_FOUND` ([SQLSTATE 42704]).
+fn is_schema_not_found(message: &str) -> bool {
+    message.contains("[SCHEMA_NOT_FOUND]") || message.contains("SCHEMA_NOT_FOUND")
+}
+
+/// Converts a `SHOW TABLE EXTENDED IN <ns> LIKE '*'` result batch into
+/// relations. Separated from query execution so it can be unit tested with
+/// synthetic batches.
+fn relations_from_show_table_extended(
+    adapter_type: AdapterType,
+    quoting: ResolvedQuoting,
+    catalog: &str,
+    schema: &str,
+    batch: &RecordBatch,
+) -> AdapterResult<Vec<Arc<dyn BaseRelation>>> {
+    if batch.num_rows() == 0 {
+        return Ok(Vec::new());
+    }
+
+    let names = batch.column_values::<StringArray>("tableName")?;
+    let is_temporary = batch.column_values::<BooleanArray>("isTemporary")?;
+    let information = batch.column_values::<StringArray>("information")?;
+
+    let mut relations = Vec::with_capacity(batch.num_rows());
+    for i in 0..batch.num_rows() {
+        if is_temporary.value(i) {
+            continue;
+        }
+        let info = information.value(i);
+        // `Type:` is MANAGED, EXTERNAL or VIEW; `Provider:` is the storage
+        // format (`delta` for regular lakehouse tables) and absent for views.
+        let table_type = information_value(info, "Type").unwrap_or("MANAGED");
+        let is_delta = information_value(info, "Provider") == Some("delta");
+
+        let relation = Arc::new(
+            Relation::new(
+                adapter_type,
+                (!catalog.is_empty()).then(|| catalog.to_string()),
+                schema.to_string(),
+                names.value(i).to_string(),
+            )
+            .with_relation_type(RelationType::from_adapter_type(adapter_type, table_type))
+            .with_quoting(quoting)
+            .with_is_delta(is_delta),
+        ) as Arc<dyn BaseRelation>;
+        relations.push(relation);
+    }
+
+    Ok(relations)
+}
+
+pub fn list_relations(
+    engine: &dyn AdapterEngine,
+    ctx: &QueryCtx,
+    conn: &'_ mut dyn Connection,
+    db_schema: &CatalogAndSchema,
+    token: CancellationToken,
+) -> AdapterResult<Vec<Arc<dyn BaseRelation>>> {
+    let catalog = &db_schema.resolved_catalog;
+    let schema = &db_schema.resolved_schema;
+    let namespace = if catalog.is_empty() {
+        format!("`{schema}`")
+    } else {
+        format!("`{catalog}`.`{schema}`")
+    };
+
+    let sql = format!("SHOW TABLE EXTENDED IN {namespace} LIKE '*'");
+    let batch = match engine.execute(None, conn, ctx, &sql, token) {
+        // A schema that doesn't exist yet has no relations; dbt will create it.
+        Err(e) if is_schema_not_found(&e.to_string()) => return Ok(Vec::new()),
+        other => other?,
+    };
+
+    relations_from_show_table_extended(
+        engine.adapter_type(),
+        engine.quoting(),
+        catalog,
+        schema,
+        &batch,
+    )
+}
+
+#[cfg(test)]
+mod show_table_extended_tests {
+    use super::*;
+    use arrow_schema::{DataType, Field, Schema};
+
+    #[test]
+    fn information_value_parses_show_table_extended_lines() {
+        let info = "Catalog: spark_catalog\nDatabase: `WS`.`lh`.`dbo`\nTable: probe\nType: MANAGED\nProvider: delta\nLocation: abfss://...\n";
+        assert_eq!(information_value(info, "Type"), Some("MANAGED"));
+        assert_eq!(information_value(info, "Provider"), Some("delta"));
+        assert_eq!(information_value(info, "Missing"), None);
+
+        let view_info = "Catalog: spark_catalog\nTable: v\nType: VIEW\nView Text: SELECT 1\n";
+        assert_eq!(information_value(view_info, "Type"), Some("VIEW"));
+        assert_eq!(information_value(view_info, "Provider"), None);
+    }
+
+    #[test]
+    fn schema_not_found_matches_fabric_error_text() {
+        // Verbatim shape of the error Fabric returns for a missing schema
+        // (captured from a live lakehouse; identifiers replaced).
+        let fabric_error = "[spark] livy: query error: Error: [SCHEMA_NOT_FOUND] \
+The schema `my_lakehouse.missing_schema` cannot be found. Verify the spelling \
+and correctness of the schema and catalog.";
+        assert!(is_schema_not_found(fabric_error));
+
+        assert!(!is_schema_not_found(
+            "[spark] livy: query error: Error: [TABLE_OR_VIEW_NOT_FOUND] ..."
+        ));
+        assert!(!is_schema_not_found("connection reset by peer"));
+    }
+
+    /// Builds a synthetic `SHOW TABLE EXTENDED` result batch.
+    fn show_table_extended_batch(rows: &[(&str, bool, &str)]) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("namespace", DataType::Utf8, true),
+            Field::new("tableName", DataType::Utf8, true),
+            Field::new("isTemporary", DataType::Boolean, true),
+            Field::new("information", DataType::Utf8, true),
+        ]));
+        let namespaces: StringArray = rows.iter().map(|_| Some("ns")).collect();
+        let names: StringArray = rows.iter().map(|(n, _, _)| Some(*n)).collect();
+        let temps: BooleanArray = rows.iter().map(|(_, t, _)| Some(*t)).collect();
+        let infos: StringArray = rows.iter().map(|(_, _, i)| Some(*i)).collect();
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(namespaces),
+                Arc::new(names),
+                Arc::new(temps),
+                Arc::new(infos),
+            ],
+        )
+        .unwrap()
+    }
+
+    const MANAGED_DELTA: &str = "Type: MANAGED\nProvider: delta\n";
+    const EXTERNAL_PARQUET: &str = "Type: EXTERNAL\nProvider: parquet\n";
+    const VIEW: &str = "Type: VIEW\nView Text: SELECT 1\n";
+
+    fn relations_for(catalog: &str, rows: &[(&str, bool, &str)]) -> Vec<Arc<dyn BaseRelation>> {
+        let batch = show_table_extended_batch(rows);
+        relations_from_show_table_extended(
+            AdapterType::Spark,
+            ResolvedQuoting::trues(),
+            catalog,
+            "dbo",
+            &batch,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn maps_relation_types_and_delta_provider() {
+        let relations = relations_for(
+            "lakehouse",
+            &[
+                ("t_managed", false, MANAGED_DELTA),
+                ("t_external", false, EXTERNAL_PARQUET),
+                ("v_view", false, VIEW),
+            ],
+        );
+        assert_eq!(relations.len(), 3);
+
+        let managed = &relations[0];
+        assert_eq!(managed.identifier_as_str().unwrap(), "t_managed");
+        assert_eq!(managed.relation_type(), Some(RelationType::Table));
+        assert!(managed.is_delta());
+
+        let external = &relations[1];
+        assert_eq!(external.relation_type(), Some(RelationType::Table));
+        assert!(!external.is_delta());
+
+        let view = &relations[2];
+        assert_eq!(view.relation_type(), Some(RelationType::View));
+        assert!(!view.is_delta());
+    }
+
+    #[test]
+    fn excludes_temporary_relations() {
+        let relations = relations_for(
+            "lakehouse",
+            &[
+                ("t_perm", false, MANAGED_DELTA),
+                ("t_temp", true, MANAGED_DELTA),
+            ],
+        );
+        assert_eq!(relations.len(), 1);
+        assert_eq!(relations[0].identifier_as_str().unwrap(), "t_perm");
+    }
+
+    #[test]
+    fn schema_enabled_lakehouses_get_three_part_relations() {
+        let relations = relations_for("lakehouse", &[("t", false, MANAGED_DELTA)]);
+        assert_eq!(relations[0].database(), Some("lakehouse"));
+        assert_eq!(relations[0].schema_as_str().unwrap(), "dbo");
+    }
+
+    #[test]
+    fn classic_lakehouses_get_two_part_relations() {
+        let relations = relations_for("", &[("t", false, MANAGED_DELTA)]);
+        // classic lakehouses are single-database: no database component
+        assert_eq!(relations[0].database(), None);
+        assert_eq!(relations[0].schema_as_str().unwrap(), "dbo");
+    }
+
+    #[test]
+    fn empty_batch_yields_no_relations() {
+        assert!(relations_for("lakehouse", &[]).is_empty());
+    }
+}
+
 use crate::column::Column;
 
 /// Keep only the leading column names from a Spark `describe extended` result,

--- a/crates/dbt-adapter/src/metadata/spark/mod.rs
+++ b/crates/dbt-adapter/src/metadata/spark/mod.rs
@@ -49,13 +49,15 @@ fn is_schema_not_found(message: &str) -> bool {
 fn relations_from_show_table_extended(
     adapter_type: AdapterType,
     quoting: ResolvedQuoting,
-    catalog: &str,
-    schema: &str,
+    db_schema: &CatalogAndSchema,
     batch: &RecordBatch,
 ) -> AdapterResult<Vec<Arc<dyn BaseRelation>>> {
     if batch.num_rows() == 0 {
         return Ok(Vec::new());
     }
+
+    let catalog = &db_schema.resolved_catalog;
+    let schema = &db_schema.resolved_schema;
 
     let names = batch.column_values::<StringArray>("tableName")?;
     let is_temporary = batch.column_values::<BooleanArray>("isTemporary")?;
@@ -114,8 +116,7 @@ pub fn list_relations(
     relations_from_show_table_extended(
         engine.adapter_type(),
         engine.quoting(),
-        catalog,
-        schema,
+        db_schema,
         &batch,
     )
 }
@@ -182,11 +183,16 @@ and correctness of the schema and catalog.";
 
     fn relations_for(catalog: &str, rows: &[(&str, bool, &str)]) -> Vec<Arc<dyn BaseRelation>> {
         let batch = show_table_extended_batch(rows);
+        let db_schema = CatalogAndSchema {
+            rendered_catalog: catalog.to_string(),
+            rendered_schema: "dbo".to_string(),
+            resolved_catalog: catalog.to_string(),
+            resolved_schema: "dbo".to_string(),
+        };
         relations_from_show_table_extended(
             AdapterType::Spark,
             ResolvedQuoting::trues(),
-            catalog,
-            "dbo",
+            &db_schema,
             &batch,
         )
         .unwrap()

--- a/crates/dbt-adapter/src/sql_types.rs
+++ b/crates/dbt-adapter/src/sql_types.rs
@@ -335,14 +335,14 @@ impl DefaultTypeOps {
                 _,
             ) => match adapter_type {
                 Bigquery => "int64",
-                Databricks => "bigint",
+                Databricks | Spark => "bigint",
                 _ => "integer",
             },
 
             // ## convert_number_type() - Float32
             (SqlType::Real | SqlType::HalfFloat, _) => match adapter_type {
                 Bigquery => "float64",
-                Databricks => "float",
+                Databricks | Spark => "float",
                 Fabric => "real",
                 _ => "float8",
             },
@@ -350,7 +350,7 @@ impl DefaultTypeOps {
             // ## convert_number_type() - Float64
             (SqlType::Double | SqlType::Float(_), _) => match adapter_type {
                 Bigquery => "float64",
-                Databricks => "double",
+                Databricks | Spark => "double",
                 // Divergence: upstream has an implicit narrowing bug we fix
                 // see https://github.com/microsoft/dbt-fabric/blob/0de219082282724a789b0d1b18509d39899da8e1/dbt/adapters/fabric/fabric_adapter.py#L117
                 // https://learn.microsoft.com/en-us/sql/t-sql/data-types/float-and-real-transact-sql?view=fabric&preserve-view=true
@@ -371,8 +371,8 @@ impl DefaultTypeOps {
                 (Bigquery, 1..) => "float64",
                 (Bigquery, ..=0) => "int64",
                 (Fabric, _) => "float",
-                (Databricks, 1..) => "double",
-                (Databricks, ..=0) => "bigint",
+                (Databricks | Spark, 1..) => "double",
+                (Databricks | Spark, ..=0) => "bigint",
                 (_, 1..) => "float8",
                 (_, ..=0) => "integer",
             },
@@ -391,7 +391,7 @@ impl DefaultTypeOps {
             // ## convert_datetime_type()
             (SqlType::Timestamp { .. }, _) => match adapter_type {
                 Bigquery => "datetime",
-                Databricks => "timestamp",
+                Databricks | Spark => "timestamp",
                 Fabric => "datetime2(6)",
                 _ => "timestamp without time zone",
             },
@@ -409,7 +409,7 @@ impl DefaultTypeOps {
             // ## convert_text_type()
             (SqlType::Varchar(..) | SqlType::Text | SqlType::Clob | SqlType::Char(_), _) => {
                 match adapter_type {
-                    Bigquery | Databricks => "string",
+                    Bigquery | Databricks | Spark => "string",
                     // technically should be `varchar(N)`
                     // where `N` is based on the max length of the strings in the column
                     // but that information isn't available here
@@ -1406,5 +1406,27 @@ mod tests {
         assert_eq!(convert_text_type(Postgres), "text");
         assert_eq!(convert_text_type(Snowflake), "text");
         assert_eq!(convert_text_type(Redshift), "text");
+    }
+
+    #[test]
+    fn test_convert_types_for_spark() {
+        // Regression test: seeds previously emitted PostgreSQL types (text,
+        // float8, timestamp without time zone) for Spark, which Spark SQL
+        // rejects at CREATE TABLE.
+        assert_eq!(convert_type(&DataType::Utf8, Spark), "string");
+        assert_eq!(convert_type(&DataType::Int32, Spark), "bigint");
+        assert_eq!(convert_type(&DataType::Int64, Spark), "bigint");
+        assert_eq!(convert_type(&DataType::Float64, Spark), "double");
+        assert_eq!(convert_type(&DataType::Float32, Spark), "float");
+        // decimals follow the Databricks coercion rules
+        assert_eq!(convert_type(&DataType::Decimal128(10, 2), Spark), "double");
+        assert_eq!(convert_type(&DataType::Decimal32(10, 0), Spark), "bigint");
+        // datetime -> timestamp (not "timestamp without time zone")
+        assert_eq!(
+            convert_type(&DataType::Timestamp(TimeUnit::Microsecond, None), Spark),
+            "timestamp"
+        );
+        assert_eq!(convert_type(&DataType::Boolean, Spark), "boolean");
+        assert_eq!(convert_type(&DataType::Date64, Spark), "date");
     }
 }

--- a/crates/dbt-adbc/src/spark.rs
+++ b/crates/dbt-adbc/src/spark.rs
@@ -22,6 +22,7 @@ pub mod auth_type {
     // Livy
     pub const BASIC: &str = "basic";
     pub const AWS_SIGV4: &str = "aws_sigv4";
+    pub const AZURE_TOKEN: &str = "azure_token";
 
     // Spark Connect
     pub const NONE: &str = "none";
@@ -44,6 +45,30 @@ pub mod livy {
     }
 
     pub const SESSION_TTL: &str = "spark.livy.session_ttl";
+
+    /// Path appended to the host to form the Livy endpoint base URL
+    /// (e.g. Microsoft Fabric's `/v1/workspaces/{id}/lakehouses/{id}/livyapi/versions/2023-12-01`).
+    pub const BASE_URL: &str = "spark.livy.base_url";
+
+    /// Microsoft Entra ID options for [`super::auth_type::AZURE_TOKEN`].
+    /// Credential parameters ride in the standard username/password options,
+    /// following the MSSQL driver's fedauth conventions: a service principal
+    /// is `username = "<client id>@<tenant id>"` with the client secret as
+    /// the password; a user-assigned managed identity's client ID is the
+    /// username.
+    pub mod azure {
+        pub const CREDENTIAL: &str = "spark.livy.azure.credential";
+        /// Credential kind names match the MSSQL driver's `fedauth` values.
+        pub mod credential {
+            pub const DEFAULT: &str = "ActiveDirectoryDefault";
+            pub const AZ_CLI: &str = "ActiveDirectoryAzCli";
+            pub const SERVICE_PRINCIPAL: &str = "ActiveDirectoryServicePrincipal";
+            pub const ENVIRONMENT: &str = "ActiveDirectoryEnvironment";
+            pub const MANAGED_IDENTITY: &str = "ActiveDirectoryManagedIdentity";
+        }
+
+        pub const TOKEN_SCOPE: &str = "spark.livy.azure.token_scope";
+    }
 
     pub mod aws {
         pub const REGION: &str = "spark.livy.aws.region";

--- a/crates/dbt-auth/src/spark/fabric.rs
+++ b/crates/dbt-auth/src/spark/fabric.rs
@@ -1,0 +1,384 @@
+//! Microsoft Fabric Lakehouse (Spark via the Fabric Livy API).
+//!
+//! This is a platform specialization of the Spark Livy transport: the driver
+//! options emitted here are the same `spark.*` options as [`super`], plus the
+//! `spark.livy.azure.*` Entra ID options and a Fabric-specific Livy base URL
+//! built from the workspace and lakehouse ids.
+//!
+//! Profile shape follows the v1 `dbt-fabricspark` adapter:
+//! `endpoint`, `workspaceid`, `lakehouseid`, `authentication: CLI|SPN`, ...
+
+use crate::{AdapterConfig, AuthError};
+use dbt_adbc::{database, spark};
+
+use std::collections::HashMap;
+
+const DEFAULT_ENDPOINT: &str = "https://api.fabric.microsoft.com/v1";
+const LIVY_API_VERSION: &str = "2023-12-01";
+
+/// Returns true when the config is shaped like a `fabricspark` profile.
+///
+/// Fabric Lakehouse profiles are identified by their required GUID fields,
+/// which no plain Spark profile has.
+pub(super) fn is_fabric_spark_config(config: &AdapterConfig) -> bool {
+    config.get_str("lakehouseid").is_some() || config.get_str("workspaceid").is_some()
+}
+
+#[derive(Debug)]
+enum AzureCredential<'a> {
+    /// The local Azure CLI (`az login`) context.
+    Cli,
+    /// The azidentity `DefaultAzureCredential` chain.
+    Default,
+    /// Credentials from `AZURE_*` environment variables only.
+    Environment,
+    /// An Azure managed identity; `client_id` selects a user-assigned identity.
+    ManagedIdentity { client_id: Option<&'a str> },
+    /// Service principal with a client secret (profile: `SPN`).
+    ClientSecret {
+        tenant_id: &'a str,
+        client_id: &'a str,
+        client_secret: &'a str,
+    },
+}
+
+#[derive(Debug)]
+pub(super) struct FabricSparkAuthIR<'a> {
+    endpoint: &'a str,
+    workspace_id: &'a str,
+    lakehouse_id: &'a str,
+    credential: AzureCredential<'a>,
+    token_scope: Option<&'a str>,
+    session_params: HashMap<&'a str, String>,
+}
+
+impl<'a> FabricSparkAuthIR<'a> {
+    pub(super) fn apply(
+        self,
+        mut builder: database::Builder,
+    ) -> Result<database::Builder, AuthError> {
+        builder.with_named_option(spark::TRANSPORT_API, spark::transport_api::LIVY)?;
+        builder.with_named_option(spark::livy::SESSION_KIND, spark::livy::session_kind::SQL)?;
+
+        // The endpoint ("https://api.fabric.microsoft.com/v1") is split into
+        // the host ("https://api.fabric.microsoft.com", scheme preserved so
+        // the driver uses TLS) and a path prefix ("/v1") that heads the Livy
+        // base URL. Owned strings are built here at the builder boundary.
+        let endpoint = self.endpoint.trim_end_matches('/');
+        let path_start = endpoint
+            .find("://")
+            .map(|scheme_end| scheme_end + "://".len())
+            .and_then(|authority_start| {
+                endpoint[authority_start..]
+                    .find('/')
+                    .map(|p| authority_start + p)
+            })
+            .unwrap_or(endpoint.len());
+        let (host, path_prefix) = endpoint.split_at(path_start);
+
+        builder.with_named_option(spark::HOST, host)?;
+        builder.with_named_option(
+            spark::livy::BASE_URL,
+            format!(
+                "{}/workspaces/{}/lakehouses/{}/livyapi/versions/{}",
+                path_prefix, self.workspace_id, self.lakehouse_id, LIVY_API_VERSION
+            ),
+        )?;
+
+        builder.with_named_option(spark::AUTH_TYPE, spark::auth_type::AZURE_TOKEN)?;
+        let credential = match self.credential {
+            AzureCredential::Cli => spark::livy::azure::credential::AZ_CLI,
+            AzureCredential::Default => spark::livy::azure::credential::DEFAULT,
+            AzureCredential::Environment => spark::livy::azure::credential::ENVIRONMENT,
+            // Credential parameters ride in username/password, following the
+            // MSSQL driver's fedauth conventions.
+            AzureCredential::ManagedIdentity { client_id } => {
+                if let Some(client_id) = client_id {
+                    builder.with_named_option(spark::USERNAME, client_id)?;
+                }
+                spark::livy::azure::credential::MANAGED_IDENTITY
+            }
+            AzureCredential::ClientSecret {
+                tenant_id,
+                client_id,
+                client_secret,
+            } => {
+                builder
+                    .with_named_option(spark::USERNAME, format!("{client_id}@{tenant_id}"))?;
+                builder.with_named_option(spark::PASSWORD, client_secret)?;
+                spark::livy::azure::credential::SERVICE_PRINCIPAL
+            }
+        };
+        builder.with_named_option(spark::livy::azure::CREDENTIAL, credential)?;
+
+        if let Some(scope) = self.token_scope {
+            builder.with_named_option(spark::livy::azure::TOKEN_SCOPE, scope)?;
+        }
+
+        super::apply_session_params(&self.session_params, &mut builder)?;
+
+        Ok(builder)
+    }
+}
+
+pub(super) fn parse_auth<'a>(
+    config: &'a AdapterConfig,
+) -> Result<FabricSparkAuthIR<'a>, AuthError> {
+    if let Some(method) = config.get_str("method")
+        && method != "livy"
+    {
+        return Err(AuthError::config(
+            "'method' must be 'livy' for Fabric Lakehouse (fabricspark) profiles",
+        ));
+    }
+
+    let workspace_id = config.get_str("workspaceid").ok_or_else(|| {
+        AuthError::config("'workspaceid' is a required fabricspark configuration")
+    })?;
+    let lakehouse_id = config.get_str("lakehouseid").ok_or_else(|| {
+        AuthError::config("'lakehouseid' is a required fabricspark configuration")
+    })?;
+
+    Ok(FabricSparkAuthIR {
+        endpoint: config.get_str("endpoint").unwrap_or(DEFAULT_ENDPOINT),
+        workspace_id,
+        lakehouse_id,
+        credential: parse_credential(config)?,
+        token_scope: config.get_str("token_scope"),
+        session_params: parse_session_params(config)?,
+    })
+}
+
+/// Parses `authentication` (v1 dbt-fabricspark used `CLI` and `SPN`; the
+/// remaining values map directly onto the driver's credential kinds).
+fn parse_credential<'a>(config: &'a AdapterConfig) -> Result<AzureCredential<'a>, AuthError> {
+    let Some(authentication) = config.get_str("authentication") else {
+        return Ok(AzureCredential::Cli);
+    };
+
+    if authentication.eq_ignore_ascii_case("cli") {
+        Ok(AzureCredential::Cli)
+    } else if authentication.eq_ignore_ascii_case("spn")
+        || authentication.eq_ignore_ascii_case("client_secret")
+    {
+        Ok(AzureCredential::ClientSecret {
+            tenant_id: require_spn_field(config, "tenant_id")?,
+            client_id: require_spn_field(config, "client_id")?,
+            client_secret: require_spn_field(config, "client_secret")?,
+        })
+    } else if authentication.eq_ignore_ascii_case("default") {
+        Ok(AzureCredential::Default)
+    } else if authentication.eq_ignore_ascii_case("environment") {
+        Ok(AzureCredential::Environment)
+    } else if authentication.eq_ignore_ascii_case("managed_identity") {
+        Ok(AzureCredential::ManagedIdentity {
+            client_id: config.get_str("client_id"),
+        })
+    } else {
+        Err(AuthError::config(
+            "invalid 'authentication' for fabricspark: must be one of \
+[CLI, SPN, default, environment, managed_identity]",
+        ))
+    }
+}
+
+fn require_spn_field<'a>(
+    config: &'a AdapterConfig,
+    field: &'static str,
+) -> Result<&'a str, AuthError> {
+    config.get_str(field).ok_or_else(|| {
+        AuthError::config(format!(
+            "'{field}' is required when authentication is 'SPN'"
+        ))
+    })
+}
+
+fn parse_session_params(config: &AdapterConfig) -> Result<HashMap<&str, String>, AuthError> {
+    let mut session_params = HashMap::new();
+    let Some(ssp) = config.get("server_side_parameters") else {
+        return Ok(session_params);
+    };
+    let super::YmlValue::Mapping(ssp, _) = ssp else {
+        return Err(AuthError::config(
+            "'server_side_parameters' must be mapping",
+        ));
+    };
+    for (key, value) in ssp {
+        let super::YmlValue::String(key, _) = key else {
+            return Err(AuthError::config(
+                "'server_side_parameters' key must be string",
+            ));
+        };
+        let value = match value {
+            super::YmlValue::String(v, _) => v.to_string(),
+            super::YmlValue::Number(v, _) => v.to_string(),
+            _ => {
+                return Err(AuthError::config(
+                    "'server_side_parameters' value must be string or number",
+                ));
+            }
+        };
+        session_params.insert(key.as_str(), value);
+    }
+    Ok(session_params)
+}
+
+pub(super) fn apply_connection_args(
+    _config: &AdapterConfig,
+    builder: database::Builder,
+) -> Result<database::Builder, AuthError> {
+    Ok(builder)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::SparkAuth;
+    use crate::test_options::other_option_value;
+    use crate::{AdapterConfig, Auth};
+    use dbt_adbc::spark;
+    use dbt_yaml::Mapping;
+
+    fn base_config() -> Mapping {
+        Mapping::from_iter([
+            ("workspaceid".into(), "ws-guid".into()),
+            ("lakehouseid".into(), "lh-guid".into()),
+            ("schema".into(), "dbo".into()),
+        ])
+    }
+
+    #[test]
+    fn fabric_defaults_to_cli_credential_and_fabric_endpoint() {
+        let builder = SparkAuth {}
+            .configure(&AdapterConfig::new(base_config()))
+            .expect("configure")
+            .builder;
+
+        assert_eq!(
+            other_option_value(&builder, spark::HOST),
+            Some("https://api.fabric.microsoft.com")
+        );
+        assert_eq!(
+            other_option_value(&builder, spark::livy::BASE_URL),
+            Some("/v1/workspaces/ws-guid/lakehouses/lh-guid/livyapi/versions/2023-12-01")
+        );
+        assert_eq!(
+            other_option_value(&builder, spark::AUTH_TYPE),
+            Some(spark::auth_type::AZURE_TOKEN)
+        );
+        assert_eq!(
+            other_option_value(&builder, spark::livy::azure::CREDENTIAL),
+            Some(spark::livy::azure::credential::AZ_CLI)
+        );
+        assert_eq!(
+            other_option_value(&builder, spark::TRANSPORT_API),
+            Some(spark::transport_api::LIVY)
+        );
+    }
+
+    #[test]
+    fn fabric_spn_credential() {
+        let mut config = base_config();
+        config.insert("authentication".into(), "SPN".into());
+        config.insert("tenant_id".into(), "tenant".into());
+        config.insert("client_id".into(), "client".into());
+        config.insert("client_secret".into(), "hunter2".into());
+
+        let builder = SparkAuth {}
+            .configure(&AdapterConfig::new(config))
+            .expect("configure")
+            .builder;
+
+        assert_eq!(
+            other_option_value(&builder, spark::livy::azure::CREDENTIAL),
+            Some(spark::livy::azure::credential::SERVICE_PRINCIPAL)
+        );
+        // SPN parameters ride in username/password (MSSQL fedauth form).
+        assert_eq!(
+            other_option_value(&builder, spark::USERNAME),
+            Some("client@tenant")
+        );
+        assert_eq!(
+            other_option_value(&builder, spark::PASSWORD),
+            Some("hunter2")
+        );
+    }
+
+    #[test]
+    fn fabric_spn_missing_secret_err() {
+        let mut config = base_config();
+        config.insert("authentication".into(), "SPN".into());
+        config.insert("tenant_id".into(), "tenant".into());
+        config.insert("client_id".into(), "client".into());
+
+        let err = SparkAuth {}
+            .configure(&AdapterConfig::new(config))
+            .expect_err("configure should fail");
+        assert!(err.msg().contains("client_secret"));
+    }
+
+    #[test]
+    fn fabric_missing_workspace_err() {
+        let config = Mapping::from_iter([("lakehouseid".into(), "lh-guid".into())]);
+        let err = SparkAuth {}
+            .configure(&AdapterConfig::new(config))
+            .expect_err("configure should fail");
+        assert!(err.msg().contains("workspaceid"));
+    }
+
+    #[test]
+    fn fabric_custom_endpoint_and_scope() {
+        let mut config = base_config();
+        config.insert(
+            "endpoint".into(),
+            "https://my.gateway.example.com/fabric/v1/".into(),
+        );
+        config.insert("token_scope".into(), "https://example.com/.default".into());
+
+        let builder = SparkAuth {}
+            .configure(&AdapterConfig::new(config))
+            .expect("configure")
+            .builder;
+
+        assert_eq!(
+            other_option_value(&builder, spark::HOST),
+            Some("https://my.gateway.example.com")
+        );
+        assert_eq!(
+            other_option_value(&builder, spark::livy::BASE_URL),
+            Some("/fabric/v1/workspaces/ws-guid/lakehouses/lh-guid/livyapi/versions/2023-12-01")
+        );
+        assert_eq!(
+            other_option_value(&builder, spark::livy::azure::TOKEN_SCOPE),
+            Some("https://example.com/.default")
+        );
+    }
+
+    #[test]
+    fn fabric_invalid_authentication_err() {
+        let mut config = base_config();
+        config.insert("authentication".into(), "carrier_pigeon".into());
+        let err = SparkAuth {}
+            .configure(&AdapterConfig::new(config))
+            .expect_err("configure should fail");
+        assert!(err.msg().contains("invalid 'authentication'"));
+    }
+
+    #[test]
+    fn plain_spark_profiles_are_not_routed_to_fabric() {
+        // A plain Spark thrift profile must keep working through the
+        // original Spark parsing path.
+        let config = Mapping::from_iter([
+            ("host".into(), "myhost".into()),
+            ("method".into(), "thrift".into()),
+            ("auth".into(), "NOSASL".into()),
+        ]);
+        let builder = SparkAuth {}
+            .configure(&AdapterConfig::new(config))
+            .expect("configure")
+            .builder;
+        assert_eq!(
+            other_option_value(&builder, spark::AUTH_TYPE),
+            Some(spark::auth_type::NOSASL)
+        );
+    }
+}

--- a/crates/dbt-auth/src/spark/mod.rs
+++ b/crates/dbt-auth/src/spark/mod.rs
@@ -1,5 +1,7 @@
 use crate::{AdapterConfig, Auth, AuthError, AuthOutcome, auth_configure_pipeline};
 use dbt_adbc::{Backend, database, spark};
+
+mod fabric;
 pub use dbt_yaml::Value as YmlValue;
 
 use std::collections::HashMap;
@@ -362,6 +364,17 @@ impl Auth for SparkAuth {
     }
 
     fn configure(&self, config: &AdapterConfig) -> Result<AuthOutcome, AuthError> {
+        // Microsoft Fabric Lakehouse targets are the "fabric" platform flavor
+        // of the spark adapter: identified by their required GUID fields and
+        // configured by the platform-specialized `fabric` module.
+        if fabric::is_fabric_spark_config(config) {
+            return auth_configure_pipeline!(
+                self.backend(),
+                &config,
+                fabric::parse_auth,
+                fabric::apply_connection_args
+            );
+        }
         auth_configure_pipeline!(self.backend(), &config, parse_auth, apply_connection_args)
     }
 }

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-spark/macros/adapters.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-spark/macros/adapters.sql
@@ -23,6 +23,10 @@
 -- funcsign: () -> string
 {% macro spark__file_format_clause() %}
   {%- set file_format = config.get('file_format', validator=validation.any[basestring]) -%}
+  {%- if file_format is none and target.get('lakehouseid') -%}
+    {#-- Fabric Lakehouse tables are Delta by default (v1 dbt-fabricspark parity). --#}
+    {%- set file_format = 'delta' -%}
+  {%- endif -%}
   {%- if file_format is not none %}
     using {{ file_format }}
   {%- endif %}
@@ -157,7 +161,12 @@
     {%- if temporary -%}
       {{ create_temporary_view(relation, compiled_code) }}
     {%- else -%}
-      {% if config.get('file_format', validator=validation.any[basestring]) in ['delta', 'iceberg'] %}
+      {%- set file_format = config.get('file_format', validator=validation.any[basestring]) -%}
+      {%- if file_format is none and target.get('lakehouseid') -%}
+        {#-- Fabric Lakehouse tables are Delta by default (v1 dbt-fabricspark parity). --#}
+        {%- set file_format = 'delta' -%}
+      {%- endif -%}
+      {% if file_format in ['delta', 'iceberg'] %}
         create or replace table {{ relation }}
       {% else %}
         create table {{ relation }}
@@ -276,13 +285,23 @@
   -- from ani, cc @gliga @xuliangs
 {% macro spark__create_schema(relation) -%}
   {%- call statement('create_schema') -%}
-    create schema if not exists {{relation.without_identifier()}}
+    {%- if target.get('lakehouseid') and not relation.database -%}
+      {#-- Classic Fabric lakehouses have no schemas: the lakehouse itself is
+          the namespace, so schema creation is a no-op. --#}
+      select 1
+    {%- else -%}
+      create schema if not exists {{relation.without_identifier()}}
+    {%- endif -%}
   {% endcall %}
 {% endmacro %}
 
 {% macro spark__drop_schema(relation) -%}
   {%- call statement('drop_schema') -%}
-    drop schema if exists {{ relation.without_identifier() }} cascade
+    {%- if target.get('lakehouseid') and not relation.database -%}
+      select 1
+    {%- else -%}
+      drop schema if exists {{ relation.without_identifier() }} cascade
+    {%- endif -%}
   {%- endcall -%}
 {% endmacro %}
 
@@ -377,7 +396,13 @@
 
 
 {% macro spark__generate_database_name(custom_database_name=none, node=none) -%}
-  {% do return(None) %}
+  {#-- Schema-enabled Fabric lakehouses put the lakehouse in the database slot
+      (3-part naming); plain Spark and classic lakehouses have no database. --#}
+  {%- if target.database -%}
+    {% do return(custom_database_name or target.database) %}
+  {%- else -%}
+    {% do return(None) %}
+  {%- endif -%}
 {%- endmacro %}
 
 {% macro spark__persist_docs(relation, model, for_relation, for_columns) -%}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-spark/macros/materializations/incremental/incremental.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-spark/macros/materializations/incremental/incremental.sql
@@ -1,6 +1,6 @@
 {% materialization incremental, adapter='spark', supported_languages=['sql', 'python'] -%}
   {#-- Validate early so we don't run SQL if the file_format + strategy combo is invalid --#}
-  {%- set raw_file_format = config.get('file_format', default='parquet') -%}
+  {%- set raw_file_format = config.get('file_format', default=('delta' if target.get('lakehouseid') else 'parquet')) -%}
   {%- set raw_strategy = config.get('incremental_strategy') or 'append' -%}
   {%- set grant_config = config.get('grants') -%}
 

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-spark/macros/materializations/snapshot.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-spark/macros/materializations/snapshot.sql
@@ -51,9 +51,10 @@
                                                     database=none,
                                                     type='view') -%}
     {% else %}
+      {#-- database carries through for 3-part naming (schema-enabled Fabric lakehouses) --#}
       {%- set tmp_relation = api.Relation.create(identifier=tmp_identifier,
                                                     schema=target_relation.schema,
-                                                    database=none,
+                                                    database=target_relation.database,
                                                     type='view') -%}
     {% endif %}
 
@@ -92,11 +93,11 @@
 
   {%- set strategy_name = config.get('strategy') -%}
   {%- set unique_key = config.get('unique_key') %}
-  {%- set file_format = config.get('file_format') or 'parquet' -%}
+  {%- set file_format = config.get('file_format') or ('delta' if target.get('lakehouseid') else 'parquet') -%}
   {%- set grant_config = config.get('grants') -%}
 
   {% set target_relation_exists, target_relation = get_or_create_relation(
-          database=none,
+          database=model.database,
           schema=model.schema,
           identifier=target_table,
           type='table') -%}

--- a/crates/dbt-loader/src/load_profiles.rs
+++ b/crates/dbt-loader/src/load_profiles.rs
@@ -90,8 +90,11 @@ pub fn load_profiles(
 
     let defer_to_target = profile_defer_to_target(&resolved.credentials);
 
+    let mut credentials = resolved.credentials;
+    rewrite_fabricspark_alias(&mut credentials);
+
     // Convert the rendered credentials mapping into a typed DbConfig
-    let credentials_value = dbt_yaml::Value::Mapping(resolved.credentials, Span::default());
+    let credentials_value = dbt_yaml::Value::Mapping(credentials, Span::default());
     let db_config: DbConfig = dbt_yaml::from_value(credentials_value).map_err(|e| {
         fs_err!(
             ErrorCode::InvalidConfig,
@@ -106,7 +109,8 @@ pub fn load_profiles(
 
     // Parse the optional alternate compute target output.
     let alt_target_db_config = match resolved.alt_target_credentials {
-        Some(credentials) => {
+        Some(mut credentials) => {
+            rewrite_fabricspark_alias(&mut credentials);
             let value = dbt_yaml::Value::Mapping(credentials, Span::default());
             let config: DbConfig = dbt_yaml::from_value(value).map_err(|e| {
                 fs_err!(
@@ -149,6 +153,23 @@ pub fn load_profiles(
         relative_profile_path,
         threads: arg.threads,
     })
+}
+
+/// `type: fabricspark` (the v1 dbt-fabricspark adapter's profile type) is an
+/// alias for the "fabric" platform flavor of the spark adapter: rewrite it to
+/// `type: spark` before typed parsing so v1 profiles work unchanged. The
+/// fabric fields themselves identify the target as a Fabric Lakehouse.
+fn rewrite_fabricspark_alias(credentials: &mut dbt_yaml::Mapping) {
+    let is_fabricspark = matches!(
+        credentials.get("type"),
+        Some(dbt_yaml::Value::String(t, _)) if t == "fabricspark"
+    );
+    if !is_fabricspark {
+        return;
+    }
+    if let Some(adapter_type) = credentials.get_mut("type") {
+        *adapter_type = dbt_yaml::Value::String("spark".to_string(), Span::default());
+    }
 }
 
 fn profile_defer_to_target(credentials: &dbt_yaml::Mapping) -> Option<String> {
@@ -201,6 +222,40 @@ mod tests {
             msg.contains("DBT_ALLOW_EXPERIMENTAL_ADAPTERS=true"),
             "expected env-var hint, got: {msg}"
         );
+    }
+
+    #[test]
+    fn fabricspark_type_is_rewritten_to_spark() {
+        let mut creds = dbt_yaml::Mapping::from_iter([
+            (
+                dbt_yaml::Value::String("type".to_string(), Span::default()),
+                dbt_yaml::Value::String("fabricspark".to_string(), Span::default()),
+            ),
+            (
+                dbt_yaml::Value::String("workspaceid".to_string(), Span::default()),
+                dbt_yaml::Value::String("00000000-0000-0000-0000-000000000000".to_string(), Span::default()),
+            ),
+        ]);
+        rewrite_fabricspark_alias(&mut creds);
+        assert!(matches!(
+            creds.get("type"),
+            Some(dbt_yaml::Value::String(t, _)) if t == "spark"
+        ));
+    }
+
+    #[test]
+    fn spark_and_other_types_are_untouched() {
+        for type_name in ["spark", "snowflake"] {
+            let mut creds = dbt_yaml::Mapping::from_iter([(
+                dbt_yaml::Value::String("type".to_string(), Span::default()),
+                dbt_yaml::Value::String(type_name.to_string(), Span::default()),
+            )]);
+            rewrite_fabricspark_alias(&mut creds);
+            assert!(matches!(
+                creds.get("type"),
+                Some(dbt_yaml::Value::String(t, _)) if t == type_name
+            ));
+        }
     }
 
     #[test]

--- a/crates/dbt-schemas/src/schemas/profiles.rs
+++ b/crates/dbt-schemas/src/schemas/profiles.rs
@@ -124,7 +124,9 @@ impl DbConfig {
             // DuckDB `path` is optional — attach-only profiles default to `:memory:`.
             DbConfig::DuckDB(config) => Some(config.path.as_deref().unwrap_or(":memory:")),
             DbConfig::Alt(config) => Some(config.path.as_deref().unwrap_or(":memory:")),
-            DbConfig::Spark(config) => config.host.as_deref(),
+            // Fabric Lakehouse targets may omit `host` (defaulted from the
+            // endpoint); the lakehouse GUID is the connection identity then.
+            DbConfig::Spark(config) => config.host.as_deref().or(config.lakehouseid.as_deref()),
             DbConfig::Fabric(config) => config.host.as_deref(),
             DbConfig::Exasol(config) => config.host.as_deref(),
             DbConfig::ClickHouse(config) => config.host.as_deref(),
@@ -255,8 +257,20 @@ impl DbConfig {
                 "attach",
                 "motherduck_token",
             ],
-            // TODO(serramatutu): Spark connection keys
-            DbConfig::Spark(_) => &[],
+            DbConfig::Spark(_) => &[
+                "method",
+                "host",
+                "port",
+                "schema",
+                "endpoint",
+                "workspaceid",
+                "lakehouse",
+                "lakehouseid",
+                "lakehouse_schemas",
+                "authentication",
+                "tenant_id",
+                "client_id",
+            ],
             // TODO: Trino and Datafusion connection keys
             DbConfig::Trino(_) => &[],
             DbConfig::Datafusion(_) => &[],
@@ -381,7 +395,7 @@ impl DbConfig {
             DbConfig::Databricks(config) => config.database.as_ref(),
             DbConfig::Salesforce(config) => config.database.as_ref(),
             DbConfig::DuckDB(config) => config.database.as_ref(),
-            DbConfig::Spark(_) => None,
+            DbConfig::Spark(config) => config.database(),
             DbConfig::Fabric(config) => config.database.as_ref(),
             DbConfig::Exasol(config) => config.database.as_ref(),
             DbConfig::ClickHouse(config) => config.database.as_ref(),
@@ -440,7 +454,7 @@ impl DbConfig {
             DbConfig::DuckDB(config) => config.threads.as_ref(),
             DbConfig::Datafusion(_) => None,
             DbConfig::Salesforce(_) => None,
-            DbConfig::Spark(_) => None,
+            DbConfig::Spark(config) => config.threads.as_ref(),
             DbConfig::Fabric(_) => None,
             DbConfig::Exasol(config) => config.threads.as_ref(),
             DbConfig::ClickHouse(config) => config.threads.as_ref(),
@@ -459,7 +473,7 @@ impl DbConfig {
             DbConfig::DuckDB(config) => config.threads = threads,
             DbConfig::Datafusion(_) => (),
             DbConfig::Salesforce(_) => (),
-            DbConfig::Spark(_) => (),
+            DbConfig::Spark(config) => config.threads = threads,
             DbConfig::Fabric(_) => (),
             DbConfig::Exasol(config) => config.threads = threads,
             DbConfig::ClickHouse(config) => config.threads = threads,
@@ -1174,6 +1188,40 @@ pub struct SparkDbConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[merge(strategy = merge_strategies_extend::overwrite_always)]
     pub server_side_parameters: Option<HashMap<String, YmlValue>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub threads: Option<StringOrInteger>,
+
+    // Microsoft Fabric Lakehouse ("fabric" platform flavor: Spark via the
+    // Fabric Livy API). Field names follow the v1 `dbt-fabricspark` adapter's
+    // profile shape; the GUID fields identify a target as Fabric.
+    /// Fabric API base endpoint. Defaults to `https://api.fabric.microsoft.com/v1`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub endpoint: Option<String>,
+    /// GUID of the Fabric workspace.
+    #[serde(skip_serializing_if = "Option::is_none", alias = "workspace_id")]
+    pub workspaceid: Option<String>,
+    /// Display name of the lakehouse.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lakehouse: Option<String>,
+    /// GUID of the lakehouse.
+    #[serde(skip_serializing_if = "Option::is_none", alias = "lakehouse_id")]
+    pub lakehouseid: Option<String>,
+    /// Schema-enabled lakehouse: the lakehouse becomes the database and
+    /// relations are 3-part `lakehouse.schema.table`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lakehouse_schemas: Option<bool>,
+    /// Entra ID credential selection: `CLI` (default) | `SPN` | `default` |
+    /// `environment` | `managed_identity`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authentication: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tenant_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_secret: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub token_scope: Option<String>,
     // TODO: python supports some extra properties:
     // - cluster
     // - connect_retries
@@ -1181,13 +1229,30 @@ pub struct SparkDbConfig {
     // - connection_string_suffix
     // - database (same as schema)
     // - driver
-    // - endpoint
     // - organization
     // - poll_interval
     // - query_retries
     // - query_timeout
     // - retry_all
     // - token
+}
+
+impl SparkDbConfig {
+    /// True when the target is a Microsoft Fabric Lakehouse (the "fabric"
+    /// platform flavor), identified by its GUID fields.
+    pub fn is_fabric(&self) -> bool {
+        self.workspaceid.is_some() || self.lakehouseid.is_some()
+    }
+
+    /// Schema-enabled lakehouses put the lakehouse in the database slot
+    /// (3-part naming); classic lakehouses and plain Spark have no database.
+    pub fn database(&self) -> Option<&String> {
+        if self.lakehouse_schemas == Some(true) {
+            self.lakehouse.as_ref()
+        } else {
+            None
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, DbtSchema, Merge)]
@@ -1676,6 +1741,22 @@ pub struct SparkTargetEnv {
     pub auth: SparkAuth,
     pub use_ssl: bool,
     pub kerberos_service_name: String,
+
+    // Microsoft Fabric Lakehouse fields (the "fabric" platform flavor);
+    // absent for plain Spark targets. Exposed so macros can branch on
+    // `target.lakehouseid` and for parity with the v1 dbt-fabricspark target.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub endpoint: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workspaceid: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lakehouse: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lakehouseid: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lakehouse_schemas: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authentication: Option<String>,
 }
 
 #[derive(Serialize, DbtSchema)]
@@ -2069,24 +2150,48 @@ impl TryFrom<DbConfig> for TargetContext {
                 }))
             }
 
-            DbConfig::Spark(config) => Ok(TargetContext::Spark(SparkTargetEnv {
-                method: config.method.ok_or_else(|| missing("method"))?,
-                host: config.host.ok_or_else(|| missing("host"))?,
-                port: config.port.unwrap_or(10000),
-                user: config.user.unwrap_or_default(),
-                password: config.password.unwrap_or_default(),
+            DbConfig::Spark(config) => {
+                // Fabric Lakehouse targets (the "fabric" platform flavor)
+                // default to the Livy method and the Fabric API host; the
+                // schema-enabled lakehouse occupies the database slot.
+                let is_fabric = config.is_fabric();
+                let database = config.database().cloned().unwrap_or_default();
+                let method = match config.method {
+                    Some(method) => method,
+                    None if is_fabric => SparkMethod::Livy,
+                    None => return Err(missing("method")),
+                };
+                let host = match config.host {
+                    Some(host) => host,
+                    None if is_fabric => "api.fabric.microsoft.com".to_string(),
+                    None => return Err(missing("host")),
+                };
+                Ok(TargetContext::Spark(SparkTargetEnv {
+                    method,
+                    host,
+                    port: config.port.unwrap_or(10000),
+                    user: config.user.unwrap_or_default(),
+                    password: config.password.unwrap_or_default(),
 
-                kerberos_service_name: config.kerberos_service_name.unwrap_or_default(),
-                use_ssl: config.use_ssl.unwrap_or(false),
-                auth: config.auth.unwrap_or_default(),
+                    kerberos_service_name: config.kerberos_service_name.unwrap_or_default(),
+                    use_ssl: config.use_ssl.unwrap_or(false),
+                    auth: config.auth.unwrap_or_default(),
 
-                __common__: CommonTargetContext {
-                    database: "".to_string(),
-                    schema: config.schema.ok_or_else(|| missing("schema"))?,
-                    type_: adapter_type,
-                    threads: None,
-                },
-            })),
+                    endpoint: config.endpoint,
+                    workspaceid: config.workspaceid,
+                    lakehouse: config.lakehouse,
+                    lakehouseid: config.lakehouseid,
+                    lakehouse_schemas: config.lakehouse_schemas,
+                    authentication: config.authentication,
+
+                    __common__: CommonTargetContext {
+                        database,
+                        schema: config.schema.ok_or_else(|| missing("schema"))?,
+                        type_: adapter_type,
+                        threads: None,
+                    },
+                }))
+            }
             DbConfig::Fabric(config) => {
                 let common = CommonTargetContext {
                     database: config.database.ok_or_else(|| missing("database"))?,

--- a/crates/dbt-schemas/src/schemas/profiles.rs
+++ b/crates/dbt-schemas/src/schemas/profiles.rs
@@ -1884,6 +1884,53 @@ impl<'a> DuckDBPathInfo<'a> {
     }
 }
 
+/// Builds the target context for a `spark` profile. Microsoft Fabric Lakehouse
+/// targets (the "fabric" platform flavor, identified by their GUID fields)
+/// default the method to Livy and the host to the Fabric API endpoint, and a
+/// schema-enabled lakehouse occupies the database slot.
+fn spark_target_context(
+    config: SparkDbConfig,
+    adapter_type: String,
+) -> Result<TargetContext, String> {
+    let is_fabric = config.is_fabric();
+    let database = config.database().cloned().unwrap_or_default();
+    let method = match config.method {
+        Some(method) => method,
+        None if is_fabric => SparkMethod::Livy,
+        None => return Err(missing("method")),
+    };
+    let host = match config.host {
+        Some(host) => host,
+        None if is_fabric => "api.fabric.microsoft.com".to_string(),
+        None => return Err(missing("host")),
+    };
+    Ok(TargetContext::Spark(SparkTargetEnv {
+        method,
+        host,
+        port: config.port.unwrap_or(10000),
+        user: config.user.unwrap_or_default(),
+        password: config.password.unwrap_or_default(),
+
+        kerberos_service_name: config.kerberos_service_name.unwrap_or_default(),
+        use_ssl: config.use_ssl.unwrap_or(false),
+        auth: config.auth.unwrap_or_default(),
+
+        endpoint: config.endpoint,
+        workspaceid: config.workspaceid,
+        lakehouse: config.lakehouse,
+        lakehouseid: config.lakehouseid,
+        lakehouse_schemas: config.lakehouse_schemas,
+        authentication: config.authentication,
+
+        __common__: CommonTargetContext {
+            database,
+            schema: config.schema.ok_or_else(|| missing("schema"))?,
+            type_: adapter_type,
+            threads: None,
+        },
+    }))
+}
+
 fn missing(field: &str) -> String {
     format!("In file `profiles.yml`, field `{field}` is required.")
 }
@@ -2150,48 +2197,7 @@ impl TryFrom<DbConfig> for TargetContext {
                 }))
             }
 
-            DbConfig::Spark(config) => {
-                // Fabric Lakehouse targets (the "fabric" platform flavor)
-                // default to the Livy method and the Fabric API host; the
-                // schema-enabled lakehouse occupies the database slot.
-                let is_fabric = config.is_fabric();
-                let database = config.database().cloned().unwrap_or_default();
-                let method = match config.method {
-                    Some(method) => method,
-                    None if is_fabric => SparkMethod::Livy,
-                    None => return Err(missing("method")),
-                };
-                let host = match config.host {
-                    Some(host) => host,
-                    None if is_fabric => "api.fabric.microsoft.com".to_string(),
-                    None => return Err(missing("host")),
-                };
-                Ok(TargetContext::Spark(SparkTargetEnv {
-                    method,
-                    host,
-                    port: config.port.unwrap_or(10000),
-                    user: config.user.unwrap_or_default(),
-                    password: config.password.unwrap_or_default(),
-
-                    kerberos_service_name: config.kerberos_service_name.unwrap_or_default(),
-                    use_ssl: config.use_ssl.unwrap_or(false),
-                    auth: config.auth.unwrap_or_default(),
-
-                    endpoint: config.endpoint,
-                    workspaceid: config.workspaceid,
-                    lakehouse: config.lakehouse,
-                    lakehouseid: config.lakehouseid,
-                    lakehouse_schemas: config.lakehouse_schemas,
-                    authentication: config.authentication,
-
-                    __common__: CommonTargetContext {
-                        database,
-                        schema: config.schema.ok_or_else(|| missing("schema"))?,
-                        type_: adapter_type,
-                        threads: None,
-                    },
-                }))
-            }
+            DbConfig::Spark(config) => spark_target_context(*config, adapter_type),
             DbConfig::Fabric(config) => {
                 let common = CommonTargetContext {
                     database: config.database.ok_or_else(|| missing("database"))?,


### PR DESCRIPTION
## Summary

Adds Microsoft Fabric Lakehouse support as a **platform flavor of the `spark` adapter**, following the `platform_hint` precedent already used for AWS EMR. There is no new adapter type: Fabric targets are `type: spark` profiles carrying the Fabric workspace and lakehouse ids, which route to a platform-specialized module inside `SparkAuth`. Connection is over the [Fabric Livy API](https://learn.microsoft.com/fabric/data-engineering/api-livy-overview) with Microsoft Entra ID auth.

This replaces the earlier version of this PR, which added a separate `fabricspark` adapter type, after @hope-wat suggested verticalizing into the spark flavor instead. The result is a considerably smaller change (14 files rather than 33) and Fabric projects inherit the spark adapter's static analysis support. The separate-type version is preserved on [`fabricspark-adapter-separate-type`](https://github.com/arkin-nz/dbt-core/tree/fabricspark-adapter-separate-type) if that shape turns out to be preferred.

Companion driver PR (required for the connection to work): adbc-drivers/spark#78, which adds Fabric support to the Livy transport (Entra credentials, Fabric Livy protocol compatibility).

## Profile

Field names follow Microsoft's v1 `dbt-fabricspark` adapter, so existing v1 profiles work unchanged:

```yaml
my_profile:
  target: dev
  outputs:
    dev:
      type: spark
      workspaceid: <workspace guid>
      lakehouse: <lakehouse name>
      lakehouseid: <lakehouse guid>
      schema: <schema>
      authentication: CLI   # or SPN (+ tenant_id/client_id/client_secret),
                            # environment, managed_identity, default
      lakehouse_schemas: true   # opt-in for schema-enabled lakehouses
```

`method` defaults to `livy` and `host` to the Fabric API endpoint for these targets. `type: fabricspark` is accepted as an alias and rewritten to `type: spark` at profile load, so profiles written for the v1 adapter keep working.

Both Fabric lakehouse flavours are supported:

- **Classic** lakehouses keep Spark's 2-part naming (`schema` is the lakehouse name).
- **Schema-enabled** lakehouses (`lakehouse_schemas: true`) use 3-part `lakehouse.schema.table` naming, Unity-Catalog-style, with the lakehouse in dbt's database slot.

## What's in the change (by commit)

1. **Auth** (`dbt-auth`, `dbt-adbc`) — a platform-specialized `spark::fabric` module, reached when a spark profile carries the Fabric GUID fields. Credential kind names and parameters match the MSSQL driver's `fedauth` conventions: a service principal rides in the username as `<client id>@<tenant id>` with the client secret as the password. Follows the crate's borrowed-data conventions; no existing enums, accessors, or accepted input shapes modified; a regression test pins plain-Spark profiles to the original path.
2. **Profiles** (`dbt-schemas`, `dbt-loader`) — Fabric fields fold into `SparkDbConfig`, with `method`/`host` defaults and lakehouse-as-database for schema-enabled targets. `threads` is now honored for spark profiles (it was silently ignored). The `type: fabricspark` alias is rewritten at load.
3. **Metadata and relations** (`dbt-adapter`) — `list_relations` for Spark now uses `SHOW TABLE EXTENDED`, and `DESCRIBE`/catalog fqns include the database when set.
4. **Macros** (`dbt-spark` package) — database name resolution for 3-part naming, schema create/drop as no-ops on classic lakehouses (where the lakehouse is itself the namespace), `file_format` defaulting to delta on Fabric targets, and snapshot relations carrying the database through.

## Two fixes that benefit the existing `spark` adapter

Both are independent of Fabric and are separated in the commits above:

- **`list_relations`** previously went through the Databricks path, which queries `system.information_schema`. That is a Unity Catalog feature, so it was silently broken on plain Spark. `SHOW TABLE EXTENDED` exists on every Spark backend.
- **Seed types**: the seed type conversion had no Spark arms, so seeds emitted PostgreSQL types (`text`, `float8`, `timestamp without time zone`) that Spark SQL rejects at `CREATE TABLE`. Spark now maps alongside Databricks (`string`, `bigint`, `double`, `timestamp`).

## Verification (live Fabric tenant)

- **jaffle-shop: 28/28** (3 seeds, 5 models, 20 tests) on **both** classic and schema-enabled lakehouses, including through the `type: fabricspark` alias.
- Materializations verified: seeds, views, tables, incremental (append, merge with unique_key, `--full-refresh`), snapshots (timestamp strategy, SCD2 valid_from/valid_to).
- Idempotent re-runs; schema auto-creation on schema-enabled lakehouses.
- Auth via Azure CLI verified live. SPN, environment and managed identity are unit-tested; live coverage welcome in warehouse validation.
- `cargo fmt` and `cargo clippy` clean on all touched crates; unit tests added for fabric auth parsing, the profile alias, `SHOW TABLE EXTENDED` parsing, and Spark seed types.

## Notes for reviewers

- Python models are not supported (matches v1).
- Since these targets are `type: spark`, static analysis applies to them without any adapter-list change.
- Happy to restructure commits, rename things, or move to the separate-type shape, whatever suits the team. Also coordinating with the Microsoft `dbt-fabricspark` maintainer on v1/v2 parity.

## Sequencing / driver dependency

This requires the companion driver change (adbc-drivers/spark#78) to be present in the Spark driver binary that dbt installs. As written, `SPARK_DRIVER_VERSION` still pins the current CDN release, so the correct landing order is:

1. Merge adbc-drivers/spark#78
2. Publish a new Spark driver build to the dbt CDN (dbt Labs)
3. Add the new version to the driver manifest/checksums and bump `SPARK_DRIVER_VERSION` (happy to push that commit here once the artifact exists)
4. Re-run adapter validation against the distributed binary

Until then this PR is intentionally stacked on #78, flagging explicitly so it isn't merged ahead of the driver release.
