### PR TITLE
Fall back to per-source freshness when batch metadata computation fails

### DIFF
--- a/.changes/unreleased/Fixes-20260722-122500.yaml
+++ b/.changes/unreleased/Fixes-20260722-122500.yaml
@@ -1,0 +1,8 @@
+kind: Fixes
+body: Fall back to per-source freshness checks when batch metadata freshness computation
+  fails, instead of skipping every selected source now that `skip_nodes_if_on_run_start_fails`
+  defaults to True
+time: 2026-07-22T12:25:00.000000+09:00
+custom:
+    Author: ota2000
+    Issue: "15634"

--- a/core/dbt/task/freshness.py
+++ b/core/dbt/task/freshness.py
@@ -320,7 +320,9 @@ class FreshnessTask(RunTask):
                 Note(msg=f"Metadata freshness could not be computed in batch: {e}"),
                 EventLevel.WARN,
             )
-            return RunStatus.Error
+            # Returning Error here would make before_run skip every node when
+            # skip_nodes_if_on_run_start_fails is set, instead of falling back.
+            return RunStatus.Success
 
     def get_freshness_metadata_cache(self) -> Dict[BaseRelation, FreshnessResponse]:
         return self._metadata_freshness_cache

--- a/tests/unit/task/test_freshness.py
+++ b/tests/unit/task/test_freshness.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 import pytest
 
+from dbt.contracts.results import RunStatus
 from dbt.task.freshness import FreshnessResponse, FreshnessTask
 
 
@@ -150,6 +151,9 @@ class TestFreshnessTaskMetadataCache:
         adapter.calculate_freshness_from_metadata_batch.side_effect = Exception()
         task = FreshnessTask(args=args, config=config, manifest=manifest, catalogs=[])
 
-        task.populate_metadata_freshness_cache(adapter, {source_no_loaded_at_field.unique_id})
+        result = task.populate_metadata_freshness_cache(
+            adapter, {source_no_loaded_at_field.unique_id}
+        )
 
+        assert result == RunStatus.Success
         assert task.get_freshness_metadata_cache() == {}


### PR DESCRIPTION
Resolves #15634

### Problem

When `populate_metadata_freshness_cache` fails, it returns `RunStatus.Error`, which `FreshnessTask.before_run` folds into its own return value. Since `skip_nodes_if_on_run_start_fails` defaults to `True` in 1.12, this now skips **every** selected source — no freshness is measured at all — contradicting the except-block comment that promises a graceful per-source fallback ("this will be gracefully handled as a cache miss and non-batch metadata-based freshness will still be performed on a source-by-source basis").

Through 1.11 (flag default `False`) the fallback worked as documented: the batch failure was logged and each source still ran its own freshness check. See #15634 for the full mechanism and 1.11-vs-1.12 log comparison, and dbt-labs/dbt-adapters#1789 for one easy-to-hit trigger on BigQuery.

### Solution

Return `RunStatus.Success` from the except block, matching the documented cache-miss semantics: the cache is simply left unpopulated and each source falls back to its per-source freshness check. `skip_nodes_if_on_run_start_fails` keeps its intended meaning for genuine on-run-start hook failures (handled in `super().before_run`).

Alternative considered: keeping the `Error` status but excluding it from the `before_run` merge — rejected as it changes `before_run`'s contract for no benefit, since nothing else consumes the populate status.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
