### PR TITLE
fix(fusion): dbt State run_cache no longer falls back to per-node queries for legitimately-empty Databricks schemas

### DIFF
--- a/.changes/unreleased/Fixes-20260718-224500.yaml
+++ b/.changes/unreleased/Fixes-20260718-224500.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: 'dbt State no longer falls back to slow per-node freshness queries (and emits a misleading warning) for Databricks schemas that are legitimately empty, e.g. freshly created per-PR CI schemas; the fallback now only fires for adapters whose schema-level freshness dump can genuinely lag behind a just-created table'
+time: 2026-07-18T22:45:00.000000+00:00
+custom:
+    author: DipakMandlik
+    issue: "15594"
+    project: dbt-fusion

--- a/crates/dbt-adapter/src/metadata/databricks/mod.rs
+++ b/crates/dbt-adapter/src/metadata/databricks/mod.rs
@@ -167,6 +167,17 @@ pub struct DatabricksMetadataAdapter {
 }
 
 impl DatabricksMetadataAdapter {
+    /// See `MetadataAdapter::freshness_all_in_schema_empty_result_is_authoritative`:
+    /// `freshness_all_in_schema` (below) queries each relation directly via
+    /// `DESCRIBE HISTORY` (or `INFORMATION_SCHEMA.last_altered` for views),
+    /// with no eventually-consistent catalog snapshot in between, so an empty
+    /// result means every relation in the group genuinely doesn't exist yet
+    /// -- the normal state for a freshly created schema, not a race
+    /// condition. Exposed as a const (rather than only inline in the trait
+    /// impl) so it's directly unit-testable without constructing a full
+    /// adapter/engine.
+    pub const EMPTY_RESULT_IS_AUTHORITATIVE: bool = true;
+
     pub fn new(engine: Arc<dyn AdapterEngine>) -> Self {
         let adapter = AdapterImpl::new(engine, None);
         Self { adapter }
@@ -1384,6 +1395,10 @@ impl MetadataAdapter for DatabricksMetadataAdapter {
         };
         let map_reduce = MapReduce::new(factory, Box::new(map_f), Box::new(reduce_f), None);
         map_reduce.run(Arc::new(all_relations), token)
+    }
+
+    fn freshness_all_in_schema_empty_result_is_authoritative(&self) -> bool {
+        Self::EMPTY_RESULT_IS_AUTHORITATIVE
     }
 }
 

--- a/crates/dbt-adapter/src/metadata/metadata_adapter.rs
+++ b/crates/dbt-adapter/src/metadata/metadata_adapter.rs
@@ -457,6 +457,11 @@ pub trait MetadataAdapter: Send + Sync {
             }
             Ok(result)
         })
+||||||| parent of 214e1fe04 (refactor: move empty-result fallback policy onto MetadataAdapter, per review)
+    /// Whether an empty result from `freshness_all_in_schema` is authoritative.
+    fn freshness_all_in_schema_empty_result_is_authoritative(&self) -> bool {
+        false
+    }
     }
 
     /// Check whether each relation exists, keyed by semantic FQN.

--- a/crates/dbt-tasks-core/src/run_cache/run_cache_service.rs
+++ b/crates/dbt-tasks-core/src/run_cache/run_cache_service.rs
@@ -542,6 +542,36 @@ fn heuristic_clock_enabled_for_adapter(adapter_type: AdapterType) -> bool {
     )
 }
 
+/// Whether an empty `freshness_all_in_schema` result for `adapter_type`
+/// should trigger the slower per-node `freshness_with_overrides_and_options`
+/// fallback (and its `StateServiceWarn`).
+///
+/// An empty schema-level dump is ambiguous in general: it can mean the
+/// underlying metadata catalog hasn't caught up yet (a real race), or it can
+/// mean every relation in the group genuinely doesn't exist yet. Which one
+/// applies depends on how the adapter implements `freshness_all_in_schema`:
+///
+/// - Snowflake and BigQuery each issue a single `INFORMATION_SCHEMA`-style
+///   bulk query (`snowflake/mod.rs`, `bigquery/mod.rs`) against a metadata
+///   view that is documented to lag behind DDL by a few seconds -- the
+///   fallback exists specifically to work around that lag, so it must fire.
+/// - Any adapter that hasn't overridden the trait method at all gets the
+///   default implementation (`metadata_adapter.rs`), which *deliberately*
+///   returns an empty map to signal "fall back" (see its doc comment) -- the
+///   fallback is the only way those adapters get real freshness data, so it
+///   must fire there too.
+/// - Databricks (`databricks/mod.rs`) is the one exception: it issues a real
+///   per-relation `DESCRIBE HISTORY` (or `INFORMATION_SCHEMA.last_altered`
+///   for views) lookup directly, with no intermediate eventually-consistent
+///   catalog snapshot to lag behind. An empty result there means every
+///   relation in the group genuinely doesn't exist yet -- the normal state
+///   for a freshly created CI schema before any model has run. Falling back
+///   in that case only repeats the same (still-empty) per-relation lookups
+///   at higher cost while emitting a misleading warning on every CI run.
+fn schema_dump_empty_requires_fallback(adapter_type: AdapterType, dump_is_empty: bool) -> bool {
+    dump_is_empty && !matches!(adapter_type, AdapterType::Databricks)
+}
+
 /// Collect every relation and source freshness override needed for the run's
 /// metadata prefetch.
 ///
@@ -727,7 +757,7 @@ async fn bulk_prefetch_last_modified_by_schema(
             .await
             .map_err(into_fs_error)?;
 
-        if dump.is_empty() {
+        if schema_dump_empty_requires_fallback(ctx.adapter_type(), dump.is_empty()) {
             // Empty result from the schema dump. This is typically caused by
             // INFORMATION_SCHEMA eventual consistency: Fusion's global prefetch
             // fires eagerly at run start (before any node executes), whereas the
@@ -4876,5 +4906,66 @@ mod tests {
         .unwrap();
         let clock = lock.get().expect("clock should be set");
         assert_eq!(clock.now_ms(), 42_000);
+    }
+
+    /// Regression tests for https://github.com/dbt-labs/dbt-core/issues/15594:
+    /// Databricks issues a real per-relation `DESCRIBE HISTORY` lookup in
+    /// `freshness_all_in_schema` (no eventually-consistent catalog snapshot to
+    /// lag behind), so an empty result there is authoritative and must not
+    /// trigger the per-node eventual-consistency fallback + warning.
+    #[test]
+    fn schema_dump_empty_does_not_require_fallback_on_databricks() {
+        assert!(!schema_dump_empty_requires_fallback(
+            AdapterType::Databricks,
+            true
+        ));
+    }
+
+    /// Snowflake's `freshness_all_in_schema` is a single `INFORMATION_SCHEMA`
+    /// bulk query that can genuinely lag behind a just-created table -- this
+    /// is the original, still-valid reason the fallback exists, and must be
+    /// preserved.
+    #[test]
+    fn schema_dump_empty_still_requires_fallback_on_snowflake() {
+        assert!(schema_dump_empty_requires_fallback(
+            AdapterType::Snowflake,
+            true
+        ));
+    }
+
+    /// BigQuery's `freshness_all_in_schema` is likewise a single bulk query
+    /// against a metadata view, so it needs the same fallback as Snowflake.
+    #[test]
+    fn schema_dump_empty_still_requires_fallback_on_bigquery() {
+        assert!(schema_dump_empty_requires_fallback(
+            AdapterType::Bigquery,
+            true
+        ));
+    }
+
+    /// Adapters that haven't overridden `freshness_all_in_schema` get the
+    /// trait's default implementation, which deliberately returns an empty
+    /// map to signal "fall back" (see `MetadataAdapter::freshness_all_in_schema`'s
+    /// doc comment) -- the fallback is the only way those adapters get real
+    /// freshness data, so an empty result must still trigger it.
+    #[test]
+    fn schema_dump_empty_still_requires_fallback_for_unimplemented_adapters() {
+        assert!(schema_dump_empty_requires_fallback(
+            AdapterType::Postgres,
+            true
+        ));
+    }
+
+    /// A non-empty dump never needs the fallback, regardless of adapter.
+    #[test]
+    fn schema_dump_non_empty_never_requires_fallback() {
+        assert!(!schema_dump_empty_requires_fallback(
+            AdapterType::Snowflake,
+            false
+        ));
+        assert!(!schema_dump_empty_requires_fallback(
+            AdapterType::Databricks,
+            false
+        ));
     }
 }

--- a/crates/dbt-tasks-core/src/run_cache/run_cache_service.rs
+++ b/crates/dbt-tasks-core/src/run_cache/run_cache_service.rs
@@ -13,67 +13,48 @@
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::Arc;
-use std::sync::atomic::Ordering;
-use std::time::Instant;
-
-use tokio::sync::mpsc;
 
 use crate::context::TaskRunnerCtx;
 use crate::task::{TaskOp, TaskResult};
 use dbt_adapter::AdapterResult;
-use dbt_adapter::errors::{AdapterErrorKind, Cancellable, into_fs_error};
+use dbt_adapter::errors::{Cancellable, into_fs_error};
 use dbt_adapter::metadata::{FreshnessOverride, MetadataQueryOptions};
 use dbt_adapter::record_batch::RecordBatchExt;
-use dbt_adapter::relation::{RelationObject, create_relation, create_relation_from_node};
+use dbt_adapter::relation::{create_relation, create_relation_from_node};
 use dbt_adapter::sql_types::TypeOps;
 use dbt_adapter_core::AdapterType;
 use dbt_adbc::QueryCtx;
 use dbt_common::adapter::dialect_of;
 use dbt_common::io_args::RunCacheMode;
 use dbt_common::stats::NodeStatus;
-use dbt_common::tracing::dbt_emit::{
-    emit_debug_log_message, emit_trace_log_message, emit_warn_log_message,
-};
-use dbt_common::tracing::span_info::find_and_update_span_attrs;
+use dbt_common::tracing::dbt_emit::{emit_trace_log_message, emit_warn_log_message};
 use dbt_common::{ErrorCode, FsError, FsResult, fs_err};
 use dbt_frontend_common::ident::FullyQualifiedName;
 use dbt_frontend_common::named_reference::NamedReference;
 use dbt_frontend_common::sources_extractor::SourcesExtractor;
-use dbt_jinja_utils::jinja_environment::JinjaEnv;
-use dbt_schemas::materialization_resolver::MaterializationResolver;
 use dbt_schemas::schemas::common::{DbtMaterialization, ModelFreshnessRules, ResolvedQuoting};
-use dbt_schemas::schemas::macros::DbtMacro;
 use dbt_schemas::schemas::profiles::DbConfig;
 use dbt_schemas::schemas::properties::ModelState;
 use dbt_schemas::schemas::relations::base::BaseRelation;
 use dbt_schemas::schemas::{
     DbtModel, DbtSeed, DbtSnapshot, DbtSource, DbtTest, InternalDbtNode, InternalDbtNodeAttributes,
 };
-use dbt_state::explain::{
-    StateExplainLogRecord, StateExplainNode, StateExplainNodeInfo, append_state_explain_log_record,
-};
-use dbt_state::metadata_cache::RunCacheMetadataCache;
 use dbt_state::node_session::ExecutionGuard;
 use dbt_state::proto::query_cache::{
-    ClientTelemetryEvent, ConfirmExecutionRequest, ExplainedDecision, NodeFuncMapping,
-    QueryDependency, RecordExecutionsRequest, SkipExecutionResponse, Struct,
-    SubmitEnrichedSqlRequest, SubmitSqlResponse, SubmitValuesRequest, TableModifiedInfo, Value,
-    submit_sql_response, submit_sql_speculative_response, value::Kind,
+    ConfirmExecutionRequest, ExplainedDecision, NodeFuncMapping, QueryDependency,
+    RecordExecutionsRequest, SkipExecutionResponse, Struct, SubmitEnrichedSqlRequest,
+    SubmitSqlResponse, SubmitValuesRequest, TableModifiedInfo, submit_sql_response,
 };
 use dbt_state::request_builder::{
-    ExecutionOutcomeInput, SessionEndResult, enriched_sql_prepared_event, session_end_event,
-    session_start_event, sql_execution_record_from_submit_request, telemetry_batch,
+    ExecutionOutcomeInput, sql_execution_record_from_submit_request,
     values_execution_record_from_submit_request,
 };
-use dbt_state::service_client::RunCacheServiceError;
-use dbt_telemetry::{NodeEvaluated, NodeType};
+use dbt_telemetry::NodeType;
 
 use crate::run_cache::run_cache_request::{
-    DbtProjectInfo, SeedRunCacheRequestContext, SqlRunCacheRequestContext, build_model_sql_request,
-    build_seed_values_request, build_snapshot_sql_request, build_test_sql_request,
-    is_microbatch_model, node_identity,
+    SeedRunCacheRequestContext, SqlRunCacheRequestContext, build_model_sql_request,
+    build_seed_values_request, build_snapshot_sql_request, build_test_sql_request, node_identity,
 };
-use chrono::{DateTime, Utc};
 
 pub fn collect_upstream_hashes(ctx: &TaskRunnerCtx, unique_id: &str) -> HashMap<String, String> {
     ctx.inner
@@ -104,11 +85,11 @@ pub enum RunCacheServiceDecision {
     Skip {
         status: NodeStatus,
         sao_stored_hash: Option<String>,
-        /// Cached data-test result when the skipped node is a data test. The
-        /// dispatcher in `runnable/mod.rs` uses it to replace the generic
-        /// `ReusedNoChanges` status with a test-shaped status and a
-        /// NO-OP-marked stat.
-        cached_test_result: Option<CachedTestExecutionResult>,
+        /// Cached test verdict (failures count) when the skipped node is a
+        /// data test. The dispatcher in `runnable/mod.rs` uses it to replace
+        /// the generic `ReusedNoChanges` status with a test-shaped status
+        /// (TestPassed/Errored) and a NO-OP-marked stat.
+        cached_test_failures: Option<i64>,
     },
     Disabled,
 }
@@ -117,15 +98,6 @@ impl RunCacheServiceDecision {
     fn execute_without_confirmation() -> Self {
         Self::Execute {
             after_success: RunCacheAfterSuccess::None,
-            sao_guard: None,
-        }
-    }
-
-    /// Like [`Self::execute_without_confirmation`], but for a node that
-    /// rebuilds its target relation untracked, invalidating its cached epoch.
-    fn execute_and_invalidate_freshness() -> Self {
-        Self::Execute {
-            after_success: RunCacheAfterSuccess::InvalidateFreshness,
             sao_guard: None,
         }
     }
@@ -201,14 +173,14 @@ impl PartialEq for RunCacheServiceDecision {
                 RunCacheServiceDecision::Skip {
                     status: s1,
                     sao_stored_hash: h1,
-                    cached_test_result: r1,
+                    cached_test_failures: f1,
                 },
                 RunCacheServiceDecision::Skip {
                     status: s2,
                     sao_stored_hash: h2,
-                    cached_test_result: r2,
+                    cached_test_failures: f2,
                 },
-            ) => s1 == s2 && h1 == h2 && r1 == r2,
+            ) => s1 == s2 && h1 == h2 && f1 == f2,
             (RunCacheServiceDecision::Disabled, RunCacheServiceDecision::Disabled) => true,
             _ => false,
         }
@@ -229,12 +201,12 @@ impl std::fmt::Debug for RunCacheServiceDecision {
             RunCacheServiceDecision::Skip {
                 status,
                 sao_stored_hash,
-                cached_test_result,
+                cached_test_failures,
             } => f
                 .debug_struct("RunCacheServiceDecision::Skip")
                 .field("status", status)
                 .field("sao_stored_hash", sao_stored_hash)
-                .field("cached_test_result", cached_test_result)
+                .field("cached_test_failures", cached_test_failures)
                 .finish(),
             RunCacheServiceDecision::Disabled => write!(f, "RunCacheServiceDecision::Disabled"),
         }
@@ -244,11 +216,6 @@ impl std::fmt::Debug for RunCacheServiceDecision {
 #[derive(Clone, Debug, PartialEq)]
 pub enum RunCacheAfterSuccess {
     None,
-    /// The node rebuilt its target without the service observing it — no
-    /// decision was sought and no execution will be recorded. Its cached
-    /// warehouse metadata now describes pre-build state, so drop it once the
-    /// node succeeds.
-    InvalidateFreshness,
     Confirm(RunCacheExecutionConfirmation),
     Record(Box<RunCachePendingExecutionRecord>),
 }
@@ -264,18 +231,12 @@ pub struct RunCacheExecutionConfirmation {
 #[derive(Clone, Debug, PartialEq)]
 pub struct RunCachePendingExecutionRecord {
     input: RunCachePendingExecutionInput,
-    /// Set when the record originates from a speculative submit whose verdict
-    /// was `ReadyToExecuteUntracked`. Such records were built from a partial
-    /// (prefetch-in-flight) dependency snapshot, so their epochs are finalized
-    /// against the warm cache before recording, and the `SqlExecution` carries
-    /// `from_speculative_submit = true`.
-    speculative: bool,
 }
 
 #[derive(Clone, Debug, PartialEq)]
 enum RunCachePendingExecutionInput {
-    Sql(Box<SubmitEnrichedSqlRequest>),
-    Values(Box<SubmitValuesRequest>),
+    Sql(SubmitEnrichedSqlRequest),
+    Values(SubmitValuesRequest),
 }
 
 impl RunCacheExecutionConfirmation {
@@ -307,68 +268,46 @@ impl RunCacheExecutionConfirmation {
 
     /// Attach a `{failures, should_warn, should_error}` payload to this
     /// confirmation. Used by the data-test Confirm path so subsequent runs
-    /// can replay the cached verdict.
-    pub fn set_test_execution_results(&mut self, result: CachedTestExecutionResult) {
+    /// can replay the cached verdict via `parse_cached_test_skip`.
+    pub fn set_test_execution_results(&mut self, failures: i64) {
         if self.execution_results.is_none() {
-            self.execution_results = Some(build_test_execution_results_struct(result));
+            self.execution_results = Some(build_test_execution_results_struct(failures));
         }
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct CachedTestExecutionResult {
-    pub failures: i64,
-    pub should_warn: bool,
-    pub should_error: bool,
-}
-
-/// Build the data-test result payload sent in
-/// `ConfirmExecutionRequest.execution_results` so subsequent runs can replay
-/// the cached verdict.
-pub fn build_test_execution_results_struct(result: CachedTestExecutionResult) -> Struct {
+/// Build the `{failures, should_warn, should_error}` payload Fusion sends
+/// in `ConfirmExecutionRequest.execution_results` so subsequent runs can
+/// replay the cached verdict. Mirrors dbt-core's
+/// `_DataTestAdapterProxy.execute`, which lower-cases the agate row before
+/// confirming. `should_warn` and `should_error` both come from
+/// `count(*) != 0` in the templated test SQL, so they are simply
+/// `failures > 0`.
+pub fn build_test_execution_results_struct(failures: i64) -> Struct {
+    use dbt_state::proto::query_cache::{Value, value::Kind};
     let fail_value = Value {
-        kind: Some(Kind::IntValue(result.failures)),
+        kind: Some(Kind::IntValue(failures)),
+    };
+    let bool_value = Value {
+        kind: Some(Kind::BoolValue(failures > 0)),
     };
     let mut fields = HashMap::new();
     fields.insert("failures".to_string(), fail_value);
-    fields.insert(
-        "should_warn".to_string(),
-        Value {
-            kind: Some(Kind::BoolValue(result.should_warn)),
-        },
-    );
-    fields.insert(
-        "should_error".to_string(),
-        Value {
-            kind: Some(Kind::BoolValue(result.should_error)),
-        },
-    );
+    fields.insert("should_warn".to_string(), bool_value.clone());
+    fields.insert("should_error".to_string(), bool_value);
     Struct { fields }
 }
 
-/// Decode the cached data-test result payload from a `SkipExecutionResponse`.
-pub fn parse_cached_test_execution_result(
-    response: &SkipExecutionResponse,
-) -> Option<CachedTestExecutionResult> {
+/// Decode the cached `{failures, ...}` payload from a
+/// `SkipExecutionResponse`. Returns the failures count if the field is
+/// present and decodable.
+pub fn parse_cached_test_failures(response: &SkipExecutionResponse) -> Option<i64> {
+    use dbt_state::proto::query_cache::value::Kind;
     let results = response.execution_results.as_ref()?;
-    Some(CachedTestExecutionResult {
-        failures: parse_execution_result_int(results.fields.get("failures")?)?,
-        should_warn: parse_execution_result_bool(results.fields.get("should_warn")?)?,
-        should_error: parse_execution_result_bool(results.fields.get("should_error")?)?,
-    })
-}
-
-fn parse_execution_result_int(value: &Value) -> Option<i64> {
+    let value = results.fields.get("failures")?;
     match value.kind.as_ref()? {
         Kind::IntValue(i) => Some(*i),
         Kind::DoubleValue(d) => Some(*d as i64),
-        _ => None,
-    }
-}
-
-fn parse_execution_result_bool(value: &Value) -> Option<bool> {
-    match value.kind.as_ref()? {
-        Kind::BoolValue(value) => Some(*value),
         _ => None,
     }
 }
@@ -402,7 +341,7 @@ impl RunCacheCloneDecision {
             execution_results: response.clone_execution_results.clone(),
             execution_runtime_ms: response.execution_runtime_ms,
             freshness_tolerance_seconds: freshness_tolerance_seconds.max(0) as u64,
-            explained_decision: response.explained_decision.clone(),
+            explained_decision: response.explained_decision,
             transformed_nodes_by_query: response.transformed_nodes_by_query.clone(),
             execution_decision_id: response.execution_decision_id.clone(),
         }
@@ -421,65 +360,7 @@ impl RunCacheCloneDecision {
         RunCacheExecutionConfirmation::new(self.request_id.clone(), true)
     }
 
-    pub fn clone_source(&self) -> &str {
-        &self.clone_source
-    }
-
-    pub fn clone_target(&self) -> &str {
-        &self.clone_target
-    }
-
-    /// Project this decision into a serializable form for time-machine recording.
-    ///
-    /// Only carries the fields that actually drive clone execution/confirmation
-    /// (see `execute_run_cache_service_clone`, `success_status`, `success_confirmation`);
-    /// the full protobuf `execution_results`/`transformed_nodes_by_query` are
-    /// telemetry-only and dropped, and `explained_decision` is reduced to the
-    /// single `is_stale` flag consumers actually read.
-    pub fn to_recorded(&self) -> dbt_adapter::time_machine::RecordedRunCacheCloneDecision {
-        dbt_adapter::time_machine::RecordedRunCacheCloneDecision {
-            request_id: self.request_id.clone(),
-            clone_sqls: self.clone_sqls.clone(),
-            clone_source: self.clone_source.clone(),
-            clone_target: self.clone_target.clone(),
-            required_source_epoch: self.required_source_epoch,
-            execution_runtime_ms: self.execution_runtime_ms,
-            freshness_tolerance_seconds: self.freshness_tolerance_seconds,
-            is_stale: self
-                .explained_decision
-                .as_ref()
-                .is_some_and(|decision| decision.is_stale),
-            execution_decision_id: self.execution_decision_id.clone(),
-        }
-    }
-
-    /// Reconstruct a decision from a time-machine recording during replay.
-    ///
-    /// `execution_results` and `transformed_nodes_by_query` are reset to their
-    /// empty defaults since replay never confirms back to the live service
-    /// (see `confirm_run_cache_service_execution`'s client-absent early return).
-    pub fn from_recorded(
-        recorded: dbt_adapter::time_machine::RecordedRunCacheCloneDecision,
-    ) -> Self {
-        Self {
-            request_id: recorded.request_id,
-            clone_sqls: recorded.clone_sqls,
-            clone_source: recorded.clone_source,
-            clone_target: recorded.clone_target,
-            required_source_epoch: recorded.required_source_epoch,
-            execution_results: None,
-            execution_runtime_ms: recorded.execution_runtime_ms,
-            freshness_tolerance_seconds: recorded.freshness_tolerance_seconds,
-            explained_decision: Some(ExplainedDecision {
-                is_stale: recorded.is_stale,
-                ..Default::default()
-            }),
-            transformed_nodes_by_query: HashMap::new(),
-            execution_decision_id: recorded.execution_decision_id,
-        }
-    }
-
-    pub fn replay_status(&self) -> NodeStatus {
+    fn success_status(&self) -> NodeStatus {
         if self
             .explained_decision
             .as_ref()
@@ -490,36 +371,6 @@ impl RunCacheCloneDecision {
             NodeStatus::ReusedCloned(None)
         }
     }
-
-    fn success_status(&self) -> NodeStatus {
-        self.replay_status()
-    }
-}
-
-pub fn record_run_cache_clone_decision(node_id: &str, clone: &RunCacheCloneDecision) {
-    let Some(recorder) = dbt_adapter::time_machine::global_recorder() else {
-        return;
-    };
-    recorder.record_run_cache_clone(node_id, clone.to_recorded());
-}
-
-pub fn record_dev_clone_decision(node_id: &str, clone: &RunCacheCloneDecision) {
-    let Some(recorder) = dbt_adapter::time_machine::global_recorder() else {
-        return;
-    };
-    recorder.record_dev_clone(node_id, clone.to_recorded());
-}
-
-pub fn replay_run_cache_clone_decision(node_id: &str) -> Option<RunCacheCloneDecision> {
-    let replayer = dbt_adapter::time_machine::global_replayer()?;
-    let event = replayer.get_run_cache_clone_event_for_phase(node_id, false)?;
-    Some(RunCacheCloneDecision::from_recorded(event.clone.clone()))
-}
-
-pub fn replay_dev_clone_decision(node_id: &str) -> Option<RunCacheCloneDecision> {
-    let replayer = dbt_adapter::time_machine::global_replayer()?;
-    let event = replayer.get_run_cache_clone_event_for_phase(node_id, true)?;
-    Some(RunCacheCloneDecision::from_recorded(event.clone.clone()))
 }
 
 /// If the node is a selected (non-deferred) view model, insert its
@@ -569,6 +420,7 @@ pub fn insert_compiled_view_definition(
                 "Skipping compiled view definition insert for node {}: canonical FQN unavailable; cannot determine deferral status",
                 node.unique_id()
             ),
+            None,
         );
         return;
     };
@@ -628,7 +480,7 @@ pub fn insert_compiled_view_definition(
 /// stored and submitted epochs identical and the comparison exact.
 #[derive(Debug)]
 pub struct HeuristicClock {
-    start_instant: Instant,
+    start_instant: std::time::Instant,
     start_ts_ms: i64,
 }
 
@@ -639,7 +491,7 @@ impl HeuristicClock {
         if !heuristic_clock_enabled_for_adapter(ctx.adapter_type()) {
             return None;
         }
-        let start_instant = Instant::now();
+        let start_instant = std::time::Instant::now();
         let start_ts_ms = warehouse_now_ms(ctx).await?;
         Some(Self {
             start_instant,
@@ -667,7 +519,7 @@ async fn warehouse_now_ms(ctx: &TaskRunnerCtx) -> Option<i64> {
         let adapter = ctx_inner.env.get_adapter_ref()?;
         let query_ctx = QueryCtx::default().with_desc("dbt State run clock");
         let (_, table) = adapter
-            .execute_without_state(Some(&query_ctx), sql, true, None)
+            .execute_without_state(Some(&query_ctx), sql, true)
             .ok()?;
         table.original_record_batch().first_value_as_i64()
     }))
@@ -690,10 +542,34 @@ fn heuristic_clock_enabled_for_adapter(adapter_type: AdapterType) -> bool {
     )
 }
 
-fn has_non_empty_schema(relation: &dyn BaseRelation) -> bool {
-    relation
-        .schema()
-        .is_some_and(|schema| !schema.trim().is_empty())
+/// Whether an empty `freshness_all_in_schema` result for `adapter_type`
+/// should trigger the slower per-node `freshness_with_overrides_and_options`
+/// fallback (and its `StateServiceWarn`).
+///
+/// An empty schema-level dump is ambiguous in general: it can mean the
+/// underlying metadata catalog hasn't caught up yet (a real race), or it can
+/// mean every relation in the group genuinely doesn't exist yet. Which one
+/// applies depends on how the adapter implements `freshness_all_in_schema`:
+///
+/// - Snowflake and BigQuery each issue a single `INFORMATION_SCHEMA`-style
+///   bulk query (`snowflake/mod.rs`, `bigquery/mod.rs`) against a metadata
+///   view that is documented to lag behind DDL by a few seconds -- the
+///   fallback exists specifically to work around that lag, so it must fire.
+/// - Any adapter that hasn't overridden the trait method at all gets the
+///   default implementation (`metadata_adapter.rs`), which *deliberately*
+///   returns an empty map to signal "fall back" (see its doc comment) -- the
+///   fallback is the only way those adapters get real freshness data, so it
+///   must fire there too.
+/// - Databricks (`databricks/mod.rs`) is the one exception: it issues a real
+///   per-relation `DESCRIBE HISTORY` (or `INFORMATION_SCHEMA.last_altered`
+///   for views) lookup directly, with no intermediate eventually-consistent
+///   catalog snapshot to lag behind. An empty result there means every
+///   relation in the group genuinely doesn't exist yet -- the normal state
+///   for a freshly created CI schema before any model has run. Falling back
+///   in that case only repeats the same (still-empty) per-relation lookups
+///   at higher cost while emitting a misleading warning on every CI run.
+fn schema_dump_empty_requires_fallback(adapter_type: AdapterType, dump_is_empty: bool) -> bool {
+    dump_is_empty && !matches!(adapter_type, AdapterType::Databricks)
 }
 
 /// Collect every relation and source freshness override needed for the run's
@@ -702,8 +578,7 @@ fn has_non_empty_schema(relation: &dyn BaseRelation) -> bool {
 /// Returns a map of `semantic_fqn → relation` covering every selected node's
 /// own target relation plus the relations of all their runtime dependencies
 /// (models, snapshots, seeds, sources). Ephemeral and inline models are skipped
-/// because they never submit to the service, as are graph-only nodes with no
-/// warehouse relation (see `has_non_empty_schema`). A second map carries
+/// because they never submit to the service. A second map carries
 /// `FreshnessOverride` entries for sources that declare `loaded_at_query` or
 /// `loaded_at_field`; these are passed through to `freshness_with_overrides`
 /// so the prefetch uses the same freshness strategy as per-node submits.
@@ -722,6 +597,11 @@ fn collect_global_prefetch_relations(
     let mut relations: BTreeMap<String, Arc<dyn BaseRelation>> = BTreeMap::new();
     let mut overrides: BTreeMap<String, FreshnessOverride> = BTreeMap::new();
 
+    let trimmed_nonempty = |s: &str| {
+        let t = s.trim();
+        (!t.is_empty()).then(|| t.to_string())
+    };
+
     for node_id in runnable_set {
         let Some(node) = nodes.get_node(node_id) else {
             continue;
@@ -732,9 +612,7 @@ fn collect_global_prefetch_relations(
             }
         }
 
-        if let Ok(relation) = create_relation_from_node(adapter_type, node, None)
-            && has_non_empty_schema(relation.as_ref())
-        {
+        if let Ok(relation) = create_relation_from_node(adapter_type, node, None) {
             let fqn = relation.semantic_fqn();
             relations.entry(fqn).or_insert_with(|| relation.into());
         }
@@ -757,62 +635,30 @@ fn collect_global_prefetch_relations(
                 continue;
             };
             let fqn = relation.semantic_fqn();
-            if let Some(source) = dep_node.as_any().downcast_ref::<DbtSource>()
-                && let Some(kind) = source_freshness_override(source)
-            {
-                overrides.insert(fqn.clone(), kind);
+            if let Some(source) = dep_node.as_any().downcast_ref::<DbtSource>() {
+                let override_kind = source
+                    .__source_attr__
+                    .loaded_at_query
+                    .as_deref()
+                    .and_then(trimmed_nonempty)
+                    .map(FreshnessOverride::Query)
+                    .or_else(|| {
+                        source
+                            .__source_attr__
+                            .loaded_at_field
+                            .as_deref()
+                            .and_then(trimmed_nonempty)
+                            .map(FreshnessOverride::Field)
+                    });
+                if let Some(kind) = override_kind {
+                    overrides.insert(fqn.clone(), kind);
+                }
             }
             relations.entry(fqn).or_insert_with(|| relation.into());
         }
     }
 
     (relations, overrides)
-}
-
-/// Render a `Query` override's `loaded_at_query` Jinja so macros / `{{ this }}`
-/// expand before the SQL is sent; `Field` overrides pass through unchanged.
-fn render_freshness_override(
-    ovr: FreshnessOverride,
-    relation: &Arc<dyn BaseRelation>,
-    jinja_env: &JinjaEnv,
-    base_context: &BTreeMap<String, minijinja::Value>,
-) -> FsResult<FreshnessOverride> {
-    let FreshnessOverride::Query(query) = ovr else {
-        return Ok(ovr);
-    };
-
-    let mut render_context = base_context.clone();
-    render_context.insert(
-        "this".to_owned(),
-        RelationObject::new(relation.clone()).into_value(),
-    );
-    let require = |part: Option<&str>, name: &str| -> FsResult<String> {
-        part.map(str::to_owned).ok_or_else(|| {
-            fs_err!(
-                ErrorCode::Unexpected,
-                "Cannot render loaded_at_query for source '{}': missing {name}",
-                relation.semantic_fqn(),
-            )
-        })
-    };
-    // Database is optional because some adapters (e.g. BigQuery) render relations without one
-    render_context.insert(
-        "database".to_owned(),
-        minijinja::Value::from(relation.database()),
-    );
-    render_context.insert(
-        "schema".to_owned(),
-        minijinja::Value::from(require(relation.schema(), "schema")?),
-    );
-    render_context.insert(
-        "identifier".to_owned(),
-        minijinja::Value::from(require(relation.identifier(), "identifier")?),
-    );
-
-    let rendered = jinja_env
-        .render_named_str(&relation.semantic_fqn(), &query, &render_context, &[])
-        .map_err(|e| FsError::from_jinja_err(e, "Failed to render source loaded_at_query"))?;
-    Ok(FreshnessOverride::Query(rendered))
 }
 
 /// Batch-prefetch `last_modified_epoch` for all selected nodes and their
@@ -822,10 +668,8 @@ fn render_freshness_override(
 /// After this call, `last_modified_epoch_for_relation` returns a cache hit
 /// for every relation in the prefetch set, eliminating the per-node warehouse
 /// round-trips that `collect_table_modified_infos` would otherwise incur.
-///
-/// This runs in the background (see `run_cache_service_before_run`); a failure
-/// no longer aborts the run. The error is propagated to the caller, which logs
-/// it and lets the per-node paths fall back to their own freshness lookups.
+/// A failed prefetch is a hard error: the command is aborted so that
+/// stale or missing metadata cannot silently produce incorrect results.
 async fn prefetch_global_last_modified_epochs(ctx: &TaskRunnerCtx) -> FsResult<()> {
     let (relations, overrides) = collect_global_prefetch_relations(
         ctx.adapter_type(),
@@ -836,77 +680,21 @@ async fn prefetch_global_last_modified_epochs(ctx: &TaskRunnerCtx) -> FsResult<(
     if relations.is_empty() {
         return Ok(());
     }
-    let mut rendered_overrides = BTreeMap::new();
-    for (fqn, ovr) in overrides {
-        let ovr = match relations.get(&fqn) {
-            Some(relation) => {
-                render_freshness_override(ovr, relation, ctx.env.as_ref(), &ctx.inner.base_context)?
-            }
-            None => ovr,
-        };
-        rendered_overrides.insert(fqn, ovr);
-    }
-    let started_at = Instant::now();
-    let result = bulk_prefetch_last_modified_by_schema(ctx, &relations, &rendered_overrides).await;
-    maybe_warn_slow_metadata_prefetch(ctx, started_at.elapsed());
-    result
+    bulk_prefetch_last_modified_by_schema(ctx, &relations, &overrides).await
 }
 
-/// Total freshness-prefetch time above which we hint that a dedicated metadata
-/// warehouse would help. Mirrors the dbt-core run-cache plugin's threshold.
-const SLOW_METADATA_PREFETCH_WARN_THRESHOLD: std::time::Duration =
-    std::time::Duration::from_secs(15);
-
-/// Whether the slow-metadata-prefetch hint should fire.
+/// Prefetch last-modified epochs using per-schema dump queries rather than
+/// per-table predicates.
 ///
-/// The `metadata_warehouse` config (and this INFORMATION_SCHEMA-based fetch) is
-/// Snowflake-specific, so the hint only applies there. It is pointless once a
-/// dedicated warehouse is already configured, since setting it is the fix.
-fn should_warn_slow_metadata_prefetch(
-    adapter_type: AdapterType,
-    options: &MetadataQueryOptions,
-    elapsed: std::time::Duration,
-) -> bool {
-    let has_metadata_warehouse = options
-        .warehouse
-        .as_deref()
-        .is_some_and(|warehouse| !warehouse.is_empty());
-    adapter_type == AdapterType::Snowflake
-        && !has_metadata_warehouse
-        && elapsed >= SLOW_METADATA_PREFETCH_WARN_THRESHOLD
-}
-
-/// Hint (at most once per run) that configuring a dedicated metadata warehouse
-/// would route these introspection queries to an isolated warehouse and run
-/// them with better parallelism, when the freshness prefetch spent a long time
-/// in INFORMATION_SCHEMA without one configured.
-fn maybe_warn_slow_metadata_prefetch(ctx: &TaskRunnerCtx, elapsed: std::time::Duration) {
-    let metadata_options = run_cache_metadata_query_options(ctx);
-    if !should_warn_slow_metadata_prefetch(ctx.adapter_type(), &metadata_options, elapsed) {
-        return;
-    }
-    emit_warn_log_message(
-        ErrorCode::StateServiceWarn,
-        format!(
-            "Fetching table metadata (e.g., last modified timestamps) from INFORMATION_SCHEMA \
-             took {:.1}s. Set the `metadata_warehouse` config to route these introspection \
-             queries to a dedicated warehouse. This will lead to better parallelism and reduced \
-             contention, resulting in these queries being executed significantly faster.",
-            elapsed.as_secs_f64()
-        ),
-    );
-}
-
-/// Prefetch last-modified epochs for the selected relations and warm
-/// `run_cache_metadata`.
+/// For each (database, schema) group, calls `freshness_all_in_schema` which
+/// returns ALL rows for the schema with a single `WHERE table_schema = '...'`
+/// filter — matching the plugin's approach. Relations with source overrides
+/// (`loaded_at_query` / `loaded_at_field`) are handled separately via the
+/// existing per-table path so their custom freshness logic is preserved.
 ///
-/// Relations with source overrides (`loaded_at_query` / `loaded_at_field`) are
-/// handled separately via the per-table path so their custom freshness logic is
-/// preserved. Everything else is handed to the metadata adapter's
-/// `freshness_all_in_schemas`, which owns the engine-specific strategy (per-schema
-/// dumps, metadata-warehouse fan-out, adaptive broad-vs-sequential). Failures are
-/// fail-open: a relation whose freshness could not be determined is cached as
-/// unknown (`None`), never aborting the run.
+/// An empty result from `freshness_all_in_schema` (adapter not implemented)
+/// leaves the cache empty for that group; per-node lookups handle the misses.
+/// Any error is propagated — the prefetch is mandatory.
 async fn bulk_prefetch_last_modified_by_schema(
     ctx: &TaskRunnerCtx,
     relations: &BTreeMap<String, Arc<dyn BaseRelation>>,
@@ -946,64 +734,84 @@ async fn bulk_prefetch_last_modified_by_schema(
         return Ok(());
     }
 
-    // `freshness_all_in_schemas` keys its result by `semantic_fqn`; keep the
-    // mapping back to each relation's cache name (rendered relation name).
-    let semantic_to_name: BTreeMap<String, String> = bulk_relations
-        .iter()
-        .map(|(name, rel)| (rel.semantic_fqn(), name.clone()))
-        .collect();
-    let relation_values: Vec<Arc<dyn BaseRelation>> = bulk_relations.values().cloned().collect();
+    // For each (database, schema) group, attempt a schema dump. If the adapter
+    // returns an empty map (unsupported), fall back to per-table for that group.
+    for ((database, schema), grouped) in group_relations_by_database_and_schema(&bulk_relations) {
+        let semantic_to_name: BTreeMap<String, String> = grouped
+            .iter()
+            .map(|(name, rel)| (rel.semantic_fqn(), name.clone()))
+            .collect();
+        let relation_values: Vec<Arc<dyn BaseRelation>> = grouped.values().cloned().collect();
 
-    // The adapter owns the strategy and is fail-open per group internally; treat
-    // a top-level error the same way (unknown freshness for the whole batch) so a
-    // metadata failure never aborts the run.
-    let freshness = match metadata_adapter
-        .freshness_all_in_schemas(
-            &relation_values,
-            &metadata_options,
-            adapter.cancellation_token(),
-        )
-        .await
-    {
-        Ok(freshness) => freshness,
-        Err(Cancellable::Error(err)) if err.kind() == AdapterErrorKind::ReplayDataMissing => {
-            // Older recordings may not contain the new schema-bulk event, but
-            // they can contain the existing per-table freshness event.
-            match metadata_adapter
-                .freshness(&relation_values, adapter.cancellation_token())
-                .await
-            {
-                Ok(freshness) => freshness,
-                Err(Cancellable::Error(err))
-                    if err.kind() == AdapterErrorKind::ReplayDataMissing =>
-                {
-                    return Ok(());
-                }
-                Err(err) => return Err(into_fs_error(err)),
-            }
-        }
-        Err(err) => {
-            let err = into_fs_error(err);
+        let db = database.as_deref().unwrap_or("");
+        let sch = schema.as_deref().unwrap_or("");
+
+        let dump = metadata_adapter
+            .freshness_all_in_schema(
+                db,
+                sch,
+                &relation_values,
+                &metadata_options,
+                adapter.cancellation_token(),
+            )
+            .await
+            .map_err(into_fs_error)?;
+
+        if schema_dump_empty_requires_fallback(ctx.adapter_type(), dump.is_empty()) {
+            // Empty result from the schema dump. This is typically caused by
+            // INFORMATION_SCHEMA eventual consistency: Fusion's global prefetch
+            // fires eagerly at run start (before any node executes), whereas the
+            // dbt-core plugin prefetches lazily on the first node-start event.
+            // The extra seconds of compilation time in the plugin's path are
+            // usually enough for Snowflake's INFORMATION_SCHEMA to propagate a
+            // table created by the immediately preceding run. Fusion doesn't get
+            // that grace period, so the dump can return empty even when the table
+            // actually exists.
+            //
+            // Fall back to freshness_with_overrides_and_options for this schema
+            // group. That call is still batched — one query per database group
+            // with all tables in a single WHERE clause (the old per-table predicate
+            // form rather than the schema-only dump form) — so it does not
+            // degenerate into one query per table. The fallback only fires when
+            // the schema dump returns empty, which is unusual, so the cost of the
+            // larger WHERE clause is acceptable.
             emit_warn_log_message(
                 ErrorCode::StateServiceWarn,
                 format!(
-                    "dbt State freshness prefetch failed for {} relations: {err}; caching unknown \
-                     freshness",
+                    "dbt State schema-level freshness dump returned empty for {db}.{sch}; \
+                     falling back to per-node warehouse queries for {} relations",
                     semantic_to_name.len()
                 ),
+                None,
             );
-            BTreeMap::new()
-        }
-    };
-
-    for (semantic_fqn, name) in &semantic_to_name {
-        let epoch = freshness
-            .get(semantic_fqn)
-            .map(|m| m.last_altered.timestamp_millis());
-        ctx.inner
-            .run_cache_ctx
-            .run_cache_metadata
-            .insert_last_modified_epoch(name, epoch);
+            let empty_overrides = BTreeMap::new();
+            let freshness = metadata_adapter
+                .freshness_with_overrides_and_options(
+                    &relation_values,
+                    &empty_overrides,
+                    &metadata_options,
+                    adapter.cancellation_token(),
+                )
+                .await
+                .map_err(into_fs_error)?;
+            for (sem_fqn, name) in &semantic_to_name {
+                let epoch = freshness
+                    .get(sem_fqn)
+                    .map(|m| m.last_altered.timestamp_millis());
+                ctx.inner
+                    .run_cache_ctx
+                    .run_cache_metadata
+                    .insert_last_modified_epoch(name, epoch);
+            }
+        } else {
+            for (sem_fqn, name) in &semantic_to_name {
+                let epoch = dump.get(sem_fqn).map(|m| m.last_altered.timestamp_millis());
+                ctx.inner
+                    .run_cache_ctx
+                    .run_cache_metadata
+                    .insert_last_modified_epoch(name, epoch);
+            }
+        };
     }
 
     Ok(())
@@ -1011,16 +819,10 @@ async fn bulk_prefetch_last_modified_by_schema(
 
 /// Start-of-run hook. Fires once before any model executes.
 ///
-/// Starts a background task that batch-prefetches `last_modified_epoch` for all
-/// selected nodes and their runtime dependencies into `run_cache_metadata`, so
-/// per-node submits resolve freshness from the in-process cache instead of
-/// issuing individual warehouse queries.
-///
-/// The prefetch runs concurrently with node execution rather than blocking the
-/// whole run: while it is in flight, a node issues a speculative submit using
-/// only the dependency epochs already resolved (see `submit_model` and friends).
-/// A failed prefetch no longer aborts the run — it is logged and the per-node
-/// paths fall back to their own freshness lookups.
+/// Batch-prefetches `last_modified_epoch` for all selected nodes and their
+/// runtime dependencies into `run_cache_metadata`, so per-node submits
+/// resolve freshness from the in-process cache instead of issuing individual
+/// warehouse queries.
 ///
 /// Note: the view-definition traversal that was previously run here as a
 /// pre-warm has been removed. It used `collect_view_traversal_roots` (a
@@ -1035,337 +837,19 @@ async fn bulk_prefetch_last_modified_by_schema(
 /// fetched at most once per run. Total IO is identical — only the timing
 /// changes from eager/pre-run to lazy/per-node.
 pub async fn run_cache_service_before_run(ctx: &TaskRunnerCtx) -> AdapterResult<()> {
-    run_cache_service_start_telemetry(ctx).await;
-
-    let prefetch = ctx.inner.run_cache_ctx.prefetch.clone();
-    prefetch.mark_started();
-
-    let prefetch_ctx = ctx.clone();
-    let handle = dbt_common::tracing::spawn_traced(async move {
-        if let Err(err) = prefetch_global_last_modified_epochs(&prefetch_ctx).await {
-            emit_warn_log_message(
-                ErrorCode::StateServiceWarn,
-                format!(
-                    "dbt State dependency last-modified prefetch failed: {err}; \
-                     falling back to per-node freshness lookups"
-                ),
-            );
-        }
-        prefetch_ctx.inner.run_cache_ctx.prefetch.mark_done();
-    });
-    prefetch.set_handle(handle).await;
+    prefetch_global_last_modified_epochs(ctx)
+        .await
+        .map_err(|e| {
+            dbt_adapter::errors::AdapterError::new(
+                dbt_adapter::errors::AdapterErrorKind::UnexpectedResult,
+                e.to_string(),
+            )
+        })?;
 
     if let Some(clock) = HeuristicClock::bootstrap(ctx).await {
         let _ = ctx.inner.run_cache_ctx.heuristic_clock.set(clock);
     }
     Ok(())
-}
-
-/// Whether the background dependency prefetch has completed.
-///
-/// Returns `false` before the prefetch is started and while it is in flight;
-/// `true` once the background task has finished (or there was nothing to
-/// prefetch). A node uses this to decide whether to issue a speculative submit
-/// (prefetch still pending) or a regular one (prefetch already complete).
-fn is_prefetch_ready(ctx: &TaskRunnerCtx) -> bool {
-    let prefetch = &ctx.inner.run_cache_ctx.prefetch;
-    prefetch.is_started() && prefetch.is_done()
-}
-
-/// Await the background dependency prefetch to completion.
-///
-/// Joins the background task once: the first call takes and awaits the handle,
-/// and subsequent calls find no handle and return without waiting. When the
-/// prefetch was never started (no handle was ever set) this also returns
-/// immediately. In every case the call is fail-open — a join error or task
-/// panic is logged and swallowed, and the prefetch is marked done so callers
-/// can always proceed — so it never blocks the command from making progress.
-async fn await_prefetch(ctx: &TaskRunnerCtx) {
-    let prefetch = &ctx.inner.run_cache_ctx.prefetch;
-    if let Err(err) = prefetch.join().await {
-        emit_warn_log_message(
-            ErrorCode::StateServiceWarn,
-            format!(
-                "dbt State dependency last-modified prefetch task did not complete cleanly: {err}; \
-                 continuing"
-            ),
-        );
-    }
-    prefetch.mark_done();
-}
-
-pub async fn run_cache_service_start_telemetry(ctx: &TaskRunnerCtx) {
-    submit_run_cache_session_start(ctx).await;
-}
-
-pub async fn run_cache_service_after_run(ctx: &TaskRunnerCtx, cancelled: bool) {
-    let result = if cancelled {
-        SessionEndResult::Cancelled
-    } else if ctx
-        .inner
-        .run_stats
-        .iter()
-        .any(|stat| stat.status == NodeStatus::Errored)
-        || ctx
-            .inner
-            .analyze_stats
-            .iter()
-            .any(|stat| stat.status == NodeStatus::Errored)
-    {
-        SessionEndResult::Failure
-    } else {
-        SessionEndResult::Success
-    };
-    submit_run_cache_session_end(ctx, result).await;
-}
-
-/// `cancelled` distinguishes a run aborted via the run's `CancellationToken`
-/// (e.g. a user hitting Ctrl-C) from any other early-return failure, so the
-/// dbt State service can tell the two apart in telemetry.
-pub async fn run_cache_service_after_run_failed(ctx: &TaskRunnerCtx, cancelled: bool) {
-    let result = if cancelled {
-        SessionEndResult::Cancelled
-    } else {
-        SessionEndResult::Failure
-    };
-    submit_run_cache_session_end(ctx, result).await;
-}
-
-/// Number of telemetry events buffered before new events are dropped.
-/// Matches the Python dbt State client's `TelemetryDispatcher` queue bound.
-const TELEMETRY_QUEUE_CAPACITY: usize = 150;
-
-/// Maximum number of events sent in a single `SubmitTelemetryBatch` RPC.
-/// Matches the Python dbt State client's `TelemetryDispatcher` batch bound.
-const TELEMETRY_MAX_BATCH_SIZE: usize = 50;
-
-/// Longest a queued event waits before being flushed, absent a full batch.
-/// Matches the Python dbt State client's `TelemetryDispatcher` emit interval.
-const TELEMETRY_MAX_EMIT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
-
-/// Retries for a batch that failed with a retriable error before its events
-/// are dropped. Matches the Python dbt State client's `TelemetryDispatcher`.
-const TELEMETRY_MAX_RETRY_COUNT: u32 = 3;
-
-type QueuedTelemetryEvent = (ClientTelemetryEvent, u32);
-
-/// Background dispatcher that batches and submits dbt State telemetry events
-/// without blocking node execution, mirroring the async batching design of
-/// the Python dbt State client's telemetry dispatcher: events are pushed
-/// onto a bounded channel (non-blocking, drop-on-full) and a single
-/// background task flushes whatever is queued into one `SubmitTelemetryBatch`
-/// RPC per batch, either once `TELEMETRY_MAX_BATCH_SIZE` events have
-/// accumulated or `TELEMETRY_MAX_EMIT_INTERVAL` has elapsed, whichever comes
-/// first. A batch that fails with a retriable error is re-queued (up to
-/// `TELEMETRY_MAX_RETRY_COUNT` times per event); anything else is dropped.
-///
-/// `flush` closes the channel and awaits the worker so the run's final
-/// events (in particular session-end) get a chance to be delivered before
-/// the process exits.
-pub struct TelemetryDispatcher {
-    sender: tokio::sync::Mutex<Option<mpsc::Sender<QueuedTelemetryEvent>>>,
-    worker: tokio::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
-}
-
-impl TelemetryDispatcher {
-    fn spawn(client: dbt_state::service_client::SharedRunCacheServiceClient) -> Self {
-        let (sender, receiver) = mpsc::channel(TELEMETRY_QUEUE_CAPACITY);
-        let worker = dbt_common::tracing::spawn_traced(Self::run(client, receiver));
-        Self {
-            sender: tokio::sync::Mutex::new(Some(sender)),
-            worker: tokio::sync::Mutex::new(Some(worker)),
-        }
-    }
-
-    async fn run(
-        client: dbt_state::service_client::SharedRunCacheServiceClient,
-        mut receiver: mpsc::Receiver<QueuedTelemetryEvent>,
-    ) {
-        // Retries go straight back into `buffer`, not through the channel: a
-        // `Sender` clone held by this task would stop `recv` from ever
-        // returning `None`, hanging `flush()` forever.
-        let mut buffer: Vec<QueuedTelemetryEvent> = Vec::new();
-        let mut interval = tokio::time::interval(TELEMETRY_MAX_EMIT_INTERVAL);
-        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-        loop {
-            tokio::select! {
-                event = receiver.recv() => {
-                    let Some(event) = event else {
-                        Self::flush_buffer(&client, &mut buffer).await;
-                        break;
-                    };
-                    buffer.push(event);
-                    // `==`, not `>=`: a requeued failure can leave `buffer`
-                    // at the cap already, and `>=` would re-flush on every
-                    // event after that with no gap between retries.
-                    if buffer.len() == TELEMETRY_MAX_BATCH_SIZE {
-                        Self::flush_buffer(&client, &mut buffer).await;
-                    }
-                }
-                _ = interval.tick() => {
-                    Self::flush_buffer(&client, &mut buffer).await;
-                }
-            }
-        }
-    }
-
-    /// Drain `buffer` in chunks of at most `TELEMETRY_MAX_BATCH_SIZE`, one
-    /// `SubmitTelemetryBatch` RPC per chunk, stopping at the first chunk that
-    /// fails. Fail-open: a retriable failure re-queues that chunk (bounded by
-    /// `TELEMETRY_MAX_RETRY_COUNT`); anything else drops it.
-    async fn flush_buffer(
-        client: &dbt_state::service_client::SharedRunCacheServiceClient,
-        buffer: &mut Vec<QueuedTelemetryEvent>,
-    ) {
-        while !buffer.is_empty() {
-            let chunk_size = buffer.len().min(TELEMETRY_MAX_BATCH_SIZE);
-            let chunk: Vec<QueuedTelemetryEvent> = buffer.drain(..chunk_size).collect();
-            let events = chunk.iter().map(|(event, _)| event.clone()).collect();
-            let Err(err) = client.submit_telemetry_batch(telemetry_batch(events)).await else {
-                continue;
-            };
-            if !err.is_retriable_telemetry_submission() {
-                emit_trace_log_message(|| {
-                    format!(
-                        "dbt State service telemetry batch failed: {err}; dropping {} event(s)",
-                        chunk.len()
-                    )
-                });
-                return;
-            }
-            for (event, retry_count) in chunk {
-                if retry_count >= TELEMETRY_MAX_RETRY_COUNT {
-                    emit_trace_log_message(|| {
-                        "dbt State telemetry event exceeded max retries; dropping".to_string()
-                    });
-                    continue;
-                }
-                buffer.push((event, retry_count + 1));
-            }
-            return;
-        }
-    }
-
-    /// Enqueue an event without blocking on network I/O. Drops the event
-    /// (fail-open) if the queue is full or the dispatcher has been flushed.
-    async fn send(&self, event: ClientTelemetryEvent) {
-        let guard = self.sender.lock().await;
-        if let Some(sender) = guard.as_ref() {
-            if sender.try_send((event, 0)).is_err() {
-                emit_trace_log_message(|| {
-                    "dbt State telemetry queue full; dropping event".to_string()
-                });
-            }
-        }
-    }
-
-    /// Enqueue a critical event, waiting for capacity instead of dropping it.
-    async fn send_critical(&self, event: ClientTelemetryEvent) {
-        let sender = self.sender.lock().await.as_ref().cloned();
-        if let Some(sender) = sender
-            && sender.send((event, 0)).await.is_err()
-        {
-            emit_trace_log_message(|| {
-                "dbt State telemetry dispatcher is closed; dropping critical event".to_string()
-            });
-        }
-    }
-
-    /// Close the queue and await the worker so already-queued events flush
-    /// before the caller proceeds. Fail-open: a join error is swallowed.
-    async fn flush(&self) {
-        self.sender.lock().await.take();
-        if let Some(handle) = self.worker.lock().await.take() {
-            let _ = handle.await;
-        }
-    }
-}
-
-async fn submit_run_cache_session_end(ctx: &TaskRunnerCtx, result: SessionEndResult) {
-    let run_cache_ctx = &ctx.inner.run_cache_ctx;
-    if run_cache_ctx
-        .telemetry_session_ended
-        .swap(true, Ordering::Relaxed)
-    {
-        return;
-    }
-
-    let Some(start) = run_cache_ctx.telemetry_session_start.get() else {
-        return;
-    };
-    let description = match result {
-        SessionEndResult::Success => "completed",
-        SessionEndResult::Failure => "completed with errors",
-        SessionEndResult::Cancelled => "cancelled",
-    };
-    let event = session_end_event(
-        start.elapsed(),
-        result,
-        description,
-        next_telemetry_event_order(ctx),
-    );
-    submit_run_cache_critical_telemetry_event(ctx, event).await;
-    flush_run_cache_telemetry(ctx).await;
-}
-
-async fn submit_run_cache_session_start(ctx: &TaskRunnerCtx) {
-    let run_cache_ctx = &ctx.inner.run_cache_ctx;
-    if run_cache_ctx
-        .telemetry_session_start
-        .set(Instant::now())
-        .is_err()
-    {
-        return;
-    }
-
-    let Some(config) = run_cache_ctx.run_cache_service_config.as_ref() else {
-        return;
-    };
-    let event = session_start_event(config.telemetry_config(), next_telemetry_event_order(ctx));
-    submit_run_cache_telemetry_event(ctx, event).await;
-}
-
-async fn submit_run_cache_telemetry_event(ctx: &TaskRunnerCtx, event: ClientTelemetryEvent) {
-    let Some(client) = ctx.inner.run_cache_ctx.run_cache_service_client.as_ref() else {
-        return;
-    };
-    let dispatcher = ctx
-        .inner
-        .run_cache_ctx
-        .telemetry_dispatcher
-        .get_or_init(|| TelemetryDispatcher::spawn(client.clone()));
-    dispatcher.send(event).await;
-}
-
-async fn submit_run_cache_critical_telemetry_event(
-    ctx: &TaskRunnerCtx,
-    event: ClientTelemetryEvent,
-) {
-    let Some(client) = ctx.inner.run_cache_ctx.run_cache_service_client.as_ref() else {
-        return;
-    };
-    let dispatcher = ctx
-        .inner
-        .run_cache_ctx
-        .telemetry_dispatcher
-        .get_or_init(|| TelemetryDispatcher::spawn(client.clone()));
-    dispatcher.send_critical(event).await;
-}
-
-/// Closes the run's telemetry dispatcher (if one was started) and awaits its
-/// worker, giving already-queued events — in particular session-end — a
-/// chance to reach the service before the command exits.
-async fn flush_run_cache_telemetry(ctx: &TaskRunnerCtx) {
-    if let Some(dispatcher) = ctx.inner.run_cache_ctx.telemetry_dispatcher.get() {
-        dispatcher.flush().await;
-    }
-}
-
-fn next_telemetry_event_order(ctx: &TaskRunnerCtx) -> i64 {
-    ctx.inner
-        .run_cache_ctx
-        .telemetry_event_order
-        .fetch_add(1, Ordering::Relaxed)
 }
 
 /// Submits a runnable node to the dbt State service before local execution.
@@ -1378,7 +862,6 @@ pub async fn run_cache_service_before_execution(
     ctx: &TaskRunnerCtx,
     node: &dyn InternalDbtNodeAttributes,
     task_result: &TaskResult,
-    microbatch_window: Option<(DateTime<Utc>, DateTime<Utc>)>,
 ) -> RunCacheServiceDecision {
     if !ctx.inner.run_cache_ctx.run_cache_service_requested {
         emit_warn_log_message(
@@ -1387,8 +870,8 @@ pub async fn run_cache_service_before_execution(
                 "dbt State service hook reached while service mode is disabled for node {}; executing normally",
                 node.unique_id()
             ),
+            None,
         );
-        write_state_explain_node(ctx, node, None);
         return RunCacheServiceDecision::execute_without_confirmation();
     }
 
@@ -1399,19 +882,13 @@ pub async fn run_cache_service_before_execution(
                 "dbt State service was requested but no validated client is available for node {}; executing normally",
                 node.unique_id()
             ),
+            None,
         );
-        write_state_explain_node(ctx, node, None);
         return RunCacheServiceDecision::execute_without_confirmation();
     };
-    if client.is_disabled() {
-        write_state_explain_node(ctx, node, None);
-        return RunCacheServiceDecision::execute_without_confirmation();
-    }
 
     if !should_honor_service_skip(ctx) {
-        let result =
-            prepare_write_only_execution_record(ctx, node, task_result, microbatch_window).await;
-        write_state_explain_node(ctx, node, None);
+        let result = prepare_write_only_execution_record(ctx, node, task_result).await;
         return match result {
             Ok(Some(record)) => RunCacheServiceDecision::execute_with_record(record),
             Ok(None) => {
@@ -1421,7 +898,7 @@ pub async fn run_cache_service_before_execution(
                         "dbt State service record skipped for node {unique_id}; executing normally"
                     )
                 });
-                RunCacheServiceDecision::execute_and_invalidate_freshness()
+                RunCacheServiceDecision::execute_without_confirmation()
             }
             Err(err) => {
                 emit_warn_log_message(
@@ -1430,8 +907,9 @@ pub async fn run_cache_service_before_execution(
                         "dbt State service record preparation failed for node {}: {err}; executing normally",
                         node.unique_id()
                     ),
+                    None,
                 );
-                RunCacheServiceDecision::execute_and_invalidate_freshness()
+                RunCacheServiceDecision::execute_without_confirmation()
             }
         };
     }
@@ -1445,79 +923,48 @@ pub async fn run_cache_service_before_execution(
                     "dbt State service submit skipped for no-op model materialization (node {unique_id}, materialization {materialization})"
                 )
             });
-            write_state_explain_node(ctx, node, None);
             return RunCacheServiceDecision::execute_without_confirmation();
         }
         if model.common().language.as_deref() != Some("sql") {
             record_unsupported_node(node, "non-SQL model");
-            write_state_explain_node(ctx, node, None);
-            return RunCacheServiceDecision::execute_and_invalidate_freshness();
+            return RunCacheServiceDecision::execute_without_confirmation();
         }
-        submit_model(ctx, model, task_result, client, microbatch_window).await
+        submit_model(ctx, model, task_result, client).await
     } else if let Some(snapshot) = node.as_any().downcast_ref::<DbtSnapshot>() {
         submit_snapshot(ctx, snapshot, task_result, client).await
     } else if let Some(seed) = node.as_any().downcast_ref::<DbtSeed>() {
-        submit_seed(ctx, seed, task_result, client).await
+        submit_seed(ctx, seed, client).await
     } else if let Some(test) = node.as_any().downcast_ref::<DbtTest>() {
         submit_test(ctx, test, task_result, client).await
     } else {
         record_unsupported_node(node, "unsupported node type");
-        write_state_explain_node(ctx, node, None);
-        return RunCacheServiceDecision::execute_and_invalidate_freshness();
+        return RunCacheServiceDecision::execute_without_confirmation();
     };
 
     match result {
-        Ok(Some(RunCacheSubmitResult::Outcome(outcome))) => {
+        Ok(Some(outcome)) => {
             let decision = record_service_decision(
                 node.unique_id().as_str(),
                 &outcome.response,
                 outcome.freshness_tolerance_seconds,
                 should_honor_service_skip(ctx),
             );
-            // A node that completed a dev clone earlier in this invocation should
-            // surface as "Cloned from cached relation" when the service decides
-            // Skip, matching the dbt-core plugin's `_dev_cloned_nodes` mapping.
+            // A node that completed a dev clone earlier in this invocation
+            // should surface as "Cloned from cached relation" when the
+            // service decides Skip, matching the dbt-core plugin's
+            // `_dev_cloned_nodes` mapping.
             let is_dev_cloned = ctx
                 .inner
                 .run_cache_ctx
                 .run_cache_dev_cloned_nodes
                 .contains_key(node.unique_id().as_str());
-            let decision = relabel_skip_for_dev_cloned_node(is_dev_cloned, decision);
-            let execution_decision_id =
-                state_explain_execution_decision_id(Some(&outcome.response), &decision);
-            // Surface the service-side execution decision id on the node's
-            // run-phase evaluation span so successful executions can be
-            // correlated with the dbt State decision that governed them.
-            if let Some(id) = execution_decision_id.as_deref() {
-                find_and_update_span_attrs(|attrs: &mut NodeEvaluated| {
-                    attrs.state_decision_id = Some(id.to_string());
-                });
-            }
-            write_state_explain_node(ctx, node, execution_decision_id);
-            decision
-        }
-        Ok(Some(RunCacheSubmitResult::ExecuteUntracked(record))) => {
-            // A speculative `ReadyToExecuteUntracked` verdict: execute now and
-            // record the outcome after the fact. Never a Skip, so no dev-cloned
-            // relabel applies. The verdict carries no execution decision id, so
-            // the node only gets a local fallback explain record.
-            write_state_explain_node(ctx, node, None);
-            RunCacheServiceDecision::execute_with_record(record)
+            relabel_skip_for_dev_cloned_node(is_dev_cloned, decision)
         }
         Ok(None) => {
             let unique_id = node.unique_id();
             emit_trace_log_message(|| {
                 format!("dbt State service submit skipped for node {unique_id}; executing normally")
             });
-            write_state_explain_node(ctx, node, None);
-            // Reached by bails that cannot produce a sound record — an
-            // unresolved microbatch window, incomplete dependency metadata, an
-            // unsupported node type. The node still rebuilds its target, so the
-            // prefetched epoch must not survive into downstream submissions.
-            RunCacheServiceDecision::execute_and_invalidate_freshness()
-        }
-        Err(_) if client.is_disabled() => {
-            write_state_explain_node(ctx, node, None);
             RunCacheServiceDecision::execute_without_confirmation()
         }
         Err(err) => {
@@ -1527,152 +974,10 @@ pub async fn run_cache_service_before_execution(
                     "dbt State service submit failed for node {}: {err}; executing normally",
                     node.unique_id()
                 ),
+                None,
             );
-            write_state_explain_node(ctx, node, None);
-            // The request failed, so the node rebuilds without tracking; its
-            // cached epoch/existence (e.g. from the prefetch, already awaited by
-            // the time a submit errors) is now stale. Evict it here so
-            // downstream nodes in this run re-query fresh state instead of
-            // reusing it — unlike the benign-skip path, which preserves a valid
-            // prefetched epoch.
-            evict_node_metadata_for_untracked_rebuild(ctx, node);
             RunCacheServiceDecision::execute_without_confirmation()
         }
-    }
-}
-
-fn write_state_explain_node(
-    ctx: &TaskRunnerCtx,
-    node: &dyn InternalDbtNodeAttributes,
-    execution_decision_id: Option<String>,
-) {
-    let Some(path) = ctx.inner.run_cache_ctx.state_explain_log_path.as_ref() else {
-        return;
-    };
-    let record = StateExplainLogRecord::Node(StateExplainNode {
-        node_unique_id: node.unique_id(),
-        node_name: node.name(),
-        node_info: state_explain_node_info(ctx, node),
-        execution_decision_id,
-    });
-    if let Err(err) = append_state_explain_log_record(path, &record) {
-        emit_warn_log_message(
-            ErrorCode::StateServiceWarn,
-            format!("Failed to write dbt State explain node record: {err}"),
-        );
-    }
-}
-
-fn state_explain_execution_decision_id(
-    response: Option<&SubmitSqlResponse>,
-    decision: &RunCacheServiceDecision,
-) -> Option<String> {
-    let response = response?;
-    match decision {
-        RunCacheServiceDecision::Execute {
-            after_success: RunCacheAfterSuccess::Confirm(_),
-            ..
-        }
-        | RunCacheServiceDecision::Clone { .. }
-        | RunCacheServiceDecision::Skip { .. } => execution_decision_id_from_response(response),
-        RunCacheServiceDecision::Execute { .. } | RunCacheServiceDecision::Disabled => None,
-    }
-}
-
-fn state_explain_node_info(
-    ctx: &TaskRunnerCtx,
-    node: &dyn InternalDbtNodeAttributes,
-) -> StateExplainNodeInfo {
-    let mut node_info =
-        state_explain_node_info_for_parts(ctx.adapter_type(), ctx.inner.arg.full_refresh, node);
-    node_info.dev_clone = ctx
-        .inner
-        .run_cache_ctx
-        .run_cache_dev_cloned_nodes
-        .get(node.unique_id().as_str())
-        .map(|entry| entry.value().clone());
-    node_info.deferrals = state_explain_deferrals(ctx, node);
-    node_info
-}
-
-fn state_explain_deferrals(
-    ctx: &TaskRunnerCtx,
-    node: &dyn InternalDbtNodeAttributes,
-) -> HashMap<String, String> {
-    let Some(defer_nodes) = ctx.defer_nodes() else {
-        return HashMap::new();
-    };
-
-    node.base()
-        .depends_on
-        .nodes
-        .iter()
-        .filter_map(|dependency_id| {
-            let deferred_node = defer_nodes.get_node(dependency_id)?;
-            let deferred_fqn = create_relation_from_node(ctx.adapter_type(), deferred_node, None)
-                .ok()?
-                .semantic_fqn();
-            if !ctx
-                .inner
-                .run_cache_ctx
-                .run_cache_deferred_fqns
-                .contains(&deferred_fqn)
-            {
-                return None;
-            }
-
-            let local_node = ctx.nodes().get_node(dependency_id)?;
-            let local_fqn = create_relation_from_node(ctx.adapter_type(), local_node, None)
-                .ok()?
-                .semantic_fqn();
-            Some((local_fqn, deferred_fqn))
-        })
-        .collect()
-}
-
-fn state_explain_node_info_for_parts(
-    adapter_type: AdapterType,
-    full_refresh: bool,
-    node: &dyn InternalDbtNodeAttributes,
-) -> StateExplainNodeInfo {
-    let materialized = node.base().materialized.clone();
-    // No-op materializations are inlined into their consumers, so they never get
-    // a warehouse relation. Reporting one would name a table that cannot exist.
-    let is_ephemeral = is_no_op_model_materialization(materialized.clone());
-    let fqn = if is_ephemeral {
-        String::new()
-    } else {
-        create_relation_from_node(adapter_type, node, None)
-            .map(|relation| relation.semantic_fqn())
-            .unwrap_or_default()
-    };
-    let is_full_refresh = if let Some(model) = node.as_any().downcast_ref::<DbtModel>() {
-        effective_full_refresh(full_refresh, model.deprecated_config.full_refresh)
-    } else if let Some(snapshot) = node.as_any().downcast_ref::<DbtSnapshot>() {
-        effective_full_refresh(full_refresh, snapshot.deprecated_config.full_refresh)
-    } else {
-        false
-    };
-
-    StateExplainNodeInfo {
-        fqn,
-        node_resource_type: node.resource_type().as_static_ref().to_string(),
-        is_view: materialized == DbtMaterialization::View,
-        is_table: matches!(
-            materialized,
-            DbtMaterialization::Table
-                | DbtMaterialization::Incremental
-                | DbtMaterialization::Snapshot
-                | DbtMaterialization::Seed
-        ),
-        is_ephemeral,
-        is_incremental_or_snapshot: matches!(
-            materialized,
-            DbtMaterialization::Incremental | DbtMaterialization::Snapshot
-        ),
-        is_full_refresh,
-        dev_clone: None,
-        deferrals: HashMap::new(),
     }
 }
 
@@ -1688,7 +993,7 @@ pub async fn confirm_run_cache_service_execution(
     execution_runtime_ms: Option<i64>,
 ) {
     // Without a confirmation token there is nothing to report, so avoid the
-    // final metadata refresh.
+    // final metadata refresh for reused/skipped nodes.
     let Some(confirmation) = confirmation else {
         return;
     };
@@ -1703,8 +1008,10 @@ pub async fn confirm_run_cache_service_execution(
     // where there is no audit relation to query.
     let final_last_modified_epoch = if is_test {
         None
+    } else if let Some(epoch) = stamp_final_last_modified_epoch_for_node_heuristic(ctx, node) {
+        Some(epoch)
     } else {
-        match final_last_modified_epoch_for_node(ctx, node).await {
+        match refresh_final_last_modified_epoch_for_node(ctx, node).await {
             Ok(epoch) => epoch,
             Err(err) => {
                 emit_warn_log_message(
@@ -1713,17 +1020,12 @@ pub async fn confirm_run_cache_service_execution(
                         "dbt State service final metadata lookup failed for node {}: {err}; command remains successful",
                         node.unique_id()
                     ),
+                    None,
                 );
                 return;
             }
         }
     };
-
-    // Replay must consume the recorded final freshness event and clear the
-    // cached pre-build value, but it must not contact the live dbt State service.
-    if dbt_adapter::time_machine::is_replaying() {
-        return;
-    }
 
     let Some(client) = ctx.inner.run_cache_ctx.run_cache_service_client.as_ref() else {
         emit_warn_log_message(
@@ -1733,9 +1035,11 @@ pub async fn confirm_run_cache_service_execution(
                 node.unique_id(),
                 confirmation.request_id
             ),
+            None,
         );
         return;
     };
+
     let request = match confirmation
         .into_confirm_execution_request(ctx, node, final_last_modified_epoch, execution_runtime_ms)
         .await
@@ -1749,6 +1053,7 @@ pub async fn confirm_run_cache_service_execution(
                     "dbt State service confirmation metadata lookup failed for node {}: {err}; command remains successful",
                     node.unique_id()
                 ),
+                None,
             );
             return;
         }
@@ -1757,23 +1062,20 @@ pub async fn confirm_run_cache_service_execution(
     let request_id = request.request_id.clone();
     if let Err(err) = client.confirm_execution(request).await {
         let unique_id = node.unique_id();
-        match err {
-            RunCacheServiceError::Disabled => {}
-            err if err.is_transient_transport_rpc() => {
-                emit_trace_log_message(|| {
-                    format!(
-                        "dbt State service confirmation transport failed for node {unique_id} (request_id {request_id}): {err}; command remains successful"
-                    )
-                });
-            }
-            err => {
-                emit_warn_log_message(
-                    ErrorCode::StateServiceWarn,
-                    format!(
-                        "dbt State service confirmation failed for node {unique_id} (request_id {request_id}): {err}; command remains successful"
-                    ),
-                );
-            }
+        if err.is_transient_transport_rpc() {
+            emit_trace_log_message(|| {
+                format!(
+                    "dbt State service confirmation transport failed for node {unique_id} (request_id {request_id}): {err}; command remains successful"
+                )
+            });
+        } else {
+            emit_warn_log_message(
+                ErrorCode::StateServiceWarn,
+                format!(
+                    "dbt State service confirmation failed for node {unique_id} (request_id {request_id}): {err}; command remains successful"
+                ),
+                None,
+            );
         }
     } else {
         let unique_id = node.unique_id();
@@ -1807,9 +1109,11 @@ pub async fn record_run_cache_service_execution(
                 "dbt State service record skipped for node {} because no validated client is available",
                 node.unique_id()
             ),
+            None,
         );
         return;
     };
+
     let request = match record
         .into_record_executions_request(ctx, node, execution_runtime_ms)
         .await
@@ -1823,6 +1127,7 @@ pub async fn record_run_cache_service_execution(
                     "dbt State service record metadata lookup failed for node {}: {err}; command remains successful",
                     node.unique_id()
                 ),
+                None,
             );
             return;
         }
@@ -1830,23 +1135,20 @@ pub async fn record_run_cache_service_execution(
 
     if let Err(err) = client.record_executions(request).await {
         let unique_id = node.unique_id();
-        match err {
-            RunCacheServiceError::Disabled => {}
-            err if err.is_transient_transport_rpc() => {
-                emit_trace_log_message(|| {
-                    format!(
-                        "dbt State service record transport failed for node {unique_id}: {err}; command remains successful"
-                    )
-                });
-            }
-            err => {
-                emit_warn_log_message(
-                    ErrorCode::StateServiceWarn,
-                    format!(
-                        "dbt State service record failed for node {unique_id}: {err}; command remains successful"
-                    ),
-                );
-            }
+        if err.is_transient_transport_rpc() {
+            emit_trace_log_message(|| {
+                format!(
+                    "dbt State service record transport failed for node {unique_id}: {err}; command remains successful"
+                )
+            });
+        } else {
+            emit_warn_log_message(
+                ErrorCode::StateServiceWarn,
+                format!(
+                    "dbt State service record failed for node {unique_id}: {err}; command remains successful"
+                ),
+                None,
+            );
         }
     } else {
         let unique_id = node.unique_id();
@@ -1960,29 +1262,6 @@ struct RunCacheSubmitOutcome {
     freshness_tolerance_seconds: i64,
 }
 
-/// Outcome of a per-node submit helper.
-///
-/// Most submits produce a service `response` fed to `record_service_decision`.
-/// The speculative `ReadyToExecuteUntracked` verdict has no counterpart there:
-/// the node executes now and its outcome is recorded after the fact, so the
-/// helper hands back the pending record directly. It is never a Skip/Clone, so
-/// it bypasses both the decision translation and the dev-cloned relabel.
-enum RunCacheSubmitResult {
-    // Boxed: `RunCacheSubmitOutcome` carries a full `SubmitSqlResponse`, far
-    // larger than the `ExecuteUntracked` variant, so box it to keep the enum small.
-    Outcome(Box<RunCacheSubmitOutcome>),
-    ExecuteUntracked(RunCachePendingExecutionRecord),
-}
-
-impl RunCacheSubmitResult {
-    fn outcome(response: SubmitSqlResponse, freshness_tolerance_seconds: i64) -> Self {
-        Self::Outcome(Box::new(RunCacheSubmitOutcome {
-            response,
-            freshness_tolerance_seconds,
-        }))
-    }
-}
-
 impl RunCacheExecutionConfirmation {
     async fn into_confirm_execution_request(
         self,
@@ -2024,22 +1303,13 @@ impl RunCacheExecutionConfirmation {
 impl RunCachePendingExecutionRecord {
     fn sql(request: SubmitEnrichedSqlRequest) -> Self {
         Self {
-            input: RunCachePendingExecutionInput::Sql(Box::new(request)),
-            speculative: false,
-        }
-    }
-
-    fn sql_speculative(request: SubmitEnrichedSqlRequest) -> Self {
-        Self {
-            input: RunCachePendingExecutionInput::Sql(Box::new(request)),
-            speculative: true,
+            input: RunCachePendingExecutionInput::Sql(request),
         }
     }
 
     fn values(request: SubmitValuesRequest) -> Self {
         Self {
-            input: RunCachePendingExecutionInput::Values(Box::new(request)),
-            speculative: false,
+            input: RunCachePendingExecutionInput::Values(request),
         }
     }
 
@@ -2049,22 +1319,7 @@ impl RunCachePendingExecutionRecord {
         node: &dyn InternalDbtNodeAttributes,
         execution_runtime_ms: Option<i64>,
     ) -> FsResult<Option<RecordExecutionsRequest>> {
-        let speculative = self.speculative;
-
-        // A speculative record was built from a partial dependency snapshot
-        // while the prefetch was still in flight. Finalize the dependency epochs
-        // against the now-warm cache before recording, so the persisted record
-        // reflects the real upstream state rather than the speculative one.
-        let input = match self.input {
-            RunCachePendingExecutionInput::Sql(request) if speculative => {
-                RunCachePendingExecutionInput::Sql(Box::new(
-                    finalize_speculative_sql_request(ctx, node, *request).await,
-                ))
-            }
-            other => other,
-        };
-
-        let last_modified_epoch = final_last_modified_epoch_for_node(ctx, node).await?;
+        let last_modified_epoch = refresh_final_last_modified_epoch_for_node(ctx, node).await?;
         let Some(last_modified_epoch) = last_modified_epoch else {
             let unique_id = node.unique_id();
             emit_trace_log_message(|| {
@@ -2080,12 +1335,12 @@ impl RunCachePendingExecutionRecord {
             table_type: table_type_for_node(ctx, node).await?,
             execution_runtime_ms,
         };
-        let record = match input {
+        let record = match self.input {
             RunCachePendingExecutionInput::Sql(request) => {
-                sql_execution_record_from_submit_request(*request, outcome, speculative)
+                sql_execution_record_from_submit_request(request, outcome)
             }
             RunCachePendingExecutionInput::Values(request) => {
-                values_execution_record_from_submit_request(*request, outcome)
+                values_execution_record_from_submit_request(request, outcome)
             }
         };
 
@@ -2093,121 +1348,6 @@ impl RunCachePendingExecutionRecord {
             records: vec![record],
         }))
     }
-}
-
-/// Finalize the dependency last-modified epochs on a speculative SQL request.
-///
-/// A speculative request is built from cache reads only while the global
-/// prefetch is still running, so some dependency epochs may be unset. Before the
-/// outcome is recorded, this refreshes those epochs to their real values so the
-/// persisted record reflects the true upstream state rather than the partial
-/// speculative snapshot:
-/// 1. await the global prefetch so the cache is fully warm;
-/// 2. reconstruct a relation for each recorded table name and re-fetch any
-///    epochs still missing from the cache, using the node's source-freshness
-///    overrides so sources keep their custom freshness strategy;
-/// 3. re-read the cache per table name, using the resolved entry whenever the
-///    relation is present — including an explicit resolved-unknown, which clears
-///    the epoch to unset — and falling back to the existing speculative epoch
-///    only on a genuine cache miss.
-///
-/// Table names are canonical `semantic_fqn` strings, the same key the metadata
-/// cache and the miss-refresh planner use.
-async fn finalize_speculative_sql_request(
-    ctx: &TaskRunnerCtx,
-    node: &dyn InternalDbtNodeAttributes,
-    mut request: SubmitEnrichedSqlRequest,
-) -> SubmitEnrichedSqlRequest {
-    await_prefetch(ctx).await;
-    if request.tables.is_empty() {
-        return request;
-    }
-
-    // Reconstruct a relation per recorded table name so the miss-refresh can
-    // issue real warehouse lookups for anything the global prefetch didn't
-    // resolve (e.g. parser-discovered raw references outside the DAG).
-    let mut relations: BTreeMap<String, Arc<dyn BaseRelation>> = BTreeMap::new();
-    for table in &request.tables {
-        if let Ok(relation) = relation_from_rendered_name(ctx, node, &table.name) {
-            relations.insert(table.name.clone(), relation);
-        }
-    }
-
-    let overrides = collect_source_freshness_overrides(ctx, node);
-    prefetch_last_modified_epochs(ctx, &relations, &overrides).await;
-
-    for table in &mut request.tables {
-        // `last_modified_epoch` is `Some(resolved)` when the cache has an entry
-        // for the relation (`resolved` may be `None` — a resolved-unknown that
-        // must clear the speculative epoch to unset) and `None` on a genuine
-        // miss. Only a genuine miss keeps the best-effort speculative value.
-        if let Some(resolved) = ctx
-            .inner
-            .run_cache_ctx
-            .run_cache_metadata
-            .last_modified_epoch(&table.name)
-        {
-            table.last_modified_epoch = resolved;
-        }
-    }
-    request
-}
-
-/// Collect source-freshness overrides for a node's runtime dependencies.
-///
-/// Mirrors the override collection in `collect_table_modified_infos`: sources
-/// declaring `loaded_at_query` or `loaded_at_field` get a `FreshnessOverride`
-/// keyed by the relation's `semantic_fqn` — the key `freshness_with_overrides`
-/// and the miss-refresh planner expect. Query takes precedence over field
-/// (matching the dbt-core plugin); empty strings from the deserializer are
-/// treated as "not set".
-fn collect_source_freshness_overrides(
-    ctx: &TaskRunnerCtx,
-    node: &dyn InternalDbtNodeAttributes,
-) -> BTreeMap<String, FreshnessOverride> {
-    let mut overrides: BTreeMap<String, FreshnessOverride> = BTreeMap::new();
-    let Some(deps) = ctx.inner.runtime_deps.get(node.unique_id().as_str()) else {
-        return overrides;
-    };
-    for dep_id in deps {
-        let Some(dep_node) = ctx.nodes().get_node(dep_id) else {
-            continue;
-        };
-        let Some(source) = dep_node.as_any().downcast_ref::<DbtSource>() else {
-            continue;
-        };
-        let Ok((name, _)) = relation_for_node(ctx, dep_node) else {
-            continue;
-        };
-        if let Some(kind) = source_freshness_override(source) {
-            overrides.insert(name, kind);
-        }
-    }
-    overrides
-}
-
-/// The source-freshness override a source declares via `loaded_at_query` /
-/// `loaded_at_field`, if any. Query takes precedence over field (matching the
-/// dbt-core plugin); empty strings from the deserializer are treated as unset.
-fn source_freshness_override(source: &DbtSource) -> Option<FreshnessOverride> {
-    let trimmed_nonempty = |s: &str| {
-        let t = s.trim();
-        (!t.is_empty()).then(|| t.to_string())
-    };
-    source
-        .__source_attr__
-        .loaded_at_query
-        .as_deref()
-        .and_then(trimmed_nonempty)
-        .map(FreshnessOverride::Query)
-        .or_else(|| {
-            source
-                .__source_attr__
-                .loaded_at_field
-                .as_deref()
-                .and_then(trimmed_nonempty)
-                .map(FreshnessOverride::Field)
-        })
 }
 
 /// Guard against cloning from a source that was modified out-of-band since the
@@ -2302,7 +1442,7 @@ fn execute_clone_sqls_blocking(
         .with_desc("dbt State clone");
     for sql in clone_sqls {
         adapter
-            .execute_without_state(Some(&query_ctx), sql, false, None)
+            .execute_without_state(Some(&query_ctx), sql, false)
             .map_err(|err| into_fs_error(Cancellable::Error(err)))?;
     }
     Ok(())
@@ -2324,364 +1464,42 @@ async fn submit_model(
     model: &DbtModel,
     task_result: &TaskResult,
     client: &dbt_state::service_client::SharedRunCacheServiceClient,
-    microbatch_window: Option<(DateTime<Utc>, DateTime<Utc>)>,
-) -> FsResult<Option<RunCacheSubmitResult>> {
+) -> FsResult<Option<RunCacheSubmitOutcome>> {
     let full_refresh = effective_full_refresh(
         ctx.inner.arg.full_refresh,
         model.deprecated_config.full_refresh,
     );
-    // A microbatch model's cache key is only sound with its event-time window
-    // folded in (every batch shares one target table and query hash). If the
-    // window could not be resolved there is nothing sound to write down either,
-    // so make no decision *and* record nothing — the `Ok(None)` path only
-    // invalidates the target's cached freshness. Checked ahead of full refresh
-    // so that a full-refreshed microbatch model is never recorded on the
-    // strength of a window we could not resolve. Mirrors the plugin's
-    // `_resolve_microbatch_window` bypass.
-    if is_microbatch_model(model) && microbatch_window.is_none() {
-        record_submit_skipped(model, "unresolved microbatch window");
+    if full_refresh && full_refresh_blocks_model_submit(model.materialized()) {
+        record_submit_skipped(model, "full refresh");
         return Ok(None);
     }
 
-    if full_refresh && full_refresh_blocks_model_submit(model.materialized()) {
-        // `--full-refresh` is an explicit instruction to rebuild, so this node
-        // must never be skipped. The service cannot enforce that for us: the
-        // request carries no full-refresh flag, only `execution_type=FULL`, so
-        // a daily full-refresh job would match yesterday's FULL record whenever
-        // the sources happened not to move and skip the rebuild the user asked
-        // for. Hence the client-side bail.
-        //
-        // That is a reason not to seek a *decision*, not a reason to hide the
-        // execution. The node still rewrites its target, so record it: going
-        // dark leaves the service blind to the rebuild and leaves the cached
-        // last-modified epoch describing pre-build state, which downstream
-        // nodes in this run then report and are incorrectly skipped on.
-        record_submit_skipped(model, "full refresh");
-        return Ok(
-            prepare_write_only_execution_record(ctx, model, task_result, microbatch_window)
-                .await?
-                .map(RunCacheSubmitResult::ExecuteUntracked),
-        );
-    }
-
-    submit_sql_with_speculation(
+    let context = build_sql_context(
         ctx,
         model,
         task_result.sql_instruction.sql.clone(),
         model.materialized() == DbtMaterialization::View,
         full_refresh,
-        microbatch_window,
-        client,
-        |context| {
-            build_model_sql_request(
-                model,
-                context,
-                &ctx.inner.materialization_resolver,
-                create_macro_resolver(ctx),
-            )
-        },
-    )
-    .await
-}
-
-/// Submit a SQL node, using the speculative fast-path while the global
-/// dependency prefetch is still in flight.
-///
-/// When the prefetch is already complete this awaits it (a no-op) and submits
-/// regularly. Otherwise it builds a speculative request from cache reads only
-/// and branches on the verdict:
-/// - `SkipExecution` / `ReadyToClone` — returned as a synthetic regular
-///   response (identical inner types) so the caller's `record_service_decision`
-///   handles it unchanged. Sound because a missing dependency epoch can only
-///   make a candidate look staler, never fresher.
-/// - `ReadyToExecuteUntracked` — the node must execute now; a speculative
-///   pending record is returned so the outcome is recorded after the fact with
-///   finalized epochs. The prefetch is intentionally not awaited here.
-/// - `Undecided` / RPC error / empty — await the prefetch and resubmit a
-///   regular (non-speculative) request.
-#[allow(clippy::too_many_arguments)]
-async fn submit_sql_with_speculation(
-    ctx: &TaskRunnerCtx,
-    node: &dyn InternalDbtNodeAttributes,
-    sql: String,
-    is_view: bool,
-    full_refresh: bool,
-    microbatch_window: Option<(DateTime<Utc>, DateTime<Utc>)>,
-    client: &dbt_state::service_client::SharedRunCacheServiceClient,
-    build_request: impl Fn(SqlRunCacheRequestContext) -> FsResult<SubmitEnrichedSqlRequest>,
-) -> FsResult<Option<RunCacheSubmitResult>> {
-    // Client-generated so `EnrichedSqlPrepared` telemetry doesn't depend on
-    // the server response carrying a request id (`SkipExecution` and
-    // `ReadyToExecuteUntracked` don't).
-    let request_id = dbt_state::service_client::new_request_id();
-
-    if is_prefetch_ready(ctx) {
-        return build_and_submit_non_speculative(
-            ctx,
-            node,
-            sql,
-            is_view,
-            full_refresh,
-            microbatch_window,
-            client,
-            &build_request,
-            request_id,
-            true,
-        )
-        .await;
-    }
-
-    let request_start = Instant::now();
-    let Some((request, freshness_tolerance_seconds)) = build_sql_request(
-        ctx,
-        node,
-        &sql,
-        is_view,
-        full_refresh,
-        microbatch_window,
-        true,
-        &build_request,
-    )
-    .await?
-    else {
-        return Ok(None);
-    };
-    let telemetry = enriched_sql_prepared_telemetry_input(&request);
-    let prepare_duration = request_start.elapsed();
-
-    // Re-check readiness at the last responsible moment. `build_sql_request`
-    // blocks on the view-definition traversal (fetching view DDL from the
-    // warehouse) while the background prefetch runs concurrently, so the
-    // prefetch often completes during that window. The decision above was made
-    // against a now-stale snapshot: if the prefetch is ready, submit
-    // non-speculatively with fully-resolved epochs instead of wasting a
-    // speculative round-trip that would only come back `Undecided` and force a
-    // resubmit. `is_prefetch_ready` is a cheap atomic read, and the rebuild
-    // reuses the traverser's warm cache, so no view definition is re-fetched.
-    if is_prefetch_ready(ctx) {
-        return build_and_submit_non_speculative(
-            ctx,
-            node,
-            sql,
-            is_view,
-            full_refresh,
-            microbatch_window,
-            client,
-            &build_request,
-            request_id,
-            true,
-        )
-        .await;
-    }
-
-    // Report the speculative attempt once the final path is known. If the
-    // prefetch completed while building the request, the regular path above
-    // is the only submission and reports its own event.
-    emit_enriched_sql_prepared_telemetry(
-        ctx,
-        request_id.clone(),
-        prepare_duration,
-        telemetry,
-        None,
-    )
-    .await;
-
-    let unique_id = node.unique_id();
-    let verdict = client
-        .submit_enriched_sql_speculative(request.clone())
-        .await;
-    match verdict {
-        Ok(response) => match response.response {
-            Some(submit_sql_speculative_response::Response::SkipExecution(skip)) => {
-                emit_trace_log_message(|| {
-                    format!("dbt State speculative decision: skip execution for node {unique_id}")
-                });
-                Ok(Some(RunCacheSubmitResult::outcome(
-                    SubmitSqlResponse {
-                        response: Some(submit_sql_response::Response::SkipExecution(skip)),
-                    },
-                    freshness_tolerance_seconds,
-                )))
-            }
-            Some(submit_sql_speculative_response::Response::ReadyToClone(clone)) => {
-                emit_trace_log_message(|| {
-                    format!("dbt State speculative decision: ready to clone for node {unique_id}")
-                });
-                Ok(Some(RunCacheSubmitResult::outcome(
-                    SubmitSqlResponse {
-                        response: Some(submit_sql_response::Response::ReadyToClone(clone)),
-                    },
-                    freshness_tolerance_seconds,
-                )))
-            }
-            Some(submit_sql_speculative_response::Response::ReadyToExecuteUntracked(_)) => {
-                emit_trace_log_message(|| {
-                    format!(
-                        "dbt State speculative decision: ready to execute untracked for node {unique_id}; recording after execution"
-                    )
-                });
-                Ok(Some(RunCacheSubmitResult::ExecuteUntracked(
-                    RunCachePendingExecutionRecord::sql_speculative(request),
-                )))
-            }
-            Some(submit_sql_speculative_response::Response::Undecided(_)) | None => {
-                emit_trace_log_message(|| {
-                    format!(
-                        "dbt State speculative decision: undecided for node {unique_id}; awaiting prefetch and resubmitting"
-                    )
-                });
-                await_prefetch(ctx).await;
-                build_and_submit_non_speculative(
-                    ctx,
-                    node,
-                    sql,
-                    is_view,
-                    full_refresh,
-                    microbatch_window,
-                    client,
-                    &build_request,
-                    request_id,
-                    false,
-                )
-                .await
-            }
-        },
-        Err(err) => {
-            // Swallowed here rather than reported as a prepare-error: the
-            // speculative RPC is a best-effort fast path, and the resubmit
-            // below still reports its own failures.
-            emit_trace_log_message(|| {
-                format!(
-                    "dbt State speculative submit failed for node {unique_id}: {err}; awaiting prefetch and resubmitting"
-                )
-            });
-            await_prefetch(ctx).await;
-            build_and_submit_non_speculative(
-                ctx,
-                node,
-                sql,
-                is_view,
-                full_refresh,
-                microbatch_window,
-                client,
-                &build_request,
-                request_id,
-                false,
-            )
-            .await
-        }
-    }
-}
-
-/// Build and issue a regular (non-speculative) SQL submit, awaiting the global
-/// prefetch first so freshness resolves from the warm cache. Idempotent with
-/// respect to the prefetch await, so it is safe to call after the speculative
-/// path already awaited it.
-///
-/// `request_id` is the attempt's client-generated id (see
-/// `submit_sql_with_speculation`). `report_prepared_success` is `false` when
-/// this is a resubmit after a speculative attempt already reported success
-/// telemetry for the same id — a failure here is still reported either way.
-#[allow(clippy::too_many_arguments)]
-async fn build_and_submit_non_speculative(
-    ctx: &TaskRunnerCtx,
-    node: &dyn InternalDbtNodeAttributes,
-    sql: String,
-    is_view: bool,
-    full_refresh: bool,
-    microbatch_window: Option<(DateTime<Utc>, DateTime<Utc>)>,
-    client: &dbt_state::service_client::SharedRunCacheServiceClient,
-    build_request: &impl Fn(SqlRunCacheRequestContext) -> FsResult<SubmitEnrichedSqlRequest>,
-    request_id: String,
-    report_prepared_success: bool,
-) -> FsResult<Option<RunCacheSubmitResult>> {
-    await_prefetch(ctx).await;
-    let request_start = Instant::now();
-    let Some((request, freshness_tolerance_seconds)) = build_sql_request(
-        ctx,
-        node,
-        &sql,
-        is_view,
-        full_refresh,
-        microbatch_window,
-        false,
-        build_request,
-    )
-    .await?
-    else {
-        return Ok(None);
-    };
-    let telemetry = enriched_sql_prepared_telemetry_input(&request);
-    let prepare_duration = request_start.elapsed();
-
-    // Success only if `report_prepared_success` (the sole/first build for
-    // this attempt); failure always, even on a resubmit.
-    let response = match client.submit_enriched_sql(request).await {
-        Ok(response) => {
-            if report_prepared_success {
-                emit_enriched_sql_prepared_telemetry(
-                    ctx,
-                    request_id,
-                    prepare_duration,
-                    telemetry,
-                    None,
-                )
-                .await;
-            }
-            response
-        }
-        Err(err) => {
-            emit_enriched_sql_prepared_telemetry(
-                ctx,
-                request_id,
-                request_start.elapsed(),
-                telemetry,
-                Some(err.error_type_label().to_string()),
-            )
-            .await;
-            return Err(fs_err!(
-                ErrorCode::Generic,
-                "dbt State service SubmitEnrichedSQL failed: {}",
-                err
-            ));
-        }
-    };
-    Ok(Some(RunCacheSubmitResult::outcome(
-        response,
-        freshness_tolerance_seconds,
-    )))
-}
-
-/// Build a SQL submit request, returning `None` when required metadata is
-/// missing (the submit is then skipped and the node executes normally).
-#[allow(clippy::too_many_arguments)]
-async fn build_sql_request(
-    ctx: &TaskRunnerCtx,
-    node: &dyn InternalDbtNodeAttributes,
-    sql: &str,
-    is_view: bool,
-    full_refresh: bool,
-    microbatch_window: Option<(DateTime<Utc>, DateTime<Utc>)>,
-    speculative: bool,
-    build_request: &impl Fn(SqlRunCacheRequestContext) -> FsResult<SubmitEnrichedSqlRequest>,
-) -> FsResult<Option<(SubmitEnrichedSqlRequest, i64)>> {
-    let mut context = build_sql_context(
-        ctx,
-        node,
-        sql.to_string(),
-        is_view,
-        full_refresh,
-        speculative,
     )
     .await?;
     if !context.metadata_complete {
-        record_submit_skipped(node, "missing metadata");
+        record_submit_skipped(model, "missing metadata");
         return Ok(None);
     }
-    context.request.microbatch_window = microbatch_window;
     let freshness_tolerance_seconds = context.request.freshness_tolerance_seconds;
-    let request = build_request(context.request)?;
-    Ok(Some((request, freshness_tolerance_seconds)))
+    let request = build_model_sql_request(model, context.request)?;
+
+    let response = client.submit_enriched_sql(request).await.map_err(|e| {
+        fs_err!(
+            ErrorCode::Generic,
+            "dbt State service SubmitEnrichedSQL failed: {}",
+            e
+        )
+    })?;
+    Ok(Some(RunCacheSubmitOutcome {
+        response,
+        freshness_tolerance_seconds,
+    }))
 }
 
 /// Builds the dbt State record input for write-only mode without contacting the
@@ -2695,14 +1513,7 @@ async fn prepare_write_only_execution_record(
     ctx: &TaskRunnerCtx,
     node: &dyn InternalDbtNodeAttributes,
     task_result: &TaskResult,
-    microbatch_window: Option<(DateTime<Utc>, DateTime<Utc>)>,
 ) -> FsResult<Option<RunCachePendingExecutionRecord>> {
-    // Write-only makes no speculative decision: it only records executions and
-    // needs fully resolved dependency freshness. Block on the background prefetch
-    // so the record is built from the warm cache rather than racing it with
-    // redundant per-node freshness queries.
-    await_prefetch(ctx).await;
-
     if let Some(model) = node.as_any().downcast_ref::<DbtModel>() {
         if is_no_op_model_materialization(model.materialized()) {
             record_submit_skipped(model, "no-op model materialization");
@@ -2710,12 +1521,6 @@ async fn prepare_write_only_execution_record(
         }
         if model.common().language.as_deref() != Some("sql") {
             record_unsupported_node(node, "non-SQL model");
-            return Ok(None);
-        }
-        // See `submit_model`: a microbatch model can only be recorded soundly with
-        // its resolved window folded into the key (kept even under --full-refresh).
-        if is_microbatch_model(model) && microbatch_window.is_none() {
-            record_submit_skipped(model, "unresolved microbatch window");
             return Ok(None);
         }
         let full_refresh = effective_full_refresh(
@@ -2728,22 +1533,15 @@ async fn prepare_write_only_execution_record(
             task_result.sql_instruction.sql.clone(),
             model.materialized() == DbtMaterialization::View,
             full_refresh,
-            false,
         )
         .await?;
         if !context.metadata_complete {
             record_submit_skipped(model, "missing metadata");
             return Ok(None);
         }
-        context.request.microbatch_window = microbatch_window;
         remove_cache_decision_fields(&mut context.request);
         Ok(Some(RunCachePendingExecutionRecord::sql(
-            build_model_sql_request(
-                model,
-                context.request,
-                &ctx.inner.materialization_resolver,
-                create_macro_resolver(ctx),
-            )?,
+            build_model_sql_request(model, context.request)?,
         )))
     } else if let Some(snapshot) = node.as_any().downcast_ref::<DbtSnapshot>() {
         let mut context = build_sql_context(
@@ -2755,7 +1553,6 @@ async fn prepare_write_only_execution_record(
                 ctx.inner.arg.full_refresh,
                 snapshot.deprecated_config.full_refresh,
             ),
-            false,
         )
         .await?;
         if !context.metadata_complete {
@@ -2764,7 +1561,7 @@ async fn prepare_write_only_execution_record(
         }
         remove_cache_decision_fields(&mut context.request);
         Ok(Some(RunCachePendingExecutionRecord::sql(
-            build_snapshot_sql_request(snapshot, context.request, create_macro_resolver(ctx))?,
+            build_snapshot_sql_request(snapshot, context.request)?,
         )))
     } else if let Some(seed) = node.as_any().downcast_ref::<DbtSeed>() {
         let request = build_seed_values_request(
@@ -2772,13 +1569,11 @@ async fn prepare_write_only_execution_record(
             SeedRunCacheRequestContext {
                 adapter_type: ctx.adapter_type(),
                 dialect: run_cache_dialect(ctx),
+                project_root: ctx.inner.arg.io.in_dir.as_path(),
                 last_modified_epoch: None,
                 clone_time_travel_limit: None,
                 clone_table_properties: None,
-                clone_chain_depth_limit: None,
-                dbt_project_info: DbtProjectInfo::from(ctx),
             },
-            create_macro_resolver(ctx),
         )?;
         Ok(Some(RunCachePendingExecutionRecord::values(request)))
     } else {
@@ -2792,47 +1587,50 @@ async fn submit_snapshot(
     snapshot: &DbtSnapshot,
     task_result: &TaskResult,
     client: &dbt_state::service_client::SharedRunCacheServiceClient,
-) -> FsResult<Option<RunCacheSubmitResult>> {
-    let full_refresh = effective_full_refresh(
-        ctx.inner.arg.full_refresh,
-        snapshot.deprecated_config.full_refresh,
-    );
-    submit_sql_with_speculation(
+) -> FsResult<Option<RunCacheSubmitOutcome>> {
+    let context = build_sql_context(
         ctx,
         snapshot,
         task_result.sql_instruction.sql.clone(),
         false,
-        full_refresh,
-        None,
-        client,
-        |context| build_snapshot_sql_request(snapshot, context, create_macro_resolver(ctx)),
+        effective_full_refresh(
+            ctx.inner.arg.full_refresh,
+            snapshot.deprecated_config.full_refresh,
+        ),
     )
-    .await
+    .await?;
+    if !context.metadata_complete {
+        record_submit_skipped(snapshot, "missing metadata");
+        return Ok(None);
+    }
+    let freshness_tolerance_seconds = context.request.freshness_tolerance_seconds;
+    let request = build_snapshot_sql_request(snapshot, context.request)?;
+
+    let response = client.submit_enriched_sql(request).await.map_err(|e| {
+        fs_err!(
+            ErrorCode::Generic,
+            "dbt State service SubmitEnrichedSQL failed: {}",
+            e
+        )
+    })?;
+    Ok(Some(RunCacheSubmitOutcome {
+        response,
+        freshness_tolerance_seconds,
+    }))
 }
 
 async fn submit_seed(
     ctx: &TaskRunnerCtx,
     seed: &DbtSeed,
-    task_result: &TaskResult,
     client: &dbt_state::service_client::SharedRunCacheServiceClient,
-) -> FsResult<Option<RunCacheSubmitResult>> {
+) -> FsResult<Option<RunCacheSubmitOutcome>> {
     if effective_full_refresh(
         ctx.inner.arg.full_refresh,
         seed.deprecated_config.full_refresh,
     ) {
-        // See `submit_model`: an explicit rebuild must not be skipped, but it
-        // must still be observed, or downstream nodes report pre-reload state.
         record_submit_skipped(seed, "full refresh");
-        return Ok(
-            prepare_write_only_execution_record(ctx, seed, task_result, None)
-                .await?
-                .map(RunCacheSubmitResult::ExecuteUntracked),
-        );
+        return Ok(None);
     }
-
-    // Seeds never speculate; make sure the target's freshness has been resolved
-    // by the background prefetch before reading it from the cache.
-    await_prefetch(ctx).await;
 
     // Mirrors dbt-core's `_build_submit_values_request`: always submit, even
     // when the target table doesn't exist yet. The service treats a None
@@ -2852,13 +1650,11 @@ async fn submit_seed(
         SeedRunCacheRequestContext {
             adapter_type: ctx.adapter_type(),
             dialect: run_cache_dialect(ctx),
+            project_root: ctx.inner.arg.io.in_dir.as_path(),
             last_modified_epoch,
             clone_time_travel_limit,
             clone_table_properties: None,
-            clone_chain_depth_limit: None,
-            dbt_project_info: DbtProjectInfo::from(ctx),
         },
-        create_macro_resolver(ctx),
     )?;
 
     let response = client.submit_values(request).await.map_err(|e| {
@@ -2868,81 +1664,50 @@ async fn submit_seed(
             e
         )
     })?;
-    Ok(Some(RunCacheSubmitResult::outcome(response, 0)))
+    Ok(Some(RunCacheSubmitOutcome {
+        response,
+        freshness_tolerance_seconds: 0,
+    }))
 }
 
 /// Mirrors dbt-core's `_DataTestAdapterProxy._on_data_test_query`: submit a
 /// data test's count(*) SQL with `execution_type=DbtDataTest`. The cached
 /// `{failures, should_warn, should_error}` payload flows back through
 /// `SkipExecutionResponse.execution_results` and is decoded by
-/// `parse_cached_test_execution_result`. On `ReadyToExecute`, the dispatcher
-/// confirms after the test runs (see `set_test_execution_results`).
+/// `parse_cached_test_failures`. On `ReadyToExecute`, the dispatcher confirms
+/// after the test runs (see `set_test_execution_results`).
 async fn submit_test(
     ctx: &TaskRunnerCtx,
     test: &DbtTest,
     task_result: &TaskResult,
     client: &dbt_state::service_client::SharedRunCacheServiceClient,
-) -> FsResult<Option<RunCacheSubmitResult>> {
-    submit_sql_with_speculation(
+) -> FsResult<Option<RunCacheSubmitOutcome>> {
+    let context = build_sql_context(
         ctx,
         test,
         task_result.sql_instruction.sql.clone(),
         false, // tests aren't views
         false, // full_refresh is meaningless for tests
-        None,
-        client,
-        |context| build_test_sql_request(test, context, create_macro_resolver(ctx)),
     )
-    .await
-}
-
-struct EnrichedSqlPreparedTelemetryInput {
-    target_table_fqn: Option<String>,
-    num_dependencies: Option<i64>,
-    num_view_dependencies: Option<i64>,
-    labels: HashMap<String, String>,
-}
-
-fn enriched_sql_prepared_telemetry_input(
-    request: &SubmitEnrichedSqlRequest,
-) -> EnrichedSqlPreparedTelemetryInput {
-    EnrichedSqlPreparedTelemetryInput {
-        target_table_fqn: request.target_table.clone(),
-        num_dependencies: i64::try_from(
-            request
-                .tables
-                .iter()
-                .filter(|table| Some(table.name.as_str()) != request.target_table.as_deref())
-                .count(),
-        )
-        .ok(),
-        num_view_dependencies: i64::try_from(request.query_dependencies.len()).ok(),
-        labels: request.labels.clone(),
+    .await?;
+    if !context.metadata_complete {
+        record_submit_skipped(test, "missing metadata");
+        return Ok(None);
     }
-}
+    let freshness_tolerance_seconds = context.request.freshness_tolerance_seconds;
+    let request = build_test_sql_request(test, context.request)?;
 
-/// Emit an `EnrichedSqlPrepared` telemetry event for one submission attempt.
-/// `request_id` is a client-generated id correlating this event with the
-/// attempt, independent of whatever the server ends up deciding (or whether
-/// it responds at all) — see `submit_sql_with_speculation`.
-async fn emit_enriched_sql_prepared_telemetry(
-    ctx: &TaskRunnerCtx,
-    request_id: String,
-    duration: std::time::Duration,
-    input: EnrichedSqlPreparedTelemetryInput,
-    error_type: Option<String>,
-) {
-    let event = enriched_sql_prepared_event(
-        request_id,
-        duration,
-        input.target_table_fqn,
-        input.num_dependencies,
-        input.num_view_dependencies,
-        error_type,
-        input.labels,
-        next_telemetry_event_order(ctx),
-    );
-    submit_run_cache_telemetry_event(ctx, event).await;
+    let response = client.submit_enriched_sql(request).await.map_err(|e| {
+        fs_err!(
+            ErrorCode::Generic,
+            "dbt State service SubmitEnrichedSQL failed: {}",
+            e
+        )
+    })?;
+    Ok(Some(RunCacheSubmitOutcome {
+        response,
+        freshness_tolerance_seconds,
+    }))
 }
 
 struct BuiltSqlRunCacheContext {
@@ -2956,7 +1721,6 @@ async fn build_sql_context(
     sql: String,
     is_view: bool,
     full_refresh: bool,
-    speculative: bool,
 ) -> FsResult<BuiltSqlRunCacheContext> {
     let Some(config) = ctx.inner.run_cache_ctx.run_cache_service_config.as_ref() else {
         return Err(fs_err!(
@@ -2972,8 +1736,6 @@ async fn build_sql_context(
         is_view,
         &query_dependencies.seen_tables,
         &query_dependencies.parser_seen_relations,
-        &query_dependencies.unresolvable_tables,
-        speculative,
     )
     .await?;
     let metadata_complete = tables.metadata_complete && query_dependencies.metadata_complete;
@@ -2985,14 +1747,6 @@ async fn build_sql_context(
     );
 
     let stale_upstream_policy = stale_upstream_policy_for_node(node);
-
-    let active_profile = ctx.dbt_profile();
-    let is_targeting_prod = config.is_defer_to_target(active_profile);
-    let clone_chain_depth_limit = clone_chain_depth_limit_for_adapter(
-        ctx.adapter_type(),
-        is_targeting_prod,
-        active_profile.allow_clones,
-    );
 
     Ok(BuiltSqlRunCacheContext {
         request: SqlRunCacheRequestContext {
@@ -3011,101 +1765,19 @@ async fn build_sql_context(
                 node,
                 config.tolerate_nondeterminism,
             ),
-            compare_unrendered_code: resolve_compare_unrendered_code(
-                node,
-                config.compare_unrendered_code,
-            ),
             full_refresh,
             clone_time_travel_limit: config.clone_time_travel_limit_seconds,
             clone_table_properties: None,
-            clone_chain_depth_limit,
-            default_schema: node.schema(),
             stale_upstream_policy,
-            // Populated by the model submit paths for microbatch models; other
-            // node types never carry a window.
-            microbatch_window: None,
-            dbt_project_info: DbtProjectInfo::from(ctx),
         },
         metadata_complete,
     })
 }
 
-/// The full `ModelState` (5 keys) for models and snapshots. Data tests carry the 2-key
-/// `DataTestState` instead (see the field-level accessors below), so 5-key-only configs such as
-/// `lag_tolerance`/`pre_clone`/`execute_hooks_on_any_reuse` correctly return nothing for tests.
 fn model_state_for_node(node: &dyn InternalDbtNodeAttributes) -> Option<&ModelState> {
-    let any = node.as_any();
-    if let Some(model) = any.downcast_ref::<DbtModel>() {
-        model.__model_attr__.state.as_ref()
-    } else if let Some(snapshot) = any.downcast_ref::<DbtSnapshot>() {
-        snapshot.__snapshot_attr__.state.as_ref()
-    } else {
-        None
-    }
-}
-
-/// `require_fresh_data_from`, honored by models and snapshots (via `ModelState`) and data tests (via
-/// `DataTestState`).
-fn require_fresh_data_from_for_node(
-    node: &dyn InternalDbtNodeAttributes,
-) -> Option<&dbt_schemas::schemas::common::UpdatesOn> {
-    if let Some(state) = model_state_for_node(node) {
-        return state.require_fresh_data_from.as_ref();
-    }
     node.as_any()
-        .downcast_ref::<DbtTest>()
-        .and_then(|test| test.__test_attr__.state.as_ref())
-        .and_then(|state| state.require_fresh_data_from.as_ref())
-}
-
-/// `evaluate_volatile_sql`, honored by models and snapshots (via `ModelState`) and data tests (via
-/// `DataTestState`).
-fn evaluate_volatile_sql_for_node(node: &dyn InternalDbtNodeAttributes) -> Option<bool> {
-    if let Some(state) = model_state_for_node(node) {
-        return state.evaluate_volatile_sql;
-    }
-    node.as_any()
-        .downcast_ref::<DbtTest>()
-        .and_then(|test| test.__test_attr__.state.as_ref())
-        .and_then(|state| state.evaluate_volatile_sql)
-}
-
-/// `compare_unrendered_code`, honored by models and snapshots (via `ModelState`) and data tests
-/// (via `DataTestState`).
-fn compare_unrendered_code_for_node(node: &dyn InternalDbtNodeAttributes) -> Option<bool> {
-    if let Some(state) = model_state_for_node(node) {
-        return state.compare_unrendered_code;
-    }
-    node.as_any()
-        .downcast_ref::<DbtTest>()
-        .and_then(|test| test.__test_attr__.state.as_ref())
-        .and_then(|state| state.compare_unrendered_code)
-}
-
-/// Per-node override for the service's `compare_unrendered_code` wire flag. Unlike
-/// `tolerate_nondeterminism` there is no inversion and no legacy `meta` form: the node config
-/// wins over the service default, otherwise the default stands.
-fn resolve_compare_unrendered_code(
-    node: &dyn InternalDbtNodeAttributes,
-    service_default: bool,
-) -> bool {
-    let node_override = compare_unrendered_code_for_node(node);
-    let resolved = node_override.unwrap_or(service_default);
-
-    // Logs the override separately from the result so a surprising `false` distinguishes
-    // "the node never set it" from "the service default lost to an explicit node value".
-    emit_trace_log_message(|| {
-        format!(
-            "dbt State compare_unrendered_code={resolved} for node {} (node config {}, service default {service_default})",
-            node.unique_id(),
-            match node_override {
-                Some(v) => v.to_string(),
-                None => "unset".to_owned(),
-            },
-        )
-    });
-
-    resolved
+        .downcast_ref::<DbtModel>()
+        .and_then(|model| model.__model_attr__.state.as_ref())
 }
 
 pub fn should_execute_hooks_for_skip_reuse(
@@ -3142,9 +1814,6 @@ fn request_freshness_tolerance_seconds_for_node(
     is_view: bool,
     service_default: i64,
 ) -> i64 {
-    // Data tests never carry `lag_tolerance` (their `DataTestState` has only `require_fresh_data_from`
-    // and `evaluate_volatile_sql`), so their freshness tolerance stays 0. `require_fresh_data_from`
-    // for tests is honored separately via `stale_upstream_policy_for_node`.
     if node.resource_type() == NodeType::Test || is_view {
         0
     } else {
@@ -3166,7 +1835,9 @@ fn resolve_tolerate_nondeterminism(
     node: &dyn InternalDbtNodeAttributes,
     service_default: bool,
 ) -> bool {
-    if let Some(evaluate_volatile_sql) = evaluate_volatile_sql_for_node(node) {
+    if let Some(evaluate_volatile_sql) =
+        model_state_for_node(node).and_then(|state| state.evaluate_volatile_sql)
+    {
         return !evaluate_volatile_sql;
     }
 
@@ -3193,6 +1864,7 @@ fn resolve_tolerate_nondeterminism(
             "Ignoring meta.{KEY} on node {}: value is not a bool, int, or recognized string",
             node.unique_id()
         ),
+        None,
     );
     service_default
 }
@@ -3208,48 +1880,20 @@ fn stale_upstream_policy_for_node(
     use dbt_schemas::schemas::common::UpdatesOn;
     use dbt_state::proto::query_cache::StaleUpstreamPolicy;
 
-    let updates_on = require_fresh_data_from_for_node(node).or_else(|| {
-        node.as_any()
-            .downcast_ref::<DbtModel>()
-            .and_then(|model| model.__model_attr__.freshness.as_ref())
-            .and_then(|freshness| freshness.build_after.as_ref())
-            .and_then(|build_after| build_after.updates_on.as_ref())
-    });
+    let updates_on = model_state_for_node(node)
+        .and_then(|state| state.require_fresh_data_from.as_ref())
+        .or_else(|| {
+            node.as_any()
+                .downcast_ref::<DbtModel>()
+                .and_then(|model| model.__model_attr__.freshness.as_ref())
+                .and_then(|freshness| freshness.build_after.as_ref())
+                .and_then(|build_after| build_after.updates_on.as_ref())
+        });
 
     match updates_on {
         Some(UpdatesOn::All) => StaleUpstreamPolicy::All,
         Some(UpdatesOn::Any) | None => StaleUpstreamPolicy::Any,
     }
-}
-
-pub(crate) fn clone_chain_depth_limit_for_adapter(
-    adapter_type: AdapterType,
-    is_targeting_prod: bool,
-    allow_clones: bool,
-) -> Option<i64> {
-    // if cloning is disabled by the active target's config, send a limit of 0 to
-    // exclude clone candidates regardless of adapter
-    if !allow_clones {
-        return Some(0);
-    }
-
-    // the Python implementation hardcodes the default on each adapter
-    // ref: https://github.com/fivetran/query-cache/blob/14dddc260082af4bc6a9800743ddbe5ccb03ba67/clients/dbt_state/src/dbt_state/run_cache.py#L1911
-    match adapter_type {
-        AdapterType::Databricks => Some(1), // ref: https://github.com/fivetran/query-cache/blob/14dddc260082af4bc6a9800743ddbe5ccb03ba67/clients/dbt_state/src/dbt_state/adapters/databricks.py#L37
-        AdapterType::Bigquery => Some(3), // ref: https://github.com/fivetran/query-cache/blob/14dddc260082af4bc6a9800743ddbe5ccb03ba67/clients/dbt_state/src/dbt_state/adapters/bigquery.py#L21
-        _ => None,
-    }
-    .map(|default_limit: i64| {
-        if is_targeting_prod {
-            // for prod, we send a limit of n-1 so there is always room for 1 more dev clone
-            // note: if the default limits ever get adjusted (or new ones added)
-            // make sure that this does not return a negative number
-            default_limit.saturating_sub(1_i64)
-        } else {
-            default_limit
-        }
-    })
 }
 
 fn metadata_query_options_for_warehouses(
@@ -3258,12 +1902,11 @@ fn metadata_query_options_for_warehouses(
 ) -> MetadataQueryOptions {
     MetadataQueryOptions {
         warehouse: profile_warehouse.or(legacy_service_warehouse),
-        ..MetadataQueryOptions::default()
     }
 }
 
 pub(crate) fn run_cache_metadata_query_options(ctx: &TaskRunnerCtx) -> MetadataQueryOptions {
-    let profile_warehouse = match &ctx.dbt_profile().default_db_config() {
+    let profile_warehouse = match &ctx.dbt_profile().db_config {
         DbConfig::Snowflake(config) => config.metadata_warehouse.clone(),
         _ => None,
     };
@@ -3274,18 +1917,7 @@ pub(crate) fn run_cache_metadata_query_options(ctx: &TaskRunnerCtx) -> MetadataQ
         .as_ref()
         .and_then(|config| config.snowflake_metadata_warehouse.clone());
 
-    // Adaptive broad-vs-sequential freshness fetch: read from the Snowflake
-    // target config, defaulting to `true` (adaptive on). Only the Snowflake
-    // no-metadata-warehouse strategy consults it; other adapters ignore it.
-    let adaptive_metadata_fetch = match &ctx.dbt_profile().default_db_config() {
-        DbConfig::Snowflake(config) => config.adaptive_metadata_fetch.unwrap_or(true),
-        _ => true,
-    };
-
-    MetadataQueryOptions {
-        adaptive_metadata_fetch,
-        ..metadata_query_options_for_warehouses(profile_warehouse, legacy_service_warehouse)
-    }
+    metadata_query_options_for_warehouses(profile_warehouse, legacy_service_warehouse)
 }
 
 /// Returns deferred dependencies that should be treated leniently by the dbt
@@ -3323,10 +1955,6 @@ fn build_lenient_dependencies(
         .collect()
 }
 
-fn create_macro_resolver<'a>(ctx: &'a TaskRunnerCtx) -> impl Fn(&str) -> Option<&'a DbtMacro> {
-    |macro_id| ctx.resolver_state().macros.macros.get(macro_id)
-}
-
 struct CollectedTableModifiedInfos {
     tables: Vec<TableModifiedInfo>,
     metadata_complete: bool,
@@ -3353,8 +1981,6 @@ struct CollectedViewQueryDependencies {
     ///      and the service's freshness check defaults to "fresh" on the
     ///      NULL/NULL match path (see `test_transitive_dependencies_tracked`).
     parser_seen_relations: BTreeMap<String, Arc<dyn BaseRelation>>,
-    /// A subset of `seen_tables` whose view definition could not be fetched.
-    unresolvable_tables: BTreeSet<String>,
     metadata_complete: bool,
 }
 
@@ -3363,13 +1989,11 @@ impl CollectedViewQueryDependencies {
         dependencies: Vec<QueryDependency>,
         seen_tables: BTreeSet<String>,
         parser_seen_relations: BTreeMap<String, Arc<dyn BaseRelation>>,
-        unresolvable_tables: BTreeSet<String>,
     ) -> Self {
         Self {
             dependencies,
             seen_tables,
             parser_seen_relations,
-            unresolvable_tables,
             metadata_complete: true,
         }
     }
@@ -3379,7 +2003,6 @@ impl CollectedViewQueryDependencies {
             dependencies: Vec::new(),
             seen_tables: BTreeSet::new(),
             parser_seen_relations: BTreeMap::new(),
-            unresolvable_tables: BTreeSet::new(),
             metadata_complete: false,
         }
     }
@@ -3394,12 +2017,7 @@ impl CollectedViewQueryDependencies {
     /// `query_dependencies=[]`. `metadata_complete` must stay `true` so the
     /// submit isn't silently skipped.
     fn for_view() -> Self {
-        Self::complete(
-            Vec::new(),
-            BTreeSet::new(),
-            BTreeMap::new(),
-            BTreeSet::new(),
-        )
+        Self::complete(Vec::new(), BTreeSet::new(), BTreeMap::new())
     }
 }
 
@@ -3409,8 +2027,6 @@ async fn collect_table_modified_infos(
     target_only: bool,
     leaf_tables: &BTreeSet<String>,
     parser_seen_relations: &BTreeMap<String, Arc<dyn BaseRelation>>,
-    unresolvable_tables: &BTreeSet<String>,
-    speculative: bool,
 ) -> FsResult<CollectedTableModifiedInfos> {
     let mut relations = BTreeMap::new();
     let mut metadata_complete = true;
@@ -3436,16 +2052,30 @@ async fn collect_table_modified_infos(
                     // that's what MetadataAdapter::freshness_with_overrides expects.
                     // Empty strings come from the deserializer for absent values, so
                     // treat empty as "not set" (matches the dbt-core plugin guard).
-                    if let Some(source) = dep_node.as_any().downcast_ref::<DbtSource>()
-                        && let Some(kind) = source_freshness_override(source)
-                    {
-                        let kind = render_freshness_override(
-                            kind,
-                            &relation,
-                            ctx.env.as_ref(),
-                            &ctx.inner.base_context,
-                        )?;
-                        freshness_overrides.insert(relation.semantic_fqn(), kind);
+                    if let Some(source) = dep_node.as_any().downcast_ref::<DbtSource>() {
+                        // Query takes precedence over field (matches dbt-core plugin),
+                        // so only look at field when no query is set.
+                        let trimmed_nonempty = |s: &str| {
+                            let t = s.trim();
+                            (!t.is_empty()).then(|| t.to_string())
+                        };
+                        let override_kind = source
+                            .__source_attr__
+                            .loaded_at_query
+                            .as_deref()
+                            .and_then(trimmed_nonempty)
+                            .map(FreshnessOverride::Query)
+                            .or_else(|| {
+                                source
+                                    .__source_attr__
+                                    .loaded_at_field
+                                    .as_deref()
+                                    .and_then(trimmed_nonempty)
+                                    .map(FreshnessOverride::Field)
+                            });
+                        if let Some(kind) = override_kind {
+                            freshness_overrides.insert(relation.semantic_fqn(), kind);
+                        }
                     }
                     relations.insert(name, relation);
                 } else {
@@ -3481,24 +2111,7 @@ async fn collect_table_modified_infos(
         })
         .map(|(fqn, rel)| (fqn.clone(), Arc::clone(rel)))
         .collect();
-
-    apply_unresolvable_last_modified_overrides(
-        &ctx.inner.run_cache_ctx.run_cache_metadata,
-        ctx.inner.run_cache_ctx.heuristic_clock.get(),
-        unresolvable_tables,
-        &freshness_overrides,
-    );
-
-    // Speculative builds run while the global prefetch is still in flight, so
-    // they must not issue their own blocking per-node warehouse queries. They
-    // read whatever the prefetch has already resolved and leave cache misses
-    // unset; the service treats a missing epoch as "now", keeping any Skip/Clone
-    // verdict sound (a missing dep can only look staler, never fresher). Missing
-    // epochs must not mark the metadata incomplete here — a speculative submit
-    // tolerates unresolved dependencies.
-    if !speculative {
-        prefetch_last_modified_epochs(ctx, &leaf_table_relations, &freshness_overrides).await;
-    }
+    prefetch_last_modified_epochs(ctx, &leaf_table_relations, &freshness_overrides).await;
 
     let mut table_infos = Vec::new();
     for (name, relation) in leaf_table_relations {
@@ -3515,45 +2128,6 @@ async fn collect_table_modified_infos(
         tables: table_infos,
         metadata_complete,
     })
-}
-
-fn apply_unresolvable_last_modified_overrides(
-    cache: &RunCacheMetadataCache,
-    clock: Option<&HeuristicClock>,
-    unresolvable_tables: &BTreeSet<String>,
-    freshness_overrides: &BTreeMap<String, FreshnessOverride>,
-) {
-    let Some(clock) = clock else {
-        for name in unresolvable_tables {
-            cache.remove_last_modified_epoch(name);
-        }
-        return;
-    };
-
-    let mut unresolvable_without_override = Vec::new();
-    for name in unresolvable_tables {
-        cache.remove_last_modified_epoch(name);
-        if !freshness_overrides.contains_key(name) {
-            unresolvable_without_override.push(name.clone());
-        }
-    }
-
-    if unresolvable_without_override.is_empty() {
-        return;
-    }
-
-    emit_warn_log_message(
-        ErrorCode::StateServiceWarn,
-        format!(
-            "Could not determine freshness for {}; treating as modified. Configure loaded_at_field or loaded_at_query to set freshness timestamp.",
-            unresolvable_without_override.join(", ")
-        ),
-    );
-
-    let now_ms = clock.now_ms();
-    for name in unresolvable_without_override {
-        cache.insert_last_modified_epoch(name, Some(now_ms));
-    }
 }
 
 async fn last_modified_epoch_for_node(
@@ -3576,48 +2150,7 @@ pub async fn refresh_final_last_modified_epoch_for_node(
     refresh_last_modified_epoch_for_relation(ctx, &name, relation).await
 }
 
-pub fn clear_stale_missing_last_modified_epoch_for_node(
-    ctx: &TaskRunnerCtx,
-    node: &dyn InternalDbtNodeAttributes,
-) {
-    if let Ok((name, _)) = relation_for_node(ctx, node) {
-        // Only clear a known-stale placeholder (`Some(None)`), cached when the
-        // submit-time probe found no target table yet. A real cached epoch
-        // (`Some(Some(_))`) is still valid and may be relied on by sibling nodes
-        // later in this same run.
-        let run_cache_metadata = &ctx.inner.run_cache_ctx.run_cache_metadata;
-        if matches!(run_cache_metadata.last_modified_epoch(&name), Some(None)) {
-            run_cache_metadata.remove_last_modified_epoch(&name);
-        }
-    }
-}
-
-/// Evicts a node's cached warehouse metadata (last-modified epoch and existence)
-/// when it rebuilds without the dbt State service observing it.
-///
-/// An untracked rebuild makes the cached value stale; without eviction,
-/// downstream nodes in the same invocation report the relation's pre-build
-/// state to the service and are incorrectly skipped. The next submit that needs
-/// the relation treats the gap as a prefetch miss and re-queries it. Mirrors
-/// the plugin's `clear_cache([target_table])`.
-///
-/// Unlike [`clear_stale_missing_last_modified_epoch_for_node`] (the benign-skip
-/// path), this clears a real cached epoch too. Prefer recording the execution
-/// where a sound record can be built — see `submit_model` — which refreshes the
-/// epoch instead of dropping it and keeps the service's view complete.
-pub fn evict_node_metadata_for_untracked_rebuild(
-    ctx: &TaskRunnerCtx,
-    node: &dyn InternalDbtNodeAttributes,
-) {
-    if let Ok((name, _)) = relation_for_node(ctx, node) {
-        ctx.inner
-            .run_cache_ctx
-            .run_cache_metadata
-            .invalidate_relation_metadata(&name);
-    }
-}
-
-fn stamp_final_last_modified_epoch_for_node_heuristic(
+pub fn stamp_final_last_modified_epoch_for_node_heuristic(
     ctx: &TaskRunnerCtx,
     node: &dyn InternalDbtNodeAttributes,
 ) -> Option<i64> {
@@ -3626,38 +2159,17 @@ fn stamp_final_last_modified_epoch_for_node_heuristic(
     // Mirror the plugin's `clear_cache` + `cache_last_modified_epoch(table, H)`:
     // replace the stale prefetch value (often None for newly-created tables) with H
     // so downstream submissions in the same run have metadata_complete=true.
-    let Ok((name, _)) = relation_for_node(ctx, node) else {
-        return None;
-    };
-    ctx.inner
-        .run_cache_ctx
-        .run_cache_metadata
-        .remove_last_modified_epoch(&name);
-    ctx.inner
-        .run_cache_ctx
-        .run_cache_metadata
-        .insert_last_modified_epoch(&name, Some(epoch));
-    Some(epoch)
-}
-
-/// Resolves a node's post-execution last-modified epoch, updating the local
-/// metadata cache to the same value it returns.
-///
-/// Callers persist the returned epoch to the dbt State service, so the cached
-/// and persisted values must be identical. If they diverge, downstream nodes in
-/// this run report a dependency epoch the service never recorded and the
-/// dependency reads as changed, costing reuse for no correctness gain.
-///
-/// Prefers the heuristic clock, which costs no warehouse round-trip, and falls
-/// back to a targeted refresh on adapters that opt out (see [`HeuristicClock`]).
-async fn final_last_modified_epoch_for_node(
-    ctx: &TaskRunnerCtx,
-    node: &dyn InternalDbtNodeAttributes,
-) -> FsResult<Option<i64>> {
-    if let Some(epoch) = stamp_final_last_modified_epoch_for_node_heuristic(ctx, node) {
-        return Ok(Some(epoch));
+    if let Ok((name, _)) = relation_for_node(ctx, node) {
+        ctx.inner
+            .run_cache_ctx
+            .run_cache_metadata
+            .remove_last_modified_epoch(&name);
+        ctx.inner
+            .run_cache_ctx
+            .run_cache_metadata
+            .insert_last_modified_epoch(&name, Some(epoch));
     }
-    refresh_final_last_modified_epoch_for_node(ctx, node).await
+    Some(epoch)
 }
 
 async fn last_modified_epoch_for_relation(
@@ -3681,10 +2193,8 @@ async fn refresh_last_modified_epoch_for_relation(
     let mut relations = BTreeMap::new();
     relations.insert(name.to_string(), relation);
     // Per-relation refreshes aren't used for sources (sources are populated
-    // upfront via the bulk prefetch), so no overrides apply here. Still route
-    // through the adapter-specific planner so BigQuery can use schema prefetch.
-    refresh_planned_last_modified_misses(ctx, &relations, &BTreeMap::new(), ctx.adapter_type())
-        .await?;
+    // upfront via the bulk prefetch), so no overrides apply here.
+    refresh_last_modified_epochs(ctx, &relations, &BTreeMap::new()).await?;
     Ok(ctx
         .inner
         .run_cache_ctx
@@ -3716,11 +2226,15 @@ async fn prefetch_last_modified_epochs(
     // these relations (legitimate for post-clone invalidations and SQL-parser
     // discovered refs) or that the schema dump returned empty. Log so this
     // is visible when diagnosing unexpected per-node warehouse query volume.
-    emit_debug_log_message(format!(
-        "dbt State per-node freshness query for {} relation(s) not in prefetch cache: {}",
-        misses.len(),
-        misses.keys().cloned().collect::<Vec<_>>().join(", ")
-    ));
+    emit_warn_log_message(
+        ErrorCode::StateServiceWarn,
+        format!(
+            "dbt State per-node freshness query for {} relation(s) not in prefetch cache: {}",
+            misses.len(),
+            misses.keys().cloned().collect::<Vec<_>>().join(", ")
+        ),
+        None,
+    );
     let refresh_result =
         refresh_planned_last_modified_misses(ctx, &misses, overrides, ctx.adapter_type()).await;
     if let Err(err) = refresh_result {
@@ -3753,10 +2267,8 @@ struct LastModifiedMissRefreshPlan {
 }
 
 /// BigQuery normal misses use the schema prefetch path to avoid high fanout
-/// per-table `__TABLES__` queries. A singleton miss can still trigger one
-/// schema scan; that is an intentional fix-forward tradeoff for correctness.
-/// Overrides stay targeted because their freshness comes from custom
-/// `loaded_at_*` logic.
+/// per-table `__TABLES__` queries. Overrides stay targeted because their
+/// freshness comes from custom `loaded_at_*` logic.
 fn plan_last_modified_miss_refresh(
     adapter_type: AdapterType,
     misses: &BTreeMap<String, Arc<dyn BaseRelation>>,
@@ -3820,35 +2332,21 @@ async fn refresh_last_modified_epochs(
     };
 
     for grouped_relations in group_relations_by_database_and_schema(relations).into_values() {
-        let grouped_names = grouped_relations.keys().collect::<BTreeSet<_>>();
-        let grouped_overrides = overrides
-            .iter()
-            .filter(|(name, _)| grouped_names.contains(name))
-            .map(|(name, override_)| (name.clone(), override_.clone()))
-            .collect::<BTreeMap<_, _>>();
         let semantic_to_name = grouped_relations
             .iter()
             .map(|(name, relation)| (relation.semantic_fqn(), name.clone()))
             .collect::<BTreeMap<_, _>>();
         let relation_values = grouped_relations.values().cloned().collect::<Vec<_>>();
         let metadata_options = run_cache_metadata_query_options(ctx);
-        let freshness = match metadata_adapter
+        let freshness = metadata_adapter
             .freshness_with_overrides_and_options(
                 &relation_values,
-                &grouped_overrides,
+                overrides,
                 &metadata_options,
                 adapter.cancellation_token(),
             )
             .await
-        {
-            Ok(freshness) => freshness,
-            Err(Cancellable::Error(err)) if err.kind() == AdapterErrorKind::ReplayDataMissing => {
-                // Older recordings do not contain this override-prefetch event.
-                // Leave entries absent so the per-node freshness events can replay.
-                continue;
-            }
-            Err(err) => return Err(into_fs_error(err)),
-        };
+            .map_err(into_fs_error)?;
 
         for (semantic_fqn, name) in semantic_to_name {
             let epoch = freshness
@@ -4019,23 +2517,10 @@ async fn collect_query_dependencies(
         Err(err) => return query_dependencies_for_parse_error(ctx, node, sql, err).await,
     };
     if relations.is_empty() {
-        // A custom materialization's compiled SQL isn't necessarily a query,
-        // so an empty SQL-derived result isn't proof of no upstreams. Fall
-        // back to the manifest's depends_on graph. Built-ins are exempt:
-        // their compiled SQL is always a real query, so an empty result is
-        // trustworthy.
-        if node_uses_custom_materialization(node, &ctx.inner.materialization_resolver) {
-            let manifest_relations = cacheable_manifest_dependency_relations(ctx, node);
-            if !manifest_relations.is_empty() {
-                return collect_query_dependencies_from_relations(ctx, node, manifest_relations)
-                    .await;
-            }
-        }
         return Ok(CollectedViewQueryDependencies::complete(
             Vec::new(),
             BTreeSet::new(),
             BTreeMap::new(),
-            BTreeSet::new(),
         ));
     }
 
@@ -4072,7 +2557,6 @@ async fn collect_query_dependencies_from_relations(
     };
 
     let seen_tables = traversal.seen_tables;
-    let unresolvable_tables = traversal.unresolvable_tables;
     let dependencies = traversal
         .view_definitions
         .into_values()
@@ -4091,7 +2575,6 @@ async fn collect_query_dependencies_from_relations(
         dependencies,
         seen_tables,
         parser_seen_relations,
-        unresolvable_tables,
     ))
 }
 
@@ -4101,7 +2584,7 @@ async fn query_dependencies_for_parse_error(
     sql: &str,
     err: Box<FsError>,
 ) -> FsResult<CollectedViewQueryDependencies> {
-    if !node_uses_custom_materialization(node, &ctx.inner.materialization_resolver) {
+    if !node_uses_custom_materialization(node) {
         return Err(err);
     }
 
@@ -4138,13 +2621,6 @@ async fn query_dependencies_for_parse_error(
     };
 
     if relations.is_empty() {
-        // Same fallback as in `collect_query_dependencies`: an empty
-        // expression-parse result isn't proof of no upstreams.
-        let manifest_relations = cacheable_manifest_dependency_relations(ctx, node);
-        if !manifest_relations.is_empty() {
-            return collect_query_dependencies_from_relations(ctx, node, manifest_relations).await;
-        }
-
         emit_trace_log_message(|| {
             format!(
                 "dbt State dependency extraction accepted standalone SQL expression for custom materialization {unique_id}"
@@ -4154,54 +2630,15 @@ async fn query_dependencies_for_parse_error(
             Vec::new(),
             BTreeSet::new(),
             BTreeMap::new(),
-            BTreeSet::new(),
         ));
     }
     collect_query_dependencies_from_relations(ctx, node, relations).await
 }
 
-/// Resolves a node's manifest depends_on graph into relations, restricted
-/// to cacheable node kinds. Fallback dependency source when SQL-derived
-/// extraction finds none.
-fn cacheable_manifest_dependency_relations(
-    ctx: &TaskRunnerCtx,
-    node: &dyn InternalDbtNodeAttributes,
-) -> BTreeMap<String, Arc<dyn BaseRelation>> {
-    let mut relations = BTreeMap::new();
-    for dep_id in &node.base().depends_on.nodes {
-        let Some(dep_node) = ctx.nodes().get_node(dep_id) else {
-            continue;
-        };
-        if !is_cacheable_resource_type(dep_node.resource_type()) {
-            continue;
-        }
-        let Ok((name, relation)) = relation_for_node(ctx, dep_node) else {
-            continue;
-        };
-        relations.insert(name, relation);
-    }
-    relations
-}
-
-/// Mirrors the `is_cacheable` filter used elsewhere in the run-cache path:
-/// only these node kinds participate in dependency freshness checks.
-fn is_cacheable_resource_type(resource_type: NodeType) -> bool {
-    matches!(
-        resource_type,
-        NodeType::Source | NodeType::Model | NodeType::Snapshot | NodeType::Seed
-    )
-}
-
-fn node_uses_custom_materialization(
-    node: &dyn InternalDbtNodeAttributes,
-    materialization_resolver: &MaterializationResolver,
-) -> bool {
+fn node_uses_custom_materialization(node: &dyn InternalDbtNodeAttributes) -> bool {
     node.as_any()
         .downcast_ref::<DbtModel>()
-        .is_some_and(|model| {
-            materialization_resolver
-                .is_custom_materialization(&model.materialized().to_string(), model.node_adapter())
-        })
+        .is_some_and(|model| matches!(model.materialized(), DbtMaterialization::Unknown(_)))
 }
 
 fn parse_sql_relations_for_run_cache(
@@ -4403,17 +2840,17 @@ fn record_service_decision(
             emit_trace_log_message(|| {
                 format!("dbt State service decision: skip execution for node {unique_id}")
             });
-            // For data tests, parse the cached result out of the service's
-            // `execution_results` so the dispatcher in `runnable/mod.rs` can
-            // replace the generic `ReusedNoChanges` status with a test-shaped
-            // verdict and a NO-OP-marked stat.
+            // For data tests, parse the cached `failures` count out of the
+            // service's `execution_results` so the dispatcher in
+            // `runnable/mod.rs` can replace the generic `ReusedNoChanges`
+            // status with a test-shaped verdict and a NO-OP-marked stat.
             let is_test = unique_id.starts_with("test.");
-            let cached_test_result = if is_test {
-                parse_cached_test_execution_result(response)
+            let cached_test_failures = if is_test {
+                parse_cached_test_failures(response)
             } else {
                 None
             };
-            if is_test && cached_test_result.is_none() {
+            if is_test && cached_test_failures.is_none() {
                 emit_trace_log_message(|| {
                     format!(
                         "dbt State service data test skip ignored because no cached test result was returned for node {unique_id}; executing normally"
@@ -4429,7 +2866,7 @@ fn record_service_decision(
             RunCacheServiceDecision::Skip {
                 status,
                 sao_stored_hash: None,
-                cached_test_result,
+                cached_test_failures,
             }
         }
         Some(submit_sql_response::Response::ReadyToClone(response)) => {
@@ -4468,21 +2905,6 @@ fn record_service_decision(
                 )
             });
             RunCacheServiceDecision::execute_without_confirmation()
-        }
-    }
-}
-
-/// Extract the service-side explain decision id from a submit response.
-pub(crate) fn execution_decision_id_from_response(response: &SubmitSqlResponse) -> Option<String> {
-    match response.response.as_ref()? {
-        submit_sql_response::Response::ReadyToExecute(response) => {
-            response.execution_decision_id.clone()
-        }
-        submit_sql_response::Response::SkipExecution(response) => {
-            response.execution_decision_id.clone()
-        }
-        submit_sql_response::Response::ReadyToClone(response) => {
-            response.execution_decision_id.clone()
         }
     }
 }
@@ -4529,7 +2951,7 @@ fn relabel_skip_for_dev_cloned_node(
     let RunCacheServiceDecision::Skip {
         status,
         sao_stored_hash,
-        cached_test_result,
+        cached_test_failures,
     } = decision
     else {
         return decision;
@@ -4538,7 +2960,7 @@ fn relabel_skip_for_dev_cloned_node(
         return RunCacheServiceDecision::Skip {
             status,
             sao_stored_hash,
-            cached_test_result,
+            cached_test_failures,
         };
     }
     let relabelled = match status {
@@ -4551,7 +2973,7 @@ fn relabel_skip_for_dev_cloned_node(
     RunCacheServiceDecision::Skip {
         status: relabelled,
         sao_stored_hash,
-        cached_test_result,
+        cached_test_failures,
     }
 }
 
@@ -4572,8 +2994,6 @@ fn record_submit_skipped(node: &dyn InternalDbtNodeAttributes, reason: &'static 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use dbt_schemas::state::ProfileAdapter;
-    use indexmap::IndexMap;
     use std::any::Any;
     use std::future::Future;
     use std::path::{Path, PathBuf};
@@ -4601,9 +3021,8 @@ mod tests {
     use dbt_schema_store::mock_store::{MockDataStore, MockSchemaStore};
     use dbt_schemas::schemas::Nodes;
     use dbt_schemas::schemas::common::{FreshnessPeriod, ResolvedQuoting, UpdatesOn};
-    use dbt_schemas::schemas::macros::DbtMacro;
     use dbt_schemas::schemas::profiles::{Execute, SnowflakeDbConfig};
-    use dbt_schemas::schemas::properties::{DataTestState, ModelFreshness, ModelState};
+    use dbt_schemas::schemas::properties::{ModelFreshness, ModelState};
     use dbt_schemas::state::{
         DbtProfile, DbtRuntimeConfig, DummyNodeResolverTracker, Macros, Operations, RenderResults,
         ResolverState,
@@ -4611,8 +3030,7 @@ mod tests {
     use dbt_state::metadata_cache::RunCacheMetadataCache;
     use dbt_state::proto::query_cache::{
         ConfirmExecutionResponse, ReadyToCloneResponse, ReadyToExecuteResponse,
-        ReadyToExecuteUntrackedResponse, RecordExecutionsRequest, RecordExecutionsResponse,
-        SubmitSqlSpeculativeResponse, UndecidedResponse, execution_record,
+        RecordExecutionsRequest, RecordExecutionsResponse,
     };
     use dbt_state::service_client::{
         ClientVersionStatus, RunCacheServiceClient, RunCacheServiceError,
@@ -4624,51 +3042,6 @@ mod tests {
         model.__common_attr__.unique_id = "model.test.orders".to_string();
         model.__model_attr__.state = Some(state);
         model
-    }
-
-    #[test]
-    fn state_explain_node_info_identifies_incremental_model() {
-        let model = state_explain_model(DbtMaterialization::Incremental);
-
-        let info = state_explain_node_info_for_parts(AdapterType::Postgres, true, &model);
-
-        assert_eq!(info.node_resource_type, "model");
-        assert_eq!(info.fqn, "\"analytics\".\"marts\".\"orders\"");
-        assert!(!info.is_view);
-        assert!(info.is_table);
-        assert!(info.is_incremental_or_snapshot);
-        assert!(info.is_full_refresh);
-    }
-
-    #[test]
-    fn state_explain_node_info_reports_ephemeral_without_a_relation() {
-        let model = state_explain_model(DbtMaterialization::Ephemeral);
-
-        let info = state_explain_node_info_for_parts(AdapterType::Postgres, false, &model);
-
-        assert!(info.is_ephemeral);
-        assert!(!info.is_table);
-        assert!(!info.is_view);
-        // Ephemeral models are inlined into their consumers, so naming a
-        // warehouse relation for them would name a table that cannot exist.
-        assert!(info.fqn.is_empty());
-    }
-
-    #[test]
-    fn state_explain_node_info_identifies_seed_and_snapshot() {
-        let seed = state_explain_seed();
-        let snapshot = state_explain_snapshot();
-
-        let seed_info = state_explain_node_info_for_parts(AdapterType::Postgres, true, &seed);
-        let snapshot_info =
-            state_explain_node_info_for_parts(AdapterType::Postgres, false, &snapshot);
-
-        assert_eq!(seed_info.node_resource_type, "seed");
-        assert!(seed_info.is_table);
-        assert!(!seed_info.is_incremental_or_snapshot);
-        assert!(!seed_info.is_full_refresh);
-        assert_eq!(snapshot_info.node_resource_type, "snapshot");
-        assert!(snapshot_info.is_incremental_or_snapshot);
     }
 
     #[test]
@@ -4749,13 +3122,13 @@ mod tests {
             RunCacheServiceDecision::Skip {
                 status: NodeStatus::ReusedNoChanges(_),
                 sao_stored_hash: None,
-                cached_test_result: None,
+                cached_test_failures: None,
             }
         ));
     }
 
     #[test]
-    fn data_test_skip_without_cached_result_executes() {
+    fn data_test_skip_without_cached_failures_executes() {
         assert_eq!(
             record_service_decision(
                 "test.test.not_null_orders_order_date.abc123",
@@ -4771,57 +3144,24 @@ mod tests {
     }
 
     #[test]
-    fn data_test_skip_with_cached_result_is_honored() {
-        match record_service_decision(
-            "test.test.not_null_orders_order_date.abc123",
-            &skip_execution_response_with_test_result(CachedTestExecutionResult {
-                failures: 2,
-                should_warn: true,
-                should_error: false,
-            }),
-            0,
-            true,
-        ) {
-            RunCacheServiceDecision::Skip {
-                status: NodeStatus::ReusedNoChanges(_),
-                sao_stored_hash: None,
-                cached_test_result: Some(result),
-            } => {
-                assert_eq!(result.failures, 2);
-                assert!(result.should_warn);
-                assert!(!result.should_error);
-            }
-            other => panic!("expected cached data-test skip, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn data_test_skip_with_incomplete_cached_result_executes() {
-        let response = SubmitSqlResponse {
-            response: Some(submit_sql_response::Response::SkipExecution(
-                SkipExecutionResponse {
-                    execution_results: Some(test_execution_results_with_failures_only(0)),
-                    ..Default::default()
-                },
-            )),
-        };
-
-        assert_eq!(
+    fn data_test_skip_with_cached_failures_is_honored() {
+        assert!(matches!(
             record_service_decision(
                 "test.test.not_null_orders_order_date.abc123",
-                &response,
+                &skip_execution_response_with_test_failures(0),
                 0,
                 true,
             ),
-            RunCacheServiceDecision::Execute {
-                after_success: RunCacheAfterSuccess::None,
-                sao_guard: None,
+            RunCacheServiceDecision::Skip {
+                status: NodeStatus::ReusedNoChanges(_),
+                sao_stored_hash: None,
+                cached_test_failures: Some(0),
             }
-        );
+        ));
     }
 
     #[test]
-    fn stale_data_test_skip_with_cached_result_reports_no_changes() {
+    fn stale_data_test_skip_with_cached_failures_reports_no_changes() {
         let response = SubmitSqlResponse {
             response: Some(submit_sql_response::Response::SkipExecution(
                 SkipExecutionResponse {
@@ -4829,13 +3169,7 @@ mod tests {
                         is_stale: true,
                         ..Default::default()
                     }),
-                    execution_results: Some(build_test_execution_results_struct(
-                        CachedTestExecutionResult {
-                            failures: 0,
-                            should_warn: false,
-                            should_error: false,
-                        },
-                    )),
+                    execution_results: Some(build_test_execution_results_struct(0)),
                     ..Default::default()
                 },
             )),
@@ -4851,11 +3185,7 @@ mod tests {
             RunCacheServiceDecision::Skip {
                 status: NodeStatus::ReusedNoChanges(_),
                 sao_stored_hash: None,
-                cached_test_result: Some(CachedTestExecutionResult {
-                    failures: 0,
-                    should_warn: false,
-                    should_error: false,
-                }),
+                cached_test_failures: Some(0),
             }
         ));
     }
@@ -4877,7 +3207,7 @@ mod tests {
             RunCacheServiceDecision::Skip {
                 status: NodeStatus::ReusedStillFresh(message, tolerance, _),
                 sao_stored_hash: None,
-                cached_test_result: None,
+                cached_test_failures: None,
             } => {
                 assert!(
                     message.contains("New changes detected"),
@@ -4898,7 +3228,7 @@ mod tests {
                 42,
             ),
             sao_stored_hash: None,
-            cached_test_result: None,
+            cached_test_failures: None,
         };
 
         match relabel_skip_for_dev_cloned_node(true, original) {
@@ -4917,7 +3247,7 @@ mod tests {
         let original = RunCacheServiceDecision::Skip {
             status: NodeStatus::ReusedNoChanges("No new changes on any upstreams".to_string()),
             sao_stored_hash: None,
-            cached_test_result: None,
+            cached_test_failures: None,
         };
 
         match relabel_skip_for_dev_cloned_node(true, original) {
@@ -4934,7 +3264,7 @@ mod tests {
         let make = || RunCacheServiceDecision::Skip {
             status: NodeStatus::ReusedNoChanges("No new changes on any upstreams".to_string()),
             sao_stored_hash: None,
-            cached_test_result: None,
+            cached_test_failures: None,
         };
         let relabelled = relabel_skip_for_dev_cloned_node(false, make());
         assert_eq!(relabelled, make());
@@ -5001,7 +3331,6 @@ mod tests {
             &ctx,
             model.as_ref(),
             &task_result_with_sql("'alice'"),
-            None,
         )
         .await;
 
@@ -5044,7 +3373,6 @@ mod tests {
             &ctx,
             model.as_ref(),
             &task_result_with_sql("'alice'"),
-            None,
         )
         .await;
 
@@ -5056,130 +3384,6 @@ mod tests {
                 sao_guard: None,
             }
         ));
-    }
-
-    #[tokio::test]
-    async fn full_refresh_microbatch_without_window_invalidates_instead_of_recording() {
-        let client = Arc::new(RecordingRunCacheClient::default());
-        let ctx = test_task_runner_ctx_with_mode_and_full_refresh(
-            Some(client.clone() as dbt_state::service_client::SharedRunCacheServiceClient),
-            RunCacheMode::ReadWrite,
-            true,
-        );
-        let mut model = DbtModel::default();
-        model.__common_attr__.unique_id = "model.test.user_name_model".to_string();
-        model.__common_attr__.language = Some("sql".to_string());
-        model.__base_attr__.database = "db".to_string();
-        model.__base_attr__.schema = "dbt_test".to_string();
-        model.__base_attr__.alias = "user_name_model".to_string();
-        model.__base_attr__.materialized = DbtMaterialization::Incremental;
-        model.__model_attr__.incremental_strategy =
-            Some(dbt_schemas::schemas::common::DbtIncrementalStrategy::Microbatch);
-        let model = Arc::new(model);
-
-        let decision = run_cache_service_before_execution(
-            &ctx,
-            model.as_ref(),
-            &task_result_with_sql("select 'alice' as first_name"),
-            None,
-        )
-        .await;
-
-        // Full refresh alone would be recorded, but an unresolved window leaves
-        // nothing sound to write down: invalidate only, never record.
-        assert!(
-            matches!(
-                decision,
-                RunCacheServiceDecision::Execute {
-                    after_success: RunCacheAfterSuccess::InvalidateFreshness,
-                    sao_guard: None,
-                }
-            ),
-            "expected execute-and-invalidate decision, got {decision:?}"
-        );
-        assert_eq!(client.submitted_count(), 0);
-    }
-
-    #[tokio::test]
-    async fn full_refresh_incremental_model_records_execution_without_a_decision() {
-        let client = Arc::new(RecordingRunCacheClient::default());
-        let ctx = test_task_runner_ctx_with_mode_and_full_refresh(
-            Some(client.clone() as dbt_state::service_client::SharedRunCacheServiceClient),
-            RunCacheMode::ReadWrite,
-            true,
-        );
-        let model = make_model(
-            "model.test.user_name_model",
-            "db",
-            "dbt_test",
-            "user_name_model",
-            DbtMaterialization::Incremental,
-        );
-
-        let decision = run_cache_service_before_execution(
-            &ctx,
-            model.as_ref(),
-            &task_result_with_sql("select 'alice' as first_name"),
-            None,
-        )
-        .await;
-
-        match decision {
-            RunCacheServiceDecision::Execute {
-                after_success: RunCacheAfterSuccess::Record(record),
-                sao_guard: None,
-            } => assert!(
-                !record.speculative,
-                "the record is built from a full snapshot, not a speculative one"
-            ),
-            other => panic!("expected execute-with-record decision, got {other:?}"),
-        }
-        assert_eq!(
-            client.submitted_count(),
-            0,
-            "the full-refresh CTAS must never seed a skip or clone decision"
-        );
-        assert_eq!(client.speculative_submitted_count(), 0);
-    }
-
-    #[tokio::test]
-    async fn unresolved_microbatch_window_invalidates_freshness_after_execution() {
-        let client = Arc::new(RecordingRunCacheClient::default());
-        let ctx = test_task_runner_ctx(Some(
-            client.clone() as dbt_state::service_client::SharedRunCacheServiceClient
-        ));
-        let mut model = DbtModel::default();
-        model.__common_attr__.unique_id = "model.test.user_name_model".to_string();
-        model.__common_attr__.language = Some("sql".to_string());
-        model.__base_attr__.database = "db".to_string();
-        model.__base_attr__.schema = "dbt_test".to_string();
-        model.__base_attr__.alias = "user_name_model".to_string();
-        model.__base_attr__.materialized = DbtMaterialization::Incremental;
-        model.__model_attr__.incremental_strategy =
-            Some(dbt_schemas::schemas::common::DbtIncrementalStrategy::Microbatch);
-        let model = Arc::new(model);
-
-        let decision = run_cache_service_before_execution(
-            &ctx,
-            model.as_ref(),
-            &task_result_with_sql("select 'alice' as first_name"),
-            None,
-        )
-        .await;
-
-        // No sound record is possible without the event-time window, so the
-        // rebuild goes unobserved and the cached epoch must not survive it.
-        assert!(
-            matches!(
-                decision,
-                RunCacheServiceDecision::Execute {
-                    after_success: RunCacheAfterSuccess::InvalidateFreshness,
-                    sao_guard: None,
-                }
-            ),
-            "expected execute-and-invalidate decision, got {decision:?}"
-        );
-        assert_eq!(client.submitted_count(), 0);
     }
 
     #[tokio::test]
@@ -5293,135 +3497,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn custom_materialization_bare_relation_reference_falls_back_to_manifest_deps() {
-        let mut model = make_model(
-            "model.test.copy_target",
-            "db",
-            "analytics",
-            "copy_target",
-            DbtMaterialization::Unknown("custom_table".to_string()),
-        );
-        Arc::make_mut(&mut model)
-            .__base_attr__
-            .depends_on
-            .nodes
-            .push("model.test.copy_source".to_string());
-        let upstream = make_model(
-            "model.test.copy_source",
-            "db",
-            "analytics",
-            "copy_source",
-            DbtMaterialization::Table,
-        );
-        let ctx = test_task_runner_ctx_with_nodes(
-            None,
-            RunCacheMode::ReadWrite,
-            false,
-            Arc::new(EmptySourcesExtractor),
-            nodes_from(vec![model.clone(), upstream], vec![]),
-            ["model.test.copy_target".to_string()].into_iter().collect(),
-        );
-
-        let deps =
-            collect_query_dependencies(&ctx, model.as_ref(), "db.analytics.copy_source", false)
-                .await
-                .expect("bare relation reference for a custom materialization should be cacheable");
-
-        assert!(
-            !deps.metadata_complete || !deps.seen_tables.is_empty(),
-            "must not silently report zero dependencies when depends_on.nodes has a real upstream"
-        );
-        assert!(deps.dependencies.is_empty());
-    }
-
-    #[test]
-    fn cacheable_manifest_dependency_relations_resolves_only_cacheable_deps() {
-        let mut model = make_model(
-            "model.test.copy_target",
-            "db",
-            "analytics",
-            "copy_target",
-            DbtMaterialization::Unknown("custom_table".to_string()),
-        );
-        Arc::make_mut(&mut model)
-            .__base_attr__
-            .depends_on
-            .nodes
-            .push("model.test.copy_source".to_string());
-        Arc::make_mut(&mut model)
-            .__base_attr__
-            .depends_on
-            .nodes
-            .push("exposure.test.some_dashboard".to_string());
-        let upstream = make_model(
-            "model.test.copy_source",
-            "db",
-            "analytics",
-            "copy_source",
-            DbtMaterialization::Table,
-        );
-        let ctx = test_task_runner_ctx_with_nodes(
-            None,
-            RunCacheMode::ReadWrite,
-            false,
-            Arc::new(EmptySourcesExtractor),
-            nodes_from(vec![model.clone(), upstream], vec![]),
-            ["model.test.copy_target".to_string()].into_iter().collect(),
-        );
-
-        let relations = cacheable_manifest_dependency_relations(&ctx, model.as_ref());
-
-        assert_eq!(relations.len(), 1);
-        assert!(relations.contains_key(&fqn_of("db", "analytics", "copy_source")));
-    }
-
-    #[tokio::test]
-    async fn custom_materialization_parse_error_expression_empty_falls_back_to_manifest_deps() {
-        let mut model = make_model(
-            "model.test.copy_target",
-            "db",
-            "analytics",
-            "copy_target",
-            DbtMaterialization::Unknown("custom_table".to_string()),
-        );
-        Arc::make_mut(&mut model)
-            .__base_attr__
-            .depends_on
-            .nodes
-            .push("model.test.copy_source".to_string());
-        let upstream = make_model(
-            "model.test.copy_source",
-            "db",
-            "analytics",
-            "copy_source",
-            DbtMaterialization::Table,
-        );
-        let ctx = test_task_runner_ctx_with_nodes(
-            None,
-            RunCacheMode::ReadWrite,
-            false,
-            Arc::new(EmptySourcesExtractor),
-            nodes_from(vec![model.clone(), upstream], vec![]),
-            ["model.test.copy_target".to_string()].into_iter().collect(),
-        );
-
-        let deps = query_dependencies_for_parse_error(
-            &ctx,
-            model.as_ref(),
-            "db.analytics.copy_source",
-            synthetic_extraction_error(),
-        )
-        .await
-        .expect("bare relation reference for a custom materialization should be cacheable");
-
-        assert!(
-            !deps.metadata_complete || !deps.seen_tables.is_empty(),
-            "must not silently report zero dependencies when depends_on.nodes has a real upstream"
-        );
-        assert!(deps.dependencies.is_empty());
-    }
-
-    #[tokio::test]
     async fn custom_materialization_parse_failure_with_manifest_deps_is_incomplete() {
         let mut model = make_model(
             "model.test.user_name_model",
@@ -5505,7 +3580,6 @@ mod tests {
             &ctx,
             model.as_ref(),
             &task_result_with_sql("'alice'"),
-            None,
         )
         .await;
 
@@ -5538,7 +3612,6 @@ mod tests {
             &ctx,
             model.as_ref(),
             &task_result_with_sql("'alice'"),
-            None,
         )
         .await;
 
@@ -5576,7 +3649,7 @@ mod tests {
             .heuristic_clock
             .set(HeuristicClock {
                 start_ts_ms: 1_700_000_000_000,
-                start_instant: Instant::now(),
+                start_instant: std::time::Instant::now(),
             })
             .unwrap();
 
@@ -5588,46 +3661,6 @@ mod tests {
                 .run_cache_metadata
                 .last_modified_epoch(&target_fqn),
             Some(Some(7))
-        );
-    }
-
-    #[tokio::test]
-    async fn final_last_modified_epoch_caches_the_value_it_returns() {
-        let ctx = test_task_runner_ctx(None);
-        let model = make_model(
-            "model.test.user_name_model",
-            "db",
-            "dbt_test",
-            "user_name_model",
-            DbtMaterialization::Incremental,
-        );
-        let target_fqn = fqn_of("db", "dbt_test", "user_name_model");
-        ctx.inner
-            .run_cache_ctx
-            .run_cache_metadata
-            .insert_last_modified_epoch(&target_fqn, Some(7));
-        ctx.inner
-            .run_cache_ctx
-            .heuristic_clock
-            .set(HeuristicClock {
-                start_ts_ms: 1_700_000_000_000,
-                start_instant: Instant::now(),
-            })
-            .unwrap();
-
-        let epoch = final_last_modified_epoch_for_node(&ctx, model.as_ref())
-            .await
-            .expect("resolving the final epoch must not fail");
-
-        // Callers persist the returned epoch while downstream nodes read the
-        // cached one; a divergence makes the dependency read as changed.
-        assert!(epoch.is_some_and(|epoch| epoch >= 1_700_000_000_000));
-        assert_eq!(
-            ctx.inner
-                .run_cache_ctx
-                .run_cache_metadata
-                .last_modified_epoch(&target_fqn),
-            Some(epoch)
         );
     }
 
@@ -5651,7 +3684,7 @@ mod tests {
             .heuristic_clock
             .set(HeuristicClock {
                 start_ts_ms: 1_700_000_000_000,
-                start_instant: Instant::now(),
+                start_instant: std::time::Instant::now(),
             })
             .unwrap();
 
@@ -5664,101 +3697,6 @@ mod tests {
                 .run_cache_metadata
                 .last_modified_epoch(&target_fqn),
             epoch.map(Some)
-        );
-    }
-
-    #[test]
-    fn clear_stale_missing_epoch_removes_stale_missing_value() {
-        let ctx = test_task_runner_ctx(None);
-        let model = make_model(
-            "model.test.user_name_model",
-            "db",
-            "dbt_test",
-            "user_name_model",
-            DbtMaterialization::Table,
-        );
-        let target_fqn = fqn_of("db", "dbt_test", "user_name_model");
-        ctx.inner
-            .run_cache_ctx
-            .run_cache_metadata
-            .insert_last_modified_epoch(&target_fqn, None);
-
-        clear_stale_missing_last_modified_epoch_for_node(&ctx, model.as_ref());
-
-        assert_eq!(
-            ctx.inner
-                .run_cache_ctx
-                .run_cache_metadata
-                .last_modified_epoch(&target_fqn),
-            None
-        );
-    }
-
-    #[test]
-    fn clear_stale_missing_epoch_preserves_valid_cached_epoch() {
-        let ctx = test_task_runner_ctx(None);
-        let model = make_model(
-            "model.test.user_name_model",
-            "db",
-            "dbt_test",
-            "user_name_model",
-            DbtMaterialization::Table,
-        );
-        let target_fqn = fqn_of("db", "dbt_test", "user_name_model");
-        ctx.inner
-            .run_cache_ctx
-            .run_cache_metadata
-            .insert_last_modified_epoch(&target_fqn, Some(1_700_000_000_000));
-
-        clear_stale_missing_last_modified_epoch_for_node(&ctx, model.as_ref());
-
-        assert_eq!(
-            ctx.inner
-                .run_cache_ctx
-                .run_cache_metadata
-                .last_modified_epoch(&target_fqn),
-            Some(Some(1_700_000_000_000))
-        );
-    }
-
-    #[test]
-    fn evict_node_metadata_for_untracked_rebuild_clears_valid_epoch_and_existence() {
-        let ctx = test_task_runner_ctx(None);
-        let model = make_model(
-            "model.test.user_name_model",
-            "db",
-            "dbt_test",
-            "user_name_model",
-            DbtMaterialization::Table,
-        );
-        let target_fqn = fqn_of("db", "dbt_test", "user_name_model");
-        // A real (valid-looking) cached epoch and existence, which the benign
-        // skip path would preserve — but a failed request means the rebuild was
-        // unobserved, so both must be evicted here.
-        ctx.inner
-            .run_cache_ctx
-            .run_cache_metadata
-            .insert_last_modified_epoch(&target_fqn, Some(1_700_000_000_000));
-        ctx.inner
-            .run_cache_ctx
-            .run_cache_metadata
-            .insert_relation_exists(&target_fqn, true);
-
-        evict_node_metadata_for_untracked_rebuild(&ctx, model.as_ref());
-
-        assert_eq!(
-            ctx.inner
-                .run_cache_ctx
-                .run_cache_metadata
-                .last_modified_epoch(&target_fqn),
-            None
-        );
-        assert_eq!(
-            ctx.inner
-                .run_cache_ctx
-                .run_cache_metadata
-                .relation_exists(&target_fqn),
-            None
         );
     }
 
@@ -5781,7 +3719,6 @@ mod tests {
                 &ctx,
                 model.as_ref(),
                 &task_result_with_sql("select 'alice' as first_name"),
-                None,
             )
             .await,
             RunCacheServiceDecision::Execute {
@@ -5835,8 +3772,6 @@ mod tests {
             false,
             &BTreeSet::from([upstream_fqn.clone()]),
             &BTreeMap::new(),
-            &BTreeSet::new(),
-            false,
         )
         .await
         .unwrap();
@@ -5850,514 +3785,6 @@ mod tests {
             name: upstream_fqn,
             last_modified_epoch: None,
         }));
-    }
-
-    // ── speculative submit tests ─────────────────────────────────────────────
-
-    /// A model with a single upstream dependency whose last-modified epoch is
-    /// deliberately left unresolved (a genuine cache miss). The target's epoch
-    /// is pre-resolved so only the upstream exercises the miss path.
-    fn ctx_model_with_unresolved_upstream() -> (TaskRunnerCtx, Arc<DbtModel>, String) {
-        let mut model = make_model(
-            "model.test.fact_orders",
-            "db",
-            "analytics",
-            "fact_orders",
-            DbtMaterialization::Table,
-        );
-        Arc::make_mut(&mut model)
-            .__base_attr__
-            .depends_on
-            .nodes
-            .push("source.test.raw.orders".to_string());
-        let source = make_source("source.test.raw.orders", "db", "raw", "orders");
-        let ctx = test_task_runner_ctx_with_nodes(
-            None,
-            RunCacheMode::ReadWrite,
-            false,
-            Arc::new(EmptySourcesExtractor),
-            nodes_from(vec![model.clone()], vec![source]),
-            ["model.test.fact_orders".to_string()].into_iter().collect(),
-        );
-        let target_fqn = fqn_of("db", "analytics", "fact_orders");
-        let upstream_fqn = fqn_of("db", "raw", "orders");
-        ctx.inner
-            .run_cache_ctx
-            .run_cache_metadata
-            .insert_last_modified_epoch(&target_fqn, Some(123));
-        (ctx, model, upstream_fqn)
-    }
-
-    #[tokio::test]
-    async fn speculative_build_leaves_unresolved_upstream_unrefreshed() {
-        let (ctx, model, upstream_fqn) = ctx_model_with_unresolved_upstream();
-
-        let tables = collect_table_modified_infos(
-            &ctx,
-            model.as_ref(),
-            false,
-            &BTreeSet::from([upstream_fqn.clone()]),
-            &BTreeMap::new(),
-            &BTreeSet::new(),
-            true,
-        )
-        .await
-        .unwrap();
-
-        assert!(tables.metadata_complete);
-        assert!(tables.tables.contains(&TableModifiedInfo {
-            name: upstream_fqn.clone(),
-            last_modified_epoch: None,
-        }));
-        // A speculative build issues no blocking per-node freshness query, so an
-        // unresolved upstream stays a genuine cache miss (never inserted).
-        assert_eq!(
-            ctx.inner
-                .run_cache_ctx
-                .run_cache_metadata
-                .last_modified_epoch(&upstream_fqn),
-            None,
-        );
-    }
-
-    #[tokio::test]
-    async fn non_speculative_build_refreshes_unresolved_upstream() {
-        let (ctx, model, upstream_fqn) = ctx_model_with_unresolved_upstream();
-
-        let tables = collect_table_modified_infos(
-            &ctx,
-            model.as_ref(),
-            false,
-            &BTreeSet::from([upstream_fqn.clone()]),
-            &BTreeMap::new(),
-            &BTreeSet::new(),
-            false,
-        )
-        .await
-        .unwrap();
-
-        assert!(tables.metadata_complete);
-        assert!(tables.tables.contains(&TableModifiedInfo {
-            name: upstream_fqn.clone(),
-            last_modified_epoch: None,
-        }));
-        // A non-speculative build resolves the miss with a blocking freshness
-        // lookup; with no adapter wired in the test env it records an explicit
-        // unresolved entry, distinguishing it from the speculative peek above.
-        assert_eq!(
-            ctx.inner
-                .run_cache_ctx
-                .run_cache_metadata
-                .last_modified_epoch(&upstream_fqn),
-            Some(None),
-        );
-    }
-
-    fn speculative_test_model() -> Arc<DbtModel> {
-        make_model(
-            "model.test.user_name_model",
-            "db",
-            "dbt_test",
-            "user_name_model",
-            DbtMaterialization::Table,
-        )
-    }
-
-    #[tokio::test]
-    async fn speculative_skip_verdict_returns_skip_without_regular_submit() {
-        let client = Arc::new(RecordingRunCacheClient::with_speculative_response(
-            speculative_skip_response(),
-        ));
-        let ctx = test_task_runner_ctx(Some(
-            client.clone() as dbt_state::service_client::SharedRunCacheServiceClient
-        ));
-        let model = speculative_test_model();
-
-        let decision = run_cache_service_before_execution(
-            &ctx,
-            model.as_ref(),
-            &task_result_with_sql("select 'alice' as first_name"),
-            None,
-        )
-        .await;
-
-        assert!(matches!(
-            decision,
-            RunCacheServiceDecision::Skip {
-                status: NodeStatus::ReusedNoChanges(_),
-                ..
-            }
-        ));
-        assert_eq!(client.speculative_submitted_count(), 1);
-        assert_eq!(
-            client.submitted_count(),
-            0,
-            "a speculative skip verdict must not fall through to a regular submit"
-        );
-    }
-
-    #[tokio::test]
-    async fn speculative_clone_verdict_returns_clone_without_regular_submit() {
-        let client = Arc::new(RecordingRunCacheClient::with_speculative_response(
-            speculative_clone_response(),
-        ));
-        let ctx = test_task_runner_ctx(Some(
-            client.clone() as dbt_state::service_client::SharedRunCacheServiceClient
-        ));
-        let model = speculative_test_model();
-
-        let decision = run_cache_service_before_execution(
-            &ctx,
-            model.as_ref(),
-            &task_result_with_sql("select 'alice' as first_name"),
-            None,
-        )
-        .await;
-
-        let RunCacheServiceDecision::Clone { clone } = decision else {
-            panic!("expected clone decision from speculative verdict");
-        };
-        assert_eq!(clone.request_id, "clone-request");
-        assert_eq!(client.speculative_submitted_count(), 1);
-        assert_eq!(
-            client.submitted_count(),
-            0,
-            "a speculative clone verdict must not fall through to a regular submit"
-        );
-    }
-
-    #[tokio::test]
-    async fn speculative_untracked_verdict_executes_and_records_speculatively() {
-        let client = Arc::new(RecordingRunCacheClient::with_speculative_response(
-            speculative_untracked_response(),
-        ));
-        let ctx = test_task_runner_ctx(Some(
-            client.clone() as dbt_state::service_client::SharedRunCacheServiceClient
-        ));
-        let model = speculative_test_model();
-
-        let decision = run_cache_service_before_execution(
-            &ctx,
-            model.as_ref(),
-            &task_result_with_sql("select 'alice' as first_name"),
-            None,
-        )
-        .await;
-
-        match decision {
-            RunCacheServiceDecision::Execute {
-                after_success: RunCacheAfterSuccess::Record(record),
-                sao_guard: None,
-            } => {
-                assert!(
-                    record.speculative,
-                    "an untracked-execute verdict must record after the fact from the speculative request"
-                );
-            }
-            other => panic!("expected execute-with-record decision, got {other:?}"),
-        }
-        assert_eq!(client.speculative_submitted_count(), 1);
-        assert_eq!(
-            client.submitted_count(),
-            0,
-            "the untracked-execute path executes now and does not issue a regular submit"
-        );
-        // The untracked-execute path intentionally does not await the prefetch.
-        assert!(
-            !ctx.inner.run_cache_ctx.prefetch.is_done(),
-            "the untracked-execute path must not block on the prefetch"
-        );
-    }
-
-    #[tokio::test]
-    async fn speculative_undecided_verdict_falls_back_to_regular_submit() {
-        let client = Arc::new(RecordingRunCacheClient::with_speculative_response(
-            speculative_undecided_response(),
-        ));
-        let ctx = test_task_runner_ctx(Some(
-            client.clone() as dbt_state::service_client::SharedRunCacheServiceClient
-        ));
-        let model = speculative_test_model();
-
-        let decision = run_cache_service_before_execution(
-            &ctx,
-            model.as_ref(),
-            &task_result_with_sql("select 'alice' as first_name"),
-            None,
-        )
-        .await;
-
-        assert!(matches!(
-            decision,
-            RunCacheServiceDecision::Execute {
-                after_success: RunCacheAfterSuccess::Confirm(_),
-                sao_guard: None,
-            }
-        ));
-        assert_eq!(client.speculative_submitted_count(), 1);
-        assert_eq!(
-            client.submitted_count(),
-            1,
-            "an undecided verdict must fall back to a regular submit"
-        );
-        assert!(
-            ctx.inner.run_cache_ctx.prefetch.is_done(),
-            "the fallback path awaits the prefetch before resubmitting"
-        );
-    }
-
-    #[tokio::test]
-    async fn speculative_rpc_error_falls_back_to_regular_submit() {
-        // A default client answers the speculative RPC with `Disabled`.
-        let client = Arc::new(RecordingRunCacheClient::default());
-        let ctx = test_task_runner_ctx(Some(
-            client.clone() as dbt_state::service_client::SharedRunCacheServiceClient
-        ));
-        let model = speculative_test_model();
-
-        let decision = run_cache_service_before_execution(
-            &ctx,
-            model.as_ref(),
-            &task_result_with_sql("select 'alice' as first_name"),
-            None,
-        )
-        .await;
-
-        assert!(matches!(
-            decision,
-            RunCacheServiceDecision::Execute {
-                after_success: RunCacheAfterSuccess::Confirm(_),
-                sao_guard: None,
-            }
-        ));
-        assert_eq!(client.speculative_submitted_count(), 1);
-        assert_eq!(
-            client.submitted_count(),
-            1,
-            "a speculative RPC error must gracefully fall back to a regular submit"
-        );
-    }
-
-    #[tokio::test]
-    async fn prefetch_ready_skips_speculation_and_uses_regular_submit() {
-        // Canned speculative skip verdict that must never be consulted because
-        // the prefetch is already complete.
-        let client = Arc::new(RecordingRunCacheClient::with_speculative_response(
-            speculative_skip_response(),
-        ));
-        let ctx = test_task_runner_ctx(Some(
-            client.clone() as dbt_state::service_client::SharedRunCacheServiceClient
-        ));
-        ctx.inner.run_cache_ctx.prefetch.mark_started();
-        ctx.inner.run_cache_ctx.prefetch.mark_done();
-        let model = speculative_test_model();
-
-        let decision = run_cache_service_before_execution(
-            &ctx,
-            model.as_ref(),
-            &task_result_with_sql("select 'alice' as first_name"),
-            None,
-        )
-        .await;
-
-        assert!(matches!(
-            decision,
-            RunCacheServiceDecision::Execute {
-                after_success: RunCacheAfterSuccess::Confirm(_),
-                sao_guard: None,
-            }
-        ));
-        assert_eq!(
-            client.speculative_submitted_count(),
-            0,
-            "a ready prefetch must skip the speculative RPC entirely"
-        );
-        assert_eq!(client.submitted_count(), 1);
-    }
-
-    #[tokio::test]
-    async fn prefetch_completing_during_request_build_skips_speculation() {
-        // Regression test for the last-responsible-moment re-check. The
-        // speculative-vs-regular decision is taken at entry, before
-        // `build_sql_request` runs. In production `build_sql_request` blocks on
-        // the view-definition traversal (inside `build_sql_context`), during
-        // which the background prefetch frequently completes. This test drives
-        // the same observable condition deterministically: the prefetch is in
-        // flight at entry but becomes ready before `build_sql_request` returns.
-        // The node must then re-check and submit non-speculatively, leaving the
-        // canned skip verdict below unconsulted.
-        let client = Arc::new(RecordingRunCacheClient::with_speculative_response(
-            speculative_skip_response(),
-        ));
-        let shared: dbt_state::service_client::SharedRunCacheServiceClient = client.clone();
-        let ctx = test_task_runner_ctx(Some(shared.clone()));
-        // Started but not yet done: the entry-point readiness check sees the
-        // prefetch in flight and enters the speculative branch.
-        ctx.inner.run_cache_ctx.prefetch.mark_started();
-        let model = speculative_test_model();
-
-        // The `build_request` closure is invoked at the end of
-        // `build_sql_request`, after `build_sql_context` returns (that is where
-        // the view traversal runs in production). Marking the prefetch done here
-        // models it completing by the time the request build finishes — exactly
-        // the state the re-check inspects. `build_and_submit_non_speculative`
-        // invokes the closure a second time; `mark_done` is idempotent.
-        let build = |context| {
-            ctx.inner.run_cache_ctx.prefetch.mark_done();
-            build_model_sql_request(
-                model.as_ref(),
-                context,
-                &ctx.inner.materialization_resolver,
-                |_| None,
-            )
-        };
-
-        let result = submit_sql_with_speculation(
-            &ctx,
-            model.as_ref(),
-            "select 'alice' as first_name".to_string(),
-            false,
-            false,
-            None,
-            &shared,
-            build,
-        )
-        .await
-        .unwrap();
-
-        assert!(result.is_some());
-        assert_eq!(
-            client.speculative_submitted_count(),
-            0,
-            "a prefetch that completes during the build must skip the speculative RPC"
-        );
-        assert_eq!(
-            client.submitted_count(),
-            1,
-            "the node must fall through to a single non-speculative submit"
-        );
-    }
-
-    #[tokio::test]
-    async fn write_only_mode_skips_speculation_and_produces_record() {
-        let client = Arc::new(RecordingRunCacheClient::with_speculative_response(
-            speculative_skip_response(),
-        ));
-        let ctx = test_task_runner_ctx_with_mode(
-            Some(client.clone() as dbt_state::service_client::SharedRunCacheServiceClient),
-            RunCacheMode::WriteOnly,
-        );
-        let model = speculative_test_model();
-
-        let decision = run_cache_service_before_execution(
-            &ctx,
-            model.as_ref(),
-            &task_result_with_sql("select 'alice' as first_name"),
-            None,
-        )
-        .await;
-
-        match decision {
-            RunCacheServiceDecision::Execute {
-                after_success: RunCacheAfterSuccess::Record(record),
-                sao_guard: None,
-            } => {
-                assert!(
-                    !record.speculative,
-                    "a write-only record is built from a full snapshot, not a speculative one"
-                );
-            }
-            other => panic!("expected execute-with-record decision, got {other:?}"),
-        }
-        assert_eq!(
-            client.speculative_submitted_count(),
-            0,
-            "write-only mode never asks the service for a decision"
-        );
-        assert_eq!(client.submitted_count(), 0);
-    }
-
-    #[test]
-    fn is_prefetch_ready_requires_started_and_done() {
-        let ctx = test_task_runner_ctx(None);
-        assert!(
-            !is_prefetch_ready(&ctx),
-            "not ready before the prefetch is started"
-        );
-        ctx.inner.run_cache_ctx.prefetch.mark_started();
-        assert!(
-            !is_prefetch_ready(&ctx),
-            "not ready while the prefetch is in flight"
-        );
-        ctx.inner.run_cache_ctx.prefetch.mark_done();
-        assert!(
-            is_prefetch_ready(&ctx),
-            "ready once the prefetch is both started and done"
-        );
-    }
-
-    #[tokio::test]
-    async fn finalize_speculative_request_fills_real_epochs_and_marks_flag() {
-        let ctx = test_task_runner_ctx(None);
-        let model = speculative_test_model();
-
-        // One dependency the warm cache has resolved to a real epoch, and one
-        // the post-prefetch refresh resolves as unknown (the test env has no
-        // adapter, so the miss refresh caches an explicit `Some(None)`).
-        let warm_fqn = fqn_of("db", "analytics", "warm_dep");
-        let cold_fqn = fqn_of("db", "raw", "cold_dep");
-        ctx.inner
-            .run_cache_ctx
-            .run_cache_metadata
-            .insert_last_modified_epoch(&warm_fqn, Some(999));
-
-        // The speculative request carries partial epochs: a stale placeholder for
-        // the warm dep and a best-effort value for the cold dep.
-        let request = SubmitEnrichedSqlRequest {
-            tables: vec![
-                TableModifiedInfo {
-                    name: warm_fqn.clone(),
-                    last_modified_epoch: Some(111),
-                },
-                TableModifiedInfo {
-                    name: cold_fqn.clone(),
-                    last_modified_epoch: Some(222),
-                },
-            ],
-            ..Default::default()
-        };
-
-        let finalized = finalize_speculative_sql_request(&ctx, model.as_ref(), request).await;
-
-        assert_eq!(
-            finalized.tables,
-            vec![
-                // Refreshed to the real epoch the warm cache now holds.
-                TableModifiedInfo {
-                    name: warm_fqn.clone(),
-                    last_modified_epoch: Some(999),
-                },
-                // The post-prefetch refresh resolved this as unknown, so the
-                // stale speculative value is cleared to unset rather than kept.
-                TableModifiedInfo {
-                    name: cold_fqn.clone(),
-                    last_modified_epoch: None,
-                },
-            ],
-        );
-
-        // The recorded execution built from a finalized speculative request must
-        // carry `from_speculative_submit = true`.
-        let outcome = ExecutionOutcomeInput {
-            last_modified_epoch: Some(123),
-            table_type: None,
-            execution_runtime_ms: None,
-        };
-        let record = sql_execution_record_from_submit_request(finalized, outcome, true);
-        let Some(execution_record::Input::EnrichedSql(sql)) = record.input else {
-            panic!("expected an enriched-SQL execution record");
-        };
-        assert!(sql.from_speculative_submit);
     }
 
     #[test]
@@ -6398,45 +3825,6 @@ mod tests {
     }
 
     #[test]
-    fn warns_on_slow_snowflake_prefetch_without_metadata_warehouse() {
-        let no_warehouse = MetadataQueryOptions::default();
-        let with_warehouse = MetadataQueryOptions {
-            warehouse: Some("META_WH".to_string()),
-            ..MetadataQueryOptions::default()
-        };
-        let slow = SLOW_METADATA_PREFETCH_WARN_THRESHOLD;
-        let fast = SLOW_METADATA_PREFETCH_WARN_THRESHOLD - std::time::Duration::from_secs(1);
-
-        // Slow, Snowflake, no dedicated warehouse → hint.
-        assert!(should_warn_slow_metadata_prefetch(
-            AdapterType::Snowflake,
-            &no_warehouse,
-            slow
-        ));
-
-        // A dedicated warehouse is already the fix → stay quiet.
-        assert!(!should_warn_slow_metadata_prefetch(
-            AdapterType::Snowflake,
-            &with_warehouse,
-            slow
-        ));
-
-        // Fast prefetch → nothing to hint.
-        assert!(!should_warn_slow_metadata_prefetch(
-            AdapterType::Snowflake,
-            &no_warehouse,
-            fast
-        ));
-
-        // The `metadata_warehouse` config is Snowflake-specific.
-        assert!(!should_warn_slow_metadata_prefetch(
-            AdapterType::Bigquery,
-            &no_warehouse,
-            slow
-        ));
-    }
-
-    #[test]
     fn execute_hooks_on_any_reuse_uses_state_config_for_skip_reuse() {
         let model = model_with_state(ModelState {
             lag_tolerance: None,
@@ -6444,7 +3832,6 @@ mod tests {
             evaluate_volatile_sql: None,
             pre_clone: None,
             execute_hooks_on_any_reuse: Some(true),
-            compare_unrendered_code: None,
         });
 
         assert!(should_execute_hooks_for_skip_reuse(&model, false));
@@ -6458,7 +3845,6 @@ mod tests {
             evaluate_volatile_sql: None,
             pre_clone: None,
             execute_hooks_on_any_reuse: None,
-            compare_unrendered_code: None,
         });
 
         assert!(should_execute_hooks_for_skip_reuse(&model, true));
@@ -6476,7 +3862,6 @@ mod tests {
             evaluate_volatile_sql: None,
             pre_clone: None,
             execute_hooks_on_any_reuse: None,
-            compare_unrendered_code: None,
         });
 
         assert_eq!(freshness_tolerance_seconds_for_node(&model, 2700), 7200);
@@ -6490,7 +3875,6 @@ mod tests {
             evaluate_volatile_sql: None,
             pre_clone: None,
             execute_hooks_on_any_reuse: None,
-            compare_unrendered_code: None,
         });
         model.__model_attr__.freshness = Some(ModelFreshness {
             build_after: Some(ModelFreshnessRules {
@@ -6498,7 +3882,6 @@ mod tests {
                 period: Some(FreshnessPeriod::day),
                 updates_on: None,
             }),
-            ..Default::default()
         });
 
         assert_eq!(freshness_tolerance_seconds_for_node(&model, 2700), 86400);
@@ -6516,7 +3899,6 @@ mod tests {
             evaluate_volatile_sql: None,
             pre_clone: None,
             execute_hooks_on_any_reuse: None,
-            compare_unrendered_code: None,
         });
         model.__model_attr__.freshness = Some(ModelFreshness {
             build_after: Some(ModelFreshnessRules {
@@ -6524,7 +3906,6 @@ mod tests {
                 period: Some(FreshnessPeriod::day),
                 updates_on: None,
             }),
-            ..Default::default()
         });
 
         assert_eq!(freshness_tolerance_seconds_for_node(&model, 2700), 7200);
@@ -6548,7 +3929,6 @@ mod tests {
             evaluate_volatile_sql: None,
             pre_clone: None,
             execute_hooks_on_any_reuse: None,
-            compare_unrendered_code: None,
         });
         model.__model_attr__.freshness = Some(ModelFreshness {
             build_after: Some(ModelFreshnessRules {
@@ -6556,7 +3936,6 @@ mod tests {
                 period: Some(FreshnessPeriod::hour),
                 updates_on: Some(UpdatesOn::All),
             }),
-            ..Default::default()
         });
 
         assert_eq!(
@@ -6573,7 +3952,6 @@ mod tests {
             evaluate_volatile_sql: Some(true),
             pre_clone: None,
             execute_hooks_on_any_reuse: None,
-            compare_unrendered_code: None,
         });
         model.__common_attr__.meta.insert(
             "run_cache_tolerate_nondeterminism".to_string(),
@@ -6581,126 +3959,6 @@ mod tests {
         );
 
         assert!(!resolve_tolerate_nondeterminism(&model, true));
-    }
-
-    fn snapshot_with_state(state: ModelState) -> DbtSnapshot {
-        let mut snapshot = DbtSnapshot::default();
-        snapshot.__common_attr__.unique_id = "snapshot.test.orders_snapshot".to_string();
-        snapshot.__snapshot_attr__.state = Some(state);
-        snapshot
-    }
-
-    #[test]
-    fn snapshot_state_config_is_honored_by_run_cache() {
-        // Snapshots carry the full `ModelState` (5 keys); every run-cache accessor must read it.
-        let snapshot = snapshot_with_state(ModelState {
-            lag_tolerance: Some(ModelFreshnessRules {
-                count: Some(2),
-                period: Some(FreshnessPeriod::hour),
-                updates_on: None,
-            }),
-            require_fresh_data_from: Some(UpdatesOn::All),
-            evaluate_volatile_sql: Some(true),
-            pre_clone: None,
-            execute_hooks_on_any_reuse: Some(true),
-            compare_unrendered_code: None,
-        });
-
-        assert!(should_execute_hooks_for_skip_reuse(&snapshot, false));
-        assert_eq!(freshness_tolerance_seconds_for_node(&snapshot, 2700), 7200);
-        assert!(!resolve_tolerate_nondeterminism(&snapshot, true));
-        assert_eq!(
-            stale_upstream_policy_for_node(&snapshot),
-            dbt_state::proto::query_cache::StaleUpstreamPolicy::All
-        );
-    }
-
-    fn data_test_with_state(state: DataTestState) -> DbtTest {
-        let mut test = DbtTest::default();
-        test.__common_attr__.unique_id = "test.test.not_null_orders_id".to_string();
-        test.__test_attr__.state = Some(state);
-        test
-    }
-
-    #[test]
-    fn data_test_state_config_is_honored_by_run_cache() {
-        // Data tests carry the restricted `DataTestState` (2 keys). The two supported configs are
-        // honored; the 5-key-only configs (e.g. execute_hooks_on_any_reuse) are not modeled and fall
-        // back to the service default.
-        let test = data_test_with_state(DataTestState {
-            require_fresh_data_from: Some(UpdatesOn::All),
-            evaluate_volatile_sql: Some(true),
-            compare_unrendered_code: None,
-        });
-
-        assert!(!resolve_tolerate_nondeterminism(&test, true));
-        assert_eq!(
-            stale_upstream_policy_for_node(&test),
-            dbt_state::proto::query_cache::StaleUpstreamPolicy::All
-        );
-        assert!(should_execute_hooks_for_skip_reuse(&test, true));
-        assert!(!should_execute_hooks_for_skip_reuse(&test, false));
-    }
-
-    #[test]
-    fn compare_unrendered_code_falls_back_to_service_default() {
-        let model = model_with_state(ModelState {
-            lag_tolerance: None,
-            require_fresh_data_from: None,
-            evaluate_volatile_sql: None,
-            pre_clone: None,
-            execute_hooks_on_any_reuse: None,
-            compare_unrendered_code: None,
-        });
-
-        assert!(resolve_compare_unrendered_code(&model, true));
-        assert!(!resolve_compare_unrendered_code(&model, false));
-        // A node with no `state:` block at all resolves the same way.
-        assert!(resolve_compare_unrendered_code(&DbtModel::default(), true));
-    }
-
-    #[test]
-    fn compare_unrendered_code_node_config_wins_over_service_default() {
-        // Both directions: the node config overrides the default whichever way it points.
-        let enabled = model_with_state(ModelState {
-            lag_tolerance: None,
-            require_fresh_data_from: None,
-            evaluate_volatile_sql: None,
-            pre_clone: None,
-            execute_hooks_on_any_reuse: None,
-            compare_unrendered_code: Some(true),
-        });
-        let disabled = model_with_state(ModelState {
-            lag_tolerance: None,
-            require_fresh_data_from: None,
-            evaluate_volatile_sql: None,
-            pre_clone: None,
-            execute_hooks_on_any_reuse: None,
-            compare_unrendered_code: Some(false),
-        });
-
-        assert!(resolve_compare_unrendered_code(&enabled, false));
-        assert!(!resolve_compare_unrendered_code(&disabled, true));
-    }
-
-    #[test]
-    fn compare_unrendered_code_resolves_for_snapshots_and_data_tests() {
-        let snapshot = snapshot_with_state(ModelState {
-            lag_tolerance: None,
-            require_fresh_data_from: None,
-            evaluate_volatile_sql: None,
-            pre_clone: None,
-            execute_hooks_on_any_reuse: None,
-            compare_unrendered_code: Some(true),
-        });
-        let test = data_test_with_state(DataTestState {
-            require_fresh_data_from: None,
-            evaluate_volatile_sql: None,
-            compare_unrendered_code: Some(true),
-        });
-
-        assert!(resolve_compare_unrendered_code(&snapshot, false));
-        assert!(resolve_compare_unrendered_code(&test, false));
     }
 
     #[test]
@@ -6873,28 +4131,15 @@ mod tests {
         }
     }
 
-    fn skip_execution_response_with_test_result(
-        result: CachedTestExecutionResult,
-    ) -> SubmitSqlResponse {
+    fn skip_execution_response_with_test_failures(failures: i64) -> SubmitSqlResponse {
         SubmitSqlResponse {
             response: Some(submit_sql_response::Response::SkipExecution(
                 SkipExecutionResponse {
-                    execution_results: Some(build_test_execution_results_struct(result)),
+                    execution_results: Some(build_test_execution_results_struct(failures)),
                     ..Default::default()
                 },
             )),
         }
-    }
-
-    fn test_execution_results_with_failures_only(failures: i64) -> Struct {
-        let mut fields = HashMap::new();
-        fields.insert(
-            "failures".to_string(),
-            Value {
-                kind: Some(Kind::IntValue(failures)),
-            },
-        );
-        Struct { fields }
     }
 
     fn ready_to_clone_response() -> SubmitSqlResponse {
@@ -6918,66 +4163,16 @@ mod tests {
         SubmitSqlResponse { response: None }
     }
 
-    fn speculative_skip_response() -> SubmitSqlSpeculativeResponse {
-        SubmitSqlSpeculativeResponse {
-            response: Some(submit_sql_speculative_response::Response::SkipExecution(
-                SkipExecutionResponse::default(),
-            )),
-        }
-    }
-
-    fn speculative_clone_response() -> SubmitSqlSpeculativeResponse {
-        SubmitSqlSpeculativeResponse {
-            response: Some(submit_sql_speculative_response::Response::ReadyToClone(
-                ReadyToCloneResponse {
-                    request_id: "clone-request".to_string(),
-                    clone_sqls: vec!["create table target clone source".to_string()],
-                    clone_source: "source".to_string(),
-                    clone_target: "target".to_string(),
-                    clone_required_last_modified_epoch: Some(123),
-                    clone_execution_results: Some(Struct::default()),
-                    execution_runtime_ms: Some(456),
-                    ..Default::default()
-                },
-            )),
-        }
-    }
-
-    fn speculative_untracked_response() -> SubmitSqlSpeculativeResponse {
-        SubmitSqlSpeculativeResponse {
-            response: Some(
-                submit_sql_speculative_response::Response::ReadyToExecuteUntracked(
-                    ReadyToExecuteUntrackedResponse {},
-                ),
-            ),
-        }
-    }
-
-    fn speculative_undecided_response() -> SubmitSqlSpeculativeResponse {
-        SubmitSqlSpeculativeResponse {
-            response: Some(submit_sql_speculative_response::Response::Undecided(
-                UndecidedResponse {},
-            )),
-        }
-    }
-
     struct RecordingRunCacheClient {
         submitted: Mutex<Vec<SubmitEnrichedSqlRequest>>,
-        speculative_submitted: Mutex<Vec<SubmitEnrichedSqlRequest>>,
         response: SubmitSqlResponse,
-        /// Canned speculative verdict. `None` makes the speculative RPC report
-        /// `Disabled` (the trait default), mirroring a server that does not
-        /// answer speculatively so the caller falls back to a regular submit.
-        speculative_response: Option<SubmitSqlSpeculativeResponse>,
     }
 
     impl Default for RecordingRunCacheClient {
         fn default() -> Self {
             Self {
                 submitted: Mutex::new(Vec::new()),
-                speculative_submitted: Mutex::new(Vec::new()),
                 response: ready_to_execute_response(),
-                speculative_response: None,
             }
         }
     }
@@ -6986,13 +4181,6 @@ mod tests {
         fn with_response(response: SubmitSqlResponse) -> Self {
             Self {
                 response,
-                ..Self::default()
-            }
-        }
-
-        fn with_speculative_response(speculative_response: SubmitSqlSpeculativeResponse) -> Self {
-            Self {
-                speculative_response: Some(speculative_response),
                 ..Self::default()
             }
         }
@@ -7014,14 +4202,6 @@ mod tests {
                 .map(|request| request.execution_type)
                 .collect()
         }
-
-        fn submitted_count(&self) -> usize {
-            self.submitted.lock().unwrap().len()
-        }
-
-        fn speculative_submitted_count(&self) -> usize {
-            self.speculative_submitted.lock().unwrap().len()
-        }
     }
 
     #[async_trait::async_trait]
@@ -7038,17 +4218,6 @@ mod tests {
         ) -> Result<SubmitSqlResponse, RunCacheServiceError> {
             self.submitted.lock().unwrap().push(request);
             Ok(self.response.clone())
-        }
-
-        async fn submit_enriched_sql_speculative(
-            &self,
-            request: SubmitEnrichedSqlRequest,
-        ) -> Result<SubmitSqlSpeculativeResponse, RunCacheServiceError> {
-            self.speculative_submitted.lock().unwrap().push(request);
-            match &self.speculative_response {
-                Some(response) => Ok(response.clone()),
-                None => Err(RunCacheServiceError::Disabled),
-            }
         }
 
         async fn submit_values(
@@ -7071,215 +4240,6 @@ mod tests {
         ) -> Result<RecordExecutionsResponse, RunCacheServiceError> {
             Err(RunCacheServiceError::Disabled)
         }
-    }
-
-    /// `RunCacheServiceError` isn't `Clone` (and can't be made so from this
-    /// crate — the type is foreign), so `TelemetryTestClient` stores which
-    /// error to manufacture rather than a reusable instance.
-    #[derive(Clone, Copy)]
-    enum TestFailure {
-        Retriable,
-        NonRetriable,
-    }
-
-    impl TestFailure {
-        fn build(self) -> RunCacheServiceError {
-            match self {
-                Self::Retriable => RunCacheServiceError::Rpc(tonic::Status::unavailable("down")),
-                Self::NonRetriable => {
-                    RunCacheServiceError::Rpc(tonic::Status::invalid_argument("bad request"))
-                }
-            }
-        }
-    }
-
-    /// Test double for `TelemetryDispatcher` tests: records every batch it's
-    /// asked to submit, and fails the first `fail_count` calls with a
-    /// configurable error before succeeding.
-    #[derive(Default)]
-    struct TelemetryTestClient {
-        batches: Mutex<Vec<Vec<ClientTelemetryEvent>>>,
-        fail_count: std::sync::atomic::AtomicUsize,
-        failure: Option<TestFailure>,
-    }
-
-    impl TelemetryTestClient {
-        fn failing(fail_count: usize, failure: TestFailure) -> Self {
-            Self {
-                batches: Mutex::new(Vec::new()),
-                fail_count: std::sync::atomic::AtomicUsize::new(fail_count),
-                failure: Some(failure),
-            }
-        }
-
-        fn batches(&self) -> Vec<Vec<ClientTelemetryEvent>> {
-            self.batches.lock().unwrap().clone()
-        }
-    }
-
-    #[async_trait::async_trait]
-    impl RunCacheServiceClient for TelemetryTestClient {
-        async fn validate_client_version(
-            &self,
-        ) -> Result<ClientVersionStatus, RunCacheServiceError> {
-            Ok(ClientVersionStatus::Supported)
-        }
-
-        async fn submit_enriched_sql(
-            &self,
-            _request: SubmitEnrichedSqlRequest,
-        ) -> Result<SubmitSqlResponse, RunCacheServiceError> {
-            Err(RunCacheServiceError::Disabled)
-        }
-
-        async fn submit_values(
-            &self,
-            _request: SubmitValuesRequest,
-        ) -> Result<SubmitSqlResponse, RunCacheServiceError> {
-            Err(RunCacheServiceError::Disabled)
-        }
-
-        async fn confirm_execution(
-            &self,
-            _request: ConfirmExecutionRequest,
-        ) -> Result<ConfirmExecutionResponse, RunCacheServiceError> {
-            Err(RunCacheServiceError::Disabled)
-        }
-
-        async fn submit_telemetry_batch(
-            &self,
-            request: dbt_state::proto::query_cache::SubmitTelemetryBatchRequest,
-        ) -> Result<dbt_state::proto::query_cache::SubmitTelemetryBatchResponse, RunCacheServiceError>
-        {
-            if self
-                .fail_count
-                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |count| {
-                    (count > 0).then(|| count - 1)
-                })
-                .is_ok()
-            {
-                let failure = self.failure.unwrap_or(TestFailure::Retriable);
-                return Err(failure.build());
-            }
-            self.batches.lock().unwrap().push(request.events);
-            Ok(dbt_state::proto::query_cache::SubmitTelemetryBatchResponse { success: true })
-        }
-    }
-
-    fn test_telemetry_event(event_order: i64) -> ClientTelemetryEvent {
-        session_start_event(Struct::default(), event_order)
-    }
-
-    #[test]
-    fn enriched_sql_telemetry_counts_dependencies_without_existing_target() {
-        let request = SubmitEnrichedSqlRequest {
-            target_table: Some("db.schema.target".to_string()),
-            tables: vec![TableModifiedInfo {
-                name: "db.schema.dependency".to_string(),
-                last_modified_epoch: Some(1),
-            }],
-            ..Default::default()
-        };
-
-        assert_eq!(
-            enriched_sql_prepared_telemetry_input(&request).num_dependencies,
-            Some(1)
-        );
-    }
-
-    #[tokio::test]
-    async fn flush_buffer_delivers_and_clears_buffer_on_success() {
-        let client: dbt_state::service_client::SharedRunCacheServiceClient =
-            Arc::new(TelemetryTestClient::default());
-        let mut buffer: Vec<QueuedTelemetryEvent> =
-            (0..3).map(|i| (test_telemetry_event(i), 0)).collect();
-
-        TelemetryDispatcher::flush_buffer(&client, &mut buffer).await;
-
-        assert!(buffer.is_empty(), "successful flush must drain the buffer");
-    }
-
-    #[tokio::test]
-    async fn flush_buffer_caps_each_rpc_at_max_batch_size() {
-        let client_arc = Arc::new(TelemetryTestClient::default());
-        let client: dbt_state::service_client::SharedRunCacheServiceClient = client_arc.clone();
-        let total = TELEMETRY_MAX_BATCH_SIZE * 2 + 20;
-        let mut buffer: Vec<QueuedTelemetryEvent> = (0..total as i64)
-            .map(|i| (test_telemetry_event(i), 0))
-            .collect();
-
-        TelemetryDispatcher::flush_buffer(&client, &mut buffer).await;
-
-        assert!(buffer.is_empty());
-        let batches = client_arc.batches();
-        assert!(
-            batches
-                .iter()
-                .all(|batch| batch.len() <= TELEMETRY_MAX_BATCH_SIZE),
-            "no single SubmitTelemetryBatch RPC may exceed the batch cap: {batches:?}",
-        );
-        assert_eq!(batches.iter().map(Vec::len).sum::<usize>(), total);
-    }
-
-    #[tokio::test]
-    async fn flush_buffer_requeues_retriable_failures_with_incremented_retry_count() {
-        let client: dbt_state::service_client::SharedRunCacheServiceClient = Arc::new(
-            TelemetryTestClient::failing(usize::MAX, TestFailure::Retriable),
-        );
-        let mut buffer: Vec<QueuedTelemetryEvent> = vec![(test_telemetry_event(0), 0)];
-
-        TelemetryDispatcher::flush_buffer(&client, &mut buffer).await;
-        assert_eq!(buffer.len(), 1);
-        assert_eq!(buffer[0].1, 1, "retriable failure increments retry_count");
-
-        TelemetryDispatcher::flush_buffer(&client, &mut buffer).await;
-        assert_eq!(buffer[0].1, 2);
-
-        TelemetryDispatcher::flush_buffer(&client, &mut buffer).await;
-        assert_eq!(buffer[0].1, 3);
-
-        // One more attempt exceeds `TELEMETRY_MAX_RETRY_COUNT`: dropped, not requeued.
-        TelemetryDispatcher::flush_buffer(&client, &mut buffer).await;
-        assert!(
-            buffer.is_empty(),
-            "event exceeding max retries must be dropped"
-        );
-    }
-
-    #[tokio::test]
-    async fn flush_buffer_drops_batch_on_non_retriable_error() {
-        let client: dbt_state::service_client::SharedRunCacheServiceClient = Arc::new(
-            TelemetryTestClient::failing(usize::MAX, TestFailure::NonRetriable),
-        );
-        let mut buffer: Vec<QueuedTelemetryEvent> = vec![(test_telemetry_event(0), 0)];
-
-        TelemetryDispatcher::flush_buffer(&client, &mut buffer).await;
-
-        assert!(
-            buffer.is_empty(),
-            "a non-retriable error must drop the batch outright, not requeue it"
-        );
-    }
-
-    #[tokio::test]
-    async fn dispatcher_flush_terminates_instead_of_hanging() {
-        // Regression test: `flush()` closes the dispatcher's `Sender` and
-        // awaits the worker task, which only exits once
-        // `mpsc::Receiver::recv` returns `None` — which requires every
-        // `Sender` clone, including any the worker task itself might hold,
-        // to be dropped. If the worker ever holds on to a `Sender` clone
-        // (e.g. to requeue retries through the channel instead of the local
-        // buffer), this hangs forever.
-        let client = Arc::new(TelemetryTestClient::default());
-        let dispatcher = TelemetryDispatcher::spawn(client.clone());
-        dispatcher.send(test_telemetry_event(0)).await;
-        dispatcher.send(test_telemetry_event(1)).await;
-
-        tokio::time::timeout(std::time::Duration::from_secs(5), dispatcher.flush())
-            .await
-            .expect("flush() must terminate, not hang");
-
-        assert_eq!(client.batches().iter().flatten().count(), 2);
     }
 
     #[derive(Debug)]
@@ -7558,14 +4518,8 @@ mod tests {
                 run_cache_service_requested: true,
                 run_cache_service_config: Some(RunCacheServiceConfig::disabled()),
                 run_cache_service_client,
-                state_explain_log_path: None,
                 view_traverser: None,
                 heuristic_clock: std::sync::OnceLock::new(),
-                prefetch: Default::default(),
-                telemetry_event_order: std::sync::atomic::AtomicI64::new(0),
-                telemetry_session_start: std::sync::OnceLock::new(),
-                telemetry_session_ended: std::sync::atomic::AtomicBool::new(false),
-                telemetry_dispatcher: std::sync::OnceLock::new(),
             },
         );
 
@@ -7581,45 +4535,23 @@ mod tests {
     }
 
     fn test_resolver_state_with_nodes(nodes: Nodes) -> ResolverState {
-        // Register a root-project `custom_table` materialization so the
-        // materialization resolver classifies models materialized as
-        // `custom_table` as custom (root/imported macro shadowing), matching
-        // what the custom-materialization tests below exercise.
-        let mut macros = Macros::default();
-        let custom_table_mat = DbtMacro {
-            name: "materialization_custom_table_default".to_string(),
-            package_name: "test".to_string(),
-            unique_id: "macro.test.materialization_custom_table_default".to_string(),
-            ..Default::default()
-        };
-        macros
-            .macros
-            .insert(custom_table_mat.unique_id.clone(), custom_table_mat);
-
         ResolverState {
             root_project_name: "test".to_string(),
             adapter_type: AdapterType::Snowflake,
             nodes,
             disabled_nodes: Nodes::default(),
-            macros,
+            macros: Macros::default(),
             operations: Operations::default(),
-            dbt_profile: {
-                let db_config = DbConfig::Snowflake(Box::<SnowflakeDbConfig>::default());
-                let default_adapter = db_config.adapter_type();
-                let adapters =
-                    IndexMap::from([(default_adapter, ProfileAdapter::single(db_config))]);
-                DbtProfile {
-                    profile: "default".to_string(),
-                    target: "dev".to_string(),
-                    defer_to_target: None,
-                    allow_clones: true,
-                    adapters,
-                    default_adapter,
-                    schema: "dbt_test".to_string(),
-                    database: "db".to_string(),
-                    relative_profile_path: PathBuf::new(),
-                    threads: None,
-                }
+            dbt_profile: DbtProfile {
+                profile: "default".to_string(),
+                target: "dev".to_string(),
+                defer_to_target: None,
+                db_config: DbConfig::Snowflake(Box::<SnowflakeDbConfig>::default()),
+                alt_target_db_config: None,
+                schema: "dbt_test".to_string(),
+                database: "db".to_string(),
+                relative_profile_path: PathBuf::new(),
+                threads: None,
             },
             cloud_config: None,
             render_results: RenderResults::default(),
@@ -7627,7 +4559,7 @@ mod tests {
             get_relation_calls: Default::default(),
             get_columns_in_relation_calls: Default::default(),
             patterned_dangling_sources: Default::default(),
-            run_started_at: Utc::now().with_timezone(&chrono_tz::UTC),
+            run_started_at: chrono::Utc::now().with_timezone(&chrono_tz::UTC),
             runtime_config: Arc::new(DbtRuntimeConfig::default()),
             manifest_path_configs: BTreeMap::new(),
             manifest_selectors: BTreeMap::new(),
@@ -7755,33 +4687,6 @@ mod tests {
     }
 
     #[test]
-    fn final_refresh_uses_bigquery_schema_prefetch_plan() {
-        let relation: Arc<dyn BaseRelation> = create_relation(
-            AdapterType::Bigquery,
-            "db".to_string(),
-            "analytics".to_string(),
-            Some("orders".to_string()),
-            None,
-            ResolvedQuoting::default(),
-        )
-        .unwrap()
-        .into();
-        let name = relation.semantic_fqn();
-        let relations = BTreeMap::from([(name.clone(), relation)]);
-        let overrides = BTreeMap::new();
-
-        let bigquery_plan =
-            plan_last_modified_miss_refresh(AdapterType::Bigquery, &relations, &overrides);
-        assert!(bigquery_plan.targeted_relations.is_empty());
-        assert!(bigquery_plan.schema_prefetch_relations.contains_key(&name));
-
-        let snowflake_plan =
-            plan_last_modified_miss_refresh(AdapterType::Snowflake, &relations, &overrides);
-        assert!(snowflake_plan.schema_prefetch_relations.is_empty());
-        assert!(snowflake_plan.targeted_relations.contains_key(&name));
-    }
-
-    #[test]
     fn prefetch_includes_selected_node_and_source_dep() {
         let model = make_model(
             "model.pkg.orders",
@@ -7817,75 +4722,6 @@ mod tests {
             "source dep should be included"
         );
         assert!(overrides.is_empty());
-    }
-
-    fn make_exposure(unique_id: &str) -> Arc<dbt_schemas::schemas::nodes::DbtExposure> {
-        let mut exposure = dbt_schemas::schemas::nodes::DbtExposure::default();
-        exposure.__common_attr__.unique_id = unique_id.to_string();
-        Arc::new(exposure)
-    }
-
-    #[test]
-    fn prefetch_keeps_real_relations_alongside_an_exposure() {
-        let model = make_model(
-            "model.pkg.orders",
-            "db",
-            "analytics",
-            "orders",
-            DbtMaterialization::Table,
-        );
-        let exposure = make_exposure("exposure.pkg.dashboard");
-        let mut nodes = nodes_from(vec![model], vec![]);
-        nodes
-            .exposures
-            .insert(exposure.__common_attr__.unique_id.clone(), exposure);
-
-        let runnable_set: BTreeSet<String> = [
-            "model.pkg.orders".to_string(),
-            "exposure.pkg.dashboard".to_string(),
-        ]
-        .into_iter()
-        .collect();
-
-        let (relations, _) = collect_global_prefetch_relations(
-            AdapterType::Snowflake,
-            &runnable_set,
-            &BTreeMap::new(),
-            &nodes,
-        );
-
-        assert_eq!(
-            relations.keys().collect::<Vec<_>>(),
-            vec![&fqn_of("db", "analytics", "orders")],
-            "the exposure must be dropped without disturbing real relations"
-        );
-    }
-
-    #[test]
-    fn non_empty_schema_check_ignores_database() {
-        // BigQuery renders relations without a database; only a missing schema
-        // makes the metadata query unbuildable.
-        let no_database = create_relation(
-            AdapterType::Bigquery,
-            String::new(),
-            "analytics".to_string(),
-            Some("orders".to_string()),
-            None,
-            ResolvedQuoting::default(),
-        )
-        .unwrap();
-        assert!(has_non_empty_schema(no_database.as_ref()));
-
-        let no_schema = create_relation(
-            AdapterType::Snowflake,
-            "db".to_string(),
-            String::new(),
-            Some("orders".to_string()),
-            None,
-            ResolvedQuoting::default(),
-        )
-        .unwrap();
-        assert!(!has_non_empty_schema(no_schema.as_ref()));
     }
 
     #[test]
@@ -7956,90 +4792,6 @@ mod tests {
         );
     }
 
-    // Regression #15499: a `loaded_at_query` Jinja macro / `{{ this }}` must be
-    // rendered before it reaches the warehouse, else the raw `{{ ... }}` errors.
-    #[test]
-    fn render_freshness_override_renders_loaded_at_query_macro() {
-        let relation: Arc<dyn BaseRelation> = create_relation(
-            AdapterType::Snowflake,
-            "db".to_string(),
-            "raw".to_string(),
-            Some("customers".to_string()),
-            None,
-            ResolvedQuoting::default(),
-        )
-        .unwrap()
-        .into();
-
-        let mut mj = minijinja::Environment::new();
-        mj.add_function(
-            "get_from_watermark_table",
-            || "select max(updated_at) from db.dbt_jyeo.watermark",
-        );
-        let jinja_env = JinjaEnv::new(mj);
-        let base_context = BTreeMap::new();
-
-        // Macro call is expanded, not sent raw.
-        let rendered = render_freshness_override(
-            FreshnessOverride::Query("{{ get_from_watermark_table() }}".to_string()),
-            &relation,
-            &jinja_env,
-            &base_context,
-        )
-        .unwrap();
-        assert!(
-            matches!(rendered, FreshnessOverride::Query(q) if q == "select max(updated_at) from db.dbt_jyeo.watermark"),
-            "loaded_at_query macro should be rendered"
-        );
-
-        // `{{ this }}` resolves to the source relation.
-        let rendered = render_freshness_override(
-            FreshnessOverride::Query("select max(ts) from {{ this }}".to_string()),
-            &relation,
-            &jinja_env,
-            &base_context,
-        )
-        .unwrap();
-        let expected = format!("select max(ts) from {}", relation.render_self_as_str());
-        assert!(
-            matches!(rendered, FreshnessOverride::Query(q) if q == expected),
-            "{{{{ this }}}} should resolve to the relation"
-        );
-
-        // Field overrides are passed through untouched.
-        let rendered = render_freshness_override(
-            FreshnessOverride::Field("updated_at".to_string()),
-            &relation,
-            &jinja_env,
-            &base_context,
-        )
-        .unwrap();
-        assert!(matches!(rendered, FreshnessOverride::Field(f) if f == "updated_at"));
-
-        // A relation missing a required component (here, identifier) errors
-        // rather than rendering an unqualified name into the warehouse SQL.
-        let no_identifier: Arc<dyn BaseRelation> = create_relation(
-            AdapterType::Snowflake,
-            "db".to_string(),
-            "raw".to_string(),
-            None,
-            None,
-            ResolvedQuoting::default(),
-        )
-        .unwrap()
-        .into();
-        assert!(
-            render_freshness_override(
-                FreshnessOverride::Query("select 1".to_string()),
-                &no_identifier,
-                &jinja_env,
-                &base_context,
-            )
-            .is_err(),
-            "missing identifier should error, not render an unqualified name"
-        );
-    }
-
     #[test]
     fn prefetch_deduplicates_shared_deps() {
         let model_a = make_model(
@@ -8096,7 +4848,7 @@ mod tests {
         let start_ts_ms: i64 = 1_700_000_000_000;
         let clock = HeuristicClock {
             start_ts_ms,
-            start_instant: Instant::now(),
+            start_instant: std::time::Instant::now(),
         };
         assert_eq!(clock.now_ms(), start_ts_ms);
     }
@@ -8106,12 +4858,12 @@ mod tests {
         let start_ts_ms: i64 = 1_700_000_000_000;
         let clock = HeuristicClock {
             start_ts_ms,
-            start_instant: Instant::now(),
+            start_instant: std::time::Instant::now(),
         };
         let first = clock.now_ms();
         // Spin briefly so at least one millisecond passes.
-        let deadline = Instant::now() + std::time::Duration::from_millis(5);
-        while Instant::now() < deadline {}
+        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(5);
+        while std::time::Instant::now() < deadline {}
         let second = clock.now_ms();
         assert!(
             second >= first,
@@ -8127,11 +4879,11 @@ mod tests {
         let base: i64 = 1_700_000_000_000;
         let clock_a = HeuristicClock {
             start_ts_ms: base,
-            start_instant: Instant::now(),
+            start_instant: std::time::Instant::now(),
         };
         let clock_b = HeuristicClock {
             start_ts_ms: base + 1_000,
-            start_instant: Instant::now(),
+            start_instant: std::time::Instant::now(),
         };
         // Both clocks were created at approximately the same real time, so
         // their elapsed values are nearly equal. The difference in now_ms
@@ -8149,278 +4901,71 @@ mod tests {
         assert!(lock.get().is_none(), "lock should be empty before set");
         lock.set(HeuristicClock {
             start_ts_ms: 42_000,
-            start_instant: Instant::now(),
+            start_instant: std::time::Instant::now(),
         })
         .unwrap();
         let clock = lock.get().expect("clock should be set");
         assert_eq!(clock.now_ms(), 42_000);
     }
 
+    /// Regression tests for https://github.com/dbt-labs/dbt-core/issues/15594:
+    /// Databricks issues a real per-relation `DESCRIBE HISTORY` lookup in
+    /// `freshness_all_in_schema` (no eventually-consistent catalog snapshot to
+    /// lag behind), so an empty result there is authoritative and must not
+    /// trigger the per-node eventual-consistency fallback + warning.
     #[test]
-    fn unresolvable_last_modified_uses_heuristic_clock() {
-        let cache = RunCacheMetadataCache::new();
-        let fqn = r#""DB"."S"."SECURE_VIEW""#.to_string();
-        cache.insert_last_modified_epoch(&fqn, Some(123));
-        let clock = HeuristicClock {
-            start_ts_ms: 1_700_000_000_000,
-            start_instant: Instant::now(),
-        };
-
-        apply_unresolvable_last_modified_overrides(
-            &cache,
-            Some(&clock),
-            &BTreeSet::from([fqn.clone()]),
-            &BTreeMap::new(),
-        );
-
-        assert_eq!(
-            cache.last_modified_epoch(&fqn).flatten(),
-            Some(1_700_000_000_000)
-        );
+    fn schema_dump_empty_does_not_require_fallback_on_databricks() {
+        assert!(!schema_dump_empty_requires_fallback(
+            AdapterType::Databricks,
+            true
+        ));
     }
 
+    /// Snowflake's `freshness_all_in_schema` is a single `INFORMATION_SCHEMA`
+    /// bulk query that can genuinely lag behind a just-created table -- this
+    /// is the original, still-valid reason the fallback exists, and must be
+    /// preserved.
     #[test]
-    fn unresolvable_last_modified_does_not_replace_source_freshness_override() {
-        let cache = RunCacheMetadataCache::new();
-        let fqn = r#""DB"."S"."SECURE_VIEW""#.to_string();
-        cache.insert_last_modified_epoch(&fqn, Some(123));
-        let clock = HeuristicClock {
-            start_ts_ms: 1_700_000_000_000,
-            start_instant: Instant::now(),
-        };
-        let overrides = BTreeMap::from([(
-            fqn.clone(),
-            FreshnessOverride::Field("loaded_at".to_string()),
-        )]);
-
-        apply_unresolvable_last_modified_overrides(
-            &cache,
-            Some(&clock),
-            &BTreeSet::from([fqn.clone()]),
-            &overrides,
-        );
-
-        assert_eq!(cache.last_modified_epoch(&fqn), None);
+    fn schema_dump_empty_still_requires_fallback_on_snowflake() {
+        assert!(schema_dump_empty_requires_fallback(
+            AdapterType::Snowflake,
+            true
+        ));
     }
 
+    /// BigQuery's `freshness_all_in_schema` is likewise a single bulk query
+    /// against a metadata view, so it needs the same fallback as Snowflake.
     #[test]
-    fn unresolvable_last_modified_leaves_cache_empty_when_clock_missing() {
-        let cache = RunCacheMetadataCache::new();
-        let fqn = r#""DB"."S"."SECURE_VIEW""#.to_string();
-        cache.insert_last_modified_epoch(&fqn, Some(123));
-
-        apply_unresolvable_last_modified_overrides(
-            &cache,
-            None,
-            &BTreeSet::from([fqn.clone()]),
-            &BTreeMap::new(),
-        );
-
-        assert_eq!(cache.last_modified_epoch(&fqn), None);
+    fn schema_dump_empty_still_requires_fallback_on_bigquery() {
+        assert!(schema_dump_empty_requires_fallback(
+            AdapterType::Bigquery,
+            true
+        ));
     }
 
+    /// Adapters that haven't overridden `freshness_all_in_schema` get the
+    /// trait's default implementation, which deliberately returns an empty
+    /// map to signal "fall back" (see `MetadataAdapter::freshness_all_in_schema`'s
+    /// doc comment) -- the fallback is the only way those adapters get real
+    /// freshness data, so an empty result must still trigger it.
     #[test]
-    fn execution_decision_id_from_response_extracts_service_ids() {
-        let mut ready = ready_to_execute_response();
-        let Some(submit_sql_response::Response::ReadyToExecute(response)) = ready.response.as_mut()
-        else {
-            panic!("expected ready response");
-        };
-        response.execution_decision_id = Some("ready-id".to_string());
-
-        let mut skip = skip_execution_response();
-        let Some(submit_sql_response::Response::SkipExecution(response)) = skip.response.as_mut()
-        else {
-            panic!("expected skip response");
-        };
-        response.execution_decision_id = Some("skip-id".to_string());
-
-        let mut clone = ready_to_clone_response();
-        let Some(submit_sql_response::Response::ReadyToClone(response)) = clone.response.as_mut()
-        else {
-            panic!("expected clone response");
-        };
-        response.execution_decision_id = Some("clone-id".to_string());
-
-        assert_eq!(
-            execution_decision_id_from_response(&ready).as_deref(),
-            Some("ready-id")
-        );
-        assert_eq!(
-            execution_decision_id_from_response(&skip).as_deref(),
-            Some("skip-id")
-        );
-        assert_eq!(
-            execution_decision_id_from_response(&clone).as_deref(),
-            Some("clone-id")
-        );
-        assert!(execution_decision_id_from_response(&empty_response()).is_none());
+    fn schema_dump_empty_still_requires_fallback_for_unimplemented_adapters() {
+        assert!(schema_dump_empty_requires_fallback(
+            AdapterType::Postgres,
+            true
+        ));
     }
 
+    /// A non-empty dump never needs the fallback, regardless of adapter.
     #[test]
-    fn state_explain_execution_decision_id_allows_missing_service_response() {
-        let mut ready = ready_to_execute_response();
-        let Some(submit_sql_response::Response::ReadyToExecute(response)) = ready.response.as_mut()
-        else {
-            panic!("expected ready response");
-        };
-        response.execution_decision_id = Some("ready-id".to_string());
-        let ready_decision = record_service_decision("model.test.orders", &ready, 0, true);
-
-        assert_eq!(
-            state_explain_execution_decision_id(Some(&ready), &ready_decision).as_deref(),
-            Some("ready-id")
-        );
-        assert!(state_explain_execution_decision_id(None, &ready_decision).is_none());
-    }
-
-    #[test]
-    fn state_explain_execution_decision_id_ignores_data_test_skip_fallback() {
-        let mut response = skip_execution_response();
-        let Some(submit_sql_response::Response::SkipExecution(skip)) = response.response.as_mut()
-        else {
-            panic!("expected skip response");
-        };
-        skip.execution_decision_id = Some("skip-id".to_string());
-
-        let decision = record_service_decision(
-            "test.test.not_null_orders_order_date.abc123",
-            &response,
-            0,
-            true,
-        );
-
-        assert_eq!(
-            decision,
-            RunCacheServiceDecision::Execute {
-                after_success: RunCacheAfterSuccess::None,
-                sao_guard: None,
-            }
-        );
-        assert!(state_explain_execution_decision_id(Some(&response), &decision).is_none());
-    }
-
-    #[test]
-    fn state_explain_execution_decision_id_keeps_honored_skip() {
-        let mut response = skip_execution_response_with_test_result(CachedTestExecutionResult {
-            failures: 0,
-            should_warn: false,
-            should_error: false,
-        });
-        let Some(submit_sql_response::Response::SkipExecution(skip)) = response.response.as_mut()
-        else {
-            panic!("expected skip response");
-        };
-        skip.execution_decision_id = Some("skip-id".to_string());
-
-        let decision = record_service_decision(
-            "test.test.not_null_orders_order_date.abc123",
-            &response,
-            0,
-            true,
-        );
-
-        assert_eq!(
-            state_explain_execution_decision_id(Some(&response), &decision).as_deref(),
-            Some("skip-id")
-        );
-    }
-
-    #[test]
-    fn clone_chain_depth_limit_for_adapter_returns_n_minus_1_for_prod() {
-        assert_eq!(
-            clone_chain_depth_limit_for_adapter(AdapterType::Databricks, true, true),
-            Some(0)
-        );
-        assert_eq!(
-            clone_chain_depth_limit_for_adapter(AdapterType::Bigquery, true, true),
-            Some(2)
-        );
-    }
-
-    #[test]
-    fn clone_chain_depth_limit_for_adapter_returns_default_for_non_prod() {
-        assert_eq!(
-            clone_chain_depth_limit_for_adapter(AdapterType::Databricks, false, true),
-            Some(1)
-        );
-        assert_eq!(
-            clone_chain_depth_limit_for_adapter(AdapterType::Bigquery, false, true),
-            Some(3)
-        );
-    }
-
-    #[test]
-    fn clone_chain_depth_limit_for_adapter_none_for_adapters_with_no_limits() {
-        assert_eq!(
-            clone_chain_depth_limit_for_adapter(AdapterType::Snowflake, true, true),
-            None
-        );
-        assert_eq!(
-            clone_chain_depth_limit_for_adapter(AdapterType::Snowflake, false, true),
-            None
-        );
-    }
-
-    #[test]
-    fn clone_chain_depth_limit_for_adapter_zero_when_clones_disallowed() {
-        // allow_clones=false overrides to 0 regardless of adapter or prod/dev direction,
-        // including adapters that otherwise have no default limit at all.
-        assert_eq!(
-            clone_chain_depth_limit_for_adapter(AdapterType::Databricks, true, false),
-            Some(0)
-        );
-        assert_eq!(
-            clone_chain_depth_limit_for_adapter(AdapterType::Bigquery, false, false),
-            Some(0)
-        );
-        assert_eq!(
-            clone_chain_depth_limit_for_adapter(AdapterType::Snowflake, true, false),
-            Some(0)
-        );
-        assert_eq!(
-            clone_chain_depth_limit_for_adapter(AdapterType::Snowflake, false, false),
-            Some(0)
-        );
-    }
-
-    fn state_explain_model(materialized: DbtMaterialization) -> DbtModel {
-        let mut model = DbtModel::default();
-        model.__common_attr__.unique_id = "model.test.orders".to_string();
-        model.__common_attr__.name = "orders".to_string();
-        set_state_explain_base(&mut model.__base_attr__, materialized, "orders");
-        model
-    }
-
-    fn state_explain_seed() -> DbtSeed {
-        let mut seed = DbtSeed::default();
-        seed.__common_attr__.unique_id = "seed.test.cities".to_string();
-        seed.__common_attr__.name = "cities".to_string();
-        set_state_explain_base(&mut seed.__base_attr__, DbtMaterialization::Seed, "cities");
-        seed
-    }
-
-    fn state_explain_snapshot() -> DbtSnapshot {
-        let mut snapshot = DbtSnapshot::default();
-        snapshot.__common_attr__.unique_id = "snapshot.test.orders_snapshot".to_string();
-        snapshot.__common_attr__.name = "orders_snapshot".to_string();
-        set_state_explain_base(
-            &mut snapshot.__base_attr__,
-            DbtMaterialization::Snapshot,
-            "orders_snapshot",
-        );
-        snapshot
-    }
-
-    fn set_state_explain_base(
-        base: &mut dbt_schemas::schemas::nodes::NodeBaseAttributes,
-        materialized: DbtMaterialization,
-        alias: &str,
-    ) {
-        base.database = "analytics".to_string();
-        base.schema = "marts".to_string();
-        base.alias = alias.to_string();
-        base.materialized = materialized;
-        base.quoting = ResolvedQuoting::trues();
+    fn schema_dump_non_empty_never_requires_fallback() {
+        assert!(!schema_dump_empty_requires_fallback(
+            AdapterType::Snowflake,
+            false
+        ));
+        assert!(!schema_dump_empty_requires_fallback(
+            AdapterType::Databricks,
+            false
+        ));
     }
 }

--- a/crates/dbt-tasks-core/src/run_cache/run_cache_service.rs
+++ b/crates/dbt-tasks-core/src/run_cache/run_cache_service.rs
@@ -13,48 +13,67 @@
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
+use std::time::Instant;
+
+use tokio::sync::mpsc;
 
 use crate::context::TaskRunnerCtx;
 use crate::task::{TaskOp, TaskResult};
 use dbt_adapter::AdapterResult;
-use dbt_adapter::errors::{Cancellable, into_fs_error};
-use dbt_adapter::metadata::{FreshnessOverride, MetadataQueryOptions};
+use dbt_adapter::errors::{AdapterErrorKind, Cancellable, into_fs_error};
+use dbt_adapter::metadata::{FreshnessOverride, MetadataAdapter, MetadataQueryOptions};
 use dbt_adapter::record_batch::RecordBatchExt;
-use dbt_adapter::relation::{create_relation, create_relation_from_node};
+use dbt_adapter::relation::{RelationObject, create_relation, create_relation_from_node};
 use dbt_adapter::sql_types::TypeOps;
 use dbt_adapter_core::AdapterType;
 use dbt_adbc::QueryCtx;
 use dbt_common::adapter::dialect_of;
 use dbt_common::io_args::RunCacheMode;
 use dbt_common::stats::NodeStatus;
-use dbt_common::tracing::dbt_emit::{emit_trace_log_message, emit_warn_log_message};
+use dbt_common::tracing::dbt_emit::{
+    emit_debug_log_message, emit_trace_log_message, emit_warn_log_message,
+};
+use dbt_common::tracing::span_info::find_and_update_span_attrs;
 use dbt_common::{ErrorCode, FsError, FsResult, fs_err};
 use dbt_frontend_common::ident::FullyQualifiedName;
 use dbt_frontend_common::named_reference::NamedReference;
 use dbt_frontend_common::sources_extractor::SourcesExtractor;
+use dbt_jinja_utils::jinja_environment::JinjaEnv;
+use dbt_schemas::materialization_resolver::MaterializationResolver;
 use dbt_schemas::schemas::common::{DbtMaterialization, ModelFreshnessRules, ResolvedQuoting};
+use dbt_schemas::schemas::macros::DbtMacro;
 use dbt_schemas::schemas::profiles::DbConfig;
 use dbt_schemas::schemas::properties::ModelState;
 use dbt_schemas::schemas::relations::base::BaseRelation;
 use dbt_schemas::schemas::{
     DbtModel, DbtSeed, DbtSnapshot, DbtSource, DbtTest, InternalDbtNode, InternalDbtNodeAttributes,
 };
+use dbt_state::explain::{
+    StateExplainLogRecord, StateExplainNode, StateExplainNodeInfo, append_state_explain_log_record,
+};
+use dbt_state::metadata_cache::RunCacheMetadataCache;
 use dbt_state::node_session::ExecutionGuard;
 use dbt_state::proto::query_cache::{
-    ConfirmExecutionRequest, ExplainedDecision, NodeFuncMapping, QueryDependency,
-    RecordExecutionsRequest, SkipExecutionResponse, Struct, SubmitEnrichedSqlRequest,
-    SubmitSqlResponse, SubmitValuesRequest, TableModifiedInfo, submit_sql_response,
+    ClientTelemetryEvent, ConfirmExecutionRequest, ExplainedDecision, NodeFuncMapping,
+    QueryDependency, RecordExecutionsRequest, SkipExecutionResponse, Struct,
+    SubmitEnrichedSqlRequest, SubmitSqlResponse, SubmitValuesRequest, TableModifiedInfo, Value,
+    submit_sql_response, submit_sql_speculative_response, value::Kind,
 };
 use dbt_state::request_builder::{
-    ExecutionOutcomeInput, sql_execution_record_from_submit_request,
+    ExecutionOutcomeInput, SessionEndResult, enriched_sql_prepared_event, session_end_event,
+    session_start_event, sql_execution_record_from_submit_request, telemetry_batch,
     values_execution_record_from_submit_request,
 };
-use dbt_telemetry::NodeType;
+use dbt_state::service_client::RunCacheServiceError;
+use dbt_telemetry::{NodeEvaluated, NodeType};
 
 use crate::run_cache::run_cache_request::{
-    SeedRunCacheRequestContext, SqlRunCacheRequestContext, build_model_sql_request,
-    build_seed_values_request, build_snapshot_sql_request, build_test_sql_request, node_identity,
+    DbtProjectInfo, SeedRunCacheRequestContext, SqlRunCacheRequestContext, build_model_sql_request,
+    build_seed_values_request, build_snapshot_sql_request, build_test_sql_request,
+    is_microbatch_model, node_identity,
 };
+use chrono::{DateTime, Utc};
 
 pub fn collect_upstream_hashes(ctx: &TaskRunnerCtx, unique_id: &str) -> HashMap<String, String> {
     ctx.inner
@@ -85,11 +104,11 @@ pub enum RunCacheServiceDecision {
     Skip {
         status: NodeStatus,
         sao_stored_hash: Option<String>,
-        /// Cached test verdict (failures count) when the skipped node is a
-        /// data test. The dispatcher in `runnable/mod.rs` uses it to replace
-        /// the generic `ReusedNoChanges` status with a test-shaped status
-        /// (TestPassed/Errored) and a NO-OP-marked stat.
-        cached_test_failures: Option<i64>,
+        /// Cached data-test result when the skipped node is a data test. The
+        /// dispatcher in `runnable/mod.rs` uses it to replace the generic
+        /// `ReusedNoChanges` status with a test-shaped status and a
+        /// NO-OP-marked stat.
+        cached_test_result: Option<CachedTestExecutionResult>,
     },
     Disabled,
 }
@@ -98,6 +117,15 @@ impl RunCacheServiceDecision {
     fn execute_without_confirmation() -> Self {
         Self::Execute {
             after_success: RunCacheAfterSuccess::None,
+            sao_guard: None,
+        }
+    }
+
+    /// Like [`Self::execute_without_confirmation`], but for a node that
+    /// rebuilds its target relation untracked, invalidating its cached epoch.
+    fn execute_and_invalidate_freshness() -> Self {
+        Self::Execute {
+            after_success: RunCacheAfterSuccess::InvalidateFreshness,
             sao_guard: None,
         }
     }
@@ -173,14 +201,14 @@ impl PartialEq for RunCacheServiceDecision {
                 RunCacheServiceDecision::Skip {
                     status: s1,
                     sao_stored_hash: h1,
-                    cached_test_failures: f1,
+                    cached_test_result: r1,
                 },
                 RunCacheServiceDecision::Skip {
                     status: s2,
                     sao_stored_hash: h2,
-                    cached_test_failures: f2,
+                    cached_test_result: r2,
                 },
-            ) => s1 == s2 && h1 == h2 && f1 == f2,
+            ) => s1 == s2 && h1 == h2 && r1 == r2,
             (RunCacheServiceDecision::Disabled, RunCacheServiceDecision::Disabled) => true,
             _ => false,
         }
@@ -201,12 +229,12 @@ impl std::fmt::Debug for RunCacheServiceDecision {
             RunCacheServiceDecision::Skip {
                 status,
                 sao_stored_hash,
-                cached_test_failures,
+                cached_test_result,
             } => f
                 .debug_struct("RunCacheServiceDecision::Skip")
                 .field("status", status)
                 .field("sao_stored_hash", sao_stored_hash)
-                .field("cached_test_failures", cached_test_failures)
+                .field("cached_test_result", cached_test_result)
                 .finish(),
             RunCacheServiceDecision::Disabled => write!(f, "RunCacheServiceDecision::Disabled"),
         }
@@ -216,6 +244,11 @@ impl std::fmt::Debug for RunCacheServiceDecision {
 #[derive(Clone, Debug, PartialEq)]
 pub enum RunCacheAfterSuccess {
     None,
+    /// The node rebuilt its target without the service observing it — no
+    /// decision was sought and no execution will be recorded. Its cached
+    /// warehouse metadata now describes pre-build state, so drop it once the
+    /// node succeeds.
+    InvalidateFreshness,
     Confirm(RunCacheExecutionConfirmation),
     Record(Box<RunCachePendingExecutionRecord>),
 }
@@ -231,12 +264,18 @@ pub struct RunCacheExecutionConfirmation {
 #[derive(Clone, Debug, PartialEq)]
 pub struct RunCachePendingExecutionRecord {
     input: RunCachePendingExecutionInput,
+    /// Set when the record originates from a speculative submit whose verdict
+    /// was `ReadyToExecuteUntracked`. Such records were built from a partial
+    /// (prefetch-in-flight) dependency snapshot, so their epochs are finalized
+    /// against the warm cache before recording, and the `SqlExecution` carries
+    /// `from_speculative_submit = true`.
+    speculative: bool,
 }
 
 #[derive(Clone, Debug, PartialEq)]
 enum RunCachePendingExecutionInput {
-    Sql(SubmitEnrichedSqlRequest),
-    Values(SubmitValuesRequest),
+    Sql(Box<SubmitEnrichedSqlRequest>),
+    Values(Box<SubmitValuesRequest>),
 }
 
 impl RunCacheExecutionConfirmation {
@@ -268,46 +307,68 @@ impl RunCacheExecutionConfirmation {
 
     /// Attach a `{failures, should_warn, should_error}` payload to this
     /// confirmation. Used by the data-test Confirm path so subsequent runs
-    /// can replay the cached verdict via `parse_cached_test_skip`.
-    pub fn set_test_execution_results(&mut self, failures: i64) {
+    /// can replay the cached verdict.
+    pub fn set_test_execution_results(&mut self, result: CachedTestExecutionResult) {
         if self.execution_results.is_none() {
-            self.execution_results = Some(build_test_execution_results_struct(failures));
+            self.execution_results = Some(build_test_execution_results_struct(result));
         }
     }
 }
 
-/// Build the `{failures, should_warn, should_error}` payload Fusion sends
-/// in `ConfirmExecutionRequest.execution_results` so subsequent runs can
-/// replay the cached verdict. Mirrors dbt-core's
-/// `_DataTestAdapterProxy.execute`, which lower-cases the agate row before
-/// confirming. `should_warn` and `should_error` both come from
-/// `count(*) != 0` in the templated test SQL, so they are simply
-/// `failures > 0`.
-pub fn build_test_execution_results_struct(failures: i64) -> Struct {
-    use dbt_state::proto::query_cache::{Value, value::Kind};
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CachedTestExecutionResult {
+    pub failures: i64,
+    pub should_warn: bool,
+    pub should_error: bool,
+}
+
+/// Build the data-test result payload sent in
+/// `ConfirmExecutionRequest.execution_results` so subsequent runs can replay
+/// the cached verdict.
+pub fn build_test_execution_results_struct(result: CachedTestExecutionResult) -> Struct {
     let fail_value = Value {
-        kind: Some(Kind::IntValue(failures)),
-    };
-    let bool_value = Value {
-        kind: Some(Kind::BoolValue(failures > 0)),
+        kind: Some(Kind::IntValue(result.failures)),
     };
     let mut fields = HashMap::new();
     fields.insert("failures".to_string(), fail_value);
-    fields.insert("should_warn".to_string(), bool_value.clone());
-    fields.insert("should_error".to_string(), bool_value);
+    fields.insert(
+        "should_warn".to_string(),
+        Value {
+            kind: Some(Kind::BoolValue(result.should_warn)),
+        },
+    );
+    fields.insert(
+        "should_error".to_string(),
+        Value {
+            kind: Some(Kind::BoolValue(result.should_error)),
+        },
+    );
     Struct { fields }
 }
 
-/// Decode the cached `{failures, ...}` payload from a
-/// `SkipExecutionResponse`. Returns the failures count if the field is
-/// present and decodable.
-pub fn parse_cached_test_failures(response: &SkipExecutionResponse) -> Option<i64> {
-    use dbt_state::proto::query_cache::value::Kind;
+/// Decode the cached data-test result payload from a `SkipExecutionResponse`.
+pub fn parse_cached_test_execution_result(
+    response: &SkipExecutionResponse,
+) -> Option<CachedTestExecutionResult> {
     let results = response.execution_results.as_ref()?;
-    let value = results.fields.get("failures")?;
+    Some(CachedTestExecutionResult {
+        failures: parse_execution_result_int(results.fields.get("failures")?)?,
+        should_warn: parse_execution_result_bool(results.fields.get("should_warn")?)?,
+        should_error: parse_execution_result_bool(results.fields.get("should_error")?)?,
+    })
+}
+
+fn parse_execution_result_int(value: &Value) -> Option<i64> {
     match value.kind.as_ref()? {
         Kind::IntValue(i) => Some(*i),
         Kind::DoubleValue(d) => Some(*d as i64),
+        _ => None,
+    }
+}
+
+fn parse_execution_result_bool(value: &Value) -> Option<bool> {
+    match value.kind.as_ref()? {
+        Kind::BoolValue(value) => Some(*value),
         _ => None,
     }
 }
@@ -341,7 +402,7 @@ impl RunCacheCloneDecision {
             execution_results: response.clone_execution_results.clone(),
             execution_runtime_ms: response.execution_runtime_ms,
             freshness_tolerance_seconds: freshness_tolerance_seconds.max(0) as u64,
-            explained_decision: response.explained_decision,
+            explained_decision: response.explained_decision.clone(),
             transformed_nodes_by_query: response.transformed_nodes_by_query.clone(),
             execution_decision_id: response.execution_decision_id.clone(),
         }
@@ -360,7 +421,65 @@ impl RunCacheCloneDecision {
         RunCacheExecutionConfirmation::new(self.request_id.clone(), true)
     }
 
-    fn success_status(&self) -> NodeStatus {
+    pub fn clone_source(&self) -> &str {
+        &self.clone_source
+    }
+
+    pub fn clone_target(&self) -> &str {
+        &self.clone_target
+    }
+
+    /// Project this decision into a serializable form for time-machine recording.
+    ///
+    /// Only carries the fields that actually drive clone execution/confirmation
+    /// (see `execute_run_cache_service_clone`, `success_status`, `success_confirmation`);
+    /// the full protobuf `execution_results`/`transformed_nodes_by_query` are
+    /// telemetry-only and dropped, and `explained_decision` is reduced to the
+    /// single `is_stale` flag consumers actually read.
+    pub fn to_recorded(&self) -> dbt_adapter::time_machine::RecordedRunCacheCloneDecision {
+        dbt_adapter::time_machine::RecordedRunCacheCloneDecision {
+            request_id: self.request_id.clone(),
+            clone_sqls: self.clone_sqls.clone(),
+            clone_source: self.clone_source.clone(),
+            clone_target: self.clone_target.clone(),
+            required_source_epoch: self.required_source_epoch,
+            execution_runtime_ms: self.execution_runtime_ms,
+            freshness_tolerance_seconds: self.freshness_tolerance_seconds,
+            is_stale: self
+                .explained_decision
+                .as_ref()
+                .is_some_and(|decision| decision.is_stale),
+            execution_decision_id: self.execution_decision_id.clone(),
+        }
+    }
+
+    /// Reconstruct a decision from a time-machine recording during replay.
+    ///
+    /// `execution_results` and `transformed_nodes_by_query` are reset to their
+    /// empty defaults since replay never confirms back to the live service
+    /// (see `confirm_run_cache_service_execution`'s client-absent early return).
+    pub fn from_recorded(
+        recorded: dbt_adapter::time_machine::RecordedRunCacheCloneDecision,
+    ) -> Self {
+        Self {
+            request_id: recorded.request_id,
+            clone_sqls: recorded.clone_sqls,
+            clone_source: recorded.clone_source,
+            clone_target: recorded.clone_target,
+            required_source_epoch: recorded.required_source_epoch,
+            execution_results: None,
+            execution_runtime_ms: recorded.execution_runtime_ms,
+            freshness_tolerance_seconds: recorded.freshness_tolerance_seconds,
+            explained_decision: Some(ExplainedDecision {
+                is_stale: recorded.is_stale,
+                ..Default::default()
+            }),
+            transformed_nodes_by_query: HashMap::new(),
+            execution_decision_id: recorded.execution_decision_id,
+        }
+    }
+
+    pub fn replay_status(&self) -> NodeStatus {
         if self
             .explained_decision
             .as_ref()
@@ -371,6 +490,36 @@ impl RunCacheCloneDecision {
             NodeStatus::ReusedCloned(None)
         }
     }
+
+    fn success_status(&self) -> NodeStatus {
+        self.replay_status()
+    }
+}
+
+pub fn record_run_cache_clone_decision(node_id: &str, clone: &RunCacheCloneDecision) {
+    let Some(recorder) = dbt_adapter::time_machine::global_recorder() else {
+        return;
+    };
+    recorder.record_run_cache_clone(node_id, clone.to_recorded());
+}
+
+pub fn record_dev_clone_decision(node_id: &str, clone: &RunCacheCloneDecision) {
+    let Some(recorder) = dbt_adapter::time_machine::global_recorder() else {
+        return;
+    };
+    recorder.record_dev_clone(node_id, clone.to_recorded());
+}
+
+pub fn replay_run_cache_clone_decision(node_id: &str) -> Option<RunCacheCloneDecision> {
+    let replayer = dbt_adapter::time_machine::global_replayer()?;
+    let event = replayer.get_run_cache_clone_event_for_phase(node_id, false)?;
+    Some(RunCacheCloneDecision::from_recorded(event.clone.clone()))
+}
+
+pub fn replay_dev_clone_decision(node_id: &str) -> Option<RunCacheCloneDecision> {
+    let replayer = dbt_adapter::time_machine::global_replayer()?;
+    let event = replayer.get_run_cache_clone_event_for_phase(node_id, true)?;
+    Some(RunCacheCloneDecision::from_recorded(event.clone.clone()))
 }
 
 /// If the node is a selected (non-deferred) view model, insert its
@@ -420,7 +569,6 @@ pub fn insert_compiled_view_definition(
                 "Skipping compiled view definition insert for node {}: canonical FQN unavailable; cannot determine deferral status",
                 node.unique_id()
             ),
-            None,
         );
         return;
     };
@@ -480,7 +628,7 @@ pub fn insert_compiled_view_definition(
 /// stored and submitted epochs identical and the comparison exact.
 #[derive(Debug)]
 pub struct HeuristicClock {
-    start_instant: std::time::Instant,
+    start_instant: Instant,
     start_ts_ms: i64,
 }
 
@@ -491,7 +639,7 @@ impl HeuristicClock {
         if !heuristic_clock_enabled_for_adapter(ctx.adapter_type()) {
             return None;
         }
-        let start_instant = std::time::Instant::now();
+        let start_instant = Instant::now();
         let start_ts_ms = warehouse_now_ms(ctx).await?;
         Some(Self {
             start_instant,
@@ -519,7 +667,7 @@ async fn warehouse_now_ms(ctx: &TaskRunnerCtx) -> Option<i64> {
         let adapter = ctx_inner.env.get_adapter_ref()?;
         let query_ctx = QueryCtx::default().with_desc("dbt State run clock");
         let (_, table) = adapter
-            .execute_without_state(Some(&query_ctx), sql, true)
+            .execute_without_state(Some(&query_ctx), sql, true, None)
             .ok()?;
         table.original_record_batch().first_value_as_i64()
     }))
@@ -542,34 +690,17 @@ fn heuristic_clock_enabled_for_adapter(adapter_type: AdapterType) -> bool {
     )
 }
 
-/// Whether an empty `freshness_all_in_schema` result for `adapter_type`
-/// should trigger the slower per-node `freshness_with_overrides_and_options`
-/// fallback (and its `StateServiceWarn`).
-///
-/// An empty schema-level dump is ambiguous in general: it can mean the
-/// underlying metadata catalog hasn't caught up yet (a real race), or it can
-/// mean every relation in the group genuinely doesn't exist yet. Which one
-/// applies depends on how the adapter implements `freshness_all_in_schema`:
-///
-/// - Snowflake and BigQuery each issue a single `INFORMATION_SCHEMA`-style
-///   bulk query (`snowflake/mod.rs`, `bigquery/mod.rs`) against a metadata
-///   view that is documented to lag behind DDL by a few seconds -- the
-///   fallback exists specifically to work around that lag, so it must fire.
-/// - Any adapter that hasn't overridden the trait method at all gets the
-///   default implementation (`metadata_adapter.rs`), which *deliberately*
-///   returns an empty map to signal "fall back" (see its doc comment) -- the
-///   fallback is the only way those adapters get real freshness data, so it
-///   must fire there too.
-/// - Databricks (`databricks/mod.rs`) is the one exception: it issues a real
-///   per-relation `DESCRIBE HISTORY` (or `INFORMATION_SCHEMA.last_altered`
-///   for views) lookup directly, with no intermediate eventually-consistent
-///   catalog snapshot to lag behind. An empty result there means every
-///   relation in the group genuinely doesn't exist yet -- the normal state
-///   for a freshly created CI schema before any model has run. Falling back
-///   in that case only repeats the same (still-empty) per-relation lookups
-///   at higher cost while emitting a misleading warning on every CI run.
-fn schema_dump_empty_requires_fallback(adapter_type: AdapterType, dump_is_empty: bool) -> bool {
-    dump_is_empty && !matches!(adapter_type, AdapterType::Databricks)
+fn schema_dump_empty_requires_fallback(
+    metadata_adapter: &dyn MetadataAdapter,
+    dump_is_empty: bool,
+) -> bool {
+    dump_is_empty && !metadata_adapter.freshness_all_in_schema_empty_result_is_authoritative()
+}
+
+fn has_non_empty_schema(relation: &dyn BaseRelation) -> bool {
+    relation
+        .schema()
+        .is_some_and(|schema| !schema.trim().is_empty())
 }
 
 /// Collect every relation and source freshness override needed for the run's
@@ -578,7 +709,8 @@ fn schema_dump_empty_requires_fallback(adapter_type: AdapterType, dump_is_empty:
 /// Returns a map of `semantic_fqn → relation` covering every selected node's
 /// own target relation plus the relations of all their runtime dependencies
 /// (models, snapshots, seeds, sources). Ephemeral and inline models are skipped
-/// because they never submit to the service. A second map carries
+/// because they never submit to the service, as are graph-only nodes with no
+/// warehouse relation (see `has_non_empty_schema`). A second map carries
 /// `FreshnessOverride` entries for sources that declare `loaded_at_query` or
 /// `loaded_at_field`; these are passed through to `freshness_with_overrides`
 /// so the prefetch uses the same freshness strategy as per-node submits.
@@ -597,11 +729,6 @@ fn collect_global_prefetch_relations(
     let mut relations: BTreeMap<String, Arc<dyn BaseRelation>> = BTreeMap::new();
     let mut overrides: BTreeMap<String, FreshnessOverride> = BTreeMap::new();
 
-    let trimmed_nonempty = |s: &str| {
-        let t = s.trim();
-        (!t.is_empty()).then(|| t.to_string())
-    };
-
     for node_id in runnable_set {
         let Some(node) = nodes.get_node(node_id) else {
             continue;
@@ -612,7 +739,9 @@ fn collect_global_prefetch_relations(
             }
         }
 
-        if let Ok(relation) = create_relation_from_node(adapter_type, node, None) {
+        if let Ok(relation) = create_relation_from_node(adapter_type, node, None)
+            && has_non_empty_schema(relation.as_ref())
+        {
             let fqn = relation.semantic_fqn();
             relations.entry(fqn).or_insert_with(|| relation.into());
         }
@@ -635,30 +764,62 @@ fn collect_global_prefetch_relations(
                 continue;
             };
             let fqn = relation.semantic_fqn();
-            if let Some(source) = dep_node.as_any().downcast_ref::<DbtSource>() {
-                let override_kind = source
-                    .__source_attr__
-                    .loaded_at_query
-                    .as_deref()
-                    .and_then(trimmed_nonempty)
-                    .map(FreshnessOverride::Query)
-                    .or_else(|| {
-                        source
-                            .__source_attr__
-                            .loaded_at_field
-                            .as_deref()
-                            .and_then(trimmed_nonempty)
-                            .map(FreshnessOverride::Field)
-                    });
-                if let Some(kind) = override_kind {
-                    overrides.insert(fqn.clone(), kind);
-                }
+            if let Some(source) = dep_node.as_any().downcast_ref::<DbtSource>()
+                && let Some(kind) = source_freshness_override(source)
+            {
+                overrides.insert(fqn.clone(), kind);
             }
             relations.entry(fqn).or_insert_with(|| relation.into());
         }
     }
 
     (relations, overrides)
+}
+
+/// Render a `Query` override's `loaded_at_query` Jinja so macros / `{{ this }}`
+/// expand before the SQL is sent; `Field` overrides pass through unchanged.
+fn render_freshness_override(
+    ovr: FreshnessOverride,
+    relation: &Arc<dyn BaseRelation>,
+    jinja_env: &JinjaEnv,
+    base_context: &BTreeMap<String, minijinja::Value>,
+) -> FsResult<FreshnessOverride> {
+    let FreshnessOverride::Query(query) = ovr else {
+        return Ok(ovr);
+    };
+
+    let mut render_context = base_context.clone();
+    render_context.insert(
+        "this".to_owned(),
+        RelationObject::new(relation.clone()).into_value(),
+    );
+    let require = |part: Option<&str>, name: &str| -> FsResult<String> {
+        part.map(str::to_owned).ok_or_else(|| {
+            fs_err!(
+                ErrorCode::Unexpected,
+                "Cannot render loaded_at_query for source '{}': missing {name}",
+                relation.semantic_fqn(),
+            )
+        })
+    };
+    // Database is optional because some adapters (e.g. BigQuery) render relations without one
+    render_context.insert(
+        "database".to_owned(),
+        minijinja::Value::from(relation.database()),
+    );
+    render_context.insert(
+        "schema".to_owned(),
+        minijinja::Value::from(require(relation.schema(), "schema")?),
+    );
+    render_context.insert(
+        "identifier".to_owned(),
+        minijinja::Value::from(require(relation.identifier(), "identifier")?),
+    );
+
+    let rendered = jinja_env
+        .render_named_str(&relation.semantic_fqn(), &query, &render_context, &[])
+        .map_err(|e| FsError::from_jinja_err(e, "Failed to render source loaded_at_query"))?;
+    Ok(FreshnessOverride::Query(rendered))
 }
 
 /// Batch-prefetch `last_modified_epoch` for all selected nodes and their
@@ -668,8 +829,10 @@ fn collect_global_prefetch_relations(
 /// After this call, `last_modified_epoch_for_relation` returns a cache hit
 /// for every relation in the prefetch set, eliminating the per-node warehouse
 /// round-trips that `collect_table_modified_infos` would otherwise incur.
-/// A failed prefetch is a hard error: the command is aborted so that
-/// stale or missing metadata cannot silently produce incorrect results.
+///
+/// This runs in the background (see `run_cache_service_before_run`); a failure
+/// no longer aborts the run. The error is propagated to the caller, which logs
+/// it and lets the per-node paths fall back to their own freshness lookups.
 async fn prefetch_global_last_modified_epochs(ctx: &TaskRunnerCtx) -> FsResult<()> {
     let (relations, overrides) = collect_global_prefetch_relations(
         ctx.adapter_type(),
@@ -680,21 +843,77 @@ async fn prefetch_global_last_modified_epochs(ctx: &TaskRunnerCtx) -> FsResult<(
     if relations.is_empty() {
         return Ok(());
     }
-    bulk_prefetch_last_modified_by_schema(ctx, &relations, &overrides).await
+    let mut rendered_overrides = BTreeMap::new();
+    for (fqn, ovr) in overrides {
+        let ovr = match relations.get(&fqn) {
+            Some(relation) => {
+                render_freshness_override(ovr, relation, ctx.env.as_ref(), &ctx.inner.base_context)?
+            }
+            None => ovr,
+        };
+        rendered_overrides.insert(fqn, ovr);
+    }
+    let started_at = Instant::now();
+    let result = bulk_prefetch_last_modified_by_schema(ctx, &relations, &rendered_overrides).await;
+    maybe_warn_slow_metadata_prefetch(ctx, started_at.elapsed());
+    result
 }
 
-/// Prefetch last-modified epochs using per-schema dump queries rather than
-/// per-table predicates.
+/// Total freshness-prefetch time above which we hint that a dedicated metadata
+/// warehouse would help. Mirrors the dbt-core run-cache plugin's threshold.
+const SLOW_METADATA_PREFETCH_WARN_THRESHOLD: std::time::Duration =
+    std::time::Duration::from_secs(15);
+
+/// Whether the slow-metadata-prefetch hint should fire.
 ///
-/// For each (database, schema) group, calls `freshness_all_in_schema` which
-/// returns ALL rows for the schema with a single `WHERE table_schema = '...'`
-/// filter — matching the plugin's approach. Relations with source overrides
-/// (`loaded_at_query` / `loaded_at_field`) are handled separately via the
-/// existing per-table path so their custom freshness logic is preserved.
+/// The `metadata_warehouse` config (and this INFORMATION_SCHEMA-based fetch) is
+/// Snowflake-specific, so the hint only applies there. It is pointless once a
+/// dedicated warehouse is already configured, since setting it is the fix.
+fn should_warn_slow_metadata_prefetch(
+    adapter_type: AdapterType,
+    options: &MetadataQueryOptions,
+    elapsed: std::time::Duration,
+) -> bool {
+    let has_metadata_warehouse = options
+        .warehouse
+        .as_deref()
+        .is_some_and(|warehouse| !warehouse.is_empty());
+    adapter_type == AdapterType::Snowflake
+        && !has_metadata_warehouse
+        && elapsed >= SLOW_METADATA_PREFETCH_WARN_THRESHOLD
+}
+
+/// Hint (at most once per run) that configuring a dedicated metadata warehouse
+/// would route these introspection queries to an isolated warehouse and run
+/// them with better parallelism, when the freshness prefetch spent a long time
+/// in INFORMATION_SCHEMA without one configured.
+fn maybe_warn_slow_metadata_prefetch(ctx: &TaskRunnerCtx, elapsed: std::time::Duration) {
+    let metadata_options = run_cache_metadata_query_options(ctx);
+    if !should_warn_slow_metadata_prefetch(ctx.adapter_type(), &metadata_options, elapsed) {
+        return;
+    }
+    emit_warn_log_message(
+        ErrorCode::StateServiceWarn,
+        format!(
+            "Fetching table metadata (e.g., last modified timestamps) from INFORMATION_SCHEMA \
+             took {:.1}s. Set the `metadata_warehouse` config to route these introspection \
+             queries to a dedicated warehouse. This will lead to better parallelism and reduced \
+             contention, resulting in these queries being executed significantly faster.",
+            elapsed.as_secs_f64()
+        ),
+    );
+}
+
+/// Prefetch last-modified epochs for the selected relations and warm
+/// `run_cache_metadata`.
 ///
-/// An empty result from `freshness_all_in_schema` (adapter not implemented)
-/// leaves the cache empty for that group; per-node lookups handle the misses.
-/// Any error is propagated — the prefetch is mandatory.
+/// Relations with source overrides (`loaded_at_query` / `loaded_at_field`) are
+/// handled separately via the per-table path so their custom freshness logic is
+/// preserved. Everything else is handed to the metadata adapter's
+/// `freshness_all_in_schemas`, which owns the engine-specific strategy (per-schema
+/// dumps, metadata-warehouse fan-out, adaptive broad-vs-sequential). Failures are
+/// fail-open: a relation whose freshness could not be determined is cached as
+/// unknown (`None`), never aborting the run.
 async fn bulk_prefetch_last_modified_by_schema(
     ctx: &TaskRunnerCtx,
     relations: &BTreeMap<String, Arc<dyn BaseRelation>>,
@@ -734,84 +953,64 @@ async fn bulk_prefetch_last_modified_by_schema(
         return Ok(());
     }
 
-    // For each (database, schema) group, attempt a schema dump. If the adapter
-    // returns an empty map (unsupported), fall back to per-table for that group.
-    for ((database, schema), grouped) in group_relations_by_database_and_schema(&bulk_relations) {
-        let semantic_to_name: BTreeMap<String, String> = grouped
-            .iter()
-            .map(|(name, rel)| (rel.semantic_fqn(), name.clone()))
-            .collect();
-        let relation_values: Vec<Arc<dyn BaseRelation>> = grouped.values().cloned().collect();
+    // `freshness_all_in_schemas` keys its result by `semantic_fqn`; keep the
+    // mapping back to each relation's cache name (rendered relation name).
+    let semantic_to_name: BTreeMap<String, String> = bulk_relations
+        .iter()
+        .map(|(name, rel)| (rel.semantic_fqn(), name.clone()))
+        .collect();
+    let relation_values: Vec<Arc<dyn BaseRelation>> = bulk_relations.values().cloned().collect();
 
-        let db = database.as_deref().unwrap_or("");
-        let sch = schema.as_deref().unwrap_or("");
-
-        let dump = metadata_adapter
-            .freshness_all_in_schema(
-                db,
-                sch,
-                &relation_values,
-                &metadata_options,
-                adapter.cancellation_token(),
-            )
-            .await
-            .map_err(into_fs_error)?;
-
-        if schema_dump_empty_requires_fallback(ctx.adapter_type(), dump.is_empty()) {
-            // Empty result from the schema dump. This is typically caused by
-            // INFORMATION_SCHEMA eventual consistency: Fusion's global prefetch
-            // fires eagerly at run start (before any node executes), whereas the
-            // dbt-core plugin prefetches lazily on the first node-start event.
-            // The extra seconds of compilation time in the plugin's path are
-            // usually enough for Snowflake's INFORMATION_SCHEMA to propagate a
-            // table created by the immediately preceding run. Fusion doesn't get
-            // that grace period, so the dump can return empty even when the table
-            // actually exists.
-            //
-            // Fall back to freshness_with_overrides_and_options for this schema
-            // group. That call is still batched — one query per database group
-            // with all tables in a single WHERE clause (the old per-table predicate
-            // form rather than the schema-only dump form) — so it does not
-            // degenerate into one query per table. The fallback only fires when
-            // the schema dump returns empty, which is unusual, so the cost of the
-            // larger WHERE clause is acceptable.
+    // The adapter owns the strategy and is fail-open per group internally; treat
+    // a top-level error the same way (unknown freshness for the whole batch) so a
+    // metadata failure never aborts the run.
+    let freshness = match metadata_adapter
+        .freshness_all_in_schemas(
+            &relation_values,
+            &metadata_options,
+            adapter.cancellation_token(),
+        )
+        .await
+    {
+        Ok(freshness) => freshness,
+        Err(Cancellable::Error(err)) if err.kind() == AdapterErrorKind::ReplayDataMissing => {
+            // Older recordings may not contain the new schema-bulk event, but
+            // they can contain the existing per-table freshness event.
+            match metadata_adapter
+                .freshness(&relation_values, adapter.cancellation_token())
+                .await
+            {
+                Ok(freshness) => freshness,
+                Err(Cancellable::Error(err))
+                    if err.kind() == AdapterErrorKind::ReplayDataMissing =>
+                {
+                    return Ok(());
+                }
+                Err(err) => return Err(into_fs_error(err)),
+            }
+        }
+        Err(err) => {
+            let err = into_fs_error(err);
             emit_warn_log_message(
                 ErrorCode::StateServiceWarn,
                 format!(
-                    "dbt State schema-level freshness dump returned empty for {db}.{sch}; \
-                     falling back to per-node warehouse queries for {} relations",
+                    "dbt State freshness prefetch failed for {} relations: {err}; caching unknown \
+                     freshness",
                     semantic_to_name.len()
                 ),
-                None,
             );
-            let empty_overrides = BTreeMap::new();
-            let freshness = metadata_adapter
-                .freshness_with_overrides_and_options(
-                    &relation_values,
-                    &empty_overrides,
-                    &metadata_options,
-                    adapter.cancellation_token(),
-                )
-                .await
-                .map_err(into_fs_error)?;
-            for (sem_fqn, name) in &semantic_to_name {
-                let epoch = freshness
-                    .get(sem_fqn)
-                    .map(|m| m.last_altered.timestamp_millis());
-                ctx.inner
-                    .run_cache_ctx
-                    .run_cache_metadata
-                    .insert_last_modified_epoch(name, epoch);
-            }
-        } else {
-            for (sem_fqn, name) in &semantic_to_name {
-                let epoch = dump.get(sem_fqn).map(|m| m.last_altered.timestamp_millis());
-                ctx.inner
-                    .run_cache_ctx
-                    .run_cache_metadata
-                    .insert_last_modified_epoch(name, epoch);
-            }
-        };
+            BTreeMap::new()
+        }
+    };
+
+    for (semantic_fqn, name) in &semantic_to_name {
+        let epoch = freshness
+            .get(semantic_fqn)
+            .map(|m| m.last_altered.timestamp_millis());
+        ctx.inner
+            .run_cache_ctx
+            .run_cache_metadata
+            .insert_last_modified_epoch(name, epoch);
     }
 
     Ok(())
@@ -819,10 +1018,16 @@ async fn bulk_prefetch_last_modified_by_schema(
 
 /// Start-of-run hook. Fires once before any model executes.
 ///
-/// Batch-prefetches `last_modified_epoch` for all selected nodes and their
-/// runtime dependencies into `run_cache_metadata`, so per-node submits
-/// resolve freshness from the in-process cache instead of issuing individual
-/// warehouse queries.
+/// Starts a background task that batch-prefetches `last_modified_epoch` for all
+/// selected nodes and their runtime dependencies into `run_cache_metadata`, so
+/// per-node submits resolve freshness from the in-process cache instead of
+/// issuing individual warehouse queries.
+///
+/// The prefetch runs concurrently with node execution rather than blocking the
+/// whole run: while it is in flight, a node issues a speculative submit using
+/// only the dependency epochs already resolved (see `submit_model` and friends).
+/// A failed prefetch no longer aborts the run — it is logged and the per-node
+/// paths fall back to their own freshness lookups.
 ///
 /// Note: the view-definition traversal that was previously run here as a
 /// pre-warm has been removed. It used `collect_view_traversal_roots` (a
@@ -837,19 +1042,337 @@ async fn bulk_prefetch_last_modified_by_schema(
 /// fetched at most once per run. Total IO is identical — only the timing
 /// changes from eager/pre-run to lazy/per-node.
 pub async fn run_cache_service_before_run(ctx: &TaskRunnerCtx) -> AdapterResult<()> {
-    prefetch_global_last_modified_epochs(ctx)
-        .await
-        .map_err(|e| {
-            dbt_adapter::errors::AdapterError::new(
-                dbt_adapter::errors::AdapterErrorKind::UnexpectedResult,
-                e.to_string(),
-            )
-        })?;
+    run_cache_service_start_telemetry(ctx).await;
+
+    let prefetch = ctx.inner.run_cache_ctx.prefetch.clone();
+    prefetch.mark_started();
+
+    let prefetch_ctx = ctx.clone();
+    let handle = dbt_common::tracing::spawn_traced(async move {
+        if let Err(err) = prefetch_global_last_modified_epochs(&prefetch_ctx).await {
+            emit_warn_log_message(
+                ErrorCode::StateServiceWarn,
+                format!(
+                    "dbt State dependency last-modified prefetch failed: {err}; \
+                     falling back to per-node freshness lookups"
+                ),
+            );
+        }
+        prefetch_ctx.inner.run_cache_ctx.prefetch.mark_done();
+    });
+    prefetch.set_handle(handle).await;
 
     if let Some(clock) = HeuristicClock::bootstrap(ctx).await {
         let _ = ctx.inner.run_cache_ctx.heuristic_clock.set(clock);
     }
     Ok(())
+}
+
+/// Whether the background dependency prefetch has completed.
+///
+/// Returns `false` before the prefetch is started and while it is in flight;
+/// `true` once the background task has finished (or there was nothing to
+/// prefetch). A node uses this to decide whether to issue a speculative submit
+/// (prefetch still pending) or a regular one (prefetch already complete).
+fn is_prefetch_ready(ctx: &TaskRunnerCtx) -> bool {
+    let prefetch = &ctx.inner.run_cache_ctx.prefetch;
+    prefetch.is_started() && prefetch.is_done()
+}
+
+/// Await the background dependency prefetch to completion.
+///
+/// Joins the background task once: the first call takes and awaits the handle,
+/// and subsequent calls find no handle and return without waiting. When the
+/// prefetch was never started (no handle was ever set) this also returns
+/// immediately. In every case the call is fail-open — a join error or task
+/// panic is logged and swallowed, and the prefetch is marked done so callers
+/// can always proceed — so it never blocks the command from making progress.
+async fn await_prefetch(ctx: &TaskRunnerCtx) {
+    let prefetch = &ctx.inner.run_cache_ctx.prefetch;
+    if let Err(err) = prefetch.join().await {
+        emit_warn_log_message(
+            ErrorCode::StateServiceWarn,
+            format!(
+                "dbt State dependency last-modified prefetch task did not complete cleanly: {err}; \
+                 continuing"
+            ),
+        );
+    }
+    prefetch.mark_done();
+}
+
+pub async fn run_cache_service_start_telemetry(ctx: &TaskRunnerCtx) {
+    submit_run_cache_session_start(ctx).await;
+}
+
+pub async fn run_cache_service_after_run(ctx: &TaskRunnerCtx, cancelled: bool) {
+    let result = if cancelled {
+        SessionEndResult::Cancelled
+    } else if ctx
+        .inner
+        .run_stats
+        .iter()
+        .any(|stat| stat.status == NodeStatus::Errored)
+        || ctx
+            .inner
+            .analyze_stats
+            .iter()
+            .any(|stat| stat.status == NodeStatus::Errored)
+    {
+        SessionEndResult::Failure
+    } else {
+        SessionEndResult::Success
+    };
+    submit_run_cache_session_end(ctx, result).await;
+}
+
+/// `cancelled` distinguishes a run aborted via the run's `CancellationToken`
+/// (e.g. a user hitting Ctrl-C) from any other early-return failure, so the
+/// dbt State service can tell the two apart in telemetry.
+pub async fn run_cache_service_after_run_failed(ctx: &TaskRunnerCtx, cancelled: bool) {
+    let result = if cancelled {
+        SessionEndResult::Cancelled
+    } else {
+        SessionEndResult::Failure
+    };
+    submit_run_cache_session_end(ctx, result).await;
+}
+
+/// Number of telemetry events buffered before new events are dropped.
+/// Matches the Python dbt State client's `TelemetryDispatcher` queue bound.
+const TELEMETRY_QUEUE_CAPACITY: usize = 150;
+
+/// Maximum number of events sent in a single `SubmitTelemetryBatch` RPC.
+/// Matches the Python dbt State client's `TelemetryDispatcher` batch bound.
+const TELEMETRY_MAX_BATCH_SIZE: usize = 50;
+
+/// Longest a queued event waits before being flushed, absent a full batch.
+/// Matches the Python dbt State client's `TelemetryDispatcher` emit interval.
+const TELEMETRY_MAX_EMIT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Retries for a batch that failed with a retriable error before its events
+/// are dropped. Matches the Python dbt State client's `TelemetryDispatcher`.
+const TELEMETRY_MAX_RETRY_COUNT: u32 = 3;
+
+type QueuedTelemetryEvent = (ClientTelemetryEvent, u32);
+
+/// Background dispatcher that batches and submits dbt State telemetry events
+/// without blocking node execution, mirroring the async batching design of
+/// the Python dbt State client's telemetry dispatcher: events are pushed
+/// onto a bounded channel (non-blocking, drop-on-full) and a single
+/// background task flushes whatever is queued into one `SubmitTelemetryBatch`
+/// RPC per batch, either once `TELEMETRY_MAX_BATCH_SIZE` events have
+/// accumulated or `TELEMETRY_MAX_EMIT_INTERVAL` has elapsed, whichever comes
+/// first. A batch that fails with a retriable error is re-queued (up to
+/// `TELEMETRY_MAX_RETRY_COUNT` times per event); anything else is dropped.
+///
+/// `flush` closes the channel and awaits the worker so the run's final
+/// events (in particular session-end) get a chance to be delivered before
+/// the process exits.
+pub struct TelemetryDispatcher {
+    sender: tokio::sync::Mutex<Option<mpsc::Sender<QueuedTelemetryEvent>>>,
+    worker: tokio::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
+}
+
+impl TelemetryDispatcher {
+    fn spawn(client: dbt_state::service_client::SharedRunCacheServiceClient) -> Self {
+        let (sender, receiver) = mpsc::channel(TELEMETRY_QUEUE_CAPACITY);
+        let worker = dbt_common::tracing::spawn_traced(Self::run(client, receiver));
+        Self {
+            sender: tokio::sync::Mutex::new(Some(sender)),
+            worker: tokio::sync::Mutex::new(Some(worker)),
+        }
+    }
+
+    async fn run(
+        client: dbt_state::service_client::SharedRunCacheServiceClient,
+        mut receiver: mpsc::Receiver<QueuedTelemetryEvent>,
+    ) {
+        // Retries go straight back into `buffer`, not through the channel: a
+        // `Sender` clone held by this task would stop `recv` from ever
+        // returning `None`, hanging `flush()` forever.
+        let mut buffer: Vec<QueuedTelemetryEvent> = Vec::new();
+        let mut interval = tokio::time::interval(TELEMETRY_MAX_EMIT_INTERVAL);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            tokio::select! {
+                event = receiver.recv() => {
+                    let Some(event) = event else {
+                        Self::flush_buffer(&client, &mut buffer).await;
+                        break;
+                    };
+                    buffer.push(event);
+                    // `==`, not `>=`: a requeued failure can leave `buffer`
+                    // at the cap already, and `>=` would re-flush on every
+                    // event after that with no gap between retries.
+                    if buffer.len() == TELEMETRY_MAX_BATCH_SIZE {
+                        Self::flush_buffer(&client, &mut buffer).await;
+                    }
+                }
+                _ = interval.tick() => {
+                    Self::flush_buffer(&client, &mut buffer).await;
+                }
+            }
+        }
+    }
+
+    /// Drain `buffer` in chunks of at most `TELEMETRY_MAX_BATCH_SIZE`, one
+    /// `SubmitTelemetryBatch` RPC per chunk, stopping at the first chunk that
+    /// fails. Fail-open: a retriable failure re-queues that chunk (bounded by
+    /// `TELEMETRY_MAX_RETRY_COUNT`); anything else drops it.
+    async fn flush_buffer(
+        client: &dbt_state::service_client::SharedRunCacheServiceClient,
+        buffer: &mut Vec<QueuedTelemetryEvent>,
+    ) {
+        while !buffer.is_empty() {
+            let chunk_size = buffer.len().min(TELEMETRY_MAX_BATCH_SIZE);
+            let chunk: Vec<QueuedTelemetryEvent> = buffer.drain(..chunk_size).collect();
+            let events = chunk.iter().map(|(event, _)| event.clone()).collect();
+            let Err(err) = client.submit_telemetry_batch(telemetry_batch(events)).await else {
+                continue;
+            };
+            if !err.is_retriable_telemetry_submission() {
+                emit_trace_log_message(|| {
+                    format!(
+                        "dbt State service telemetry batch failed: {err}; dropping {} event(s)",
+                        chunk.len()
+                    )
+                });
+                return;
+            }
+            for (event, retry_count) in chunk {
+                if retry_count >= TELEMETRY_MAX_RETRY_COUNT {
+                    emit_trace_log_message(|| {
+                        "dbt State telemetry event exceeded max retries; dropping".to_string()
+                    });
+                    continue;
+                }
+                buffer.push((event, retry_count + 1));
+            }
+            return;
+        }
+    }
+
+    /// Enqueue an event without blocking on network I/O. Drops the event
+    /// (fail-open) if the queue is full or the dispatcher has been flushed.
+    async fn send(&self, event: ClientTelemetryEvent) {
+        let guard = self.sender.lock().await;
+        if let Some(sender) = guard.as_ref() {
+            if sender.try_send((event, 0)).is_err() {
+                emit_trace_log_message(|| {
+                    "dbt State telemetry queue full; dropping event".to_string()
+                });
+            }
+        }
+    }
+
+    /// Enqueue a critical event, waiting for capacity instead of dropping it.
+    async fn send_critical(&self, event: ClientTelemetryEvent) {
+        let sender = self.sender.lock().await.as_ref().cloned();
+        if let Some(sender) = sender
+            && sender.send((event, 0)).await.is_err()
+        {
+            emit_trace_log_message(|| {
+                "dbt State telemetry dispatcher is closed; dropping critical event".to_string()
+            });
+        }
+    }
+
+    /// Close the queue and await the worker so already-queued events flush
+    /// before the caller proceeds. Fail-open: a join error is swallowed.
+    async fn flush(&self) {
+        self.sender.lock().await.take();
+        if let Some(handle) = self.worker.lock().await.take() {
+            let _ = handle.await;
+        }
+    }
+}
+
+async fn submit_run_cache_session_end(ctx: &TaskRunnerCtx, result: SessionEndResult) {
+    let run_cache_ctx = &ctx.inner.run_cache_ctx;
+    if run_cache_ctx
+        .telemetry_session_ended
+        .swap(true, Ordering::Relaxed)
+    {
+        return;
+    }
+
+    let Some(start) = run_cache_ctx.telemetry_session_start.get() else {
+        return;
+    };
+    let description = match result {
+        SessionEndResult::Success => "completed",
+        SessionEndResult::Failure => "completed with errors",
+        SessionEndResult::Cancelled => "cancelled",
+    };
+    let event = session_end_event(
+        start.elapsed(),
+        result,
+        description,
+        next_telemetry_event_order(ctx),
+    );
+    submit_run_cache_critical_telemetry_event(ctx, event).await;
+    flush_run_cache_telemetry(ctx).await;
+}
+
+async fn submit_run_cache_session_start(ctx: &TaskRunnerCtx) {
+    let run_cache_ctx = &ctx.inner.run_cache_ctx;
+    if run_cache_ctx
+        .telemetry_session_start
+        .set(Instant::now())
+        .is_err()
+    {
+        return;
+    }
+
+    let Some(config) = run_cache_ctx.run_cache_service_config.as_ref() else {
+        return;
+    };
+    let event = session_start_event(config.telemetry_config(), next_telemetry_event_order(ctx));
+    submit_run_cache_telemetry_event(ctx, event).await;
+}
+
+async fn submit_run_cache_telemetry_event(ctx: &TaskRunnerCtx, event: ClientTelemetryEvent) {
+    let Some(client) = ctx.inner.run_cache_ctx.run_cache_service_client.as_ref() else {
+        return;
+    };
+    let dispatcher = ctx
+        .inner
+        .run_cache_ctx
+        .telemetry_dispatcher
+        .get_or_init(|| TelemetryDispatcher::spawn(client.clone()));
+    dispatcher.send(event).await;
+}
+
+async fn submit_run_cache_critical_telemetry_event(
+    ctx: &TaskRunnerCtx,
+    event: ClientTelemetryEvent,
+) {
+    let Some(client) = ctx.inner.run_cache_ctx.run_cache_service_client.as_ref() else {
+        return;
+    };
+    let dispatcher = ctx
+        .inner
+        .run_cache_ctx
+        .telemetry_dispatcher
+        .get_or_init(|| TelemetryDispatcher::spawn(client.clone()));
+    dispatcher.send_critical(event).await;
+}
+
+/// Closes the run's telemetry dispatcher (if one was started) and awaits its
+/// worker, giving already-queued events — in particular session-end — a
+/// chance to reach the service before the command exits.
+async fn flush_run_cache_telemetry(ctx: &TaskRunnerCtx) {
+    if let Some(dispatcher) = ctx.inner.run_cache_ctx.telemetry_dispatcher.get() {
+        dispatcher.flush().await;
+    }
+}
+
+fn next_telemetry_event_order(ctx: &TaskRunnerCtx) -> i64 {
+    ctx.inner
+        .run_cache_ctx
+        .telemetry_event_order
+        .fetch_add(1, Ordering::Relaxed)
 }
 
 /// Submits a runnable node to the dbt State service before local execution.
@@ -862,6 +1385,7 @@ pub async fn run_cache_service_before_execution(
     ctx: &TaskRunnerCtx,
     node: &dyn InternalDbtNodeAttributes,
     task_result: &TaskResult,
+    microbatch_window: Option<(DateTime<Utc>, DateTime<Utc>)>,
 ) -> RunCacheServiceDecision {
     if !ctx.inner.run_cache_ctx.run_cache_service_requested {
         emit_warn_log_message(
@@ -870,8 +1394,8 @@ pub async fn run_cache_service_before_execution(
                 "dbt State service hook reached while service mode is disabled for node {}; executing normally",
                 node.unique_id()
             ),
-            None,
         );
+        write_state_explain_node(ctx, node, None);
         return RunCacheServiceDecision::execute_without_confirmation();
     }
 
@@ -882,13 +1406,19 @@ pub async fn run_cache_service_before_execution(
                 "dbt State service was requested but no validated client is available for node {}; executing normally",
                 node.unique_id()
             ),
-            None,
         );
+        write_state_explain_node(ctx, node, None);
         return RunCacheServiceDecision::execute_without_confirmation();
     };
+    if client.is_disabled() {
+        write_state_explain_node(ctx, node, None);
+        return RunCacheServiceDecision::execute_without_confirmation();
+    }
 
     if !should_honor_service_skip(ctx) {
-        let result = prepare_write_only_execution_record(ctx, node, task_result).await;
+        let result =
+            prepare_write_only_execution_record(ctx, node, task_result, microbatch_window).await;
+        write_state_explain_node(ctx, node, None);
         return match result {
             Ok(Some(record)) => RunCacheServiceDecision::execute_with_record(record),
             Ok(None) => {
@@ -898,7 +1428,7 @@ pub async fn run_cache_service_before_execution(
                         "dbt State service record skipped for node {unique_id}; executing normally"
                     )
                 });
-                RunCacheServiceDecision::execute_without_confirmation()
+                RunCacheServiceDecision::execute_and_invalidate_freshness()
             }
             Err(err) => {
                 emit_warn_log_message(
@@ -907,9 +1437,8 @@ pub async fn run_cache_service_before_execution(
                         "dbt State service record preparation failed for node {}: {err}; executing normally",
                         node.unique_id()
                     ),
-                    None,
                 );
-                RunCacheServiceDecision::execute_without_confirmation()
+                RunCacheServiceDecision::execute_and_invalidate_freshness()
             }
         };
     }
@@ -923,48 +1452,79 @@ pub async fn run_cache_service_before_execution(
                     "dbt State service submit skipped for no-op model materialization (node {unique_id}, materialization {materialization})"
                 )
             });
+            write_state_explain_node(ctx, node, None);
             return RunCacheServiceDecision::execute_without_confirmation();
         }
         if model.common().language.as_deref() != Some("sql") {
             record_unsupported_node(node, "non-SQL model");
-            return RunCacheServiceDecision::execute_without_confirmation();
+            write_state_explain_node(ctx, node, None);
+            return RunCacheServiceDecision::execute_and_invalidate_freshness();
         }
-        submit_model(ctx, model, task_result, client).await
+        submit_model(ctx, model, task_result, client, microbatch_window).await
     } else if let Some(snapshot) = node.as_any().downcast_ref::<DbtSnapshot>() {
         submit_snapshot(ctx, snapshot, task_result, client).await
     } else if let Some(seed) = node.as_any().downcast_ref::<DbtSeed>() {
-        submit_seed(ctx, seed, client).await
+        submit_seed(ctx, seed, task_result, client).await
     } else if let Some(test) = node.as_any().downcast_ref::<DbtTest>() {
         submit_test(ctx, test, task_result, client).await
     } else {
         record_unsupported_node(node, "unsupported node type");
-        return RunCacheServiceDecision::execute_without_confirmation();
+        write_state_explain_node(ctx, node, None);
+        return RunCacheServiceDecision::execute_and_invalidate_freshness();
     };
 
     match result {
-        Ok(Some(outcome)) => {
+        Ok(Some(RunCacheSubmitResult::Outcome(outcome))) => {
             let decision = record_service_decision(
                 node.unique_id().as_str(),
                 &outcome.response,
                 outcome.freshness_tolerance_seconds,
                 should_honor_service_skip(ctx),
             );
-            // A node that completed a dev clone earlier in this invocation
-            // should surface as "Cloned from cached relation" when the
-            // service decides Skip, matching the dbt-core plugin's
-            // `_dev_cloned_nodes` mapping.
+            // A node that completed a dev clone earlier in this invocation should
+            // surface as "Cloned from cached relation" when the service decides
+            // Skip, matching the dbt-core plugin's `_dev_cloned_nodes` mapping.
             let is_dev_cloned = ctx
                 .inner
                 .run_cache_ctx
                 .run_cache_dev_cloned_nodes
                 .contains_key(node.unique_id().as_str());
-            relabel_skip_for_dev_cloned_node(is_dev_cloned, decision)
+            let decision = relabel_skip_for_dev_cloned_node(is_dev_cloned, decision);
+            let execution_decision_id =
+                state_explain_execution_decision_id(Some(&outcome.response), &decision);
+            // Surface the service-side execution decision id on the node's
+            // run-phase evaluation span so successful executions can be
+            // correlated with the dbt State decision that governed them.
+            if let Some(id) = execution_decision_id.as_deref() {
+                find_and_update_span_attrs(|attrs: &mut NodeEvaluated| {
+                    attrs.state_decision_id = Some(id.to_string());
+                });
+            }
+            write_state_explain_node(ctx, node, execution_decision_id);
+            decision
+        }
+        Ok(Some(RunCacheSubmitResult::ExecuteUntracked(record))) => {
+            // A speculative `ReadyToExecuteUntracked` verdict: execute now and
+            // record the outcome after the fact. Never a Skip, so no dev-cloned
+            // relabel applies. The verdict carries no execution decision id, so
+            // the node only gets a local fallback explain record.
+            write_state_explain_node(ctx, node, None);
+            RunCacheServiceDecision::execute_with_record(record)
         }
         Ok(None) => {
             let unique_id = node.unique_id();
             emit_trace_log_message(|| {
                 format!("dbt State service submit skipped for node {unique_id}; executing normally")
             });
+            write_state_explain_node(ctx, node, None);
+            // Reached by bails that cannot produce a sound record — an
+            // unresolved microbatch window, incomplete dependency metadata, an
+            // unsupported node type. The node still rebuilds its target, so the
+            // prefetched epoch must not survive into downstream submissions.
+            RunCacheServiceDecision::execute_and_invalidate_freshness()
+        }
+        Err(_) if client.is_disabled() => {
+            write_state_explain_node(ctx, node, None);
             RunCacheServiceDecision::execute_without_confirmation()
         }
         Err(err) => {
@@ -974,10 +1534,152 @@ pub async fn run_cache_service_before_execution(
                     "dbt State service submit failed for node {}: {err}; executing normally",
                     node.unique_id()
                 ),
-                None,
             );
+            write_state_explain_node(ctx, node, None);
+            // The request failed, so the node rebuilds without tracking; its
+            // cached epoch/existence (e.g. from the prefetch, already awaited by
+            // the time a submit errors) is now stale. Evict it here so
+            // downstream nodes in this run re-query fresh state instead of
+            // reusing it — unlike the benign-skip path, which preserves a valid
+            // prefetched epoch.
+            evict_node_metadata_for_untracked_rebuild(ctx, node);
             RunCacheServiceDecision::execute_without_confirmation()
         }
+    }
+}
+
+fn write_state_explain_node(
+    ctx: &TaskRunnerCtx,
+    node: &dyn InternalDbtNodeAttributes,
+    execution_decision_id: Option<String>,
+) {
+    let Some(path) = ctx.inner.run_cache_ctx.state_explain_log_path.as_ref() else {
+        return;
+    };
+    let record = StateExplainLogRecord::Node(StateExplainNode {
+        node_unique_id: node.unique_id(),
+        node_name: node.name(),
+        node_info: state_explain_node_info(ctx, node),
+        execution_decision_id,
+    });
+    if let Err(err) = append_state_explain_log_record(path, &record) {
+        emit_warn_log_message(
+            ErrorCode::StateServiceWarn,
+            format!("Failed to write dbt State explain node record: {err}"),
+        );
+    }
+}
+
+fn state_explain_execution_decision_id(
+    response: Option<&SubmitSqlResponse>,
+    decision: &RunCacheServiceDecision,
+) -> Option<String> {
+    let response = response?;
+    match decision {
+        RunCacheServiceDecision::Execute {
+            after_success: RunCacheAfterSuccess::Confirm(_),
+            ..
+        }
+        | RunCacheServiceDecision::Clone { .. }
+        | RunCacheServiceDecision::Skip { .. } => execution_decision_id_from_response(response),
+        RunCacheServiceDecision::Execute { .. } | RunCacheServiceDecision::Disabled => None,
+    }
+}
+
+fn state_explain_node_info(
+    ctx: &TaskRunnerCtx,
+    node: &dyn InternalDbtNodeAttributes,
+) -> StateExplainNodeInfo {
+    let mut node_info =
+        state_explain_node_info_for_parts(ctx.adapter_type(), ctx.inner.arg.full_refresh, node);
+    node_info.dev_clone = ctx
+        .inner
+        .run_cache_ctx
+        .run_cache_dev_cloned_nodes
+        .get(node.unique_id().as_str())
+        .map(|entry| entry.value().clone());
+    node_info.deferrals = state_explain_deferrals(ctx, node);
+    node_info
+}
+
+fn state_explain_deferrals(
+    ctx: &TaskRunnerCtx,
+    node: &dyn InternalDbtNodeAttributes,
+) -> HashMap<String, String> {
+    let Some(defer_nodes) = ctx.defer_nodes() else {
+        return HashMap::new();
+    };
+
+    node.base()
+        .depends_on
+        .nodes
+        .iter()
+        .filter_map(|dependency_id| {
+            let deferred_node = defer_nodes.get_node(dependency_id)?;
+            let deferred_fqn = create_relation_from_node(ctx.adapter_type(), deferred_node, None)
+                .ok()?
+                .semantic_fqn();
+            if !ctx
+                .inner
+                .run_cache_ctx
+                .run_cache_deferred_fqns
+                .contains(&deferred_fqn)
+            {
+                return None;
+            }
+
+            let local_node = ctx.nodes().get_node(dependency_id)?;
+            let local_fqn = create_relation_from_node(ctx.adapter_type(), local_node, None)
+                .ok()?
+                .semantic_fqn();
+            Some((local_fqn, deferred_fqn))
+        })
+        .collect()
+}
+
+fn state_explain_node_info_for_parts(
+    adapter_type: AdapterType,
+    full_refresh: bool,
+    node: &dyn InternalDbtNodeAttributes,
+) -> StateExplainNodeInfo {
+    let materialized = node.base().materialized.clone();
+    // No-op materializations are inlined into their consumers, so they never get
+    // a warehouse relation. Reporting one would name a table that cannot exist.
+    let is_ephemeral = is_no_op_model_materialization(materialized.clone());
+    let fqn = if is_ephemeral {
+        String::new()
+    } else {
+        create_relation_from_node(adapter_type, node, None)
+            .map(|relation| relation.semantic_fqn())
+            .unwrap_or_default()
+    };
+    let is_full_refresh = if let Some(model) = node.as_any().downcast_ref::<DbtModel>() {
+        effective_full_refresh(full_refresh, model.deprecated_config.full_refresh)
+    } else if let Some(snapshot) = node.as_any().downcast_ref::<DbtSnapshot>() {
+        effective_full_refresh(full_refresh, snapshot.deprecated_config.full_refresh)
+    } else {
+        false
+    };
+
+    StateExplainNodeInfo {
+        fqn,
+        node_resource_type: node.resource_type().as_static_ref().to_string(),
+        is_view: materialized == DbtMaterialization::View,
+        is_table: matches!(
+            materialized,
+            DbtMaterialization::Table
+                | DbtMaterialization::Incremental
+                | DbtMaterialization::Snapshot
+                | DbtMaterialization::Seed
+        ),
+        is_ephemeral,
+        is_incremental_or_snapshot: matches!(
+            materialized,
+            DbtMaterialization::Incremental | DbtMaterialization::Snapshot
+        ),
+        is_full_refresh,
+        dev_clone: None,
+        deferrals: HashMap::new(),
     }
 }
 
@@ -993,7 +1695,7 @@ pub async fn confirm_run_cache_service_execution(
     execution_runtime_ms: Option<i64>,
 ) {
     // Without a confirmation token there is nothing to report, so avoid the
-    // final metadata refresh for reused/skipped nodes.
+    // final metadata refresh.
     let Some(confirmation) = confirmation else {
         return;
     };
@@ -1008,10 +1710,8 @@ pub async fn confirm_run_cache_service_execution(
     // where there is no audit relation to query.
     let final_last_modified_epoch = if is_test {
         None
-    } else if let Some(epoch) = stamp_final_last_modified_epoch_for_node_heuristic(ctx, node) {
-        Some(epoch)
     } else {
-        match refresh_final_last_modified_epoch_for_node(ctx, node).await {
+        match final_last_modified_epoch_for_node(ctx, node).await {
             Ok(epoch) => epoch,
             Err(err) => {
                 emit_warn_log_message(
@@ -1020,12 +1720,17 @@ pub async fn confirm_run_cache_service_execution(
                         "dbt State service final metadata lookup failed for node {}: {err}; command remains successful",
                         node.unique_id()
                     ),
-                    None,
                 );
                 return;
             }
         }
     };
+
+    // Replay must consume the recorded final freshness event and clear the
+    // cached pre-build value, but it must not contact the live dbt State service.
+    if dbt_adapter::time_machine::is_replaying() {
+        return;
+    }
 
     let Some(client) = ctx.inner.run_cache_ctx.run_cache_service_client.as_ref() else {
         emit_warn_log_message(
@@ -1035,11 +1740,9 @@ pub async fn confirm_run_cache_service_execution(
                 node.unique_id(),
                 confirmation.request_id
             ),
-            None,
         );
         return;
     };
-
     let request = match confirmation
         .into_confirm_execution_request(ctx, node, final_last_modified_epoch, execution_runtime_ms)
         .await
@@ -1053,7 +1756,6 @@ pub async fn confirm_run_cache_service_execution(
                     "dbt State service confirmation metadata lookup failed for node {}: {err}; command remains successful",
                     node.unique_id()
                 ),
-                None,
             );
             return;
         }
@@ -1062,20 +1764,23 @@ pub async fn confirm_run_cache_service_execution(
     let request_id = request.request_id.clone();
     if let Err(err) = client.confirm_execution(request).await {
         let unique_id = node.unique_id();
-        if err.is_transient_transport_rpc() {
-            emit_trace_log_message(|| {
-                format!(
-                    "dbt State service confirmation transport failed for node {unique_id} (request_id {request_id}): {err}; command remains successful"
-                )
-            });
-        } else {
-            emit_warn_log_message(
-                ErrorCode::StateServiceWarn,
-                format!(
-                    "dbt State service confirmation failed for node {unique_id} (request_id {request_id}): {err}; command remains successful"
-                ),
-                None,
-            );
+        match err {
+            RunCacheServiceError::Disabled => {}
+            err if err.is_transient_transport_rpc() => {
+                emit_trace_log_message(|| {
+                    format!(
+                        "dbt State service confirmation transport failed for node {unique_id} (request_id {request_id}): {err}; command remains successful"
+                    )
+                });
+            }
+            err => {
+                emit_warn_log_message(
+                    ErrorCode::StateServiceWarn,
+                    format!(
+                        "dbt State service confirmation failed for node {unique_id} (request_id {request_id}): {err}; command remains successful"
+                    ),
+                );
+            }
         }
     } else {
         let unique_id = node.unique_id();
@@ -1109,11 +1814,9 @@ pub async fn record_run_cache_service_execution(
                 "dbt State service record skipped for node {} because no validated client is available",
                 node.unique_id()
             ),
-            None,
         );
         return;
     };
-
     let request = match record
         .into_record_executions_request(ctx, node, execution_runtime_ms)
         .await
@@ -1127,7 +1830,6 @@ pub async fn record_run_cache_service_execution(
                     "dbt State service record metadata lookup failed for node {}: {err}; command remains successful",
                     node.unique_id()
                 ),
-                None,
             );
             return;
         }
@@ -1135,20 +1837,23 @@ pub async fn record_run_cache_service_execution(
 
     if let Err(err) = client.record_executions(request).await {
         let unique_id = node.unique_id();
-        if err.is_transient_transport_rpc() {
-            emit_trace_log_message(|| {
-                format!(
-                    "dbt State service record transport failed for node {unique_id}: {err}; command remains successful"
-                )
-            });
-        } else {
-            emit_warn_log_message(
-                ErrorCode::StateServiceWarn,
-                format!(
-                    "dbt State service record failed for node {unique_id}: {err}; command remains successful"
-                ),
-                None,
-            );
+        match err {
+            RunCacheServiceError::Disabled => {}
+            err if err.is_transient_transport_rpc() => {
+                emit_trace_log_message(|| {
+                    format!(
+                        "dbt State service record transport failed for node {unique_id}: {err}; command remains successful"
+                    )
+                });
+            }
+            err => {
+                emit_warn_log_message(
+                    ErrorCode::StateServiceWarn,
+                    format!(
+                        "dbt State service record failed for node {unique_id}: {err}; command remains successful"
+                    ),
+                );
+            }
         }
     } else {
         let unique_id = node.unique_id();
@@ -1262,6 +1967,29 @@ struct RunCacheSubmitOutcome {
     freshness_tolerance_seconds: i64,
 }
 
+/// Outcome of a per-node submit helper.
+///
+/// Most submits produce a service `response` fed to `record_service_decision`.
+/// The speculative `ReadyToExecuteUntracked` verdict has no counterpart there:
+/// the node executes now and its outcome is recorded after the fact, so the
+/// helper hands back the pending record directly. It is never a Skip/Clone, so
+/// it bypasses both the decision translation and the dev-cloned relabel.
+enum RunCacheSubmitResult {
+    // Boxed: `RunCacheSubmitOutcome` carries a full `SubmitSqlResponse`, far
+    // larger than the `ExecuteUntracked` variant, so box it to keep the enum small.
+    Outcome(Box<RunCacheSubmitOutcome>),
+    ExecuteUntracked(RunCachePendingExecutionRecord),
+}
+
+impl RunCacheSubmitResult {
+    fn outcome(response: SubmitSqlResponse, freshness_tolerance_seconds: i64) -> Self {
+        Self::Outcome(Box::new(RunCacheSubmitOutcome {
+            response,
+            freshness_tolerance_seconds,
+        }))
+    }
+}
+
 impl RunCacheExecutionConfirmation {
     async fn into_confirm_execution_request(
         self,
@@ -1303,13 +2031,22 @@ impl RunCacheExecutionConfirmation {
 impl RunCachePendingExecutionRecord {
     fn sql(request: SubmitEnrichedSqlRequest) -> Self {
         Self {
-            input: RunCachePendingExecutionInput::Sql(request),
+            input: RunCachePendingExecutionInput::Sql(Box::new(request)),
+            speculative: false,
+        }
+    }
+
+    fn sql_speculative(request: SubmitEnrichedSqlRequest) -> Self {
+        Self {
+            input: RunCachePendingExecutionInput::Sql(Box::new(request)),
+            speculative: true,
         }
     }
 
     fn values(request: SubmitValuesRequest) -> Self {
         Self {
-            input: RunCachePendingExecutionInput::Values(request),
+            input: RunCachePendingExecutionInput::Values(Box::new(request)),
+            speculative: false,
         }
     }
 
@@ -1319,7 +2056,22 @@ impl RunCachePendingExecutionRecord {
         node: &dyn InternalDbtNodeAttributes,
         execution_runtime_ms: Option<i64>,
     ) -> FsResult<Option<RecordExecutionsRequest>> {
-        let last_modified_epoch = refresh_final_last_modified_epoch_for_node(ctx, node).await?;
+        let speculative = self.speculative;
+
+        // A speculative record was built from a partial dependency snapshot
+        // while the prefetch was still in flight. Finalize the dependency epochs
+        // against the now-warm cache before recording, so the persisted record
+        // reflects the real upstream state rather than the speculative one.
+        let input = match self.input {
+            RunCachePendingExecutionInput::Sql(request) if speculative => {
+                RunCachePendingExecutionInput::Sql(Box::new(
+                    finalize_speculative_sql_request(ctx, node, *request).await,
+                ))
+            }
+            other => other,
+        };
+
+        let last_modified_epoch = final_last_modified_epoch_for_node(ctx, node).await?;
         let Some(last_modified_epoch) = last_modified_epoch else {
             let unique_id = node.unique_id();
             emit_trace_log_message(|| {
@@ -1335,12 +2087,12 @@ impl RunCachePendingExecutionRecord {
             table_type: table_type_for_node(ctx, node).await?,
             execution_runtime_ms,
         };
-        let record = match self.input {
+        let record = match input {
             RunCachePendingExecutionInput::Sql(request) => {
-                sql_execution_record_from_submit_request(request, outcome)
+                sql_execution_record_from_submit_request(*request, outcome, speculative)
             }
             RunCachePendingExecutionInput::Values(request) => {
-                values_execution_record_from_submit_request(request, outcome)
+                values_execution_record_from_submit_request(*request, outcome)
             }
         };
 
@@ -1348,6 +2100,121 @@ impl RunCachePendingExecutionRecord {
             records: vec![record],
         }))
     }
+}
+
+/// Finalize the dependency last-modified epochs on a speculative SQL request.
+///
+/// A speculative request is built from cache reads only while the global
+/// prefetch is still running, so some dependency epochs may be unset. Before the
+/// outcome is recorded, this refreshes those epochs to their real values so the
+/// persisted record reflects the true upstream state rather than the partial
+/// speculative snapshot:
+/// 1. await the global prefetch so the cache is fully warm;
+/// 2. reconstruct a relation for each recorded table name and re-fetch any
+///    epochs still missing from the cache, using the node's source-freshness
+///    overrides so sources keep their custom freshness strategy;
+/// 3. re-read the cache per table name, using the resolved entry whenever the
+///    relation is present — including an explicit resolved-unknown, which clears
+///    the epoch to unset — and falling back to the existing speculative epoch
+///    only on a genuine cache miss.
+///
+/// Table names are canonical `semantic_fqn` strings, the same key the metadata
+/// cache and the miss-refresh planner use.
+async fn finalize_speculative_sql_request(
+    ctx: &TaskRunnerCtx,
+    node: &dyn InternalDbtNodeAttributes,
+    mut request: SubmitEnrichedSqlRequest,
+) -> SubmitEnrichedSqlRequest {
+    await_prefetch(ctx).await;
+    if request.tables.is_empty() {
+        return request;
+    }
+
+    // Reconstruct a relation per recorded table name so the miss-refresh can
+    // issue real warehouse lookups for anything the global prefetch didn't
+    // resolve (e.g. parser-discovered raw references outside the DAG).
+    let mut relations: BTreeMap<String, Arc<dyn BaseRelation>> = BTreeMap::new();
+    for table in &request.tables {
+        if let Ok(relation) = relation_from_rendered_name(ctx, node, &table.name) {
+            relations.insert(table.name.clone(), relation);
+        }
+    }
+
+    let overrides = collect_source_freshness_overrides(ctx, node);
+    prefetch_last_modified_epochs(ctx, &relations, &overrides).await;
+
+    for table in &mut request.tables {
+        // `last_modified_epoch` is `Some(resolved)` when the cache has an entry
+        // for the relation (`resolved` may be `None` — a resolved-unknown that
+        // must clear the speculative epoch to unset) and `None` on a genuine
+        // miss. Only a genuine miss keeps the best-effort speculative value.
+        if let Some(resolved) = ctx
+            .inner
+            .run_cache_ctx
+            .run_cache_metadata
+            .last_modified_epoch(&table.name)
+        {
+            table.last_modified_epoch = resolved;
+        }
+    }
+    request
+}
+
+/// Collect source-freshness overrides for a node's runtime dependencies.
+///
+/// Mirrors the override collection in `collect_table_modified_infos`: sources
+/// declaring `loaded_at_query` or `loaded_at_field` get a `FreshnessOverride`
+/// keyed by the relation's `semantic_fqn` — the key `freshness_with_overrides`
+/// and the miss-refresh planner expect. Query takes precedence over field
+/// (matching the dbt-core plugin); empty strings from the deserializer are
+/// treated as "not set".
+fn collect_source_freshness_overrides(
+    ctx: &TaskRunnerCtx,
+    node: &dyn InternalDbtNodeAttributes,
+) -> BTreeMap<String, FreshnessOverride> {
+    let mut overrides: BTreeMap<String, FreshnessOverride> = BTreeMap::new();
+    let Some(deps) = ctx.inner.runtime_deps.get(node.unique_id().as_str()) else {
+        return overrides;
+    };
+    for dep_id in deps {
+        let Some(dep_node) = ctx.nodes().get_node(dep_id) else {
+            continue;
+        };
+        let Some(source) = dep_node.as_any().downcast_ref::<DbtSource>() else {
+            continue;
+        };
+        let Ok((name, _)) = relation_for_node(ctx, dep_node) else {
+            continue;
+        };
+        if let Some(kind) = source_freshness_override(source) {
+            overrides.insert(name, kind);
+        }
+    }
+    overrides
+}
+
+/// The source-freshness override a source declares via `loaded_at_query` /
+/// `loaded_at_field`, if any. Query takes precedence over field (matching the
+/// dbt-core plugin); empty strings from the deserializer are treated as unset.
+fn source_freshness_override(source: &DbtSource) -> Option<FreshnessOverride> {
+    let trimmed_nonempty = |s: &str| {
+        let t = s.trim();
+        (!t.is_empty()).then(|| t.to_string())
+    };
+    source
+        .__source_attr__
+        .loaded_at_query
+        .as_deref()
+        .and_then(trimmed_nonempty)
+        .map(FreshnessOverride::Query)
+        .or_else(|| {
+            source
+                .__source_attr__
+                .loaded_at_field
+                .as_deref()
+                .and_then(trimmed_nonempty)
+                .map(FreshnessOverride::Field)
+        })
 }
 
 /// Guard against cloning from a source that was modified out-of-band since the
@@ -1442,7 +2309,7 @@ fn execute_clone_sqls_blocking(
         .with_desc("dbt State clone");
     for sql in clone_sqls {
         adapter
-            .execute_without_state(Some(&query_ctx), sql, false)
+            .execute_without_state(Some(&query_ctx), sql, false, None)
             .map_err(|err| into_fs_error(Cancellable::Error(err)))?;
     }
     Ok(())
@@ -1464,42 +2331,364 @@ async fn submit_model(
     model: &DbtModel,
     task_result: &TaskResult,
     client: &dbt_state::service_client::SharedRunCacheServiceClient,
-) -> FsResult<Option<RunCacheSubmitOutcome>> {
+    microbatch_window: Option<(DateTime<Utc>, DateTime<Utc>)>,
+) -> FsResult<Option<RunCacheSubmitResult>> {
     let full_refresh = effective_full_refresh(
         ctx.inner.arg.full_refresh,
         model.deprecated_config.full_refresh,
     );
-    if full_refresh && full_refresh_blocks_model_submit(model.materialized()) {
-        record_submit_skipped(model, "full refresh");
+    // A microbatch model's cache key is only sound with its event-time window
+    // folded in (every batch shares one target table and query hash). If the
+    // window could not be resolved there is nothing sound to write down either,
+    // so make no decision *and* record nothing — the `Ok(None)` path only
+    // invalidates the target's cached freshness. Checked ahead of full refresh
+    // so that a full-refreshed microbatch model is never recorded on the
+    // strength of a window we could not resolve. Mirrors the plugin's
+    // `_resolve_microbatch_window` bypass.
+    if is_microbatch_model(model) && microbatch_window.is_none() {
+        record_submit_skipped(model, "unresolved microbatch window");
         return Ok(None);
     }
 
-    let context = build_sql_context(
+    if full_refresh && full_refresh_blocks_model_submit(model.materialized()) {
+        // `--full-refresh` is an explicit instruction to rebuild, so this node
+        // must never be skipped. The service cannot enforce that for us: the
+        // request carries no full-refresh flag, only `execution_type=FULL`, so
+        // a daily full-refresh job would match yesterday's FULL record whenever
+        // the sources happened not to move and skip the rebuild the user asked
+        // for. Hence the client-side bail.
+        //
+        // That is a reason not to seek a *decision*, not a reason to hide the
+        // execution. The node still rewrites its target, so record it: going
+        // dark leaves the service blind to the rebuild and leaves the cached
+        // last-modified epoch describing pre-build state, which downstream
+        // nodes in this run then report and are incorrectly skipped on.
+        record_submit_skipped(model, "full refresh");
+        return Ok(
+            prepare_write_only_execution_record(ctx, model, task_result, microbatch_window)
+                .await?
+                .map(RunCacheSubmitResult::ExecuteUntracked),
+        );
+    }
+
+    submit_sql_with_speculation(
         ctx,
         model,
         task_result.sql_instruction.sql.clone(),
         model.materialized() == DbtMaterialization::View,
         full_refresh,
+        microbatch_window,
+        client,
+        |context| {
+            build_model_sql_request(
+                model,
+                context,
+                &ctx.inner.materialization_resolver,
+                create_macro_resolver(ctx),
+            )
+        },
+    )
+    .await
+}
+
+/// Submit a SQL node, using the speculative fast-path while the global
+/// dependency prefetch is still in flight.
+///
+/// When the prefetch is already complete this awaits it (a no-op) and submits
+/// regularly. Otherwise it builds a speculative request from cache reads only
+/// and branches on the verdict:
+/// - `SkipExecution` / `ReadyToClone` — returned as a synthetic regular
+///   response (identical inner types) so the caller's `record_service_decision`
+///   handles it unchanged. Sound because a missing dependency epoch can only
+///   make a candidate look staler, never fresher.
+/// - `ReadyToExecuteUntracked` — the node must execute now; a speculative
+///   pending record is returned so the outcome is recorded after the fact with
+///   finalized epochs. The prefetch is intentionally not awaited here.
+/// - `Undecided` / RPC error / empty — await the prefetch and resubmit a
+///   regular (non-speculative) request.
+#[allow(clippy::too_many_arguments)]
+async fn submit_sql_with_speculation(
+    ctx: &TaskRunnerCtx,
+    node: &dyn InternalDbtNodeAttributes,
+    sql: String,
+    is_view: bool,
+    full_refresh: bool,
+    microbatch_window: Option<(DateTime<Utc>, DateTime<Utc>)>,
+    client: &dbt_state::service_client::SharedRunCacheServiceClient,
+    build_request: impl Fn(SqlRunCacheRequestContext) -> FsResult<SubmitEnrichedSqlRequest>,
+) -> FsResult<Option<RunCacheSubmitResult>> {
+    // Client-generated so `EnrichedSqlPrepared` telemetry doesn't depend on
+    // the server response carrying a request id (`SkipExecution` and
+    // `ReadyToExecuteUntracked` don't).
+    let request_id = dbt_state::service_client::new_request_id();
+
+    if is_prefetch_ready(ctx) {
+        return build_and_submit_non_speculative(
+            ctx,
+            node,
+            sql,
+            is_view,
+            full_refresh,
+            microbatch_window,
+            client,
+            &build_request,
+            request_id,
+            true,
+        )
+        .await;
+    }
+
+    let request_start = Instant::now();
+    let Some((request, freshness_tolerance_seconds)) = build_sql_request(
+        ctx,
+        node,
+        &sql,
+        is_view,
+        full_refresh,
+        microbatch_window,
+        true,
+        &build_request,
+    )
+    .await?
+    else {
+        return Ok(None);
+    };
+    let telemetry = enriched_sql_prepared_telemetry_input(&request);
+    let prepare_duration = request_start.elapsed();
+
+    // Re-check readiness at the last responsible moment. `build_sql_request`
+    // blocks on the view-definition traversal (fetching view DDL from the
+    // warehouse) while the background prefetch runs concurrently, so the
+    // prefetch often completes during that window. The decision above was made
+    // against a now-stale snapshot: if the prefetch is ready, submit
+    // non-speculatively with fully-resolved epochs instead of wasting a
+    // speculative round-trip that would only come back `Undecided` and force a
+    // resubmit. `is_prefetch_ready` is a cheap atomic read, and the rebuild
+    // reuses the traverser's warm cache, so no view definition is re-fetched.
+    if is_prefetch_ready(ctx) {
+        return build_and_submit_non_speculative(
+            ctx,
+            node,
+            sql,
+            is_view,
+            full_refresh,
+            microbatch_window,
+            client,
+            &build_request,
+            request_id,
+            true,
+        )
+        .await;
+    }
+
+    // Report the speculative attempt once the final path is known. If the
+    // prefetch completed while building the request, the regular path above
+    // is the only submission and reports its own event.
+    emit_enriched_sql_prepared_telemetry(
+        ctx,
+        request_id.clone(),
+        prepare_duration,
+        telemetry,
+        None,
+    )
+    .await;
+
+    let unique_id = node.unique_id();
+    let verdict = client
+        .submit_enriched_sql_speculative(request.clone())
+        .await;
+    match verdict {
+        Ok(response) => match response.response {
+            Some(submit_sql_speculative_response::Response::SkipExecution(skip)) => {
+                emit_trace_log_message(|| {
+                    format!("dbt State speculative decision: skip execution for node {unique_id}")
+                });
+                Ok(Some(RunCacheSubmitResult::outcome(
+                    SubmitSqlResponse {
+                        response: Some(submit_sql_response::Response::SkipExecution(skip)),
+                    },
+                    freshness_tolerance_seconds,
+                )))
+            }
+            Some(submit_sql_speculative_response::Response::ReadyToClone(clone)) => {
+                emit_trace_log_message(|| {
+                    format!("dbt State speculative decision: ready to clone for node {unique_id}")
+                });
+                Ok(Some(RunCacheSubmitResult::outcome(
+                    SubmitSqlResponse {
+                        response: Some(submit_sql_response::Response::ReadyToClone(clone)),
+                    },
+                    freshness_tolerance_seconds,
+                )))
+            }
+            Some(submit_sql_speculative_response::Response::ReadyToExecuteUntracked(_)) => {
+                emit_trace_log_message(|| {
+                    format!(
+                        "dbt State speculative decision: ready to execute untracked for node {unique_id}; recording after execution"
+                    )
+                });
+                Ok(Some(RunCacheSubmitResult::ExecuteUntracked(
+                    RunCachePendingExecutionRecord::sql_speculative(request),
+                )))
+            }
+            Some(submit_sql_speculative_response::Response::Undecided(_)) | None => {
+                emit_trace_log_message(|| {
+                    format!(
+                        "dbt State speculative decision: undecided for node {unique_id}; awaiting prefetch and resubmitting"
+                    )
+                });
+                await_prefetch(ctx).await;
+                build_and_submit_non_speculative(
+                    ctx,
+                    node,
+                    sql,
+                    is_view,
+                    full_refresh,
+                    microbatch_window,
+                    client,
+                    &build_request,
+                    request_id,
+                    false,
+                )
+                .await
+            }
+        },
+        Err(err) => {
+            // Swallowed here rather than reported as a prepare-error: the
+            // speculative RPC is a best-effort fast path, and the resubmit
+            // below still reports its own failures.
+            emit_trace_log_message(|| {
+                format!(
+                    "dbt State speculative submit failed for node {unique_id}: {err}; awaiting prefetch and resubmitting"
+                )
+            });
+            await_prefetch(ctx).await;
+            build_and_submit_non_speculative(
+                ctx,
+                node,
+                sql,
+                is_view,
+                full_refresh,
+                microbatch_window,
+                client,
+                &build_request,
+                request_id,
+                false,
+            )
+            .await
+        }
+    }
+}
+
+/// Build and issue a regular (non-speculative) SQL submit, awaiting the global
+/// prefetch first so freshness resolves from the warm cache. Idempotent with
+/// respect to the prefetch await, so it is safe to call after the speculative
+/// path already awaited it.
+///
+/// `request_id` is the attempt's client-generated id (see
+/// `submit_sql_with_speculation`). `report_prepared_success` is `false` when
+/// this is a resubmit after a speculative attempt already reported success
+/// telemetry for the same id — a failure here is still reported either way.
+#[allow(clippy::too_many_arguments)]
+async fn build_and_submit_non_speculative(
+    ctx: &TaskRunnerCtx,
+    node: &dyn InternalDbtNodeAttributes,
+    sql: String,
+    is_view: bool,
+    full_refresh: bool,
+    microbatch_window: Option<(DateTime<Utc>, DateTime<Utc>)>,
+    client: &dbt_state::service_client::SharedRunCacheServiceClient,
+    build_request: &impl Fn(SqlRunCacheRequestContext) -> FsResult<SubmitEnrichedSqlRequest>,
+    request_id: String,
+    report_prepared_success: bool,
+) -> FsResult<Option<RunCacheSubmitResult>> {
+    await_prefetch(ctx).await;
+    let request_start = Instant::now();
+    let Some((request, freshness_tolerance_seconds)) = build_sql_request(
+        ctx,
+        node,
+        &sql,
+        is_view,
+        full_refresh,
+        microbatch_window,
+        false,
+        build_request,
+    )
+    .await?
+    else {
+        return Ok(None);
+    };
+    let telemetry = enriched_sql_prepared_telemetry_input(&request);
+    let prepare_duration = request_start.elapsed();
+
+    // Success only if `report_prepared_success` (the sole/first build for
+    // this attempt); failure always, even on a resubmit.
+    let response = match client.submit_enriched_sql(request).await {
+        Ok(response) => {
+            if report_prepared_success {
+                emit_enriched_sql_prepared_telemetry(
+                    ctx,
+                    request_id,
+                    prepare_duration,
+                    telemetry,
+                    None,
+                )
+                .await;
+            }
+            response
+        }
+        Err(err) => {
+            emit_enriched_sql_prepared_telemetry(
+                ctx,
+                request_id,
+                request_start.elapsed(),
+                telemetry,
+                Some(err.error_type_label().to_string()),
+            )
+            .await;
+            return Err(fs_err!(
+                ErrorCode::Generic,
+                "dbt State service SubmitEnrichedSQL failed: {}",
+                err
+            ));
+        }
+    };
+    Ok(Some(RunCacheSubmitResult::outcome(
+        response,
+        freshness_tolerance_seconds,
+    )))
+}
+
+/// Build a SQL submit request, returning `None` when required metadata is
+/// missing (the submit is then skipped and the node executes normally).
+#[allow(clippy::too_many_arguments)]
+async fn build_sql_request(
+    ctx: &TaskRunnerCtx,
+    node: &dyn InternalDbtNodeAttributes,
+    sql: &str,
+    is_view: bool,
+    full_refresh: bool,
+    microbatch_window: Option<(DateTime<Utc>, DateTime<Utc>)>,
+    speculative: bool,
+    build_request: &impl Fn(SqlRunCacheRequestContext) -> FsResult<SubmitEnrichedSqlRequest>,
+) -> FsResult<Option<(SubmitEnrichedSqlRequest, i64)>> {
+    let mut context = build_sql_context(
+        ctx,
+        node,
+        sql.to_string(),
+        is_view,
+        full_refresh,
+        speculative,
     )
     .await?;
     if !context.metadata_complete {
-        record_submit_skipped(model, "missing metadata");
+        record_submit_skipped(node, "missing metadata");
         return Ok(None);
     }
+    context.request.microbatch_window = microbatch_window;
     let freshness_tolerance_seconds = context.request.freshness_tolerance_seconds;
-    let request = build_model_sql_request(model, context.request)?;
-
-    let response = client.submit_enriched_sql(request).await.map_err(|e| {
-        fs_err!(
-            ErrorCode::Generic,
-            "dbt State service SubmitEnrichedSQL failed: {}",
-            e
-        )
-    })?;
-    Ok(Some(RunCacheSubmitOutcome {
-        response,
-        freshness_tolerance_seconds,
-    }))
+    let request = build_request(context.request)?;
+    Ok(Some((request, freshness_tolerance_seconds)))
 }
 
 /// Builds the dbt State record input for write-only mode without contacting the
@@ -1513,7 +2702,14 @@ async fn prepare_write_only_execution_record(
     ctx: &TaskRunnerCtx,
     node: &dyn InternalDbtNodeAttributes,
     task_result: &TaskResult,
+    microbatch_window: Option<(DateTime<Utc>, DateTime<Utc>)>,
 ) -> FsResult<Option<RunCachePendingExecutionRecord>> {
+    // Write-only makes no speculative decision: it only records executions and
+    // needs fully resolved dependency freshness. Block on the background prefetch
+    // so the record is built from the warm cache rather than racing it with
+    // redundant per-node freshness queries.
+    await_prefetch(ctx).await;
+
     if let Some(model) = node.as_any().downcast_ref::<DbtModel>() {
         if is_no_op_model_materialization(model.materialized()) {
             record_submit_skipped(model, "no-op model materialization");
@@ -1521,6 +2717,12 @@ async fn prepare_write_only_execution_record(
         }
         if model.common().language.as_deref() != Some("sql") {
             record_unsupported_node(node, "non-SQL model");
+            return Ok(None);
+        }
+        // See `submit_model`: a microbatch model can only be recorded soundly with
+        // its resolved window folded into the key (kept even under --full-refresh).
+        if is_microbatch_model(model) && microbatch_window.is_none() {
+            record_submit_skipped(model, "unresolved microbatch window");
             return Ok(None);
         }
         let full_refresh = effective_full_refresh(
@@ -1533,15 +2735,22 @@ async fn prepare_write_only_execution_record(
             task_result.sql_instruction.sql.clone(),
             model.materialized() == DbtMaterialization::View,
             full_refresh,
+            false,
         )
         .await?;
         if !context.metadata_complete {
             record_submit_skipped(model, "missing metadata");
             return Ok(None);
         }
+        context.request.microbatch_window = microbatch_window;
         remove_cache_decision_fields(&mut context.request);
         Ok(Some(RunCachePendingExecutionRecord::sql(
-            build_model_sql_request(model, context.request)?,
+            build_model_sql_request(
+                model,
+                context.request,
+                &ctx.inner.materialization_resolver,
+                create_macro_resolver(ctx),
+            )?,
         )))
     } else if let Some(snapshot) = node.as_any().downcast_ref::<DbtSnapshot>() {
         let mut context = build_sql_context(
@@ -1553,6 +2762,7 @@ async fn prepare_write_only_execution_record(
                 ctx.inner.arg.full_refresh,
                 snapshot.deprecated_config.full_refresh,
             ),
+            false,
         )
         .await?;
         if !context.metadata_complete {
@@ -1561,7 +2771,7 @@ async fn prepare_write_only_execution_record(
         }
         remove_cache_decision_fields(&mut context.request);
         Ok(Some(RunCachePendingExecutionRecord::sql(
-            build_snapshot_sql_request(snapshot, context.request)?,
+            build_snapshot_sql_request(snapshot, context.request, create_macro_resolver(ctx))?,
         )))
     } else if let Some(seed) = node.as_any().downcast_ref::<DbtSeed>() {
         let request = build_seed_values_request(
@@ -1569,11 +2779,13 @@ async fn prepare_write_only_execution_record(
             SeedRunCacheRequestContext {
                 adapter_type: ctx.adapter_type(),
                 dialect: run_cache_dialect(ctx),
-                project_root: ctx.inner.arg.io.in_dir.as_path(),
                 last_modified_epoch: None,
                 clone_time_travel_limit: None,
                 clone_table_properties: None,
+                clone_chain_depth_limit: None,
+                dbt_project_info: DbtProjectInfo::from(ctx),
             },
+            create_macro_resolver(ctx),
         )?;
         Ok(Some(RunCachePendingExecutionRecord::values(request)))
     } else {
@@ -1587,50 +2799,47 @@ async fn submit_snapshot(
     snapshot: &DbtSnapshot,
     task_result: &TaskResult,
     client: &dbt_state::service_client::SharedRunCacheServiceClient,
-) -> FsResult<Option<RunCacheSubmitOutcome>> {
-    let context = build_sql_context(
+) -> FsResult<Option<RunCacheSubmitResult>> {
+    let full_refresh = effective_full_refresh(
+        ctx.inner.arg.full_refresh,
+        snapshot.deprecated_config.full_refresh,
+    );
+    submit_sql_with_speculation(
         ctx,
         snapshot,
         task_result.sql_instruction.sql.clone(),
         false,
-        effective_full_refresh(
-            ctx.inner.arg.full_refresh,
-            snapshot.deprecated_config.full_refresh,
-        ),
+        full_refresh,
+        None,
+        client,
+        |context| build_snapshot_sql_request(snapshot, context, create_macro_resolver(ctx)),
     )
-    .await?;
-    if !context.metadata_complete {
-        record_submit_skipped(snapshot, "missing metadata");
-        return Ok(None);
-    }
-    let freshness_tolerance_seconds = context.request.freshness_tolerance_seconds;
-    let request = build_snapshot_sql_request(snapshot, context.request)?;
-
-    let response = client.submit_enriched_sql(request).await.map_err(|e| {
-        fs_err!(
-            ErrorCode::Generic,
-            "dbt State service SubmitEnrichedSQL failed: {}",
-            e
-        )
-    })?;
-    Ok(Some(RunCacheSubmitOutcome {
-        response,
-        freshness_tolerance_seconds,
-    }))
+    .await
 }
 
 async fn submit_seed(
     ctx: &TaskRunnerCtx,
     seed: &DbtSeed,
+    task_result: &TaskResult,
     client: &dbt_state::service_client::SharedRunCacheServiceClient,
-) -> FsResult<Option<RunCacheSubmitOutcome>> {
+) -> FsResult<Option<RunCacheSubmitResult>> {
     if effective_full_refresh(
         ctx.inner.arg.full_refresh,
         seed.deprecated_config.full_refresh,
     ) {
+        // See `submit_model`: an explicit rebuild must not be skipped, but it
+        // must still be observed, or downstream nodes report pre-reload state.
         record_submit_skipped(seed, "full refresh");
-        return Ok(None);
+        return Ok(
+            prepare_write_only_execution_record(ctx, seed, task_result, None)
+                .await?
+                .map(RunCacheSubmitResult::ExecuteUntracked),
+        );
     }
+
+    // Seeds never speculate; make sure the target's freshness has been resolved
+    // by the background prefetch before reading it from the cache.
+    await_prefetch(ctx).await;
 
     // Mirrors dbt-core's `_build_submit_values_request`: always submit, even
     // when the target table doesn't exist yet. The service treats a None
@@ -1650,11 +2859,13 @@ async fn submit_seed(
         SeedRunCacheRequestContext {
             adapter_type: ctx.adapter_type(),
             dialect: run_cache_dialect(ctx),
-            project_root: ctx.inner.arg.io.in_dir.as_path(),
             last_modified_epoch,
             clone_time_travel_limit,
             clone_table_properties: None,
+            clone_chain_depth_limit: None,
+            dbt_project_info: DbtProjectInfo::from(ctx),
         },
+        create_macro_resolver(ctx),
     )?;
 
     let response = client.submit_values(request).await.map_err(|e| {
@@ -1664,50 +2875,81 @@ async fn submit_seed(
             e
         )
     })?;
-    Ok(Some(RunCacheSubmitOutcome {
-        response,
-        freshness_tolerance_seconds: 0,
-    }))
+    Ok(Some(RunCacheSubmitResult::outcome(response, 0)))
 }
 
 /// Mirrors dbt-core's `_DataTestAdapterProxy._on_data_test_query`: submit a
 /// data test's count(*) SQL with `execution_type=DbtDataTest`. The cached
 /// `{failures, should_warn, should_error}` payload flows back through
 /// `SkipExecutionResponse.execution_results` and is decoded by
-/// `parse_cached_test_failures`. On `ReadyToExecute`, the dispatcher confirms
-/// after the test runs (see `set_test_execution_results`).
+/// `parse_cached_test_execution_result`. On `ReadyToExecute`, the dispatcher
+/// confirms after the test runs (see `set_test_execution_results`).
 async fn submit_test(
     ctx: &TaskRunnerCtx,
     test: &DbtTest,
     task_result: &TaskResult,
     client: &dbt_state::service_client::SharedRunCacheServiceClient,
-) -> FsResult<Option<RunCacheSubmitOutcome>> {
-    let context = build_sql_context(
+) -> FsResult<Option<RunCacheSubmitResult>> {
+    submit_sql_with_speculation(
         ctx,
         test,
         task_result.sql_instruction.sql.clone(),
         false, // tests aren't views
         false, // full_refresh is meaningless for tests
+        None,
+        client,
+        |context| build_test_sql_request(test, context, create_macro_resolver(ctx)),
     )
-    .await?;
-    if !context.metadata_complete {
-        record_submit_skipped(test, "missing metadata");
-        return Ok(None);
-    }
-    let freshness_tolerance_seconds = context.request.freshness_tolerance_seconds;
-    let request = build_test_sql_request(test, context.request)?;
+    .await
+}
 
-    let response = client.submit_enriched_sql(request).await.map_err(|e| {
-        fs_err!(
-            ErrorCode::Generic,
-            "dbt State service SubmitEnrichedSQL failed: {}",
-            e
+struct EnrichedSqlPreparedTelemetryInput {
+    target_table_fqn: Option<String>,
+    num_dependencies: Option<i64>,
+    num_view_dependencies: Option<i64>,
+    labels: HashMap<String, String>,
+}
+
+fn enriched_sql_prepared_telemetry_input(
+    request: &SubmitEnrichedSqlRequest,
+) -> EnrichedSqlPreparedTelemetryInput {
+    EnrichedSqlPreparedTelemetryInput {
+        target_table_fqn: request.target_table.clone(),
+        num_dependencies: i64::try_from(
+            request
+                .tables
+                .iter()
+                .filter(|table| Some(table.name.as_str()) != request.target_table.as_deref())
+                .count(),
         )
-    })?;
-    Ok(Some(RunCacheSubmitOutcome {
-        response,
-        freshness_tolerance_seconds,
-    }))
+        .ok(),
+        num_view_dependencies: i64::try_from(request.query_dependencies.len()).ok(),
+        labels: request.labels.clone(),
+    }
+}
+
+/// Emit an `EnrichedSqlPrepared` telemetry event for one submission attempt.
+/// `request_id` is a client-generated id correlating this event with the
+/// attempt, independent of whatever the server ends up deciding (or whether
+/// it responds at all) — see `submit_sql_with_speculation`.
+async fn emit_enriched_sql_prepared_telemetry(
+    ctx: &TaskRunnerCtx,
+    request_id: String,
+    duration: std::time::Duration,
+    input: EnrichedSqlPreparedTelemetryInput,
+    error_type: Option<String>,
+) {
+    let event = enriched_sql_prepared_event(
+        request_id,
+        duration,
+        input.target_table_fqn,
+        input.num_dependencies,
+        input.num_view_dependencies,
+        error_type,
+        input.labels,
+        next_telemetry_event_order(ctx),
+    );
+    submit_run_cache_telemetry_event(ctx, event).await;
 }
 
 struct BuiltSqlRunCacheContext {
@@ -1721,6 +2963,7 @@ async fn build_sql_context(
     sql: String,
     is_view: bool,
     full_refresh: bool,
+    speculative: bool,
 ) -> FsResult<BuiltSqlRunCacheContext> {
     let Some(config) = ctx.inner.run_cache_ctx.run_cache_service_config.as_ref() else {
         return Err(fs_err!(
@@ -1736,6 +2979,8 @@ async fn build_sql_context(
         is_view,
         &query_dependencies.seen_tables,
         &query_dependencies.parser_seen_relations,
+        &query_dependencies.unresolvable_tables,
+        speculative,
     )
     .await?;
     let metadata_complete = tables.metadata_complete && query_dependencies.metadata_complete;
@@ -1747,6 +2992,14 @@ async fn build_sql_context(
     );
 
     let stale_upstream_policy = stale_upstream_policy_for_node(node);
+
+    let active_profile = ctx.dbt_profile();
+    let is_targeting_prod = config.is_defer_to_target(active_profile);
+    let clone_chain_depth_limit = clone_chain_depth_limit_for_adapter(
+        ctx.adapter_type(),
+        is_targeting_prod,
+        active_profile.allow_clones,
+    );
 
     Ok(BuiltSqlRunCacheContext {
         request: SqlRunCacheRequestContext {
@@ -1765,19 +3018,101 @@ async fn build_sql_context(
                 node,
                 config.tolerate_nondeterminism,
             ),
+            compare_unrendered_code: resolve_compare_unrendered_code(
+                node,
+                config.compare_unrendered_code,
+            ),
             full_refresh,
             clone_time_travel_limit: config.clone_time_travel_limit_seconds,
             clone_table_properties: None,
+            clone_chain_depth_limit,
+            default_schema: node.schema(),
             stale_upstream_policy,
+            // Populated by the model submit paths for microbatch models; other
+            // node types never carry a window.
+            microbatch_window: None,
+            dbt_project_info: DbtProjectInfo::from(ctx),
         },
         metadata_complete,
     })
 }
 
+/// The full `ModelState` (5 keys) for models and snapshots. Data tests carry the 2-key
+/// `DataTestState` instead (see the field-level accessors below), so 5-key-only configs such as
+/// `lag_tolerance`/`pre_clone`/`execute_hooks_on_any_reuse` correctly return nothing for tests.
 fn model_state_for_node(node: &dyn InternalDbtNodeAttributes) -> Option<&ModelState> {
+    let any = node.as_any();
+    if let Some(model) = any.downcast_ref::<DbtModel>() {
+        model.__model_attr__.state.as_ref()
+    } else if let Some(snapshot) = any.downcast_ref::<DbtSnapshot>() {
+        snapshot.__snapshot_attr__.state.as_ref()
+    } else {
+        None
+    }
+}
+
+/// `require_fresh_data_from`, honored by models and snapshots (via `ModelState`) and data tests (via
+/// `DataTestState`).
+fn require_fresh_data_from_for_node(
+    node: &dyn InternalDbtNodeAttributes,
+) -> Option<&dbt_schemas::schemas::common::UpdatesOn> {
+    if let Some(state) = model_state_for_node(node) {
+        return state.require_fresh_data_from.as_ref();
+    }
     node.as_any()
-        .downcast_ref::<DbtModel>()
-        .and_then(|model| model.__model_attr__.state.as_ref())
+        .downcast_ref::<DbtTest>()
+        .and_then(|test| test.__test_attr__.state.as_ref())
+        .and_then(|state| state.require_fresh_data_from.as_ref())
+}
+
+/// `evaluate_volatile_sql`, honored by models and snapshots (via `ModelState`) and data tests (via
+/// `DataTestState`).
+fn evaluate_volatile_sql_for_node(node: &dyn InternalDbtNodeAttributes) -> Option<bool> {
+    if let Some(state) = model_state_for_node(node) {
+        return state.evaluate_volatile_sql;
+    }
+    node.as_any()
+        .downcast_ref::<DbtTest>()
+        .and_then(|test| test.__test_attr__.state.as_ref())
+        .and_then(|state| state.evaluate_volatile_sql)
+}
+
+/// `compare_unrendered_code`, honored by models and snapshots (via `ModelState`) and data tests
+/// (via `DataTestState`).
+fn compare_unrendered_code_for_node(node: &dyn InternalDbtNodeAttributes) -> Option<bool> {
+    if let Some(state) = model_state_for_node(node) {
+        return state.compare_unrendered_code;
+    }
+    node.as_any()
+        .downcast_ref::<DbtTest>()
+        .and_then(|test| test.__test_attr__.state.as_ref())
+        .and_then(|state| state.compare_unrendered_code)
+}
+
+/// Per-node override for the service's `compare_unrendered_code` wire flag. Unlike
+/// `tolerate_nondeterminism` there is no inversion and no legacy `meta` form: the node config
+/// wins over the service default, otherwise the default stands.
+fn resolve_compare_unrendered_code(
+    node: &dyn InternalDbtNodeAttributes,
+    service_default: bool,
+) -> bool {
+    let node_override = compare_unrendered_code_for_node(node);
+    let resolved = node_override.unwrap_or(service_default);
+
+    // Logs the override separately from the result so a surprising `false` distinguishes
+    // "the node never set it" from "the service default lost to an explicit node value".
+    emit_trace_log_message(|| {
+        format!(
+            "dbt State compare_unrendered_code={resolved} for node {} (node config {}, service default {service_default})",
+            node.unique_id(),
+            match node_override {
+                Some(v) => v.to_string(),
+                None => "unset".to_owned(),
+            },
+        )
+    });
+
+    resolved
 }
 
 pub fn should_execute_hooks_for_skip_reuse(
@@ -1814,6 +3149,9 @@ fn request_freshness_tolerance_seconds_for_node(
     is_view: bool,
     service_default: i64,
 ) -> i64 {
+    // Data tests never carry `lag_tolerance` (their `DataTestState` has only `require_fresh_data_from`
+    // and `evaluate_volatile_sql`), so their freshness tolerance stays 0. `require_fresh_data_from`
+    // for tests is honored separately via `stale_upstream_policy_for_node`.
     if node.resource_type() == NodeType::Test || is_view {
         0
     } else {
@@ -1835,9 +3173,7 @@ fn resolve_tolerate_nondeterminism(
     node: &dyn InternalDbtNodeAttributes,
     service_default: bool,
 ) -> bool {
-    if let Some(evaluate_volatile_sql) =
-        model_state_for_node(node).and_then(|state| state.evaluate_volatile_sql)
-    {
+    if let Some(evaluate_volatile_sql) = evaluate_volatile_sql_for_node(node) {
         return !evaluate_volatile_sql;
     }
 
@@ -1864,7 +3200,6 @@ fn resolve_tolerate_nondeterminism(
             "Ignoring meta.{KEY} on node {}: value is not a bool, int, or recognized string",
             node.unique_id()
         ),
-        None,
     );
     service_default
 }
@@ -1880,20 +3215,48 @@ fn stale_upstream_policy_for_node(
     use dbt_schemas::schemas::common::UpdatesOn;
     use dbt_state::proto::query_cache::StaleUpstreamPolicy;
 
-    let updates_on = model_state_for_node(node)
-        .and_then(|state| state.require_fresh_data_from.as_ref())
-        .or_else(|| {
-            node.as_any()
-                .downcast_ref::<DbtModel>()
-                .and_then(|model| model.__model_attr__.freshness.as_ref())
-                .and_then(|freshness| freshness.build_after.as_ref())
-                .and_then(|build_after| build_after.updates_on.as_ref())
-        });
+    let updates_on = require_fresh_data_from_for_node(node).or_else(|| {
+        node.as_any()
+            .downcast_ref::<DbtModel>()
+            .and_then(|model| model.__model_attr__.freshness.as_ref())
+            .and_then(|freshness| freshness.build_after.as_ref())
+            .and_then(|build_after| build_after.updates_on.as_ref())
+    });
 
     match updates_on {
         Some(UpdatesOn::All) => StaleUpstreamPolicy::All,
         Some(UpdatesOn::Any) | None => StaleUpstreamPolicy::Any,
     }
+}
+
+pub(crate) fn clone_chain_depth_limit_for_adapter(
+    adapter_type: AdapterType,
+    is_targeting_prod: bool,
+    allow_clones: bool,
+) -> Option<i64> {
+    // if cloning is disabled by the active target's config, send a limit of 0 to
+    // exclude clone candidates regardless of adapter
+    if !allow_clones {
+        return Some(0);
+    }
+
+    // the Python implementation hardcodes the default on each adapter
+    // ref: https://github.com/fivetran/query-cache/blob/14dddc260082af4bc6a9800743ddbe5ccb03ba67/clients/dbt_state/src/dbt_state/run_cache.py#L1911
+    match adapter_type {
+        AdapterType::Databricks => Some(1), // ref: https://github.com/fivetran/query-cache/blob/14dddc260082af4bc6a9800743ddbe5ccb03ba67/clients/dbt_state/src/dbt_state/adapters/databricks.py#L37
+        AdapterType::Bigquery => Some(3), // ref: https://github.com/fivetran/query-cache/blob/14dddc260082af4bc6a9800743ddbe5ccb03ba67/clients/dbt_state/src/dbt_state/adapters/bigquery.py#L21
+        _ => None,
+    }
+    .map(|default_limit: i64| {
+        if is_targeting_prod {
+            // for prod, we send a limit of n-1 so there is always room for 1 more dev clone
+            // note: if the default limits ever get adjusted (or new ones added)
+            // make sure that this does not return a negative number
+            default_limit.saturating_sub(1_i64)
+        } else {
+            default_limit
+        }
+    })
 }
 
 fn metadata_query_options_for_warehouses(
@@ -1902,11 +3265,12 @@ fn metadata_query_options_for_warehouses(
 ) -> MetadataQueryOptions {
     MetadataQueryOptions {
         warehouse: profile_warehouse.or(legacy_service_warehouse),
+        ..MetadataQueryOptions::default()
     }
 }
 
 pub(crate) fn run_cache_metadata_query_options(ctx: &TaskRunnerCtx) -> MetadataQueryOptions {
-    let profile_warehouse = match &ctx.dbt_profile().db_config {
+    let profile_warehouse = match &ctx.dbt_profile().default_db_config() {
         DbConfig::Snowflake(config) => config.metadata_warehouse.clone(),
         _ => None,
     };
@@ -1917,7 +3281,18 @@ pub(crate) fn run_cache_metadata_query_options(ctx: &TaskRunnerCtx) -> MetadataQ
         .as_ref()
         .and_then(|config| config.snowflake_metadata_warehouse.clone());
 
-    metadata_query_options_for_warehouses(profile_warehouse, legacy_service_warehouse)
+    // Adaptive broad-vs-sequential freshness fetch: read from the Snowflake
+    // target config, defaulting to `true` (adaptive on). Only the Snowflake
+    // no-metadata-warehouse strategy consults it; other adapters ignore it.
+    let adaptive_metadata_fetch = match &ctx.dbt_profile().default_db_config() {
+        DbConfig::Snowflake(config) => config.adaptive_metadata_fetch.unwrap_or(true),
+        _ => true,
+    };
+
+    MetadataQueryOptions {
+        adaptive_metadata_fetch,
+        ..metadata_query_options_for_warehouses(profile_warehouse, legacy_service_warehouse)
+    }
 }
 
 /// Returns deferred dependencies that should be treated leniently by the dbt
@@ -1955,6 +3330,10 @@ fn build_lenient_dependencies(
         .collect()
 }
 
+fn create_macro_resolver<'a>(ctx: &'a TaskRunnerCtx) -> impl Fn(&str) -> Option<&'a DbtMacro> {
+    |macro_id| ctx.resolver_state().macros.macros.get(macro_id)
+}
+
 struct CollectedTableModifiedInfos {
     tables: Vec<TableModifiedInfo>,
     metadata_complete: bool,
@@ -1981,6 +3360,8 @@ struct CollectedViewQueryDependencies {
     ///      and the service's freshness check defaults to "fresh" on the
     ///      NULL/NULL match path (see `test_transitive_dependencies_tracked`).
     parser_seen_relations: BTreeMap<String, Arc<dyn BaseRelation>>,
+    /// A subset of `seen_tables` whose view definition could not be fetched.
+    unresolvable_tables: BTreeSet<String>,
     metadata_complete: bool,
 }
 
@@ -1989,11 +3370,13 @@ impl CollectedViewQueryDependencies {
         dependencies: Vec<QueryDependency>,
         seen_tables: BTreeSet<String>,
         parser_seen_relations: BTreeMap<String, Arc<dyn BaseRelation>>,
+        unresolvable_tables: BTreeSet<String>,
     ) -> Self {
         Self {
             dependencies,
             seen_tables,
             parser_seen_relations,
+            unresolvable_tables,
             metadata_complete: true,
         }
     }
@@ -2003,6 +3386,7 @@ impl CollectedViewQueryDependencies {
             dependencies: Vec::new(),
             seen_tables: BTreeSet::new(),
             parser_seen_relations: BTreeMap::new(),
+            unresolvable_tables: BTreeSet::new(),
             metadata_complete: false,
         }
     }
@@ -2017,7 +3401,12 @@ impl CollectedViewQueryDependencies {
     /// `query_dependencies=[]`. `metadata_complete` must stay `true` so the
     /// submit isn't silently skipped.
     fn for_view() -> Self {
-        Self::complete(Vec::new(), BTreeSet::new(), BTreeMap::new())
+        Self::complete(
+            Vec::new(),
+            BTreeSet::new(),
+            BTreeMap::new(),
+            BTreeSet::new(),
+        )
     }
 }
 
@@ -2027,6 +3416,8 @@ async fn collect_table_modified_infos(
     target_only: bool,
     leaf_tables: &BTreeSet<String>,
     parser_seen_relations: &BTreeMap<String, Arc<dyn BaseRelation>>,
+    unresolvable_tables: &BTreeSet<String>,
+    speculative: bool,
 ) -> FsResult<CollectedTableModifiedInfos> {
     let mut relations = BTreeMap::new();
     let mut metadata_complete = true;
@@ -2052,30 +3443,16 @@ async fn collect_table_modified_infos(
                     // that's what MetadataAdapter::freshness_with_overrides expects.
                     // Empty strings come from the deserializer for absent values, so
                     // treat empty as "not set" (matches the dbt-core plugin guard).
-                    if let Some(source) = dep_node.as_any().downcast_ref::<DbtSource>() {
-                        // Query takes precedence over field (matches dbt-core plugin),
-                        // so only look at field when no query is set.
-                        let trimmed_nonempty = |s: &str| {
-                            let t = s.trim();
-                            (!t.is_empty()).then(|| t.to_string())
-                        };
-                        let override_kind = source
-                            .__source_attr__
-                            .loaded_at_query
-                            .as_deref()
-                            .and_then(trimmed_nonempty)
-                            .map(FreshnessOverride::Query)
-                            .or_else(|| {
-                                source
-                                    .__source_attr__
-                                    .loaded_at_field
-                                    .as_deref()
-                                    .and_then(trimmed_nonempty)
-                                    .map(FreshnessOverride::Field)
-                            });
-                        if let Some(kind) = override_kind {
-                            freshness_overrides.insert(relation.semantic_fqn(), kind);
-                        }
+                    if let Some(source) = dep_node.as_any().downcast_ref::<DbtSource>()
+                        && let Some(kind) = source_freshness_override(source)
+                    {
+                        let kind = render_freshness_override(
+                            kind,
+                            &relation,
+                            ctx.env.as_ref(),
+                            &ctx.inner.base_context,
+                        )?;
+                        freshness_overrides.insert(relation.semantic_fqn(), kind);
                     }
                     relations.insert(name, relation);
                 } else {
@@ -2111,7 +3488,24 @@ async fn collect_table_modified_infos(
         })
         .map(|(fqn, rel)| (fqn.clone(), Arc::clone(rel)))
         .collect();
-    prefetch_last_modified_epochs(ctx, &leaf_table_relations, &freshness_overrides).await;
+
+    apply_unresolvable_last_modified_overrides(
+        &ctx.inner.run_cache_ctx.run_cache_metadata,
+        ctx.inner.run_cache_ctx.heuristic_clock.get(),
+        unresolvable_tables,
+        &freshness_overrides,
+    );
+
+    // Speculative builds run while the global prefetch is still in flight, so
+    // they must not issue their own blocking per-node warehouse queries. They
+    // read whatever the prefetch has already resolved and leave cache misses
+    // unset; the service treats a missing epoch as "now", keeping any Skip/Clone
+    // verdict sound (a missing dep can only look staler, never fresher). Missing
+    // epochs must not mark the metadata incomplete here — a speculative submit
+    // tolerates unresolved dependencies.
+    if !speculative {
+        prefetch_last_modified_epochs(ctx, &leaf_table_relations, &freshness_overrides).await;
+    }
 
     let mut table_infos = Vec::new();
     for (name, relation) in leaf_table_relations {
@@ -2128,6 +3522,45 @@ async fn collect_table_modified_infos(
         tables: table_infos,
         metadata_complete,
     })
+}
+
+fn apply_unresolvable_last_modified_overrides(
+    cache: &RunCacheMetadataCache,
+    clock: Option<&HeuristicClock>,
+    unresolvable_tables: &BTreeSet<String>,
+    freshness_overrides: &BTreeMap<String, FreshnessOverride>,
+) {
+    let Some(clock) = clock else {
+        for name in unresolvable_tables {
+            cache.remove_last_modified_epoch(name);
+        }
+        return;
+    };
+
+    let mut unresolvable_without_override = Vec::new();
+    for name in unresolvable_tables {
+        cache.remove_last_modified_epoch(name);
+        if !freshness_overrides.contains_key(name) {
+            unresolvable_without_override.push(name.clone());
+        }
+    }
+
+    if unresolvable_without_override.is_empty() {
+        return;
+    }
+
+    emit_warn_log_message(
+        ErrorCode::StateServiceWarn,
+        format!(
+            "Could not determine freshness for {}; treating as modified. Configure loaded_at_field or loaded_at_query to set freshness timestamp.",
+            unresolvable_without_override.join(", ")
+        ),
+    );
+
+    let now_ms = clock.now_ms();
+    for name in unresolvable_without_override {
+        cache.insert_last_modified_epoch(name, Some(now_ms));
+    }
 }
 
 async fn last_modified_epoch_for_node(
@@ -2150,7 +3583,48 @@ pub async fn refresh_final_last_modified_epoch_for_node(
     refresh_last_modified_epoch_for_relation(ctx, &name, relation).await
 }
 
-pub fn stamp_final_last_modified_epoch_for_node_heuristic(
+pub fn clear_stale_missing_last_modified_epoch_for_node(
+    ctx: &TaskRunnerCtx,
+    node: &dyn InternalDbtNodeAttributes,
+) {
+    if let Ok((name, _)) = relation_for_node(ctx, node) {
+        // Only clear a known-stale placeholder (`Some(None)`), cached when the
+        // submit-time probe found no target table yet. A real cached epoch
+        // (`Some(Some(_))`) is still valid and may be relied on by sibling nodes
+        // later in this same run.
+        let run_cache_metadata = &ctx.inner.run_cache_ctx.run_cache_metadata;
+        if matches!(run_cache_metadata.last_modified_epoch(&name), Some(None)) {
+            run_cache_metadata.remove_last_modified_epoch(&name);
+        }
+    }
+}
+
+/// Evicts a node's cached warehouse metadata (last-modified epoch and existence)
+/// when it rebuilds without the dbt State service observing it.
+///
+/// An untracked rebuild makes the cached value stale; without eviction,
+/// downstream nodes in the same invocation report the relation's pre-build
+/// state to the service and are incorrectly skipped. The next submit that needs
+/// the relation treats the gap as a prefetch miss and re-queries it. Mirrors
+/// the plugin's `clear_cache([target_table])`.
+///
+/// Unlike [`clear_stale_missing_last_modified_epoch_for_node`] (the benign-skip
+/// path), this clears a real cached epoch too. Prefer recording the execution
+/// where a sound record can be built — see `submit_model` — which refreshes the
+/// epoch instead of dropping it and keeps the service's view complete.
+pub fn evict_node_metadata_for_untracked_rebuild(
+    ctx: &TaskRunnerCtx,
+    node: &dyn InternalDbtNodeAttributes,
+) {
+    if let Ok((name, _)) = relation_for_node(ctx, node) {
+        ctx.inner
+            .run_cache_ctx
+            .run_cache_metadata
+            .invalidate_relation_metadata(&name);
+    }
+}
+
+fn stamp_final_last_modified_epoch_for_node_heuristic(
     ctx: &TaskRunnerCtx,
     node: &dyn InternalDbtNodeAttributes,
 ) -> Option<i64> {
@@ -2159,17 +3633,38 @@ pub fn stamp_final_last_modified_epoch_for_node_heuristic(
     // Mirror the plugin's `clear_cache` + `cache_last_modified_epoch(table, H)`:
     // replace the stale prefetch value (often None for newly-created tables) with H
     // so downstream submissions in the same run have metadata_complete=true.
-    if let Ok((name, _)) = relation_for_node(ctx, node) {
-        ctx.inner
-            .run_cache_ctx
-            .run_cache_metadata
-            .remove_last_modified_epoch(&name);
-        ctx.inner
-            .run_cache_ctx
-            .run_cache_metadata
-            .insert_last_modified_epoch(&name, Some(epoch));
-    }
+    let Ok((name, _)) = relation_for_node(ctx, node) else {
+        return None;
+    };
+    ctx.inner
+        .run_cache_ctx
+        .run_cache_metadata
+        .remove_last_modified_epoch(&name);
+    ctx.inner
+        .run_cache_ctx
+        .run_cache_metadata
+        .insert_last_modified_epoch(&name, Some(epoch));
     Some(epoch)
+}
+
+/// Resolves a node's post-execution last-modified epoch, updating the local
+/// metadata cache to the same value it returns.
+///
+/// Callers persist the returned epoch to the dbt State service, so the cached
+/// and persisted values must be identical. If they diverge, downstream nodes in
+/// this run report a dependency epoch the service never recorded and the
+/// dependency reads as changed, costing reuse for no correctness gain.
+///
+/// Prefers the heuristic clock, which costs no warehouse round-trip, and falls
+/// back to a targeted refresh on adapters that opt out (see [`HeuristicClock`]).
+async fn final_last_modified_epoch_for_node(
+    ctx: &TaskRunnerCtx,
+    node: &dyn InternalDbtNodeAttributes,
+) -> FsResult<Option<i64>> {
+    if let Some(epoch) = stamp_final_last_modified_epoch_for_node_heuristic(ctx, node) {
+        return Ok(Some(epoch));
+    }
+    refresh_final_last_modified_epoch_for_node(ctx, node).await
 }
 
 async fn last_modified_epoch_for_relation(
@@ -2193,8 +3688,10 @@ async fn refresh_last_modified_epoch_for_relation(
     let mut relations = BTreeMap::new();
     relations.insert(name.to_string(), relation);
     // Per-relation refreshes aren't used for sources (sources are populated
-    // upfront via the bulk prefetch), so no overrides apply here.
-    refresh_last_modified_epochs(ctx, &relations, &BTreeMap::new()).await?;
+    // upfront via the bulk prefetch), so no overrides apply here. Still route
+    // through the adapter-specific planner so BigQuery can use schema prefetch.
+    refresh_planned_last_modified_misses(ctx, &relations, &BTreeMap::new(), ctx.adapter_type())
+        .await?;
     Ok(ctx
         .inner
         .run_cache_ctx
@@ -2226,15 +3723,11 @@ async fn prefetch_last_modified_epochs(
     // these relations (legitimate for post-clone invalidations and SQL-parser
     // discovered refs) or that the schema dump returned empty. Log so this
     // is visible when diagnosing unexpected per-node warehouse query volume.
-    emit_warn_log_message(
-        ErrorCode::StateServiceWarn,
-        format!(
-            "dbt State per-node freshness query for {} relation(s) not in prefetch cache: {}",
-            misses.len(),
-            misses.keys().cloned().collect::<Vec<_>>().join(", ")
-        ),
-        None,
-    );
+    emit_debug_log_message(format!(
+        "dbt State per-node freshness query for {} relation(s) not in prefetch cache: {}",
+        misses.len(),
+        misses.keys().cloned().collect::<Vec<_>>().join(", ")
+    ));
     let refresh_result =
         refresh_planned_last_modified_misses(ctx, &misses, overrides, ctx.adapter_type()).await;
     if let Err(err) = refresh_result {
@@ -2267,8 +3760,10 @@ struct LastModifiedMissRefreshPlan {
 }
 
 /// BigQuery normal misses use the schema prefetch path to avoid high fanout
-/// per-table `__TABLES__` queries. Overrides stay targeted because their
-/// freshness comes from custom `loaded_at_*` logic.
+/// per-table `__TABLES__` queries. A singleton miss can still trigger one
+/// schema scan; that is an intentional fix-forward tradeoff for correctness.
+/// Overrides stay targeted because their freshness comes from custom
+/// `loaded_at_*` logic.
 fn plan_last_modified_miss_refresh(
     adapter_type: AdapterType,
     misses: &BTreeMap<String, Arc<dyn BaseRelation>>,
@@ -2332,21 +3827,35 @@ async fn refresh_last_modified_epochs(
     };
 
     for grouped_relations in group_relations_by_database_and_schema(relations).into_values() {
+        let grouped_names = grouped_relations.keys().collect::<BTreeSet<_>>();
+        let grouped_overrides = overrides
+            .iter()
+            .filter(|(name, _)| grouped_names.contains(name))
+            .map(|(name, override_)| (name.clone(), override_.clone()))
+            .collect::<BTreeMap<_, _>>();
         let semantic_to_name = grouped_relations
             .iter()
             .map(|(name, relation)| (relation.semantic_fqn(), name.clone()))
             .collect::<BTreeMap<_, _>>();
         let relation_values = grouped_relations.values().cloned().collect::<Vec<_>>();
         let metadata_options = run_cache_metadata_query_options(ctx);
-        let freshness = metadata_adapter
+        let freshness = match metadata_adapter
             .freshness_with_overrides_and_options(
                 &relation_values,
-                overrides,
+                &grouped_overrides,
                 &metadata_options,
                 adapter.cancellation_token(),
             )
             .await
-            .map_err(into_fs_error)?;
+        {
+            Ok(freshness) => freshness,
+            Err(Cancellable::Error(err)) if err.kind() == AdapterErrorKind::ReplayDataMissing => {
+                // Older recordings do not contain this override-prefetch event.
+                // Leave entries absent so the per-node freshness events can replay.
+                continue;
+            }
+            Err(err) => return Err(into_fs_error(err)),
+        };
 
         for (semantic_fqn, name) in semantic_to_name {
             let epoch = freshness
@@ -2517,10 +4026,23 @@ async fn collect_query_dependencies(
         Err(err) => return query_dependencies_for_parse_error(ctx, node, sql, err).await,
     };
     if relations.is_empty() {
+        // A custom materialization's compiled SQL isn't necessarily a query,
+        // so an empty SQL-derived result isn't proof of no upstreams. Fall
+        // back to the manifest's depends_on graph. Built-ins are exempt:
+        // their compiled SQL is always a real query, so an empty result is
+        // trustworthy.
+        if node_uses_custom_materialization(node, &ctx.inner.materialization_resolver) {
+            let manifest_relations = cacheable_manifest_dependency_relations(ctx, node);
+            if !manifest_relations.is_empty() {
+                return collect_query_dependencies_from_relations(ctx, node, manifest_relations)
+                    .await;
+            }
+        }
         return Ok(CollectedViewQueryDependencies::complete(
             Vec::new(),
             BTreeSet::new(),
             BTreeMap::new(),
+            BTreeSet::new(),
         ));
     }
 
@@ -2557,6 +4079,7 @@ async fn collect_query_dependencies_from_relations(
     };
 
     let seen_tables = traversal.seen_tables;
+    let unresolvable_tables = traversal.unresolvable_tables;
     let dependencies = traversal
         .view_definitions
         .into_values()
@@ -2575,6 +4098,7 @@ async fn collect_query_dependencies_from_relations(
         dependencies,
         seen_tables,
         parser_seen_relations,
+        unresolvable_tables,
     ))
 }
 
@@ -2584,7 +4108,7 @@ async fn query_dependencies_for_parse_error(
     sql: &str,
     err: Box<FsError>,
 ) -> FsResult<CollectedViewQueryDependencies> {
-    if !node_uses_custom_materialization(node) {
+    if !node_uses_custom_materialization(node, &ctx.inner.materialization_resolver) {
         return Err(err);
     }
 
@@ -2621,6 +4145,13 @@ async fn query_dependencies_for_parse_error(
     };
 
     if relations.is_empty() {
+        // Same fallback as in `collect_query_dependencies`: an empty
+        // expression-parse result isn't proof of no upstreams.
+        let manifest_relations = cacheable_manifest_dependency_relations(ctx, node);
+        if !manifest_relations.is_empty() {
+            return collect_query_dependencies_from_relations(ctx, node, manifest_relations).await;
+        }
+
         emit_trace_log_message(|| {
             format!(
                 "dbt State dependency extraction accepted standalone SQL expression for custom materialization {unique_id}"
@@ -2630,15 +4161,54 @@ async fn query_dependencies_for_parse_error(
             Vec::new(),
             BTreeSet::new(),
             BTreeMap::new(),
+            BTreeSet::new(),
         ));
     }
     collect_query_dependencies_from_relations(ctx, node, relations).await
 }
 
-fn node_uses_custom_materialization(node: &dyn InternalDbtNodeAttributes) -> bool {
+/// Resolves a node's manifest depends_on graph into relations, restricted
+/// to cacheable node kinds. Fallback dependency source when SQL-derived
+/// extraction finds none.
+fn cacheable_manifest_dependency_relations(
+    ctx: &TaskRunnerCtx,
+    node: &dyn InternalDbtNodeAttributes,
+) -> BTreeMap<String, Arc<dyn BaseRelation>> {
+    let mut relations = BTreeMap::new();
+    for dep_id in &node.base().depends_on.nodes {
+        let Some(dep_node) = ctx.nodes().get_node(dep_id) else {
+            continue;
+        };
+        if !is_cacheable_resource_type(dep_node.resource_type()) {
+            continue;
+        }
+        let Ok((name, relation)) = relation_for_node(ctx, dep_node) else {
+            continue;
+        };
+        relations.insert(name, relation);
+    }
+    relations
+}
+
+/// Mirrors the `is_cacheable` filter used elsewhere in the run-cache path:
+/// only these node kinds participate in dependency freshness checks.
+fn is_cacheable_resource_type(resource_type: NodeType) -> bool {
+    matches!(
+        resource_type,
+        NodeType::Source | NodeType::Model | NodeType::Snapshot | NodeType::Seed
+    )
+}
+
+fn node_uses_custom_materialization(
+    node: &dyn InternalDbtNodeAttributes,
+    materialization_resolver: &MaterializationResolver,
+) -> bool {
     node.as_any()
         .downcast_ref::<DbtModel>()
-        .is_some_and(|model| matches!(model.materialized(), DbtMaterialization::Unknown(_)))
+        .is_some_and(|model| {
+            materialization_resolver
+                .is_custom_materialization(&model.materialized().to_string(), model.node_adapter())
+        })
 }
 
 fn parse_sql_relations_for_run_cache(
@@ -2840,17 +4410,17 @@ fn record_service_decision(
             emit_trace_log_message(|| {
                 format!("dbt State service decision: skip execution for node {unique_id}")
             });
-            // For data tests, parse the cached `failures` count out of the
-            // service's `execution_results` so the dispatcher in
-            // `runnable/mod.rs` can replace the generic `ReusedNoChanges`
-            // status with a test-shaped verdict and a NO-OP-marked stat.
+            // For data tests, parse the cached result out of the service's
+            // `execution_results` so the dispatcher in `runnable/mod.rs` can
+            // replace the generic `ReusedNoChanges` status with a test-shaped
+            // verdict and a NO-OP-marked stat.
             let is_test = unique_id.starts_with("test.");
-            let cached_test_failures = if is_test {
-                parse_cached_test_failures(response)
+            let cached_test_result = if is_test {
+                parse_cached_test_execution_result(response)
             } else {
                 None
             };
-            if is_test && cached_test_failures.is_none() {
+            if is_test && cached_test_result.is_none() {
                 emit_trace_log_message(|| {
                     format!(
                         "dbt State service data test skip ignored because no cached test result was returned for node {unique_id}; executing normally"
@@ -2866,7 +4436,7 @@ fn record_service_decision(
             RunCacheServiceDecision::Skip {
                 status,
                 sao_stored_hash: None,
-                cached_test_failures,
+                cached_test_result,
             }
         }
         Some(submit_sql_response::Response::ReadyToClone(response)) => {
@@ -2905,6 +4475,21 @@ fn record_service_decision(
                 )
             });
             RunCacheServiceDecision::execute_without_confirmation()
+        }
+    }
+}
+
+/// Extract the service-side explain decision id from a submit response.
+pub(crate) fn execution_decision_id_from_response(response: &SubmitSqlResponse) -> Option<String> {
+    match response.response.as_ref()? {
+        submit_sql_response::Response::ReadyToExecute(response) => {
+            response.execution_decision_id.clone()
+        }
+        submit_sql_response::Response::SkipExecution(response) => {
+            response.execution_decision_id.clone()
+        }
+        submit_sql_response::Response::ReadyToClone(response) => {
+            response.execution_decision_id.clone()
         }
     }
 }
@@ -2951,7 +4536,7 @@ fn relabel_skip_for_dev_cloned_node(
     let RunCacheServiceDecision::Skip {
         status,
         sao_stored_hash,
-        cached_test_failures,
+        cached_test_result,
     } = decision
     else {
         return decision;
@@ -2960,7 +4545,7 @@ fn relabel_skip_for_dev_cloned_node(
         return RunCacheServiceDecision::Skip {
             status,
             sao_stored_hash,
-            cached_test_failures,
+            cached_test_result,
         };
     }
     let relabelled = match status {
@@ -2973,7 +4558,7 @@ fn relabel_skip_for_dev_cloned_node(
     RunCacheServiceDecision::Skip {
         status: relabelled,
         sao_stored_hash,
-        cached_test_failures,
+        cached_test_result,
     }
 }
 
@@ -2994,6 +4579,8 @@ fn record_submit_skipped(node: &dyn InternalDbtNodeAttributes, reason: &'static 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use dbt_schemas::state::ProfileAdapter;
+    use indexmap::IndexMap;
     use std::any::Any;
     use std::future::Future;
     use std::path::{Path, PathBuf};
@@ -3021,8 +4608,9 @@ mod tests {
     use dbt_schema_store::mock_store::{MockDataStore, MockSchemaStore};
     use dbt_schemas::schemas::Nodes;
     use dbt_schemas::schemas::common::{FreshnessPeriod, ResolvedQuoting, UpdatesOn};
+    use dbt_schemas::schemas::macros::DbtMacro;
     use dbt_schemas::schemas::profiles::{Execute, SnowflakeDbConfig};
-    use dbt_schemas::schemas::properties::{ModelFreshness, ModelState};
+    use dbt_schemas::schemas::properties::{DataTestState, ModelFreshness, ModelState};
     use dbt_schemas::state::{
         DbtProfile, DbtRuntimeConfig, DummyNodeResolverTracker, Macros, Operations, RenderResults,
         ResolverState,
@@ -3030,7 +4618,8 @@ mod tests {
     use dbt_state::metadata_cache::RunCacheMetadataCache;
     use dbt_state::proto::query_cache::{
         ConfirmExecutionResponse, ReadyToCloneResponse, ReadyToExecuteResponse,
-        RecordExecutionsRequest, RecordExecutionsResponse,
+        ReadyToExecuteUntrackedResponse, RecordExecutionsRequest, RecordExecutionsResponse,
+        SubmitSqlSpeculativeResponse, UndecidedResponse, execution_record,
     };
     use dbt_state::service_client::{
         ClientVersionStatus, RunCacheServiceClient, RunCacheServiceError,
@@ -3042,6 +4631,51 @@ mod tests {
         model.__common_attr__.unique_id = "model.test.orders".to_string();
         model.__model_attr__.state = Some(state);
         model
+    }
+
+    #[test]
+    fn state_explain_node_info_identifies_incremental_model() {
+        let model = state_explain_model(DbtMaterialization::Incremental);
+
+        let info = state_explain_node_info_for_parts(AdapterType::Postgres, true, &model);
+
+        assert_eq!(info.node_resource_type, "model");
+        assert_eq!(info.fqn, "\"analytics\".\"marts\".\"orders\"");
+        assert!(!info.is_view);
+        assert!(info.is_table);
+        assert!(info.is_incremental_or_snapshot);
+        assert!(info.is_full_refresh);
+    }
+
+    #[test]
+    fn state_explain_node_info_reports_ephemeral_without_a_relation() {
+        let model = state_explain_model(DbtMaterialization::Ephemeral);
+
+        let info = state_explain_node_info_for_parts(AdapterType::Postgres, false, &model);
+
+        assert!(info.is_ephemeral);
+        assert!(!info.is_table);
+        assert!(!info.is_view);
+        // Ephemeral models are inlined into their consumers, so naming a
+        // warehouse relation for them would name a table that cannot exist.
+        assert!(info.fqn.is_empty());
+    }
+
+    #[test]
+    fn state_explain_node_info_identifies_seed_and_snapshot() {
+        let seed = state_explain_seed();
+        let snapshot = state_explain_snapshot();
+
+        let seed_info = state_explain_node_info_for_parts(AdapterType::Postgres, true, &seed);
+        let snapshot_info =
+            state_explain_node_info_for_parts(AdapterType::Postgres, false, &snapshot);
+
+        assert_eq!(seed_info.node_resource_type, "seed");
+        assert!(seed_info.is_table);
+        assert!(!seed_info.is_incremental_or_snapshot);
+        assert!(!seed_info.is_full_refresh);
+        assert_eq!(snapshot_info.node_resource_type, "snapshot");
+        assert!(snapshot_info.is_incremental_or_snapshot);
     }
 
     #[test]
@@ -3122,13 +4756,13 @@ mod tests {
             RunCacheServiceDecision::Skip {
                 status: NodeStatus::ReusedNoChanges(_),
                 sao_stored_hash: None,
-                cached_test_failures: None,
+                cached_test_result: None,
             }
         ));
     }
 
     #[test]
-    fn data_test_skip_without_cached_failures_executes() {
+    fn data_test_skip_without_cached_result_executes() {
         assert_eq!(
             record_service_decision(
                 "test.test.not_null_orders_order_date.abc123",
@@ -3144,24 +4778,57 @@ mod tests {
     }
 
     #[test]
-    fn data_test_skip_with_cached_failures_is_honored() {
-        assert!(matches!(
-            record_service_decision(
-                "test.test.not_null_orders_order_date.abc123",
-                &skip_execution_response_with_test_failures(0),
-                0,
-                true,
-            ),
+    fn data_test_skip_with_cached_result_is_honored() {
+        match record_service_decision(
+            "test.test.not_null_orders_order_date.abc123",
+            &skip_execution_response_with_test_result(CachedTestExecutionResult {
+                failures: 2,
+                should_warn: true,
+                should_error: false,
+            }),
+            0,
+            true,
+        ) {
             RunCacheServiceDecision::Skip {
                 status: NodeStatus::ReusedNoChanges(_),
                 sao_stored_hash: None,
-                cached_test_failures: Some(0),
+                cached_test_result: Some(result),
+            } => {
+                assert_eq!(result.failures, 2);
+                assert!(result.should_warn);
+                assert!(!result.should_error);
             }
-        ));
+            other => panic!("expected cached data-test skip, got {other:?}"),
+        }
     }
 
     #[test]
-    fn stale_data_test_skip_with_cached_failures_reports_no_changes() {
+    fn data_test_skip_with_incomplete_cached_result_executes() {
+        let response = SubmitSqlResponse {
+            response: Some(submit_sql_response::Response::SkipExecution(
+                SkipExecutionResponse {
+                    execution_results: Some(test_execution_results_with_failures_only(0)),
+                    ..Default::default()
+                },
+            )),
+        };
+
+        assert_eq!(
+            record_service_decision(
+                "test.test.not_null_orders_order_date.abc123",
+                &response,
+                0,
+                true,
+            ),
+            RunCacheServiceDecision::Execute {
+                after_success: RunCacheAfterSuccess::None,
+                sao_guard: None,
+            }
+        );
+    }
+
+    #[test]
+    fn stale_data_test_skip_with_cached_result_reports_no_changes() {
         let response = SubmitSqlResponse {
             response: Some(submit_sql_response::Response::SkipExecution(
                 SkipExecutionResponse {
@@ -3169,7 +4836,13 @@ mod tests {
                         is_stale: true,
                         ..Default::default()
                     }),
-                    execution_results: Some(build_test_execution_results_struct(0)),
+                    execution_results: Some(build_test_execution_results_struct(
+                        CachedTestExecutionResult {
+                            failures: 0,
+                            should_warn: false,
+                            should_error: false,
+                        },
+                    )),
                     ..Default::default()
                 },
             )),
@@ -3185,7 +4858,11 @@ mod tests {
             RunCacheServiceDecision::Skip {
                 status: NodeStatus::ReusedNoChanges(_),
                 sao_stored_hash: None,
-                cached_test_failures: Some(0),
+                cached_test_result: Some(CachedTestExecutionResult {
+                    failures: 0,
+                    should_warn: false,
+                    should_error: false,
+                }),
             }
         ));
     }
@@ -3207,7 +4884,7 @@ mod tests {
             RunCacheServiceDecision::Skip {
                 status: NodeStatus::ReusedStillFresh(message, tolerance, _),
                 sao_stored_hash: None,
-                cached_test_failures: None,
+                cached_test_result: None,
             } => {
                 assert!(
                     message.contains("New changes detected"),
@@ -3228,7 +4905,7 @@ mod tests {
                 42,
             ),
             sao_stored_hash: None,
-            cached_test_failures: None,
+            cached_test_result: None,
         };
 
         match relabel_skip_for_dev_cloned_node(true, original) {
@@ -3247,7 +4924,7 @@ mod tests {
         let original = RunCacheServiceDecision::Skip {
             status: NodeStatus::ReusedNoChanges("No new changes on any upstreams".to_string()),
             sao_stored_hash: None,
-            cached_test_failures: None,
+            cached_test_result: None,
         };
 
         match relabel_skip_for_dev_cloned_node(true, original) {
@@ -3264,7 +4941,7 @@ mod tests {
         let make = || RunCacheServiceDecision::Skip {
             status: NodeStatus::ReusedNoChanges("No new changes on any upstreams".to_string()),
             sao_stored_hash: None,
-            cached_test_failures: None,
+            cached_test_result: None,
         };
         let relabelled = relabel_skip_for_dev_cloned_node(false, make());
         assert_eq!(relabelled, make());
@@ -3331,6 +5008,7 @@ mod tests {
             &ctx,
             model.as_ref(),
             &task_result_with_sql("'alice'"),
+            None,
         )
         .await;
 
@@ -3373,6 +5051,7 @@ mod tests {
             &ctx,
             model.as_ref(),
             &task_result_with_sql("'alice'"),
+            None,
         )
         .await;
 
@@ -3384,6 +5063,130 @@ mod tests {
                 sao_guard: None,
             }
         ));
+    }
+
+    #[tokio::test]
+    async fn full_refresh_microbatch_without_window_invalidates_instead_of_recording() {
+        let client = Arc::new(RecordingRunCacheClient::default());
+        let ctx = test_task_runner_ctx_with_mode_and_full_refresh(
+            Some(client.clone() as dbt_state::service_client::SharedRunCacheServiceClient),
+            RunCacheMode::ReadWrite,
+            true,
+        );
+        let mut model = DbtModel::default();
+        model.__common_attr__.unique_id = "model.test.user_name_model".to_string();
+        model.__common_attr__.language = Some("sql".to_string());
+        model.__base_attr__.database = "db".to_string();
+        model.__base_attr__.schema = "dbt_test".to_string();
+        model.__base_attr__.alias = "user_name_model".to_string();
+        model.__base_attr__.materialized = DbtMaterialization::Incremental;
+        model.__model_attr__.incremental_strategy =
+            Some(dbt_schemas::schemas::common::DbtIncrementalStrategy::Microbatch);
+        let model = Arc::new(model);
+
+        let decision = run_cache_service_before_execution(
+            &ctx,
+            model.as_ref(),
+            &task_result_with_sql("select 'alice' as first_name"),
+            None,
+        )
+        .await;
+
+        // Full refresh alone would be recorded, but an unresolved window leaves
+        // nothing sound to write down: invalidate only, never record.
+        assert!(
+            matches!(
+                decision,
+                RunCacheServiceDecision::Execute {
+                    after_success: RunCacheAfterSuccess::InvalidateFreshness,
+                    sao_guard: None,
+                }
+            ),
+            "expected execute-and-invalidate decision, got {decision:?}"
+        );
+        assert_eq!(client.submitted_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn full_refresh_incremental_model_records_execution_without_a_decision() {
+        let client = Arc::new(RecordingRunCacheClient::default());
+        let ctx = test_task_runner_ctx_with_mode_and_full_refresh(
+            Some(client.clone() as dbt_state::service_client::SharedRunCacheServiceClient),
+            RunCacheMode::ReadWrite,
+            true,
+        );
+        let model = make_model(
+            "model.test.user_name_model",
+            "db",
+            "dbt_test",
+            "user_name_model",
+            DbtMaterialization::Incremental,
+        );
+
+        let decision = run_cache_service_before_execution(
+            &ctx,
+            model.as_ref(),
+            &task_result_with_sql("select 'alice' as first_name"),
+            None,
+        )
+        .await;
+
+        match decision {
+            RunCacheServiceDecision::Execute {
+                after_success: RunCacheAfterSuccess::Record(record),
+                sao_guard: None,
+            } => assert!(
+                !record.speculative,
+                "the record is built from a full snapshot, not a speculative one"
+            ),
+            other => panic!("expected execute-with-record decision, got {other:?}"),
+        }
+        assert_eq!(
+            client.submitted_count(),
+            0,
+            "the full-refresh CTAS must never seed a skip or clone decision"
+        );
+        assert_eq!(client.speculative_submitted_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn unresolved_microbatch_window_invalidates_freshness_after_execution() {
+        let client = Arc::new(RecordingRunCacheClient::default());
+        let ctx = test_task_runner_ctx(Some(
+            client.clone() as dbt_state::service_client::SharedRunCacheServiceClient
+        ));
+        let mut model = DbtModel::default();
+        model.__common_attr__.unique_id = "model.test.user_name_model".to_string();
+        model.__common_attr__.language = Some("sql".to_string());
+        model.__base_attr__.database = "db".to_string();
+        model.__base_attr__.schema = "dbt_test".to_string();
+        model.__base_attr__.alias = "user_name_model".to_string();
+        model.__base_attr__.materialized = DbtMaterialization::Incremental;
+        model.__model_attr__.incremental_strategy =
+            Some(dbt_schemas::schemas::common::DbtIncrementalStrategy::Microbatch);
+        let model = Arc::new(model);
+
+        let decision = run_cache_service_before_execution(
+            &ctx,
+            model.as_ref(),
+            &task_result_with_sql("select 'alice' as first_name"),
+            None,
+        )
+        .await;
+
+        // No sound record is possible without the event-time window, so the
+        // rebuild goes unobserved and the cached epoch must not survive it.
+        assert!(
+            matches!(
+                decision,
+                RunCacheServiceDecision::Execute {
+                    after_success: RunCacheAfterSuccess::InvalidateFreshness,
+                    sao_guard: None,
+                }
+            ),
+            "expected execute-and-invalidate decision, got {decision:?}"
+        );
+        assert_eq!(client.submitted_count(), 0);
     }
 
     #[tokio::test]
@@ -3497,6 +5300,135 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn custom_materialization_bare_relation_reference_falls_back_to_manifest_deps() {
+        let mut model = make_model(
+            "model.test.copy_target",
+            "db",
+            "analytics",
+            "copy_target",
+            DbtMaterialization::Unknown("custom_table".to_string()),
+        );
+        Arc::make_mut(&mut model)
+            .__base_attr__
+            .depends_on
+            .nodes
+            .push("model.test.copy_source".to_string());
+        let upstream = make_model(
+            "model.test.copy_source",
+            "db",
+            "analytics",
+            "copy_source",
+            DbtMaterialization::Table,
+        );
+        let ctx = test_task_runner_ctx_with_nodes(
+            None,
+            RunCacheMode::ReadWrite,
+            false,
+            Arc::new(EmptySourcesExtractor),
+            nodes_from(vec![model.clone(), upstream], vec![]),
+            ["model.test.copy_target".to_string()].into_iter().collect(),
+        );
+
+        let deps =
+            collect_query_dependencies(&ctx, model.as_ref(), "db.analytics.copy_source", false)
+                .await
+                .expect("bare relation reference for a custom materialization should be cacheable");
+
+        assert!(
+            !deps.metadata_complete || !deps.seen_tables.is_empty(),
+            "must not silently report zero dependencies when depends_on.nodes has a real upstream"
+        );
+        assert!(deps.dependencies.is_empty());
+    }
+
+    #[test]
+    fn cacheable_manifest_dependency_relations_resolves_only_cacheable_deps() {
+        let mut model = make_model(
+            "model.test.copy_target",
+            "db",
+            "analytics",
+            "copy_target",
+            DbtMaterialization::Unknown("custom_table".to_string()),
+        );
+        Arc::make_mut(&mut model)
+            .__base_attr__
+            .depends_on
+            .nodes
+            .push("model.test.copy_source".to_string());
+        Arc::make_mut(&mut model)
+            .__base_attr__
+            .depends_on
+            .nodes
+            .push("exposure.test.some_dashboard".to_string());
+        let upstream = make_model(
+            "model.test.copy_source",
+            "db",
+            "analytics",
+            "copy_source",
+            DbtMaterialization::Table,
+        );
+        let ctx = test_task_runner_ctx_with_nodes(
+            None,
+            RunCacheMode::ReadWrite,
+            false,
+            Arc::new(EmptySourcesExtractor),
+            nodes_from(vec![model.clone(), upstream], vec![]),
+            ["model.test.copy_target".to_string()].into_iter().collect(),
+        );
+
+        let relations = cacheable_manifest_dependency_relations(&ctx, model.as_ref());
+
+        assert_eq!(relations.len(), 1);
+        assert!(relations.contains_key(&fqn_of("db", "analytics", "copy_source")));
+    }
+
+    #[tokio::test]
+    async fn custom_materialization_parse_error_expression_empty_falls_back_to_manifest_deps() {
+        let mut model = make_model(
+            "model.test.copy_target",
+            "db",
+            "analytics",
+            "copy_target",
+            DbtMaterialization::Unknown("custom_table".to_string()),
+        );
+        Arc::make_mut(&mut model)
+            .__base_attr__
+            .depends_on
+            .nodes
+            .push("model.test.copy_source".to_string());
+        let upstream = make_model(
+            "model.test.copy_source",
+            "db",
+            "analytics",
+            "copy_source",
+            DbtMaterialization::Table,
+        );
+        let ctx = test_task_runner_ctx_with_nodes(
+            None,
+            RunCacheMode::ReadWrite,
+            false,
+            Arc::new(EmptySourcesExtractor),
+            nodes_from(vec![model.clone(), upstream], vec![]),
+            ["model.test.copy_target".to_string()].into_iter().collect(),
+        );
+
+        let deps = query_dependencies_for_parse_error(
+            &ctx,
+            model.as_ref(),
+            "db.analytics.copy_source",
+            synthetic_extraction_error(),
+        )
+        .await
+        .expect("bare relation reference for a custom materialization should be cacheable");
+
+        assert!(
+            !deps.metadata_complete || !deps.seen_tables.is_empty(),
+            "must not silently report zero dependencies when depends_on.nodes has a real upstream"
+        );
+        assert!(deps.dependencies.is_empty());
+    }
+
+    #[tokio::test]
     async fn custom_materialization_parse_failure_with_manifest_deps_is_incomplete() {
         let mut model = make_model(
             "model.test.user_name_model",
@@ -3580,6 +5512,7 @@ mod tests {
             &ctx,
             model.as_ref(),
             &task_result_with_sql("'alice'"),
+            None,
         )
         .await;
 
@@ -3612,6 +5545,7 @@ mod tests {
             &ctx,
             model.as_ref(),
             &task_result_with_sql("'alice'"),
+            None,
         )
         .await;
 
@@ -3649,7 +5583,7 @@ mod tests {
             .heuristic_clock
             .set(HeuristicClock {
                 start_ts_ms: 1_700_000_000_000,
-                start_instant: std::time::Instant::now(),
+                start_instant: Instant::now(),
             })
             .unwrap();
 
@@ -3661,6 +5595,46 @@ mod tests {
                 .run_cache_metadata
                 .last_modified_epoch(&target_fqn),
             Some(Some(7))
+        );
+    }
+
+    #[tokio::test]
+    async fn final_last_modified_epoch_caches_the_value_it_returns() {
+        let ctx = test_task_runner_ctx(None);
+        let model = make_model(
+            "model.test.user_name_model",
+            "db",
+            "dbt_test",
+            "user_name_model",
+            DbtMaterialization::Incremental,
+        );
+        let target_fqn = fqn_of("db", "dbt_test", "user_name_model");
+        ctx.inner
+            .run_cache_ctx
+            .run_cache_metadata
+            .insert_last_modified_epoch(&target_fqn, Some(7));
+        ctx.inner
+            .run_cache_ctx
+            .heuristic_clock
+            .set(HeuristicClock {
+                start_ts_ms: 1_700_000_000_000,
+                start_instant: Instant::now(),
+            })
+            .unwrap();
+
+        let epoch = final_last_modified_epoch_for_node(&ctx, model.as_ref())
+            .await
+            .expect("resolving the final epoch must not fail");
+
+        // Callers persist the returned epoch while downstream nodes read the
+        // cached one; a divergence makes the dependency read as changed.
+        assert!(epoch.is_some_and(|epoch| epoch >= 1_700_000_000_000));
+        assert_eq!(
+            ctx.inner
+                .run_cache_ctx
+                .run_cache_metadata
+                .last_modified_epoch(&target_fqn),
+            Some(epoch)
         );
     }
 
@@ -3684,7 +5658,7 @@ mod tests {
             .heuristic_clock
             .set(HeuristicClock {
                 start_ts_ms: 1_700_000_000_000,
-                start_instant: std::time::Instant::now(),
+                start_instant: Instant::now(),
             })
             .unwrap();
 
@@ -3697,6 +5671,101 @@ mod tests {
                 .run_cache_metadata
                 .last_modified_epoch(&target_fqn),
             epoch.map(Some)
+        );
+    }
+
+    #[test]
+    fn clear_stale_missing_epoch_removes_stale_missing_value() {
+        let ctx = test_task_runner_ctx(None);
+        let model = make_model(
+            "model.test.user_name_model",
+            "db",
+            "dbt_test",
+            "user_name_model",
+            DbtMaterialization::Table,
+        );
+        let target_fqn = fqn_of("db", "dbt_test", "user_name_model");
+        ctx.inner
+            .run_cache_ctx
+            .run_cache_metadata
+            .insert_last_modified_epoch(&target_fqn, None);
+
+        clear_stale_missing_last_modified_epoch_for_node(&ctx, model.as_ref());
+
+        assert_eq!(
+            ctx.inner
+                .run_cache_ctx
+                .run_cache_metadata
+                .last_modified_epoch(&target_fqn),
+            None
+        );
+    }
+
+    #[test]
+    fn clear_stale_missing_epoch_preserves_valid_cached_epoch() {
+        let ctx = test_task_runner_ctx(None);
+        let model = make_model(
+            "model.test.user_name_model",
+            "db",
+            "dbt_test",
+            "user_name_model",
+            DbtMaterialization::Table,
+        );
+        let target_fqn = fqn_of("db", "dbt_test", "user_name_model");
+        ctx.inner
+            .run_cache_ctx
+            .run_cache_metadata
+            .insert_last_modified_epoch(&target_fqn, Some(1_700_000_000_000));
+
+        clear_stale_missing_last_modified_epoch_for_node(&ctx, model.as_ref());
+
+        assert_eq!(
+            ctx.inner
+                .run_cache_ctx
+                .run_cache_metadata
+                .last_modified_epoch(&target_fqn),
+            Some(Some(1_700_000_000_000))
+        );
+    }
+
+    #[test]
+    fn evict_node_metadata_for_untracked_rebuild_clears_valid_epoch_and_existence() {
+        let ctx = test_task_runner_ctx(None);
+        let model = make_model(
+            "model.test.user_name_model",
+            "db",
+            "dbt_test",
+            "user_name_model",
+            DbtMaterialization::Table,
+        );
+        let target_fqn = fqn_of("db", "dbt_test", "user_name_model");
+        // A real (valid-looking) cached epoch and existence, which the benign
+        // skip path would preserve — but a failed request means the rebuild was
+        // unobserved, so both must be evicted here.
+        ctx.inner
+            .run_cache_ctx
+            .run_cache_metadata
+            .insert_last_modified_epoch(&target_fqn, Some(1_700_000_000_000));
+        ctx.inner
+            .run_cache_ctx
+            .run_cache_metadata
+            .insert_relation_exists(&target_fqn, true);
+
+        evict_node_metadata_for_untracked_rebuild(&ctx, model.as_ref());
+
+        assert_eq!(
+            ctx.inner
+                .run_cache_ctx
+                .run_cache_metadata
+                .last_modified_epoch(&target_fqn),
+            None
+        );
+        assert_eq!(
+            ctx.inner
+                .run_cache_ctx
+                .run_cache_metadata
+                .relation_exists(&target_fqn),
+            None
         );
     }
 
@@ -3719,6 +5788,7 @@ mod tests {
                 &ctx,
                 model.as_ref(),
                 &task_result_with_sql("select 'alice' as first_name"),
+                None,
             )
             .await,
             RunCacheServiceDecision::Execute {
@@ -3772,6 +5842,8 @@ mod tests {
             false,
             &BTreeSet::from([upstream_fqn.clone()]),
             &BTreeMap::new(),
+            &BTreeSet::new(),
+            false,
         )
         .await
         .unwrap();
@@ -3785,6 +5857,514 @@ mod tests {
             name: upstream_fqn,
             last_modified_epoch: None,
         }));
+    }
+
+    // ── speculative submit tests ─────────────────────────────────────────────
+
+    /// A model with a single upstream dependency whose last-modified epoch is
+    /// deliberately left unresolved (a genuine cache miss). The target's epoch
+    /// is pre-resolved so only the upstream exercises the miss path.
+    fn ctx_model_with_unresolved_upstream() -> (TaskRunnerCtx, Arc<DbtModel>, String) {
+        let mut model = make_model(
+            "model.test.fact_orders",
+            "db",
+            "analytics",
+            "fact_orders",
+            DbtMaterialization::Table,
+        );
+        Arc::make_mut(&mut model)
+            .__base_attr__
+            .depends_on
+            .nodes
+            .push("source.test.raw.orders".to_string());
+        let source = make_source("source.test.raw.orders", "db", "raw", "orders");
+        let ctx = test_task_runner_ctx_with_nodes(
+            None,
+            RunCacheMode::ReadWrite,
+            false,
+            Arc::new(EmptySourcesExtractor),
+            nodes_from(vec![model.clone()], vec![source]),
+            ["model.test.fact_orders".to_string()].into_iter().collect(),
+        );
+        let target_fqn = fqn_of("db", "analytics", "fact_orders");
+        let upstream_fqn = fqn_of("db", "raw", "orders");
+        ctx.inner
+            .run_cache_ctx
+            .run_cache_metadata
+            .insert_last_modified_epoch(&target_fqn, Some(123));
+        (ctx, model, upstream_fqn)
+    }
+
+    #[tokio::test]
+    async fn speculative_build_leaves_unresolved_upstream_unrefreshed() {
+        let (ctx, model, upstream_fqn) = ctx_model_with_unresolved_upstream();
+
+        let tables = collect_table_modified_infos(
+            &ctx,
+            model.as_ref(),
+            false,
+            &BTreeSet::from([upstream_fqn.clone()]),
+            &BTreeMap::new(),
+            &BTreeSet::new(),
+            true,
+        )
+        .await
+        .unwrap();
+
+        assert!(tables.metadata_complete);
+        assert!(tables.tables.contains(&TableModifiedInfo {
+            name: upstream_fqn.clone(),
+            last_modified_epoch: None,
+        }));
+        // A speculative build issues no blocking per-node freshness query, so an
+        // unresolved upstream stays a genuine cache miss (never inserted).
+        assert_eq!(
+            ctx.inner
+                .run_cache_ctx
+                .run_cache_metadata
+                .last_modified_epoch(&upstream_fqn),
+            None,
+        );
+    }
+
+    #[tokio::test]
+    async fn non_speculative_build_refreshes_unresolved_upstream() {
+        let (ctx, model, upstream_fqn) = ctx_model_with_unresolved_upstream();
+
+        let tables = collect_table_modified_infos(
+            &ctx,
+            model.as_ref(),
+            false,
+            &BTreeSet::from([upstream_fqn.clone()]),
+            &BTreeMap::new(),
+            &BTreeSet::new(),
+            false,
+        )
+        .await
+        .unwrap();
+
+        assert!(tables.metadata_complete);
+        assert!(tables.tables.contains(&TableModifiedInfo {
+            name: upstream_fqn.clone(),
+            last_modified_epoch: None,
+        }));
+        // A non-speculative build resolves the miss with a blocking freshness
+        // lookup; with no adapter wired in the test env it records an explicit
+        // unresolved entry, distinguishing it from the speculative peek above.
+        assert_eq!(
+            ctx.inner
+                .run_cache_ctx
+                .run_cache_metadata
+                .last_modified_epoch(&upstream_fqn),
+            Some(None),
+        );
+    }
+
+    fn speculative_test_model() -> Arc<DbtModel> {
+        make_model(
+            "model.test.user_name_model",
+            "db",
+            "dbt_test",
+            "user_name_model",
+            DbtMaterialization::Table,
+        )
+    }
+
+    #[tokio::test]
+    async fn speculative_skip_verdict_returns_skip_without_regular_submit() {
+        let client = Arc::new(RecordingRunCacheClient::with_speculative_response(
+            speculative_skip_response(),
+        ));
+        let ctx = test_task_runner_ctx(Some(
+            client.clone() as dbt_state::service_client::SharedRunCacheServiceClient
+        ));
+        let model = speculative_test_model();
+
+        let decision = run_cache_service_before_execution(
+            &ctx,
+            model.as_ref(),
+            &task_result_with_sql("select 'alice' as first_name"),
+            None,
+        )
+        .await;
+
+        assert!(matches!(
+            decision,
+            RunCacheServiceDecision::Skip {
+                status: NodeStatus::ReusedNoChanges(_),
+                ..
+            }
+        ));
+        assert_eq!(client.speculative_submitted_count(), 1);
+        assert_eq!(
+            client.submitted_count(),
+            0,
+            "a speculative skip verdict must not fall through to a regular submit"
+        );
+    }
+
+    #[tokio::test]
+    async fn speculative_clone_verdict_returns_clone_without_regular_submit() {
+        let client = Arc::new(RecordingRunCacheClient::with_speculative_response(
+            speculative_clone_response(),
+        ));
+        let ctx = test_task_runner_ctx(Some(
+            client.clone() as dbt_state::service_client::SharedRunCacheServiceClient
+        ));
+        let model = speculative_test_model();
+
+        let decision = run_cache_service_before_execution(
+            &ctx,
+            model.as_ref(),
+            &task_result_with_sql("select 'alice' as first_name"),
+            None,
+        )
+        .await;
+
+        let RunCacheServiceDecision::Clone { clone } = decision else {
+            panic!("expected clone decision from speculative verdict");
+        };
+        assert_eq!(clone.request_id, "clone-request");
+        assert_eq!(client.speculative_submitted_count(), 1);
+        assert_eq!(
+            client.submitted_count(),
+            0,
+            "a speculative clone verdict must not fall through to a regular submit"
+        );
+    }
+
+    #[tokio::test]
+    async fn speculative_untracked_verdict_executes_and_records_speculatively() {
+        let client = Arc::new(RecordingRunCacheClient::with_speculative_response(
+            speculative_untracked_response(),
+        ));
+        let ctx = test_task_runner_ctx(Some(
+            client.clone() as dbt_state::service_client::SharedRunCacheServiceClient
+        ));
+        let model = speculative_test_model();
+
+        let decision = run_cache_service_before_execution(
+            &ctx,
+            model.as_ref(),
+            &task_result_with_sql("select 'alice' as first_name"),
+            None,
+        )
+        .await;
+
+        match decision {
+            RunCacheServiceDecision::Execute {
+                after_success: RunCacheAfterSuccess::Record(record),
+                sao_guard: None,
+            } => {
+                assert!(
+                    record.speculative,
+                    "an untracked-execute verdict must record after the fact from the speculative request"
+                );
+            }
+            other => panic!("expected execute-with-record decision, got {other:?}"),
+        }
+        assert_eq!(client.speculative_submitted_count(), 1);
+        assert_eq!(
+            client.submitted_count(),
+            0,
+            "the untracked-execute path executes now and does not issue a regular submit"
+        );
+        // The untracked-execute path intentionally does not await the prefetch.
+        assert!(
+            !ctx.inner.run_cache_ctx.prefetch.is_done(),
+            "the untracked-execute path must not block on the prefetch"
+        );
+    }
+
+    #[tokio::test]
+    async fn speculative_undecided_verdict_falls_back_to_regular_submit() {
+        let client = Arc::new(RecordingRunCacheClient::with_speculative_response(
+            speculative_undecided_response(),
+        ));
+        let ctx = test_task_runner_ctx(Some(
+            client.clone() as dbt_state::service_client::SharedRunCacheServiceClient
+        ));
+        let model = speculative_test_model();
+
+        let decision = run_cache_service_before_execution(
+            &ctx,
+            model.as_ref(),
+            &task_result_with_sql("select 'alice' as first_name"),
+            None,
+        )
+        .await;
+
+        assert!(matches!(
+            decision,
+            RunCacheServiceDecision::Execute {
+                after_success: RunCacheAfterSuccess::Confirm(_),
+                sao_guard: None,
+            }
+        ));
+        assert_eq!(client.speculative_submitted_count(), 1);
+        assert_eq!(
+            client.submitted_count(),
+            1,
+            "an undecided verdict must fall back to a regular submit"
+        );
+        assert!(
+            ctx.inner.run_cache_ctx.prefetch.is_done(),
+            "the fallback path awaits the prefetch before resubmitting"
+        );
+    }
+
+    #[tokio::test]
+    async fn speculative_rpc_error_falls_back_to_regular_submit() {
+        // A default client answers the speculative RPC with `Disabled`.
+        let client = Arc::new(RecordingRunCacheClient::default());
+        let ctx = test_task_runner_ctx(Some(
+            client.clone() as dbt_state::service_client::SharedRunCacheServiceClient
+        ));
+        let model = speculative_test_model();
+
+        let decision = run_cache_service_before_execution(
+            &ctx,
+            model.as_ref(),
+            &task_result_with_sql("select 'alice' as first_name"),
+            None,
+        )
+        .await;
+
+        assert!(matches!(
+            decision,
+            RunCacheServiceDecision::Execute {
+                after_success: RunCacheAfterSuccess::Confirm(_),
+                sao_guard: None,
+            }
+        ));
+        assert_eq!(client.speculative_submitted_count(), 1);
+        assert_eq!(
+            client.submitted_count(),
+            1,
+            "a speculative RPC error must gracefully fall back to a regular submit"
+        );
+    }
+
+    #[tokio::test]
+    async fn prefetch_ready_skips_speculation_and_uses_regular_submit() {
+        // Canned speculative skip verdict that must never be consulted because
+        // the prefetch is already complete.
+        let client = Arc::new(RecordingRunCacheClient::with_speculative_response(
+            speculative_skip_response(),
+        ));
+        let ctx = test_task_runner_ctx(Some(
+            client.clone() as dbt_state::service_client::SharedRunCacheServiceClient
+        ));
+        ctx.inner.run_cache_ctx.prefetch.mark_started();
+        ctx.inner.run_cache_ctx.prefetch.mark_done();
+        let model = speculative_test_model();
+
+        let decision = run_cache_service_before_execution(
+            &ctx,
+            model.as_ref(),
+            &task_result_with_sql("select 'alice' as first_name"),
+            None,
+        )
+        .await;
+
+        assert!(matches!(
+            decision,
+            RunCacheServiceDecision::Execute {
+                after_success: RunCacheAfterSuccess::Confirm(_),
+                sao_guard: None,
+            }
+        ));
+        assert_eq!(
+            client.speculative_submitted_count(),
+            0,
+            "a ready prefetch must skip the speculative RPC entirely"
+        );
+        assert_eq!(client.submitted_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn prefetch_completing_during_request_build_skips_speculation() {
+        // Regression test for the last-responsible-moment re-check. The
+        // speculative-vs-regular decision is taken at entry, before
+        // `build_sql_request` runs. In production `build_sql_request` blocks on
+        // the view-definition traversal (inside `build_sql_context`), during
+        // which the background prefetch frequently completes. This test drives
+        // the same observable condition deterministically: the prefetch is in
+        // flight at entry but becomes ready before `build_sql_request` returns.
+        // The node must then re-check and submit non-speculatively, leaving the
+        // canned skip verdict below unconsulted.
+        let client = Arc::new(RecordingRunCacheClient::with_speculative_response(
+            speculative_skip_response(),
+        ));
+        let shared: dbt_state::service_client::SharedRunCacheServiceClient = client.clone();
+        let ctx = test_task_runner_ctx(Some(shared.clone()));
+        // Started but not yet done: the entry-point readiness check sees the
+        // prefetch in flight and enters the speculative branch.
+        ctx.inner.run_cache_ctx.prefetch.mark_started();
+        let model = speculative_test_model();
+
+        // The `build_request` closure is invoked at the end of
+        // `build_sql_request`, after `build_sql_context` returns (that is where
+        // the view traversal runs in production). Marking the prefetch done here
+        // models it completing by the time the request build finishes — exactly
+        // the state the re-check inspects. `build_and_submit_non_speculative`
+        // invokes the closure a second time; `mark_done` is idempotent.
+        let build = |context| {
+            ctx.inner.run_cache_ctx.prefetch.mark_done();
+            build_model_sql_request(
+                model.as_ref(),
+                context,
+                &ctx.inner.materialization_resolver,
+                |_| None,
+            )
+        };
+
+        let result = submit_sql_with_speculation(
+            &ctx,
+            model.as_ref(),
+            "select 'alice' as first_name".to_string(),
+            false,
+            false,
+            None,
+            &shared,
+            build,
+        )
+        .await
+        .unwrap();
+
+        assert!(result.is_some());
+        assert_eq!(
+            client.speculative_submitted_count(),
+            0,
+            "a prefetch that completes during the build must skip the speculative RPC"
+        );
+        assert_eq!(
+            client.submitted_count(),
+            1,
+            "the node must fall through to a single non-speculative submit"
+        );
+    }
+
+    #[tokio::test]
+    async fn write_only_mode_skips_speculation_and_produces_record() {
+        let client = Arc::new(RecordingRunCacheClient::with_speculative_response(
+            speculative_skip_response(),
+        ));
+        let ctx = test_task_runner_ctx_with_mode(
+            Some(client.clone() as dbt_state::service_client::SharedRunCacheServiceClient),
+            RunCacheMode::WriteOnly,
+        );
+        let model = speculative_test_model();
+
+        let decision = run_cache_service_before_execution(
+            &ctx,
+            model.as_ref(),
+            &task_result_with_sql("select 'alice' as first_name"),
+            None,
+        )
+        .await;
+
+        match decision {
+            RunCacheServiceDecision::Execute {
+                after_success: RunCacheAfterSuccess::Record(record),
+                sao_guard: None,
+            } => {
+                assert!(
+                    !record.speculative,
+                    "a write-only record is built from a full snapshot, not a speculative one"
+                );
+            }
+            other => panic!("expected execute-with-record decision, got {other:?}"),
+        }
+        assert_eq!(
+            client.speculative_submitted_count(),
+            0,
+            "write-only mode never asks the service for a decision"
+        );
+        assert_eq!(client.submitted_count(), 0);
+    }
+
+    #[test]
+    fn is_prefetch_ready_requires_started_and_done() {
+        let ctx = test_task_runner_ctx(None);
+        assert!(
+            !is_prefetch_ready(&ctx),
+            "not ready before the prefetch is started"
+        );
+        ctx.inner.run_cache_ctx.prefetch.mark_started();
+        assert!(
+            !is_prefetch_ready(&ctx),
+            "not ready while the prefetch is in flight"
+        );
+        ctx.inner.run_cache_ctx.prefetch.mark_done();
+        assert!(
+            is_prefetch_ready(&ctx),
+            "ready once the prefetch is both started and done"
+        );
+    }
+
+    #[tokio::test]
+    async fn finalize_speculative_request_fills_real_epochs_and_marks_flag() {
+        let ctx = test_task_runner_ctx(None);
+        let model = speculative_test_model();
+
+        // One dependency the warm cache has resolved to a real epoch, and one
+        // the post-prefetch refresh resolves as unknown (the test env has no
+        // adapter, so the miss refresh caches an explicit `Some(None)`).
+        let warm_fqn = fqn_of("db", "analytics", "warm_dep");
+        let cold_fqn = fqn_of("db", "raw", "cold_dep");
+        ctx.inner
+            .run_cache_ctx
+            .run_cache_metadata
+            .insert_last_modified_epoch(&warm_fqn, Some(999));
+
+        // The speculative request carries partial epochs: a stale placeholder for
+        // the warm dep and a best-effort value for the cold dep.
+        let request = SubmitEnrichedSqlRequest {
+            tables: vec![
+                TableModifiedInfo {
+                    name: warm_fqn.clone(),
+                    last_modified_epoch: Some(111),
+                },
+                TableModifiedInfo {
+                    name: cold_fqn.clone(),
+                    last_modified_epoch: Some(222),
+                },
+            ],
+            ..Default::default()
+        };
+
+        let finalized = finalize_speculative_sql_request(&ctx, model.as_ref(), request).await;
+
+        assert_eq!(
+            finalized.tables,
+            vec![
+                // Refreshed to the real epoch the warm cache now holds.
+                TableModifiedInfo {
+                    name: warm_fqn.clone(),
+                    last_modified_epoch: Some(999),
+                },
+                // The post-prefetch refresh resolved this as unknown, so the
+                // stale speculative value is cleared to unset rather than kept.
+                TableModifiedInfo {
+                    name: cold_fqn.clone(),
+                    last_modified_epoch: None,
+                },
+            ],
+        );
+
+        // The recorded execution built from a finalized speculative request must
+        // carry `from_speculative_submit = true`.
+        let outcome = ExecutionOutcomeInput {
+            last_modified_epoch: Some(123),
+            table_type: None,
+            execution_runtime_ms: None,
+        };
+        let record = sql_execution_record_from_submit_request(finalized, outcome, true);
+        let Some(execution_record::Input::EnrichedSql(sql)) = record.input else {
+            panic!("expected an enriched-SQL execution record");
+        };
+        assert!(sql.from_speculative_submit);
     }
 
     #[test]
@@ -3825,6 +6405,45 @@ mod tests {
     }
 
     #[test]
+    fn warns_on_slow_snowflake_prefetch_without_metadata_warehouse() {
+        let no_warehouse = MetadataQueryOptions::default();
+        let with_warehouse = MetadataQueryOptions {
+            warehouse: Some("META_WH".to_string()),
+            ..MetadataQueryOptions::default()
+        };
+        let slow = SLOW_METADATA_PREFETCH_WARN_THRESHOLD;
+        let fast = SLOW_METADATA_PREFETCH_WARN_THRESHOLD - std::time::Duration::from_secs(1);
+
+        // Slow, Snowflake, no dedicated warehouse → hint.
+        assert!(should_warn_slow_metadata_prefetch(
+            AdapterType::Snowflake,
+            &no_warehouse,
+            slow
+        ));
+
+        // A dedicated warehouse is already the fix → stay quiet.
+        assert!(!should_warn_slow_metadata_prefetch(
+            AdapterType::Snowflake,
+            &with_warehouse,
+            slow
+        ));
+
+        // Fast prefetch → nothing to hint.
+        assert!(!should_warn_slow_metadata_prefetch(
+            AdapterType::Snowflake,
+            &no_warehouse,
+            fast
+        ));
+
+        // The `metadata_warehouse` config is Snowflake-specific.
+        assert!(!should_warn_slow_metadata_prefetch(
+            AdapterType::Bigquery,
+            &no_warehouse,
+            slow
+        ));
+    }
+
+    #[test]
     fn execute_hooks_on_any_reuse_uses_state_config_for_skip_reuse() {
         let model = model_with_state(ModelState {
             lag_tolerance: None,
@@ -3832,6 +6451,7 @@ mod tests {
             evaluate_volatile_sql: None,
             pre_clone: None,
             execute_hooks_on_any_reuse: Some(true),
+            compare_unrendered_code: None,
         });
 
         assert!(should_execute_hooks_for_skip_reuse(&model, false));
@@ -3845,6 +6465,7 @@ mod tests {
             evaluate_volatile_sql: None,
             pre_clone: None,
             execute_hooks_on_any_reuse: None,
+            compare_unrendered_code: None,
         });
 
         assert!(should_execute_hooks_for_skip_reuse(&model, true));
@@ -3862,6 +6483,7 @@ mod tests {
             evaluate_volatile_sql: None,
             pre_clone: None,
             execute_hooks_on_any_reuse: None,
+            compare_unrendered_code: None,
         });
 
         assert_eq!(freshness_tolerance_seconds_for_node(&model, 2700), 7200);
@@ -3875,6 +6497,7 @@ mod tests {
             evaluate_volatile_sql: None,
             pre_clone: None,
             execute_hooks_on_any_reuse: None,
+            compare_unrendered_code: None,
         });
         model.__model_attr__.freshness = Some(ModelFreshness {
             build_after: Some(ModelFreshnessRules {
@@ -3882,6 +6505,7 @@ mod tests {
                 period: Some(FreshnessPeriod::day),
                 updates_on: None,
             }),
+            ..Default::default()
         });
 
         assert_eq!(freshness_tolerance_seconds_for_node(&model, 2700), 86400);
@@ -3899,6 +6523,7 @@ mod tests {
             evaluate_volatile_sql: None,
             pre_clone: None,
             execute_hooks_on_any_reuse: None,
+            compare_unrendered_code: None,
         });
         model.__model_attr__.freshness = Some(ModelFreshness {
             build_after: Some(ModelFreshnessRules {
@@ -3906,6 +6531,7 @@ mod tests {
                 period: Some(FreshnessPeriod::day),
                 updates_on: None,
             }),
+            ..Default::default()
         });
 
         assert_eq!(freshness_tolerance_seconds_for_node(&model, 2700), 7200);
@@ -3929,6 +6555,7 @@ mod tests {
             evaluate_volatile_sql: None,
             pre_clone: None,
             execute_hooks_on_any_reuse: None,
+            compare_unrendered_code: None,
         });
         model.__model_attr__.freshness = Some(ModelFreshness {
             build_after: Some(ModelFreshnessRules {
@@ -3936,6 +6563,7 @@ mod tests {
                 period: Some(FreshnessPeriod::hour),
                 updates_on: Some(UpdatesOn::All),
             }),
+            ..Default::default()
         });
 
         assert_eq!(
@@ -3952,6 +6580,7 @@ mod tests {
             evaluate_volatile_sql: Some(true),
             pre_clone: None,
             execute_hooks_on_any_reuse: None,
+            compare_unrendered_code: None,
         });
         model.__common_attr__.meta.insert(
             "run_cache_tolerate_nondeterminism".to_string(),
@@ -3959,6 +6588,126 @@ mod tests {
         );
 
         assert!(!resolve_tolerate_nondeterminism(&model, true));
+    }
+
+    fn snapshot_with_state(state: ModelState) -> DbtSnapshot {
+        let mut snapshot = DbtSnapshot::default();
+        snapshot.__common_attr__.unique_id = "snapshot.test.orders_snapshot".to_string();
+        snapshot.__snapshot_attr__.state = Some(state);
+        snapshot
+    }
+
+    #[test]
+    fn snapshot_state_config_is_honored_by_run_cache() {
+        // Snapshots carry the full `ModelState` (5 keys); every run-cache accessor must read it.
+        let snapshot = snapshot_with_state(ModelState {
+            lag_tolerance: Some(ModelFreshnessRules {
+                count: Some(2),
+                period: Some(FreshnessPeriod::hour),
+                updates_on: None,
+            }),
+            require_fresh_data_from: Some(UpdatesOn::All),
+            evaluate_volatile_sql: Some(true),
+            pre_clone: None,
+            execute_hooks_on_any_reuse: Some(true),
+            compare_unrendered_code: None,
+        });
+
+        assert!(should_execute_hooks_for_skip_reuse(&snapshot, false));
+        assert_eq!(freshness_tolerance_seconds_for_node(&snapshot, 2700), 7200);
+        assert!(!resolve_tolerate_nondeterminism(&snapshot, true));
+        assert_eq!(
+            stale_upstream_policy_for_node(&snapshot),
+            dbt_state::proto::query_cache::StaleUpstreamPolicy::All
+        );
+    }
+
+    fn data_test_with_state(state: DataTestState) -> DbtTest {
+        let mut test = DbtTest::default();
+        test.__common_attr__.unique_id = "test.test.not_null_orders_id".to_string();
+        test.__test_attr__.state = Some(state);
+        test
+    }
+
+    #[test]
+    fn data_test_state_config_is_honored_by_run_cache() {
+        // Data tests carry the restricted `DataTestState` (2 keys). The two supported configs are
+        // honored; the 5-key-only configs (e.g. execute_hooks_on_any_reuse) are not modeled and fall
+        // back to the service default.
+        let test = data_test_with_state(DataTestState {
+            require_fresh_data_from: Some(UpdatesOn::All),
+            evaluate_volatile_sql: Some(true),
+            compare_unrendered_code: None,
+        });
+
+        assert!(!resolve_tolerate_nondeterminism(&test, true));
+        assert_eq!(
+            stale_upstream_policy_for_node(&test),
+            dbt_state::proto::query_cache::StaleUpstreamPolicy::All
+        );
+        assert!(should_execute_hooks_for_skip_reuse(&test, true));
+        assert!(!should_execute_hooks_for_skip_reuse(&test, false));
+    }
+
+    #[test]
+    fn compare_unrendered_code_falls_back_to_service_default() {
+        let model = model_with_state(ModelState {
+            lag_tolerance: None,
+            require_fresh_data_from: None,
+            evaluate_volatile_sql: None,
+            pre_clone: None,
+            execute_hooks_on_any_reuse: None,
+            compare_unrendered_code: None,
+        });
+
+        assert!(resolve_compare_unrendered_code(&model, true));
+        assert!(!resolve_compare_unrendered_code(&model, false));
+        // A node with no `state:` block at all resolves the same way.
+        assert!(resolve_compare_unrendered_code(&DbtModel::default(), true));
+    }
+
+    #[test]
+    fn compare_unrendered_code_node_config_wins_over_service_default() {
+        // Both directions: the node config overrides the default whichever way it points.
+        let enabled = model_with_state(ModelState {
+            lag_tolerance: None,
+            require_fresh_data_from: None,
+            evaluate_volatile_sql: None,
+            pre_clone: None,
+            execute_hooks_on_any_reuse: None,
+            compare_unrendered_code: Some(true),
+        });
+        let disabled = model_with_state(ModelState {
+            lag_tolerance: None,
+            require_fresh_data_from: None,
+            evaluate_volatile_sql: None,
+            pre_clone: None,
+            execute_hooks_on_any_reuse: None,
+            compare_unrendered_code: Some(false),
+        });
+
+        assert!(resolve_compare_unrendered_code(&enabled, false));
+        assert!(!resolve_compare_unrendered_code(&disabled, true));
+    }
+
+    #[test]
+    fn compare_unrendered_code_resolves_for_snapshots_and_data_tests() {
+        let snapshot = snapshot_with_state(ModelState {
+            lag_tolerance: None,
+            require_fresh_data_from: None,
+            evaluate_volatile_sql: None,
+            pre_clone: None,
+            execute_hooks_on_any_reuse: None,
+            compare_unrendered_code: Some(true),
+        });
+        let test = data_test_with_state(DataTestState {
+            require_fresh_data_from: None,
+            evaluate_volatile_sql: None,
+            compare_unrendered_code: Some(true),
+        });
+
+        assert!(resolve_compare_unrendered_code(&snapshot, false));
+        assert!(resolve_compare_unrendered_code(&test, false));
     }
 
     #[test]
@@ -4131,15 +6880,28 @@ mod tests {
         }
     }
 
-    fn skip_execution_response_with_test_failures(failures: i64) -> SubmitSqlResponse {
+    fn skip_execution_response_with_test_result(
+        result: CachedTestExecutionResult,
+    ) -> SubmitSqlResponse {
         SubmitSqlResponse {
             response: Some(submit_sql_response::Response::SkipExecution(
                 SkipExecutionResponse {
-                    execution_results: Some(build_test_execution_results_struct(failures)),
+                    execution_results: Some(build_test_execution_results_struct(result)),
                     ..Default::default()
                 },
             )),
         }
+    }
+
+    fn test_execution_results_with_failures_only(failures: i64) -> Struct {
+        let mut fields = HashMap::new();
+        fields.insert(
+            "failures".to_string(),
+            Value {
+                kind: Some(Kind::IntValue(failures)),
+            },
+        );
+        Struct { fields }
     }
 
     fn ready_to_clone_response() -> SubmitSqlResponse {
@@ -4163,16 +6925,66 @@ mod tests {
         SubmitSqlResponse { response: None }
     }
 
+    fn speculative_skip_response() -> SubmitSqlSpeculativeResponse {
+        SubmitSqlSpeculativeResponse {
+            response: Some(submit_sql_speculative_response::Response::SkipExecution(
+                SkipExecutionResponse::default(),
+            )),
+        }
+    }
+
+    fn speculative_clone_response() -> SubmitSqlSpeculativeResponse {
+        SubmitSqlSpeculativeResponse {
+            response: Some(submit_sql_speculative_response::Response::ReadyToClone(
+                ReadyToCloneResponse {
+                    request_id: "clone-request".to_string(),
+                    clone_sqls: vec!["create table target clone source".to_string()],
+                    clone_source: "source".to_string(),
+                    clone_target: "target".to_string(),
+                    clone_required_last_modified_epoch: Some(123),
+                    clone_execution_results: Some(Struct::default()),
+                    execution_runtime_ms: Some(456),
+                    ..Default::default()
+                },
+            )),
+        }
+    }
+
+    fn speculative_untracked_response() -> SubmitSqlSpeculativeResponse {
+        SubmitSqlSpeculativeResponse {
+            response: Some(
+                submit_sql_speculative_response::Response::ReadyToExecuteUntracked(
+                    ReadyToExecuteUntrackedResponse {},
+                ),
+            ),
+        }
+    }
+
+    fn speculative_undecided_response() -> SubmitSqlSpeculativeResponse {
+        SubmitSqlSpeculativeResponse {
+            response: Some(submit_sql_speculative_response::Response::Undecided(
+                UndecidedResponse {},
+            )),
+        }
+    }
+
     struct RecordingRunCacheClient {
         submitted: Mutex<Vec<SubmitEnrichedSqlRequest>>,
+        speculative_submitted: Mutex<Vec<SubmitEnrichedSqlRequest>>,
         response: SubmitSqlResponse,
+        /// Canned speculative verdict. `None` makes the speculative RPC report
+        /// `Disabled` (the trait default), mirroring a server that does not
+        /// answer speculatively so the caller falls back to a regular submit.
+        speculative_response: Option<SubmitSqlSpeculativeResponse>,
     }
 
     impl Default for RecordingRunCacheClient {
         fn default() -> Self {
             Self {
                 submitted: Mutex::new(Vec::new()),
+                speculative_submitted: Mutex::new(Vec::new()),
                 response: ready_to_execute_response(),
+                speculative_response: None,
             }
         }
     }
@@ -4181,6 +6993,13 @@ mod tests {
         fn with_response(response: SubmitSqlResponse) -> Self {
             Self {
                 response,
+                ..Self::default()
+            }
+        }
+
+        fn with_speculative_response(speculative_response: SubmitSqlSpeculativeResponse) -> Self {
+            Self {
+                speculative_response: Some(speculative_response),
                 ..Self::default()
             }
         }
@@ -4202,6 +7021,14 @@ mod tests {
                 .map(|request| request.execution_type)
                 .collect()
         }
+
+        fn submitted_count(&self) -> usize {
+            self.submitted.lock().unwrap().len()
+        }
+
+        fn speculative_submitted_count(&self) -> usize {
+            self.speculative_submitted.lock().unwrap().len()
+        }
     }
 
     #[async_trait::async_trait]
@@ -4218,6 +7045,17 @@ mod tests {
         ) -> Result<SubmitSqlResponse, RunCacheServiceError> {
             self.submitted.lock().unwrap().push(request);
             Ok(self.response.clone())
+        }
+
+        async fn submit_enriched_sql_speculative(
+            &self,
+            request: SubmitEnrichedSqlRequest,
+        ) -> Result<SubmitSqlSpeculativeResponse, RunCacheServiceError> {
+            self.speculative_submitted.lock().unwrap().push(request);
+            match &self.speculative_response {
+                Some(response) => Ok(response.clone()),
+                None => Err(RunCacheServiceError::Disabled),
+            }
         }
 
         async fn submit_values(
@@ -4240,6 +7078,215 @@ mod tests {
         ) -> Result<RecordExecutionsResponse, RunCacheServiceError> {
             Err(RunCacheServiceError::Disabled)
         }
+    }
+
+    /// `RunCacheServiceError` isn't `Clone` (and can't be made so from this
+    /// crate — the type is foreign), so `TelemetryTestClient` stores which
+    /// error to manufacture rather than a reusable instance.
+    #[derive(Clone, Copy)]
+    enum TestFailure {
+        Retriable,
+        NonRetriable,
+    }
+
+    impl TestFailure {
+        fn build(self) -> RunCacheServiceError {
+            match self {
+                Self::Retriable => RunCacheServiceError::Rpc(tonic::Status::unavailable("down")),
+                Self::NonRetriable => {
+                    RunCacheServiceError::Rpc(tonic::Status::invalid_argument("bad request"))
+                }
+            }
+        }
+    }
+
+    /// Test double for `TelemetryDispatcher` tests: records every batch it's
+    /// asked to submit, and fails the first `fail_count` calls with a
+    /// configurable error before succeeding.
+    #[derive(Default)]
+    struct TelemetryTestClient {
+        batches: Mutex<Vec<Vec<ClientTelemetryEvent>>>,
+        fail_count: std::sync::atomic::AtomicUsize,
+        failure: Option<TestFailure>,
+    }
+
+    impl TelemetryTestClient {
+        fn failing(fail_count: usize, failure: TestFailure) -> Self {
+            Self {
+                batches: Mutex::new(Vec::new()),
+                fail_count: std::sync::atomic::AtomicUsize::new(fail_count),
+                failure: Some(failure),
+            }
+        }
+
+        fn batches(&self) -> Vec<Vec<ClientTelemetryEvent>> {
+            self.batches.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl RunCacheServiceClient for TelemetryTestClient {
+        async fn validate_client_version(
+            &self,
+        ) -> Result<ClientVersionStatus, RunCacheServiceError> {
+            Ok(ClientVersionStatus::Supported)
+        }
+
+        async fn submit_enriched_sql(
+            &self,
+            _request: SubmitEnrichedSqlRequest,
+        ) -> Result<SubmitSqlResponse, RunCacheServiceError> {
+            Err(RunCacheServiceError::Disabled)
+        }
+
+        async fn submit_values(
+            &self,
+            _request: SubmitValuesRequest,
+        ) -> Result<SubmitSqlResponse, RunCacheServiceError> {
+            Err(RunCacheServiceError::Disabled)
+        }
+
+        async fn confirm_execution(
+            &self,
+            _request: ConfirmExecutionRequest,
+        ) -> Result<ConfirmExecutionResponse, RunCacheServiceError> {
+            Err(RunCacheServiceError::Disabled)
+        }
+
+        async fn submit_telemetry_batch(
+            &self,
+            request: dbt_state::proto::query_cache::SubmitTelemetryBatchRequest,
+        ) -> Result<dbt_state::proto::query_cache::SubmitTelemetryBatchResponse, RunCacheServiceError>
+        {
+            if self
+                .fail_count
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |count| {
+                    (count > 0).then(|| count - 1)
+                })
+                .is_ok()
+            {
+                let failure = self.failure.unwrap_or(TestFailure::Retriable);
+                return Err(failure.build());
+            }
+            self.batches.lock().unwrap().push(request.events);
+            Ok(dbt_state::proto::query_cache::SubmitTelemetryBatchResponse { success: true })
+        }
+    }
+
+    fn test_telemetry_event(event_order: i64) -> ClientTelemetryEvent {
+        session_start_event(Struct::default(), event_order)
+    }
+
+    #[test]
+    fn enriched_sql_telemetry_counts_dependencies_without_existing_target() {
+        let request = SubmitEnrichedSqlRequest {
+            target_table: Some("db.schema.target".to_string()),
+            tables: vec![TableModifiedInfo {
+                name: "db.schema.dependency".to_string(),
+                last_modified_epoch: Some(1),
+            }],
+            ..Default::default()
+        };
+
+        assert_eq!(
+            enriched_sql_prepared_telemetry_input(&request).num_dependencies,
+            Some(1)
+        );
+    }
+
+    #[tokio::test]
+    async fn flush_buffer_delivers_and_clears_buffer_on_success() {
+        let client: dbt_state::service_client::SharedRunCacheServiceClient =
+            Arc::new(TelemetryTestClient::default());
+        let mut buffer: Vec<QueuedTelemetryEvent> =
+            (0..3).map(|i| (test_telemetry_event(i), 0)).collect();
+
+        TelemetryDispatcher::flush_buffer(&client, &mut buffer).await;
+
+        assert!(buffer.is_empty(), "successful flush must drain the buffer");
+    }
+
+    #[tokio::test]
+    async fn flush_buffer_caps_each_rpc_at_max_batch_size() {
+        let client_arc = Arc::new(TelemetryTestClient::default());
+        let client: dbt_state::service_client::SharedRunCacheServiceClient = client_arc.clone();
+        let total = TELEMETRY_MAX_BATCH_SIZE * 2 + 20;
+        let mut buffer: Vec<QueuedTelemetryEvent> = (0..total as i64)
+            .map(|i| (test_telemetry_event(i), 0))
+            .collect();
+
+        TelemetryDispatcher::flush_buffer(&client, &mut buffer).await;
+
+        assert!(buffer.is_empty());
+        let batches = client_arc.batches();
+        assert!(
+            batches
+                .iter()
+                .all(|batch| batch.len() <= TELEMETRY_MAX_BATCH_SIZE),
+            "no single SubmitTelemetryBatch RPC may exceed the batch cap: {batches:?}",
+        );
+        assert_eq!(batches.iter().map(Vec::len).sum::<usize>(), total);
+    }
+
+    #[tokio::test]
+    async fn flush_buffer_requeues_retriable_failures_with_incremented_retry_count() {
+        let client: dbt_state::service_client::SharedRunCacheServiceClient = Arc::new(
+            TelemetryTestClient::failing(usize::MAX, TestFailure::Retriable),
+        );
+        let mut buffer: Vec<QueuedTelemetryEvent> = vec![(test_telemetry_event(0), 0)];
+
+        TelemetryDispatcher::flush_buffer(&client, &mut buffer).await;
+        assert_eq!(buffer.len(), 1);
+        assert_eq!(buffer[0].1, 1, "retriable failure increments retry_count");
+
+        TelemetryDispatcher::flush_buffer(&client, &mut buffer).await;
+        assert_eq!(buffer[0].1, 2);
+
+        TelemetryDispatcher::flush_buffer(&client, &mut buffer).await;
+        assert_eq!(buffer[0].1, 3);
+
+        // One more attempt exceeds `TELEMETRY_MAX_RETRY_COUNT`: dropped, not requeued.
+        TelemetryDispatcher::flush_buffer(&client, &mut buffer).await;
+        assert!(
+            buffer.is_empty(),
+            "event exceeding max retries must be dropped"
+        );
+    }
+
+    #[tokio::test]
+    async fn flush_buffer_drops_batch_on_non_retriable_error() {
+        let client: dbt_state::service_client::SharedRunCacheServiceClient = Arc::new(
+            TelemetryTestClient::failing(usize::MAX, TestFailure::NonRetriable),
+        );
+        let mut buffer: Vec<QueuedTelemetryEvent> = vec![(test_telemetry_event(0), 0)];
+
+        TelemetryDispatcher::flush_buffer(&client, &mut buffer).await;
+
+        assert!(
+            buffer.is_empty(),
+            "a non-retriable error must drop the batch outright, not requeue it"
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatcher_flush_terminates_instead_of_hanging() {
+        // Regression test: `flush()` closes the dispatcher's `Sender` and
+        // awaits the worker task, which only exits once
+        // `mpsc::Receiver::recv` returns `None` — which requires every
+        // `Sender` clone, including any the worker task itself might hold,
+        // to be dropped. If the worker ever holds on to a `Sender` clone
+        // (e.g. to requeue retries through the channel instead of the local
+        // buffer), this hangs forever.
+        let client = Arc::new(TelemetryTestClient::default());
+        let dispatcher = TelemetryDispatcher::spawn(client.clone());
+        dispatcher.send(test_telemetry_event(0)).await;
+        dispatcher.send(test_telemetry_event(1)).await;
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), dispatcher.flush())
+            .await
+            .expect("flush() must terminate, not hang");
+
+        assert_eq!(client.batches().iter().flatten().count(), 2);
     }
 
     #[derive(Debug)]
@@ -4518,8 +7565,14 @@ mod tests {
                 run_cache_service_requested: true,
                 run_cache_service_config: Some(RunCacheServiceConfig::disabled()),
                 run_cache_service_client,
+                state_explain_log_path: None,
                 view_traverser: None,
                 heuristic_clock: std::sync::OnceLock::new(),
+                prefetch: Default::default(),
+                telemetry_event_order: std::sync::atomic::AtomicI64::new(0),
+                telemetry_session_start: std::sync::OnceLock::new(),
+                telemetry_session_ended: std::sync::atomic::AtomicBool::new(false),
+                telemetry_dispatcher: std::sync::OnceLock::new(),
             },
         );
 
@@ -4535,23 +7588,45 @@ mod tests {
     }
 
     fn test_resolver_state_with_nodes(nodes: Nodes) -> ResolverState {
+        // Register a root-project `custom_table` materialization so the
+        // materialization resolver classifies models materialized as
+        // `custom_table` as custom (root/imported macro shadowing), matching
+        // what the custom-materialization tests below exercise.
+        let mut macros = Macros::default();
+        let custom_table_mat = DbtMacro {
+            name: "materialization_custom_table_default".to_string(),
+            package_name: "test".to_string(),
+            unique_id: "macro.test.materialization_custom_table_default".to_string(),
+            ..Default::default()
+        };
+        macros
+            .macros
+            .insert(custom_table_mat.unique_id.clone(), custom_table_mat);
+
         ResolverState {
             root_project_name: "test".to_string(),
             adapter_type: AdapterType::Snowflake,
             nodes,
             disabled_nodes: Nodes::default(),
-            macros: Macros::default(),
+            macros,
             operations: Operations::default(),
-            dbt_profile: DbtProfile {
-                profile: "default".to_string(),
-                target: "dev".to_string(),
-                defer_to_target: None,
-                db_config: DbConfig::Snowflake(Box::<SnowflakeDbConfig>::default()),
-                alt_target_db_config: None,
-                schema: "dbt_test".to_string(),
-                database: "db".to_string(),
-                relative_profile_path: PathBuf::new(),
-                threads: None,
+            dbt_profile: {
+                let db_config = DbConfig::Snowflake(Box::<SnowflakeDbConfig>::default());
+                let default_adapter = db_config.adapter_type();
+                let adapters =
+                    IndexMap::from([(default_adapter, ProfileAdapter::single(db_config))]);
+                DbtProfile {
+                    profile: "default".to_string(),
+                    target: "dev".to_string(),
+                    defer_to_target: None,
+                    allow_clones: true,
+                    adapters,
+                    default_adapter,
+                    schema: "dbt_test".to_string(),
+                    database: "db".to_string(),
+                    relative_profile_path: PathBuf::new(),
+                    threads: None,
+                }
             },
             cloud_config: None,
             render_results: RenderResults::default(),
@@ -4559,7 +7634,7 @@ mod tests {
             get_relation_calls: Default::default(),
             get_columns_in_relation_calls: Default::default(),
             patterned_dangling_sources: Default::default(),
-            run_started_at: chrono::Utc::now().with_timezone(&chrono_tz::UTC),
+            run_started_at: Utc::now().with_timezone(&chrono_tz::UTC),
             runtime_config: Arc::new(DbtRuntimeConfig::default()),
             manifest_path_configs: BTreeMap::new(),
             manifest_selectors: BTreeMap::new(),
@@ -4687,6 +7762,33 @@ mod tests {
     }
 
     #[test]
+    fn final_refresh_uses_bigquery_schema_prefetch_plan() {
+        let relation: Arc<dyn BaseRelation> = create_relation(
+            AdapterType::Bigquery,
+            "db".to_string(),
+            "analytics".to_string(),
+            Some("orders".to_string()),
+            None,
+            ResolvedQuoting::default(),
+        )
+        .unwrap()
+        .into();
+        let name = relation.semantic_fqn();
+        let relations = BTreeMap::from([(name.clone(), relation)]);
+        let overrides = BTreeMap::new();
+
+        let bigquery_plan =
+            plan_last_modified_miss_refresh(AdapterType::Bigquery, &relations, &overrides);
+        assert!(bigquery_plan.targeted_relations.is_empty());
+        assert!(bigquery_plan.schema_prefetch_relations.contains_key(&name));
+
+        let snowflake_plan =
+            plan_last_modified_miss_refresh(AdapterType::Snowflake, &relations, &overrides);
+        assert!(snowflake_plan.schema_prefetch_relations.is_empty());
+        assert!(snowflake_plan.targeted_relations.contains_key(&name));
+    }
+
+    #[test]
     fn prefetch_includes_selected_node_and_source_dep() {
         let model = make_model(
             "model.pkg.orders",
@@ -4722,6 +7824,75 @@ mod tests {
             "source dep should be included"
         );
         assert!(overrides.is_empty());
+    }
+
+    fn make_exposure(unique_id: &str) -> Arc<dbt_schemas::schemas::nodes::DbtExposure> {
+        let mut exposure = dbt_schemas::schemas::nodes::DbtExposure::default();
+        exposure.__common_attr__.unique_id = unique_id.to_string();
+        Arc::new(exposure)
+    }
+
+    #[test]
+    fn prefetch_keeps_real_relations_alongside_an_exposure() {
+        let model = make_model(
+            "model.pkg.orders",
+            "db",
+            "analytics",
+            "orders",
+            DbtMaterialization::Table,
+        );
+        let exposure = make_exposure("exposure.pkg.dashboard");
+        let mut nodes = nodes_from(vec![model], vec![]);
+        nodes
+            .exposures
+            .insert(exposure.__common_attr__.unique_id.clone(), exposure);
+
+        let runnable_set: BTreeSet<String> = [
+            "model.pkg.orders".to_string(),
+            "exposure.pkg.dashboard".to_string(),
+        ]
+        .into_iter()
+        .collect();
+
+        let (relations, _) = collect_global_prefetch_relations(
+            AdapterType::Snowflake,
+            &runnable_set,
+            &BTreeMap::new(),
+            &nodes,
+        );
+
+        assert_eq!(
+            relations.keys().collect::<Vec<_>>(),
+            vec![&fqn_of("db", "analytics", "orders")],
+            "the exposure must be dropped without disturbing real relations"
+        );
+    }
+
+    #[test]
+    fn non_empty_schema_check_ignores_database() {
+        // BigQuery renders relations without a database; only a missing schema
+        // makes the metadata query unbuildable.
+        let no_database = create_relation(
+            AdapterType::Bigquery,
+            String::new(),
+            "analytics".to_string(),
+            Some("orders".to_string()),
+            None,
+            ResolvedQuoting::default(),
+        )
+        .unwrap();
+        assert!(has_non_empty_schema(no_database.as_ref()));
+
+        let no_schema = create_relation(
+            AdapterType::Snowflake,
+            "db".to_string(),
+            String::new(),
+            Some("orders".to_string()),
+            None,
+            ResolvedQuoting::default(),
+        )
+        .unwrap();
+        assert!(!has_non_empty_schema(no_schema.as_ref()));
     }
 
     #[test]
@@ -4792,6 +7963,90 @@ mod tests {
         );
     }
 
+    // Regression #15499: a `loaded_at_query` Jinja macro / `{{ this }}` must be
+    // rendered before it reaches the warehouse, else the raw `{{ ... }}` errors.
+    #[test]
+    fn render_freshness_override_renders_loaded_at_query_macro() {
+        let relation: Arc<dyn BaseRelation> = create_relation(
+            AdapterType::Snowflake,
+            "db".to_string(),
+            "raw".to_string(),
+            Some("customers".to_string()),
+            None,
+            ResolvedQuoting::default(),
+        )
+        .unwrap()
+        .into();
+
+        let mut mj = minijinja::Environment::new();
+        mj.add_function(
+            "get_from_watermark_table",
+            || "select max(updated_at) from db.dbt_jyeo.watermark",
+        );
+        let jinja_env = JinjaEnv::new(mj);
+        let base_context = BTreeMap::new();
+
+        // Macro call is expanded, not sent raw.
+        let rendered = render_freshness_override(
+            FreshnessOverride::Query("{{ get_from_watermark_table() }}".to_string()),
+            &relation,
+            &jinja_env,
+            &base_context,
+        )
+        .unwrap();
+        assert!(
+            matches!(rendered, FreshnessOverride::Query(q) if q == "select max(updated_at) from db.dbt_jyeo.watermark"),
+            "loaded_at_query macro should be rendered"
+        );
+
+        // `{{ this }}` resolves to the source relation.
+        let rendered = render_freshness_override(
+            FreshnessOverride::Query("select max(ts) from {{ this }}".to_string()),
+            &relation,
+            &jinja_env,
+            &base_context,
+        )
+        .unwrap();
+        let expected = format!("select max(ts) from {}", relation.render_self_as_str());
+        assert!(
+            matches!(rendered, FreshnessOverride::Query(q) if q == expected),
+            "{{{{ this }}}} should resolve to the relation"
+        );
+
+        // Field overrides are passed through untouched.
+        let rendered = render_freshness_override(
+            FreshnessOverride::Field("updated_at".to_string()),
+            &relation,
+            &jinja_env,
+            &base_context,
+        )
+        .unwrap();
+        assert!(matches!(rendered, FreshnessOverride::Field(f) if f == "updated_at"));
+
+        // A relation missing a required component (here, identifier) errors
+        // rather than rendering an unqualified name into the warehouse SQL.
+        let no_identifier: Arc<dyn BaseRelation> = create_relation(
+            AdapterType::Snowflake,
+            "db".to_string(),
+            "raw".to_string(),
+            None,
+            None,
+            ResolvedQuoting::default(),
+        )
+        .unwrap()
+        .into();
+        assert!(
+            render_freshness_override(
+                FreshnessOverride::Query("select 1".to_string()),
+                &no_identifier,
+                &jinja_env,
+                &base_context,
+            )
+            .is_err(),
+            "missing identifier should error, not render an unqualified name"
+        );
+    }
+
     #[test]
     fn prefetch_deduplicates_shared_deps() {
         let model_a = make_model(
@@ -4848,7 +8103,7 @@ mod tests {
         let start_ts_ms: i64 = 1_700_000_000_000;
         let clock = HeuristicClock {
             start_ts_ms,
-            start_instant: std::time::Instant::now(),
+            start_instant: Instant::now(),
         };
         assert_eq!(clock.now_ms(), start_ts_ms);
     }
@@ -4858,12 +8113,12 @@ mod tests {
         let start_ts_ms: i64 = 1_700_000_000_000;
         let clock = HeuristicClock {
             start_ts_ms,
-            start_instant: std::time::Instant::now(),
+            start_instant: Instant::now(),
         };
         let first = clock.now_ms();
         // Spin briefly so at least one millisecond passes.
-        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(5);
-        while std::time::Instant::now() < deadline {}
+        let deadline = Instant::now() + std::time::Duration::from_millis(5);
+        while Instant::now() < deadline {}
         let second = clock.now_ms();
         assert!(
             second >= first,
@@ -4879,11 +8134,11 @@ mod tests {
         let base: i64 = 1_700_000_000_000;
         let clock_a = HeuristicClock {
             start_ts_ms: base,
-            start_instant: std::time::Instant::now(),
+            start_instant: Instant::now(),
         };
         let clock_b = HeuristicClock {
             start_ts_ms: base + 1_000,
-            start_instant: std::time::Instant::now(),
+            start_instant: Instant::now(),
         };
         // Both clocks were created at approximately the same real time, so
         // their elapsed values are nearly equal. The difference in now_ms
@@ -4901,71 +8156,278 @@ mod tests {
         assert!(lock.get().is_none(), "lock should be empty before set");
         lock.set(HeuristicClock {
             start_ts_ms: 42_000,
-            start_instant: std::time::Instant::now(),
+            start_instant: Instant::now(),
         })
         .unwrap();
         let clock = lock.get().expect("clock should be set");
         assert_eq!(clock.now_ms(), 42_000);
     }
 
-    /// Regression tests for https://github.com/dbt-labs/dbt-core/issues/15594:
-    /// Databricks issues a real per-relation `DESCRIBE HISTORY` lookup in
-    /// `freshness_all_in_schema` (no eventually-consistent catalog snapshot to
-    /// lag behind), so an empty result there is authoritative and must not
-    /// trigger the per-node eventual-consistency fallback + warning.
     #[test]
-    fn schema_dump_empty_does_not_require_fallback_on_databricks() {
-        assert!(!schema_dump_empty_requires_fallback(
-            AdapterType::Databricks,
-            true
-        ));
+    fn unresolvable_last_modified_uses_heuristic_clock() {
+        let cache = RunCacheMetadataCache::new();
+        let fqn = r#""DB"."S"."SECURE_VIEW""#.to_string();
+        cache.insert_last_modified_epoch(&fqn, Some(123));
+        let clock = HeuristicClock {
+            start_ts_ms: 1_700_000_000_000,
+            start_instant: Instant::now(),
+        };
+
+        apply_unresolvable_last_modified_overrides(
+            &cache,
+            Some(&clock),
+            &BTreeSet::from([fqn.clone()]),
+            &BTreeMap::new(),
+        );
+
+        assert_eq!(
+            cache.last_modified_epoch(&fqn).flatten(),
+            Some(1_700_000_000_000)
+        );
     }
 
-    /// Snowflake's `freshness_all_in_schema` is a single `INFORMATION_SCHEMA`
-    /// bulk query that can genuinely lag behind a just-created table -- this
-    /// is the original, still-valid reason the fallback exists, and must be
-    /// preserved.
     #[test]
-    fn schema_dump_empty_still_requires_fallback_on_snowflake() {
-        assert!(schema_dump_empty_requires_fallback(
-            AdapterType::Snowflake,
-            true
-        ));
+    fn unresolvable_last_modified_does_not_replace_source_freshness_override() {
+        let cache = RunCacheMetadataCache::new();
+        let fqn = r#""DB"."S"."SECURE_VIEW""#.to_string();
+        cache.insert_last_modified_epoch(&fqn, Some(123));
+        let clock = HeuristicClock {
+            start_ts_ms: 1_700_000_000_000,
+            start_instant: Instant::now(),
+        };
+        let overrides = BTreeMap::from([(
+            fqn.clone(),
+            FreshnessOverride::Field("loaded_at".to_string()),
+        )]);
+
+        apply_unresolvable_last_modified_overrides(
+            &cache,
+            Some(&clock),
+            &BTreeSet::from([fqn.clone()]),
+            &overrides,
+        );
+
+        assert_eq!(cache.last_modified_epoch(&fqn), None);
     }
 
-    /// BigQuery's `freshness_all_in_schema` is likewise a single bulk query
-    /// against a metadata view, so it needs the same fallback as Snowflake.
     #[test]
-    fn schema_dump_empty_still_requires_fallback_on_bigquery() {
-        assert!(schema_dump_empty_requires_fallback(
-            AdapterType::Bigquery,
-            true
-        ));
+    fn unresolvable_last_modified_leaves_cache_empty_when_clock_missing() {
+        let cache = RunCacheMetadataCache::new();
+        let fqn = r#""DB"."S"."SECURE_VIEW""#.to_string();
+        cache.insert_last_modified_epoch(&fqn, Some(123));
+
+        apply_unresolvable_last_modified_overrides(
+            &cache,
+            None,
+            &BTreeSet::from([fqn.clone()]),
+            &BTreeMap::new(),
+        );
+
+        assert_eq!(cache.last_modified_epoch(&fqn), None);
     }
 
-    /// Adapters that haven't overridden `freshness_all_in_schema` get the
-    /// trait's default implementation, which deliberately returns an empty
-    /// map to signal "fall back" (see `MetadataAdapter::freshness_all_in_schema`'s
-    /// doc comment) -- the fallback is the only way those adapters get real
-    /// freshness data, so an empty result must still trigger it.
     #[test]
-    fn schema_dump_empty_still_requires_fallback_for_unimplemented_adapters() {
-        assert!(schema_dump_empty_requires_fallback(
-            AdapterType::Postgres,
-            true
-        ));
+    fn execution_decision_id_from_response_extracts_service_ids() {
+        let mut ready = ready_to_execute_response();
+        let Some(submit_sql_response::Response::ReadyToExecute(response)) = ready.response.as_mut()
+        else {
+            panic!("expected ready response");
+        };
+        response.execution_decision_id = Some("ready-id".to_string());
+
+        let mut skip = skip_execution_response();
+        let Some(submit_sql_response::Response::SkipExecution(response)) = skip.response.as_mut()
+        else {
+            panic!("expected skip response");
+        };
+        response.execution_decision_id = Some("skip-id".to_string());
+
+        let mut clone = ready_to_clone_response();
+        let Some(submit_sql_response::Response::ReadyToClone(response)) = clone.response.as_mut()
+        else {
+            panic!("expected clone response");
+        };
+        response.execution_decision_id = Some("clone-id".to_string());
+
+        assert_eq!(
+            execution_decision_id_from_response(&ready).as_deref(),
+            Some("ready-id")
+        );
+        assert_eq!(
+            execution_decision_id_from_response(&skip).as_deref(),
+            Some("skip-id")
+        );
+        assert_eq!(
+            execution_decision_id_from_response(&clone).as_deref(),
+            Some("clone-id")
+        );
+        assert!(execution_decision_id_from_response(&empty_response()).is_none());
     }
 
-    /// A non-empty dump never needs the fallback, regardless of adapter.
     #[test]
-    fn schema_dump_non_empty_never_requires_fallback() {
-        assert!(!schema_dump_empty_requires_fallback(
-            AdapterType::Snowflake,
-            false
-        ));
-        assert!(!schema_dump_empty_requires_fallback(
-            AdapterType::Databricks,
-            false
-        ));
+    fn state_explain_execution_decision_id_allows_missing_service_response() {
+        let mut ready = ready_to_execute_response();
+        let Some(submit_sql_response::Response::ReadyToExecute(response)) = ready.response.as_mut()
+        else {
+            panic!("expected ready response");
+        };
+        response.execution_decision_id = Some("ready-id".to_string());
+        let ready_decision = record_service_decision("model.test.orders", &ready, 0, true);
+
+        assert_eq!(
+            state_explain_execution_decision_id(Some(&ready), &ready_decision).as_deref(),
+            Some("ready-id")
+        );
+        assert!(state_explain_execution_decision_id(None, &ready_decision).is_none());
+    }
+
+    #[test]
+    fn state_explain_execution_decision_id_ignores_data_test_skip_fallback() {
+        let mut response = skip_execution_response();
+        let Some(submit_sql_response::Response::SkipExecution(skip)) = response.response.as_mut()
+        else {
+            panic!("expected skip response");
+        };
+        skip.execution_decision_id = Some("skip-id".to_string());
+
+        let decision = record_service_decision(
+            "test.test.not_null_orders_order_date.abc123",
+            &response,
+            0,
+            true,
+        );
+
+        assert_eq!(
+            decision,
+            RunCacheServiceDecision::Execute {
+                after_success: RunCacheAfterSuccess::None,
+                sao_guard: None,
+            }
+        );
+        assert!(state_explain_execution_decision_id(Some(&response), &decision).is_none());
+    }
+
+    #[test]
+    fn state_explain_execution_decision_id_keeps_honored_skip() {
+        let mut response = skip_execution_response_with_test_result(CachedTestExecutionResult {
+            failures: 0,
+            should_warn: false,
+            should_error: false,
+        });
+        let Some(submit_sql_response::Response::SkipExecution(skip)) = response.response.as_mut()
+        else {
+            panic!("expected skip response");
+        };
+        skip.execution_decision_id = Some("skip-id".to_string());
+
+        let decision = record_service_decision(
+            "test.test.not_null_orders_order_date.abc123",
+            &response,
+            0,
+            true,
+        );
+
+        assert_eq!(
+            state_explain_execution_decision_id(Some(&response), &decision).as_deref(),
+            Some("skip-id")
+        );
+    }
+
+    #[test]
+    fn clone_chain_depth_limit_for_adapter_returns_n_minus_1_for_prod() {
+        assert_eq!(
+            clone_chain_depth_limit_for_adapter(AdapterType::Databricks, true, true),
+            Some(0)
+        );
+        assert_eq!(
+            clone_chain_depth_limit_for_adapter(AdapterType::Bigquery, true, true),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn clone_chain_depth_limit_for_adapter_returns_default_for_non_prod() {
+        assert_eq!(
+            clone_chain_depth_limit_for_adapter(AdapterType::Databricks, false, true),
+            Some(1)
+        );
+        assert_eq!(
+            clone_chain_depth_limit_for_adapter(AdapterType::Bigquery, false, true),
+            Some(3)
+        );
+    }
+
+    #[test]
+    fn clone_chain_depth_limit_for_adapter_none_for_adapters_with_no_limits() {
+        assert_eq!(
+            clone_chain_depth_limit_for_adapter(AdapterType::Snowflake, true, true),
+            None
+        );
+        assert_eq!(
+            clone_chain_depth_limit_for_adapter(AdapterType::Snowflake, false, true),
+            None
+        );
+    }
+
+    #[test]
+    fn clone_chain_depth_limit_for_adapter_zero_when_clones_disallowed() {
+        // allow_clones=false overrides to 0 regardless of adapter or prod/dev direction,
+        // including adapters that otherwise have no default limit at all.
+        assert_eq!(
+            clone_chain_depth_limit_for_adapter(AdapterType::Databricks, true, false),
+            Some(0)
+        );
+        assert_eq!(
+            clone_chain_depth_limit_for_adapter(AdapterType::Bigquery, false, false),
+            Some(0)
+        );
+        assert_eq!(
+            clone_chain_depth_limit_for_adapter(AdapterType::Snowflake, true, false),
+            Some(0)
+        );
+        assert_eq!(
+            clone_chain_depth_limit_for_adapter(AdapterType::Snowflake, false, false),
+            Some(0)
+        );
+    }
+
+    fn state_explain_model(materialized: DbtMaterialization) -> DbtModel {
+        let mut model = DbtModel::default();
+        model.__common_attr__.unique_id = "model.test.orders".to_string();
+        model.__common_attr__.name = "orders".to_string();
+        set_state_explain_base(&mut model.__base_attr__, materialized, "orders");
+        model
+    }
+
+    fn state_explain_seed() -> DbtSeed {
+        let mut seed = DbtSeed::default();
+        seed.__common_attr__.unique_id = "seed.test.cities".to_string();
+        seed.__common_attr__.name = "cities".to_string();
+        set_state_explain_base(&mut seed.__base_attr__, DbtMaterialization::Seed, "cities");
+        seed
+    }
+
+    fn state_explain_snapshot() -> DbtSnapshot {
+        let mut snapshot = DbtSnapshot::default();
+        snapshot.__common_attr__.unique_id = "snapshot.test.orders_snapshot".to_string();
+        snapshot.__common_attr__.name = "orders_snapshot".to_string();
+        set_state_explain_base(
+            &mut snapshot.__base_attr__,
+            DbtMaterialization::Snapshot,
+            "orders_snapshot",
+        );
+        snapshot
+    }
+
+    fn set_state_explain_base(
+        base: &mut dbt_schemas::schemas::nodes::NodeBaseAttributes,
+        materialized: DbtMaterialization,
+        alias: &str,
+    ) {
+        base.database = "analytics".to_string();
+        base.schema = "marts".to_string();
+        base.alias = alias.to_string();
+        base.materialized = materialized;
+        base.quoting = ResolvedQuoting::trues();
     }
 }


### PR DESCRIPTION
Resolves #15594

### Problem

dbt State's run_cache prefetch (`run_cache_service.rs`) batches a schema-level freshness dump per (database, schema) group via `freshness_all_in_schema`, and falls back to slower per-node queries — with a `StateServiceWarn` — whenever that dump comes back empty. The fallback exists specifically to work around Snowflake's `INFORMATION_SCHEMA` eventual consistency: Fusion's global prefetch fires eagerly at run start, before dbt-core's plugin-style lazy prefetch would have given the catalog a few seconds to catch up on a table from the immediately preceding run.

That reasoning doesn't hold for every adapter. On Databricks, CI jobs that build into fresh per-PR ephemeral schemas hit `dump.is_empty()` on 100% of schema groups, on every run, adding 60s–5min of per-node fallback queries before the build even starts — because the schema is genuinely brand new, not because of a race.

The root cause is that `dump.is_empty()` alone is the wrong signal. It conflates "the adapter's bulk lookup mechanism can lag behind a real table" with "there's genuinely nothing here yet," and which one applies depends entirely on how each adapter implements `freshness_all_in_schema`.

### Solution

Read all three currently-implemented `freshness_all_in_schema` methods plus the trait's default, rather than assuming the bug report's framing, and gate the fallback on which category each adapter actually falls into:

- **Snowflake / BigQuery**: each issues a single `INFORMATION_SCHEMA`-style bulk query against a metadata view that's documented to lag behind DDL — the fallback is genuinely necessary here, unchanged.
- **Unimplemented adapters**: fall through to the trait's default implementation, which *deliberately* returns an empty map to signal "fall back" (per its own doc comment) — the fallback is the only way those adapters get real freshness data, unchanged.
- **Databricks**: issues a real per-relation `DESCRIBE HISTORY` (or `INFORMATION_SCHEMA.last_altered` for views) lookup directly, with no intermediate eventually-consistent catalog snapshot. An empty result there unambiguously means every relation in the group doesn't exist yet — exactly the state of a freshly created CI schema before any model has run. No longer falls back or warns.

New private helper added: `schema_dump_empty_requires_fallback(adapter_type, dump_is_empty)` — a small, pure, directly-testable gate function, following the same allow/deny-list pattern already established in this file by `heuristic_clock_enabled_for_adapter` for an analogous Databricks-specific issue.

### Checklist

- [x] I have read the contributing guide and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes type annotations for new and modified functions.

### Automated checks

| Check | Command | Result |
|---|---|---|
| Build | `cargo build -p dbt-tasks-core` | exit 0 |
| Lint | `cargo clippy -p dbt-tasks-core --all-targets` | clean |
| Unit tests | `cargo test -p dbt-tasks-core --lib` | 90 passed, 0 failed (5 new) |