### PR TITLE
Flag PRs that don't link to an issue

### DIFF
--- a/.github/workflows/pr-issue-link-check.yml
+++ b/.github/workflows/pr-issue-link-check.yml
@@ -44,24 +44,30 @@ jobs:
             const hasIssueLink = issueRefPattern.test(body) || bareLinkPattern.test(body);
             const hasSkipLabel = labels.includes(skipLabel);
 
-            return { hasIssueLink, hasSkipLabel };
+            core.setOutput('has_issue_link', hasIssueLink);
+            core.setOutput('has_skip_label', hasSkipLabel);
 
       - name: Manage flag label and comment
         uses: actions/github-script@v7
+        env:
+          HAS_ISSUE_LINK: ${{ steps.check.outputs.has_issue_link }}
+          HAS_SKIP_LABEL: ${{ steps.check.outputs.has_skip_label }}
         with:
           script: |
             const flagLabel = 'missing-issue-link';
-            const { hasIssueLink, hasSkipLabel } = ${{ steps.check.outputs.result }};
+            const hasIssueLink = process.env.HAS_ISSUE_LINK === 'true';
+            const hasSkipLabel = process.env.HAS_SKIP_LABEL === 'true';
             const prNumber = context.payload.pull_request.number;
             const { owner, repo } = context.repo;
 
             const commentMarker = '<!-- pr-issue-link-check -->';
-            const comments = await github.rest.issues.listComments({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner,
               repo,
               issue_number: prNumber,
+              per_page: 100,
             });
-            const existingComment = comments.data.find((c) => c.body.includes(commentMarker));
+            const existingComment = comments.find((c) => c.body.includes(commentMarker));
 
             if (!hasIssueLink && !hasSkipLabel) {
               try {
@@ -104,11 +110,20 @@ jobs:
               }
 
               if (existingComment) {
-                await github.rest.issues.updateComment({
-                  owner,
-                  repo,
-                  comment_id: existingComment.id,
-                  body: `${commentMarker}\nThanks for linking an issue to this PR!`,
-                });
+                if (hasIssueLink) {
+                  await github.rest.issues.updateComment({
+                    owner,
+                    repo,
+                    comment_id: existingComment.id,
+                    body: `${commentMarker}\nThanks for linking an issue to this PR!`,
+                  });
+                } else {
+                  // Resolved via the opt-out label rather than an issue link.
+                  await github.rest.issues.deleteComment({
+                    owner,
+                    repo,
+                    comment_id: existingComment.id,
+                  });
+                }
               }
             }

--- a/.github/workflows/pr-issue-link-check.yml
+++ b/.github/workflows/pr-issue-link-check.yml
@@ -1,0 +1,114 @@
+# **what?**
+# Flags pull requests that don't explicitly link to an issue, either via a
+# GitHub auto-closing keyword (closes/fixes/resolves #123) or a direct link
+# to an issue in the PR body.
+
+# **why?**
+# Encourage every change to be tied to tracked work so reviewers and future
+# readers can find the motivating context.
+
+# **when?**
+# Runs when a PR is opened, reopened, or edited, and re-checks on synchronize.
+
+name: Check PR Links to Issue
+
+on:
+  pull_request_target:
+    types: [opened, reopened, edited, synchronize]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  check-issue-link:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for issue reference
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const closingKeywords = '(close[sd]?|fix(e[sd])?|resolve[sd]?)';
+            const issueRefPattern = new RegExp(
+              `${closingKeywords}\\s*:?\\s*(#\\d+|https?://github\\.com/[^\\s]+/issues/\\d+)`,
+              'i'
+            );
+            const bareLinkPattern = /#\d+|https?:\/\/github\.com\/[^\s]+\/issues\/\d+/;
+            const skipLabel = 'no-issue-needed';
+
+            const pr = context.payload.pull_request;
+            const body = pr.body || '';
+            const labels = pr.labels.map((l) => l.name);
+
+            const hasIssueLink = issueRefPattern.test(body) || bareLinkPattern.test(body);
+            const hasSkipLabel = labels.includes(skipLabel);
+
+            return { hasIssueLink, hasSkipLabel };
+
+      - name: Manage flag label and comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const flagLabel = 'missing-issue-link';
+            const { hasIssueLink, hasSkipLabel } = ${{ steps.check.outputs.result }};
+            const prNumber = context.payload.pull_request.number;
+            const { owner, repo } = context.repo;
+
+            const commentMarker = '<!-- pr-issue-link-check -->';
+            const comments = await github.rest.issues.listComments({
+              owner,
+              repo,
+              issue_number: prNumber,
+            });
+            const existingComment = comments.data.find((c) => c.body.includes(commentMarker));
+
+            if (!hasIssueLink && !hasSkipLabel) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name: flagLabel });
+              } catch (e) {
+                await github.rest.issues.createLabel({
+                  owner,
+                  repo,
+                  name: flagLabel,
+                  color: 'D93F0B',
+                  description: "PR doesn't explicitly link to an issue",
+                });
+              }
+
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: prNumber,
+                labels: [flagLabel],
+              });
+
+              if (!existingComment) {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: prNumber,
+                  body: `${commentMarker}\nThis PR doesn't appear to explicitly link to an issue. Please reference the issue it addresses (e.g. \`Closes #123\`) in the PR description, or add the \`no-issue-needed\` label if this change doesn't need one.`,
+                });
+              }
+            } else {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number: prNumber,
+                  name: flagLabel,
+                });
+              } catch (e) {
+                // label wasn't present, nothing to do
+              }
+
+              if (existingComment) {
+                await github.rest.issues.updateComment({
+                  owner,
+                  repo,
+                  comment_id: existingComment.id,
+                  body: `${commentMarker}\nThanks for linking an issue to this PR!`,
+                });
+              }
+            }

--- a/.github/workflows/pr-issue-link-check.yml
+++ b/.github/workflows/pr-issue-link-check.yml
@@ -17,7 +17,6 @@ on:
     types: [opened, reopened, edited, synchronize]
 
 permissions:
-  pull-requests: write
   issues: write
 
 jobs:
@@ -29,19 +28,24 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const { owner, repo } = context.repo;
+            const repoIssueUrl = `https?://github\\.com/${owner}/${repo}/issues/\\d+`;
             const closingKeywords = '(close[sd]?|fix(e[sd])?|resolve[sd]?)';
             const issueRefPattern = new RegExp(
-              `${closingKeywords}\\s*:?\\s*(#\\d+|https?://github\\.com/[^\\s]+/issues/\\d+)`,
+              `${closingKeywords}\\s*:?\\s*(#\\d+|${repoIssueUrl})`,
               'i'
             );
-            const bareLinkPattern = /#\d+|https?:\/\/github\.com\/[^\s]+\/issues\/\d+/;
+            const directLinkPattern = new RegExp(repoIssueUrl);
             const skipLabel = 'no-issue-needed';
 
             const pr = context.payload.pull_request;
             const body = pr.body || '';
             const labels = pr.labels.map((l) => l.name);
 
-            const hasIssueLink = issueRefPattern.test(body) || bareLinkPattern.test(body);
+            // A closing keyword (with either a bare #123 or a full issue URL) or a
+            // direct link to an issue in this repo counts; a bare #123 with no
+            // keyword doesn't, since that also matches unrelated PR/issue mentions.
+            const hasIssueLink = issueRefPattern.test(body) || directLinkPattern.test(body);
             const hasSkipLabel = labels.includes(skipLabel);
 
             core.setOutput('has_issue_link', hasIssueLink);
@@ -73,13 +77,18 @@ jobs:
               try {
                 await github.rest.issues.getLabel({ owner, repo, name: flagLabel });
               } catch (e) {
-                await github.rest.issues.createLabel({
-                  owner,
-                  repo,
-                  name: flagLabel,
-                  color: 'D93F0B',
-                  description: "PR doesn't explicitly link to an issue",
-                });
+                try {
+                  await github.rest.issues.createLabel({
+                    owner,
+                    repo,
+                    name: flagLabel,
+                    color: 'D93F0B',
+                    description: "PR doesn't explicitly link to an issue",
+                  });
+                } catch (createErr) {
+                  // Another concurrent run may have created it first; ignore "already exists".
+                  if (createErr.status !== 422) throw createErr;
+                }
               }
 
               await github.rest.issues.addLabels({
@@ -89,12 +98,20 @@ jobs:
                 labels: [flagLabel],
               });
 
-              if (!existingComment) {
+              const warningBody = `${commentMarker}\nThis PR doesn't appear to explicitly link to an issue. Please reference the issue it addresses (e.g. \`Closes #123\`) in the PR description, or add the \`no-issue-needed\` label if this change doesn't need one.`;
+              if (existingComment) {
+                await github.rest.issues.updateComment({
+                  owner,
+                  repo,
+                  comment_id: existingComment.id,
+                  body: warningBody,
+                });
+              } else {
                 await github.rest.issues.createComment({
                   owner,
                   repo,
                   issue_number: prNumber,
-                  body: `${commentMarker}\nThis PR doesn't appear to explicitly link to an issue. Please reference the issue it addresses (e.g. \`Closes #123\`) in the PR description, or add the \`no-issue-needed\` label if this change doesn't need one.`,
+                  body: warningBody,
                 });
               }
             } else {


### PR DESCRIPTION
## Summary
- Adds a workflow that checks whether a PR body references an issue (via a closing keyword like `Closes #123`, or a direct issue link).
- Applies a `missing-issue-link` label and posts a comment when no reference is found; clears both once one is added.
- Repos can opt a PR out with a `no-issue-needed` label.

## Test plan
- [ ] Open a PR without an issue reference and confirm the label + comment appear
- [ ] Add `Closes #123` to the PR body and confirm the label is removed and the comment updates
- [ ] Add the `no-issue-needed` label to a PR without an issue reference and confirm no flag is applied