### PR TITLE
Exclude silenced deprecations from the deprecations summary

### DIFF
--- a/.changes/unreleased/Fixes-20260723-150000.yaml
+++ b/.changes/unreleased/Fixes-20260723-150000.yaml
@@ -1,0 +1,8 @@
+kind: Fixes
+body: Exclude deprecations silenced via warn_error_options from the deprecations
+  summary, so a run whose only deprecations are silenced no longer fails under
+  `error: Deprecations`
+time: 2026-07-23T15:00:00.000000+09:00
+custom:
+    Author: ota2000
+    Issue: "15646"

--- a/.changes/unreleased/Fixes-20260723-150000.yaml
+++ b/.changes/unreleased/Fixes-20260723-150000.yaml
@@ -1,7 +1,7 @@
 kind: Fixes
-body: Exclude deprecations silenced via warn_error_options from the deprecations
+body: 'Exclude deprecations silenced via warn_error_options from the deprecations
   summary, so a run whose only deprecations are silenced no longer fails under
-  `error: Deprecations`
+  `error: Deprecations`'
 time: 2026-07-23T15:00:00.000000+09:00
 custom:
     Author: ota2000

--- a/core/dbt/deprecations.py
+++ b/core/dbt/deprecations.py
@@ -7,6 +7,7 @@ import dbt.tracking
 from dbt.events import types as core_types
 from dbt.flags import get_flags
 from dbt_common.dataclass_schema import dbtClassMixin
+from dbt_common.events.event_manager_client import get_event_manager
 from dbt_common.events.functions import fire_event
 from dbt_common.events.types import Note
 from dbt_common.exceptions import DbtInternalError
@@ -282,12 +283,20 @@ def buffer(name: str, *args, **kwargs):
 
 
 def show_deprecations_summary() -> None:
+    warn_error_options = get_event_manager().warn_error_options
     summaries: List[Dict[str, Any]] = []
     for deprecation, occurrences in active_deprecations.items():
         deprecation_event = deprecations[deprecation].event()
+        event_name = type(deprecation_event).__name__
+        # Deprecations silenced via warn_error_options should not resurface
+        # through the summary: with `error: Deprecations` the summary event
+        # itself is error-handled, so counting silenced occurrences would turn
+        # them back into a hard failure.
+        if warn_error_options.silenced(event_name):
+            continue
         summaries.append(
             DeprecationSummary(
-                event_name=type(deprecation_event).__name__,
+                event_name=event_name,
                 event_code=deprecation_event.code(),
                 occurrences=occurrences,
             ).to_msg_dict()

--- a/tests/unit/test_deprecations.py
+++ b/tests/unit/test_deprecations.py
@@ -1,10 +1,13 @@
 import pytest
 
 import dbt.deprecations as deprecations
-from dbt.events.types import ProjectFlagsMovedDeprecation
+from dbt.events import ALL_EVENT_NAMES
+from dbt.events.types import DeprecationsSummary, ProjectFlagsMovedDeprecation
 from dbt_common.events.event_catcher import EventCatcher
-from dbt_common.events.event_manager_client import add_callback_to_manager
+from dbt_common.events.event_manager_client import add_callback_to_manager, get_event_manager
 from dbt_common.events.types import Note
+from dbt_common.exceptions import EventCompilationError
+from dbt_common.helper_types import WarnErrorOptionsV2
 
 
 @pytest.fixture(scope="function")
@@ -95,3 +98,40 @@ class TestPreviewDeprecation:
         assert "previewed-deprecation" not in deprecations.active_deprecations
         assert len(pfmd_catcher.caught_events) == 0
         assert len(note_catcher.caught_events) == 1
+@pytest.fixture(scope="function")
+def silenced_project_flags_moved():
+    event_manager = get_event_manager()
+    previous = event_manager._warn_error_options
+    event_manager.warn_error_options = WarnErrorOptionsV2(
+        error=["Deprecations"],
+        silence=["ProjectFlagsMovedDeprecation"],
+        valid_error_names=ALL_EVENT_NAMES,
+    )
+
+    yield
+
+    event_manager._warn_error_options = previous
+
+
+def test_summary_skips_silenced_deprecations(active_deprecations, silenced_project_flags_moved):
+    summary_catcher = EventCatcher(event_to_catch=DeprecationsSummary)
+    add_callback_to_manager(summary_catcher.catch)
+
+    deprecations.active_deprecations["project-flags-moved"] += 1
+    deprecations.show_deprecations_summary()
+
+    assert len(summary_catcher.caught_events) == 0
+
+
+def test_summary_keeps_unsilenced_deprecations(active_deprecations, silenced_project_flags_moved):
+    deprecations.active_deprecations["project-flags-moved"] += 1
+    deprecations.active_deprecations["custom-key-in-config-deprecation"] += 1
+
+    # The unsilenced deprecation keeps the summary alive (and, with
+    # `error: Deprecations`, error-handled) — but the silenced one is
+    # excluded from it.
+    with pytest.raises(EventCompilationError) as excinfo:
+        deprecations.show_deprecations_summary()
+
+    assert "CustomKeyInConfigDeprecation" in str(excinfo.value)
+    assert "ProjectFlagsMovedDeprecation" not in str(excinfo.value)

--- a/tests/unit/test_deprecations.py
+++ b/tests/unit/test_deprecations.py
@@ -98,19 +98,22 @@ class TestPreviewDeprecation:
         assert "previewed-deprecation" not in deprecations.active_deprecations
         assert len(pfmd_catcher.caught_events) == 0
         assert len(note_catcher.caught_events) == 1
+
+
 @pytest.fixture(scope="function")
-def silenced_project_flags_moved():
-    event_manager = get_event_manager()
-    previous = event_manager._warn_error_options
-    event_manager.warn_error_options = WarnErrorOptionsV2(
-        error=["Deprecations"],
-        silence=["ProjectFlagsMovedDeprecation"],
-        valid_error_names=ALL_EVENT_NAMES,
+def silenced_project_flags_moved(monkeypatch):
+    # There is no public API for saving/restoring the underlying options slot,
+    # so patch the attribute via monkeypatch, which restores the previous value
+    # on teardown.
+    monkeypatch.setattr(
+        get_event_manager(),
+        "_warn_error_options",
+        WarnErrorOptionsV2(
+            error=["Deprecations"],
+            silence=["ProjectFlagsMovedDeprecation"],
+            valid_error_names=ALL_EVENT_NAMES,
+        ),
     )
-
-    yield
-
-    event_manager._warn_error_options = previous
 
 
 def test_summary_skips_silenced_deprecations(active_deprecations, silenced_project_flags_moved):

--- a/tests/unit/test_deprecations.py
+++ b/tests/unit/test_deprecations.py
@@ -4,7 +4,10 @@ import dbt.deprecations as deprecations
 from dbt.events import ALL_EVENT_NAMES
 from dbt.events.types import DeprecationsSummary, ProjectFlagsMovedDeprecation
 from dbt_common.events.event_catcher import EventCatcher
-from dbt_common.events.event_manager_client import add_callback_to_manager, get_event_manager
+from dbt_common.events.event_manager_client import (
+    add_callback_to_manager,
+    get_event_manager,
+)
 from dbt_common.events.types import Note
 from dbt_common.exceptions import EventCompilationError
 from dbt_common.helper_types import WarnErrorOptionsV2


### PR DESCRIPTION
Resolves #15646. Supersedes #15648, whose head stopped tracking the branch after the base was retargeted from `1.12.latest` to `1.latest` during the branch restructuring, and which could not be reopened after a resync attempt — apologies for the noise there.

## Problem

`show_deprecations_summary` counts every active deprecation, including ones silenced via `warn_error_options.silence`. Because the summary event is fired with `force_warn_or_error_handling=True`, a run whose **only** encountered deprecations are silenced still hard-fails under `error: Deprecations` — parsing completes and the manifest is written, then `DeprecationsSummary` raises at the end.

## Solution

Skip silenced deprecations when building the summary, using the same `warn_error_options` the event manager applies to the individual events. If everything encountered was silenced, no summary fires; a mixed run fires the summary with only the unsilenced entries (and still errors under `error: Deprecations`, as before).

Review history on #15648: Copilot's two comments (fixture via monkeypatch, blank lines) are already addressed in these commits.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development, and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX