### PR TITLE
fix: tags config inheritance appends parent-then-child without dedup/sort, matching dbt-core

### DIFF
--- a/.changes/unreleased/Fixes-20260718-211500.yaml
+++ b/.changes/unreleased/Fixes-20260718-211500.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: 'Fix `tags` config inheritance appending parent and child tags in the wrong order and incorrectly deduplicating/sorting them, causing Fusion to diverge from dbt Core on which tag comes first (and therefore on schema naming) for nested `+tags` config'
+time: 2026-07-18T21:15:00.000000+00:00
+custom:
+    author: DipakMandlik
+    issue: "15590"
+    project: dbt-fusion

--- a/crates/dbt-parser/src/resolve/resolve_sources.rs
+++ b/crates/dbt-parser/src/resolve/resolve_sources.rs
@@ -16,7 +16,7 @@ use dbt_jinja_utils::serde::{Omissible, into_typed_with_jinja};
 use dbt_jinja_utils::utils::generate_relation_name;
 use dbt_schemas::schemas::common::{
     DbtChecksum, DbtMaterialization, DbtQuoting, FreshnessDefinition, FreshnessRules,
-    NodeDependsOn, merge_meta, merge_vec, normalize_quoting,
+    NodeDependsOn, append_vec, merge_meta, normalize_quoting,
 };
 use dbt_schemas::schemas::dbt_column::process_columns;
 use dbt_schemas::schemas::project::SourceConfig;
@@ -352,10 +352,12 @@ pub async fn resolve_sources(
                     .formatter
                     .clone()
                     .or_else(|| c.formatter.clone());
+                // Append, don't dedup/sort: matches dbt-core's `MergeBehavior.Append`
+                // for the `tags` field (see `dbt_schemas::schemas::common::append_vec`).
                 let source_tags: Option<Vec<String>> = c.tags.take().map(|t| t.into());
                 let table_tags: Option<Vec<String>> = table_config.tags.clone().map(|t| t.into());
                 c.tags =
-                    merge_vec(source_tags, table_tags).map(StringOrArrayOfStrings::ArrayOfStrings);
+                    append_vec(source_tags, table_tags).map(StringOrArrayOfStrings::ArrayOfStrings);
                 c.meta = merge_meta(c.meta.take(), table_config.meta.clone());
                 let merged = merge_loaded_at_pair(
                     c.loaded_at_field.as_deref(),

--- a/crates/dbt-schemas/src/schemas/common.rs
+++ b/crates/dbt-schemas/src/schemas/common.rs
@@ -1581,33 +1581,6 @@ pub fn merge_meta(
     }
 }
 
-/// Merge two lists into a deduplicated, sorted union. Used for fields like
-/// classifiers where set-like union semantics are wanted.
-///
-/// Do *not* use this for `tags`: dbt-core's `MergeBehavior.Append` (the
-/// merge behavior the `tags` field actually declares in `dbt_common`) is a
-/// plain, order-preserving, non-deduplicating concatenation. Use
-/// [`append_vec`] for that.
-pub fn merge_vec(
-    base_vec: Option<Vec<String>>,
-    update_vec: Option<Vec<String>>,
-) -> Option<Vec<String>> {
-    match (base_vec, update_vec) {
-        // If both are None, result is None
-        (None, None) => None,
-        // If either has a value (even empty), we preserve that semantic meaning
-        (Some(mut base), Some(update)) => {
-            base.extend(update);
-            base.sort();
-            base.dedup();
-            Some(base)
-        }
-        // If only one side has a value, use it
-        (Some(base), None) => Some(base),
-        (None, Some(update)) => Some(update),
-    }
-}
-
 /// Append `update_vec` after `base_vec`, preserving declaration order and
 /// duplicates. Matches dbt-core's `MergeBehavior.Append` semantics (plain
 /// concatenation: `self_value + other_value`, no dedup, no sort) used for
@@ -1627,6 +1600,29 @@ pub fn append_vec(
         (Some(base), None) => Some(base),
         (None, Some(update)) => Some(update),
     }
+}
+
+/// Merge two lists into a deduplicated, sorted union. Used for fields like
+/// classifiers where set-like union semantics are wanted.
+///
+/// Do *not* use this for `tags`: dbt-core's `MergeBehavior.Append` (the
+/// merge behavior the `tags` field actually declares in `dbt_common`) is a
+/// plain, order-preserving, non-deduplicating concatenation. Use
+/// [`append_vec`] for that.
+pub fn merge_vec(
+    base_vec: Option<Vec<String>>,
+    update_vec: Option<Vec<String>>,
+) -> Option<Vec<String>> {
+    // Only sort/dedup when both sides actually contributed values, matching
+    // this function's original behavior: a single-sided result is returned
+    // as-is, unsorted and undeduplicated.
+    let both_present = base_vec.is_some() && update_vec.is_some();
+    let mut merged = append_vec(base_vec, update_vec)?;
+    if both_present {
+        merged.sort();
+        merged.dedup();
+    }
+    Some(merged)
 }
 
 pub fn conform_normalized_snapshot_raw_code_to_mantle_format(normalized_full: &str) -> String {

--- a/crates/dbt-schemas/src/schemas/common.rs
+++ b/crates/dbt-schemas/src/schemas/common.rs
@@ -1581,7 +1581,13 @@ pub fn merge_meta(
     }
 }
 
-/// Merge two tag lists, deduplicating and sorting the result.
+/// Merge two lists into a deduplicated, sorted union. Used for fields like
+/// classifiers where set-like union semantics are wanted.
+///
+/// Do *not* use this for `tags`: dbt-core's `MergeBehavior.Append` (the
+/// merge behavior the `tags` field actually declares in `dbt_common`) is a
+/// plain, order-preserving, non-deduplicating concatenation. Use
+/// [`append_vec`] for that.
 pub fn merge_vec(
     base_vec: Option<Vec<String>>,
     update_vec: Option<Vec<String>>,
@@ -1597,6 +1603,27 @@ pub fn merge_vec(
             Some(base)
         }
         // If only one side has a value, use it
+        (Some(base), None) => Some(base),
+        (None, Some(update)) => Some(update),
+    }
+}
+
+/// Append `update_vec` after `base_vec`, preserving declaration order and
+/// duplicates. Matches dbt-core's `MergeBehavior.Append` semantics (plain
+/// concatenation: `self_value + other_value`, no dedup, no sort) used for
+/// fields such as `tags` and `packages` -- as opposed to [`merge_vec`]'s
+/// deduplicated, sorted union, which is a different merge behavior only
+/// appropriate for fields that actually want set semantics.
+pub fn append_vec(
+    base_vec: Option<Vec<String>>,
+    update_vec: Option<Vec<String>>,
+) -> Option<Vec<String>> {
+    match (base_vec, update_vec) {
+        (None, None) => None,
+        (Some(mut base), Some(update)) => {
+            base.extend(update);
+            Some(base)
+        }
         (Some(base), None) => Some(base),
         (None, Some(update)) => Some(update),
     }
@@ -2596,6 +2623,53 @@ period: hour
     #[test]
     fn test_merge_classifiers_both_none_is_none() {
         assert_eq!(merge_vec(None, None), None);
+    }
+
+    /// Regression test for https://github.com/dbt-labs/dbt-core/issues/15590:
+    /// tags must preserve declaration order (base/parent first, then
+    /// update/child), matching dbt-core's `MergeBehavior.Append`, not be
+    /// sorted alphabetically like `merge_vec`'s classifier union.
+    #[test]
+    fn test_append_vec_preserves_order_and_duplicates() {
+        let base = Some(vec!["intermediate".to_string()]);
+        let update = Some(vec!["daily".to_string()]);
+        let result = append_vec(base, update);
+        assert_eq!(
+            result,
+            Some(vec!["intermediate".to_string(), "daily".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_append_vec_does_not_deduplicate() {
+        let base = Some(vec!["pii".to_string()]);
+        let update = Some(vec!["pii".to_string(), "gdpr".to_string()]);
+        let result = append_vec(base, update);
+        assert_eq!(
+            result,
+            Some(vec![
+                "pii".to_string(),
+                "pii".to_string(),
+                "gdpr".to_string()
+            ])
+        );
+    }
+
+    #[test]
+    fn test_append_vec_none_base_uses_update() {
+        let update = Some(vec!["daily".to_string()]);
+        assert_eq!(append_vec(None, update.clone()), update);
+    }
+
+    #[test]
+    fn test_append_vec_none_update_uses_base() {
+        let base = Some(vec!["intermediate".to_string()]);
+        assert_eq!(append_vec(base.clone(), None), base);
+    }
+
+    #[test]
+    fn test_append_vec_both_none_is_none() {
+        assert_eq!(append_vec(None, None), None);
     }
 
     #[test]

--- a/crates/dbt-schemas/src/schemas/project/configs/common.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/common.rs
@@ -14,6 +14,7 @@ use dbt_telemetry::StateModifiedDiff;
 use crate::default_to;
 use crate::schemas::common::Hooks;
 use crate::schemas::common::PartitionConfig;
+use crate::schemas::common::append_vec;
 use crate::schemas::common::merge_meta;
 use crate::schemas::common::merge_vec;
 use crate::schemas::common::{ClusterConfig, DbtQuoting, DocsConfig, Schedule};
@@ -103,11 +104,14 @@ pub fn default_meta_and_tags(
     // Handle meta using existing merge function
     *child_meta = merge_meta(parent_meta.clone(), child_meta.take());
 
-    // Handle tags using existing merge function
+    // Tags append parent values before child values (parent first, then
+    // child), preserving declaration order and duplicates -- matches
+    // dbt-core's `MergeBehavior.Append` for the `tags` field. See
+    // `default_packages` below for the same pattern.
     let child_tags_vec = child_tags.take().map(|tags| tags.into());
     let parent_tags_vec = parent_tags.clone().map(|tags| tags.into());
     *child_tags =
-        merge_vec(child_tags_vec, parent_tags_vec).map(StringOrArrayOfStrings::ArrayOfStrings);
+        append_vec(parent_tags_vec, child_tags_vec).map(StringOrArrayOfStrings::ArrayOfStrings);
 }
 
 /// Helper function to handle default_to logic for classifiers.
@@ -124,7 +128,8 @@ pub fn default_classifiers(
 
 /// Helper function to handle default_to logic for packages
 /// Packages should append parent values to child values (parent first, then child)
-/// Note: Unlike tags, packages are NOT deduplicated or sorted, matching dbt-core behavior
+/// Note: like tags (see `default_meta_and_tags`), packages are NOT deduplicated
+/// or sorted, matching dbt-core's `MergeBehavior.Append` behavior
 pub fn default_packages(
     child_packages: &mut Option<StringOrArrayOfStrings>,
     parent_packages: &Option<StringOrArrayOfStrings>,
@@ -133,16 +138,7 @@ pub fn default_packages(
     let child_vec: Option<Vec<String>> = child_packages.take().map(|packages| packages.into());
     let parent_vec: Option<Vec<String>> = parent_packages.clone().map(|packages| packages.into());
 
-    // Simple append without deduplication or sorting (matches dbt-core)
-    let merged = match (parent_vec, child_vec) {
-        (None, None) => None,
-        (Some(mut parent), Some(child)) => {
-            parent.extend(child);
-            Some(parent)
-        }
-        (Some(parent), None) => Some(parent),
-        (None, Some(child)) => Some(child),
-    };
+    let merged = append_vec(parent_vec, child_vec);
 
     *child_packages = merged.map(StringOrArrayOfStrings::ArrayOfStrings);
 }
@@ -1530,6 +1526,57 @@ pub(crate) fn unrendered_value_eq(a: Option<&YmlValue>, b: Option<&YmlValue>) ->
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for https://github.com/dbt-labs/dbt-core/issues/15590:
+    /// given `intermediate: {+tags: [INTERMEDIATE]}` with a nested
+    /// `someIdea: {+tags: [DAILY]}`, the merged tag list must be
+    /// `[INTERMEDIATE, DAILY]` (parent first, declaration order preserved),
+    /// not alphabetically sorted (which put `DAILY` first and made Fusion
+    /// disagree with dbt Core on the resulting schema name).
+    #[test]
+    fn test_default_meta_and_tags_preserves_parent_then_child_tag_order() {
+        let mut child_meta = None;
+        let parent_meta = None;
+        let mut child_tags = Some(StringOrArrayOfStrings::ArrayOfStrings(vec![
+            "DAILY".to_string(),
+        ]));
+        let parent_tags = Some(StringOrArrayOfStrings::ArrayOfStrings(vec![
+            "INTERMEDIATE".to_string(),
+        ]));
+
+        default_meta_and_tags(&mut child_meta, &parent_meta, &mut child_tags, &parent_tags);
+
+        assert_eq!(
+            child_tags,
+            Some(StringOrArrayOfStrings::ArrayOfStrings(vec![
+                "INTERMEDIATE".to_string(),
+                "DAILY".to_string(),
+            ]))
+        );
+    }
+
+    #[test]
+    fn test_default_meta_and_tags_does_not_deduplicate_tags() {
+        let mut child_meta = None;
+        let parent_meta = None;
+        let mut child_tags = Some(StringOrArrayOfStrings::ArrayOfStrings(vec![
+            "pii".to_string(),
+        ]));
+        let parent_tags = Some(StringOrArrayOfStrings::ArrayOfStrings(vec![
+            "pii".to_string(),
+        ]));
+
+        default_meta_and_tags(&mut child_meta, &parent_meta, &mut child_tags, &parent_tags);
+
+        // dbt-core's `MergeBehavior.Append` does not deduplicate `tags`.
+        assert_eq!(
+            child_tags,
+            Some(StringOrArrayOfStrings::ArrayOfStrings(vec![
+                "pii".to_string(),
+                "pii".to_string(),
+            ]))
+        );
+    }
 
     #[test]
     fn test_array_of_strings_eq_none_and_empty_array() {


### PR DESCRIPTION
Resolves #15590

### Problem

dbt-core's `tags` field declares `MergeBehavior.Append` in `dbt_common` (confirmed directly against `dbt-labs/dbt-common`'s `_merge_field_value`: plain `self_value + other_value` concatenation — no dedup, no sort). Fusion's `default_meta_and_tags` (`crates/dbt-schemas/src/schemas/project/configs/common.rs`) instead called `merge_vec`, which both **reversed the merge order** (child tags were placed before parent tags) **and deduplicated + alphabetically sorted** the result.

So a project declaring:
```yaml
intermediate:
  +tags: ['INTERMEDIATE']
  someIdea:
    +tags: ['DAILY']