### PR TITLE
Bump astral-tokio-tar to 0.6.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -484,7 +484,7 @@ xshell = "0.2.7"
 zip = "8.3.0"
 
 # async + threading
-astral-tokio-tar = { version = "0.5.6" }
+astral-tokio-tar = { version = "0.6.4" }
 async-compression = { version = "0.4", features = ["tokio", "gzip"] }
 async-trait = "0.1.83"
 crossbeam-queue = "0.3.12"


### PR DESCRIPTION
### Problem

Four RUSTSEC advisories affecting tarball extraction in dbt-deps and dbt-main:

- [RUSTSEC-2026-0066](https://rustsec.org/advisories/RUSTSEC-2026-0066.html) (CVE-2026-32766, 2026-03-23) - Insufficient validation of PAX extensions, fixed in 0.6.0. (https://github.com/advisories/GHSA-6gx3-4362-rf54 / https://github.com/astral-sh/tokio-tar/security/advisories/GHSA-6gx3-4362-rf54)
- [RUSTSEC-2026-0112](https://rustsec.org/advisories/RUSTSEC-2026-0112.html) (2026-04-28) - PAX header desynchronisation, fixed in 0.6.1.
- [RUSTSEC-2026-0113](https://rustsec.org/advisories/RUSTSEC-2026-0113.html) (2026-04-28) - `unpack_in` can chmod arbitrary dirs via symlinks, fixed in 0.6.1.
- [RUSTSEC-2026-0145](https://rustsec.org/advisories/RUSTSEC-2026-0145.html) (2026-05-19) - PAX header desynchronisation, fixed in 0.6.2.

### Solution

Bump the crate.

No actual code change is required - the two places it is used (dbt-deps/src/tarball_client.rs and dbt-main/src/update.rs) compiles unchanged against 0.6.

As per https://github.com/advisories/GHSA-6gx3-4362-rf54 -
> Users are advised to upgrade to version 0.6.0 or newer to address this advisory.
> Most users should experience no breaking changes as a result of the patch above. Some users who attempt to extract poorly constructed tar files may experience errors; users should re-construct their tar files with a conforming tar parser.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.