### PR TITLE
fix: allow databricks query_tags config without deprecation warning (#15291)

### DIFF
--- a/.changes/unreleased/Fixes-20260716-204146.yaml
+++ b/.changes/unreleased/Fixes-20260716-204146.yaml
@@ -1,0 +1,8 @@
+kind: Fixes
+body: Stop firing a false-positive `CustomKeyInConfigDeprecation` warning for the
+  Databricks-specific `query_tags` model config, matching the existing allowance
+  for BigQuery's `dataset`/`project` aliases
+time: 2026-07-16T20:41:46.000000000Z
+custom:
+    Author: zerafachris
+    Issue: "15291"

--- a/core/dbt/jsonschemas/jsonschemas.py
+++ b/core/dbt/jsonschemas/jsonschemas.py
@@ -39,6 +39,7 @@ _HIERARCHICAL_CONFIG_KEYS = {
 
 _ADAPTER_TO_CONFIG_ALIASES = {
     "bigquery": ["dataset", "project"],
+    "databricks": ["query_tags"],
 }
 
 

--- a/tests/unit/test_jsonschemas.py
+++ b/tests/unit/test_jsonschemas.py
@@ -9,6 +9,7 @@ from dbt.deprecations import (
 )
 from dbt.jsonschemas.jsonschemas import (
     jsonschema_validate,
+    project_schema,
     resources_schema,
     validate_model_config,
 )
@@ -166,3 +167,44 @@ class TestSourceBigQueryAliases:
 
         jsonschema_validate(resources_schema(), source_with_dataset, "test.yml")
         assert active_deprecations == {"custom-key-in-object-deprecation": 1}
+
+
+class TestDatabricksConfigAliases:
+    """https://github.com/dbt-labs/dbt-core/issues/15291
+
+    Databricks-specific config keys set in dbt_project.yml (e.g. `query_tags`)
+    should not trigger the `custom-key-in-config-deprecation` warning, the same
+    way BigQuery's `dataset`/`project` aliases are exempted.
+    """
+
+    @pytest.fixture(scope="class")
+    def project_dict_with_query_tags(self):
+        return {
+            "name": "my_proj",
+            "version": "1.0",
+            "profile": "default",
+            "models": {
+                "my_proj": {
+                    "+query_tags": ["team:data"],
+                },
+            },
+        }
+
+    def test_databricks_query_tags_no_warning(self, project_dict_with_query_tags):
+        reset_deprecations()
+
+        safe_set_invocation_context()
+        get_invocation_context().uses_adapter("databricks")
+
+        jsonschema_validate(project_schema(), project_dict_with_query_tags, "dbt_project.yml")
+        assert active_deprecations == {}
+
+    def test_snowflake_query_tags_warns(self, project_dict_with_query_tags):
+        reset_deprecations()
+
+        safe_set_invocation_context()
+        # Set to adapter that doesn't support the `query_tags` alias
+        get_invocation_context().uses_adapter("snowflake")
+
+        jsonschema_validate(project_schema(), project_dict_with_query_tags, "dbt_project.yml")
+        assert active_deprecations == {"custom-key-in-config-deprecation": 1}


### PR DESCRIPTION
Fixes #15291

`_ADAPTER_TO_CONFIG_ALIASES` only listed BigQuery's `dataset`/`project` aliases, so the Databricks-specific `query_tags` model config (a legitimate, documented Databricks adapter config) was flagged by `CustomKeyInConfigDeprecation` even though it isn't actually a custom/unknown key.

What changed: added `"databricks": ["query_tags"]` to `_ADAPTER_TO_CONFIG_ALIASES` in `core/dbt/jsonschemas/jsonschemas.py`, mirroring the existing BigQuery entry, so the false-positive warning is suppressed for Databricks projects while still firing correctly for adapters that don't support this key.

Test evidence: added `TestDatabricksConfigAliases` in `tests/unit/test_jsonschemas.py`. Before the fix, `test_databricks_query_tags_no_warning` failed with `active_deprecations == {'custom-key-in-config-deprecation': 1}` instead of `{}`; after the fix it passes, and a companion test confirms Snowflake (unsupported adapter) still gets the warning. Full unit suite: 2084 passed, 10 skipped.

Note: targeting `1.latest` rather than `main`, since `main` now hosts the Rust ("Fusion") rewrite with no Python dbt-core code — this is where current Python-era PRs are merged.

Prepared with AI assistance (Claude, agent: claude-sonnet-5), reviewed for correctness before submission.