### PR TITLE
fix(dbt-profile): preserve rendered profile strings

### DIFF
--- a/.changes/unreleased/Fixes-20260719-profile-jinja-string-rendering.yaml
+++ b/.changes/unreleased/Fixes-20260719-profile-jinja-string-rendering.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Preserve string types when rendering Jinja in profiles.yml while retaining native types for whole expressions.
+time: 2026-07-19T02:00:00.000000+09:00
+custom:
+    author: BOKJUNSOO
+    issue: "15596"
+    project: dbt-core

--- a/crates/dbt-profile/src/resolve.rs
+++ b/crates/dbt-profile/src/resolve.rs
@@ -406,26 +406,39 @@ fn render_value_recursive<S: Serialize>(
     match value {
         dbt_yaml::Value::String(s, span) => {
             let has_jinja = s.contains("{{") || s.contains("{%");
-            let rendered = if has_jinja {
-                env.render_str(s, ctx, listeners)
-                    .map_err(ProfileError::Jinja)?
-            } else {
-                s.clone()
-            };
-            let resolved = render_secrets(&rendered)?;
-            if !has_jinja && resolved == rendered {
-                Ok(value.clone())
-            } else {
-                match dbt_yaml::from_str::<dbt_yaml::Value>(&resolved) {
-                    Ok(parsed) => match &parsed {
-                        dbt_yaml::Value::String(_, _) => {
-                            Ok(dbt_yaml::Value::String(resolved, span.clone()))
-                        }
-                        _ => Ok(parsed),
-                    },
-                    Err(_) => Ok(dbt_yaml::Value::String(resolved, span.clone())),
-                }
+            if !has_jinja {
+                return Ok(value.clone());
             }
+
+            if is_single_jinja_expression(s) {
+                let expression = env
+                    .compile_expression(&s[2..s.len() - 2])
+                    .map_err(ProfileError::Jinja)?;
+                let evaluated = expression
+                    .eval(ctx, listeners)
+                    .map_err(ProfileError::Jinja)?;
+                let rendered = dbt_yaml::to_value(evaluated).map_err(|error| {
+                    ProfileError::Other(format!(
+                        "failed to convert rendered profile value to YAML: {error}"
+                    ))
+                })?;
+
+                return match rendered {
+                    dbt_yaml::Value::String(rendered, _) => Ok(dbt_yaml::Value::String(
+                        render_secrets(&rendered)?,
+                        span.clone(),
+                    )),
+                    _ => Ok(rendered.with_span(span.clone())),
+                };
+            }
+
+            let rendered = env
+                .render_str(s, ctx, listeners)
+                .map_err(ProfileError::Jinja)?;
+            Ok(dbt_yaml::Value::String(
+                render_secrets(&rendered)?,
+                span.clone(),
+            ))
         }
         dbt_yaml::Value::Mapping(map, span) => {
             let mut new_map = dbt_yaml::Mapping::new();
@@ -443,6 +456,35 @@ fn render_value_recursive<S: Serialize>(
         }
         _ => Ok(value.clone()),
     }
+}
+
+/// Return whether `input` consists of exactly one Jinja expression.
+///
+/// Whole expressions are evaluated natively so explicit filters such as
+/// `as_number` keep their type. Mixed templates are rendered as strings,
+/// matching dbt's profile renderer and avoiding accidental YAML coercion.
+fn is_single_jinja_expression(input: &str) -> bool {
+    let Some(body) = input
+        .strip_prefix("{{")
+        .and_then(|input| input.strip_suffix("}}"))
+    else {
+        return false;
+    };
+
+    if body.starts_with('-') {
+        return false;
+    }
+    if body.ends_with('-') {
+        return false;
+    }
+    if body.ends_with('}') {
+        return false;
+    }
+
+    const NESTED_DELIMITERS: [&str; 6] = ["{{", "}}", "{%", "%}", "{#", "#}"];
+    !NESTED_DELIMITERS
+        .iter()
+        .any(|delimiter| body.contains(delimiter))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/dbt-profile/tests/resolve_test.rs
+++ b/crates/dbt-profile/tests/resolve_test.rs
@@ -384,13 +384,86 @@ proj:
 
     let result = resolve(&args).unwrap();
     let port = result.credentials.get("port").unwrap();
-    // The rendered value should be parsed back as a number
-    assert!(
-        port.as_i64().is_some() || (port.as_str() == Some("5432")),
-        "port should be a number or '5432', got: {port:?}"
-    );
+    assert_eq!(port.as_i64(), Some(5432));
 
     unsafe { std::env::remove_var("DBT_PROFILE_TEST_PORT2") };
+}
+
+#[test]
+fn test_numeric_env_var_without_filter_remains_a_string() {
+    let tmp = tempfile::tempdir().unwrap();
+    let profiles_dir = tmp.path();
+
+    unsafe { std::env::set_var("DBT_PROFILE_TEST_ACCOUNT_ID", "5432") };
+
+    write_file(
+        profiles_dir,
+        "profiles.yml",
+        r#"
+proj:
+  target: dev
+  outputs:
+    dev:
+      type: snowflake
+      account: "{{ env_var('DBT_PROFILE_TEST_ACCOUNT_ID') }}"
+"#,
+    );
+
+    let args = ResolveArgs {
+        profiles_dir: Some(profiles_dir.to_path_buf()),
+        profile: Some("proj".to_owned()),
+        ..Default::default()
+    };
+
+    let result = resolve(&args).unwrap();
+    assert_eq!(result.get_str("account"), Some("5432"));
+
+    unsafe { std::env::remove_var("DBT_PROFILE_TEST_ACCOUNT_ID") };
+}
+
+#[test]
+fn test_rendered_connection_string_remains_a_string() {
+    let tmp = tempfile::tempdir().unwrap();
+    let profiles_dir = tmp.path();
+
+    unsafe { std::env::set_var("DBT_PROFILE_TEST_HOST", "db.example") };
+
+    write_file(
+        profiles_dir,
+        "profiles.yml",
+        r#"
+proj:
+  target: dev
+  outputs:
+    dev:
+      type: duckdb
+      path: ":memory:"
+      attach:
+        - path: "ducklake:postgres: host={{ env_var('DBT_PROFILE_TEST_HOST') }} port=5432"
+          alias: lake
+"#,
+    );
+
+    let args = ResolveArgs {
+        profiles_dir: Some(profiles_dir.to_path_buf()),
+        profile: Some("proj".to_owned()),
+        ..Default::default()
+    };
+
+    let result = resolve(&args).unwrap();
+    let attach = result
+        .credentials
+        .get("attach")
+        .and_then(|value| value.as_sequence())
+        .expect("attach should be a sequence");
+    let path = attach[0]
+        .as_mapping()
+        .and_then(|attachment| attachment.get("path"))
+        .and_then(|value| value.as_str());
+
+    assert_eq!(path, Some("ducklake:postgres: host=db.example port=5432"));
+
+    unsafe { std::env::remove_var("DBT_PROFILE_TEST_HOST") };
 }
 
 #[test]


### PR DESCRIPTION
Resolves #15596

### Problem

The Rust `dbt-profile` renderer reparses every Jinja-rendered string as a standalone YAML document. That changes the type of valid profile strings when their rendered value happens to use YAML syntax.

For example, this dbt-duckdb attachment path:

```yaml
path: "ducklake:postgres: host={{ env_var('DB_HOST') }} port=5432"
```

renders to a string containing `: `, then gets coerced into a YAML mapping. Profile loading subsequently fails with `attach[0].path: invalid type: map, expected a string`.

The same coercion also turns an exact `env_var` result such as `"5432"` into a number even when the profile does not use `as_number`.

### Solution

Split profile rendering along the same boundary already used by `dbt-jinja-utils`:

- evaluate a value natively only when it consists of one complete Jinja expression
- render mixed literal/Jinja templates directly to strings without reparsing them as YAML
- retain secret placeholder resolution and source spans in both paths

This preserves connection strings and unfiltered environment variables while continuing to return a number for explicit expressions such as `{{ env_var('PORT') | as_number }}`.

Regression coverage verifies the DuckLake/Postgres attachment case, numeric environment variables without a filter, and explicit `as_number` typing.

### Validation

- `cargo fmt --package dbt-profile`
- `cargo test -p dbt-profile` (18 passed)
- `cargo clippy -p dbt-profile --tests -- -D warnings`
- `git diff --check`

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes type annotations for new and modified functions.
