### PR TITLE
Configurable application name for snowflake auth

### DIFF
--- a/.changes/unreleased/Features-20260722-172953.yaml
+++ b/.changes/unreleased/Features-20260722-172953.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Add config key for snowflake auth to customize application name
+time: 2026-07-22T17:29:53.619351357+02:00
+custom:
+    author: lgirault
+    issue: ""
+    project: dbt-core

--- a/crates/dbt-auth/src/snowflake/mod.rs
+++ b/crates/dbt-auth/src/snowflake/mod.rs
@@ -618,7 +618,9 @@ fn apply_connection_args(
             }?;
         }
     }
-    builder.with_named_option(snowflake::APPLICATION_NAME, APP_NAME)?;
+
+    let application_name = config.get_str("application_name").unwrap_or(APP_NAME);
+    builder.with_named_option(snowflake::APPLICATION_NAME, application_name)?;
 
     // LOGIN_TIMEOUT defaults to 300s,
     // see https://github.com/dbt-labs/gosnowflake/blob/c1d9c4ea1fde32184cbce1f728a4db2ea0cec048/dsn.go         = 300 * time.Second // Timeout for retry for login EXCLUDING clientTimeout
@@ -802,6 +804,24 @@ mod tests {
         ];
         run_config_test(config, &expected);
     }
+
+    #[test]
+    fn test_application_name_override() {
+        let mut config = base_config();
+        config.insert("application_name".into(), "custom_app".into());
+        let expected = [
+            ("user", "U"),
+            ("password", "P"),
+            (snowflake::ACCOUNT, "A"),
+            (snowflake::ROLE, "role"),
+            (snowflake::WAREHOUSE, "warehouse"),
+            (snowflake::APPLICATION_NAME, "custom_app"),
+            (snowflake::LOG_TRACING, "fatal"),
+            (snowflake::REQUEST_TIMEOUT, DEFAULT_REQUEST_TIMEOUT),
+        ];
+        run_config_test(config, &expected);
+    }
+
 
     #[test]
     fn test_simple_pass_with_driver_log_level_override() {


### PR DESCRIPTION
Add the capability to put a custom value for the application in the snowflake connection

Resolves #

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

The application name of the snowflake connection string is hard-coded while I need to pass custom value.

### Solution

expose an optional config key in snowflake auth config that allow to pass a custom value and fallback to the hard coded one if none is provided

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
