### PR TITLE
fix: capture and re-emit fusion parser subprocess output through dbt-core's event system

### DIFF
--- a/.changes/unreleased/Fixes-20260903-000000.yaml
+++ b/.changes/unreleased/Fixes-20260903-000000.yaml
@@ -1,0 +1,8 @@
+kind: Fixes
+body: Capture and re-emit fusion parser subprocess output through dbt-core's event
+  system instead of letting it pass through to raw stdout/stderr, re-leveling each
+  line by its json-compat severity when available
+time: 2026-09-03T00:00:00.000000+00:00
+custom:
+    Author: aiguofer
+    Issue: "15672"

--- a/core/dbt/parser/fusion.py
+++ b/core/dbt/parser/fusion.py
@@ -402,6 +402,8 @@ def _run_fusion(argv: List[str]) -> None:
             f"point to an alternate engine binary."
         ) from e
 
+    assert proc.stdout is not None and proc.stderr is not None  # guaranteed by stdout/stderr=PIPE above
+
     def _pump(stream, fallback_level: EventLevel) -> None:
         for raw_line in stream:
             line = raw_line.rstrip("\n")
@@ -426,6 +428,8 @@ def _run_fusion(argv: List[str]) -> None:
         reader.start()
     for reader in readers:
         reader.join()
+    proc.stdout.close()
+    proc.stderr.close()
     returncode = proc.wait()
 
     if returncode != 0:

--- a/core/dbt/parser/fusion.py
+++ b/core/dbt/parser/fusion.py
@@ -10,6 +10,7 @@ resulting manifest artifacts.
 
 from __future__ import annotations
 
+import json
 import os
 import platform
 import shlex
@@ -19,9 +20,8 @@ import sysconfig
 import tempfile
 import threading
 import time
-from collections import deque
 from pathlib import Path
-from typing import TYPE_CHECKING, Deque, List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 from dbt.artifacts.exceptions import IncompatibleSchemaError
 from dbt.artifacts.schemas.manifest import WritableManifest
@@ -40,12 +40,6 @@ from dbt_common.events.types import Note
 
 if TYPE_CHECKING:
     from dbt.config import RuntimeConfig
-
-# Trailing output lines (stdout+stderr, interleaved by arrival order) kept in
-# memory and surfaced in FusionParserError on a nonzero exit, so the failure
-# reason is visible even to a consumer that only sees the raised exception
-# rather than the live event stream (e.g. dbt Studio's error surfacing).
-_OUTPUT_TAIL_LINES = 40
 
 
 def parse_with_fusion(
@@ -243,6 +237,12 @@ def _build_argv(flags, target_path_override: Optional[str] = None) -> List[str]:
       --project-dir, --profiles-dir, --profile, --target,
       --target-path, --vars, --packages-install-path
 
+    Also always forwards --log-format json so the subprocess emits structured
+    per-line JSON on stdout/stderr instead of human-formatted text. This is not
+    a user-configurable passthrough (unlike the flags above) — it's how
+    _run_fusion talks to the subprocess, so it's added unconditionally rather
+    than gated on a dbt-core flag.
+
     When target_path_override is provided, it replaces the user's --target-path
     so the fusion parser writes its handoff manifest where dbt expects it (a
     temp dir).
@@ -295,6 +295,12 @@ def _build_argv(flags, target_path_override: Optional[str] = None) -> List[str]:
     if invocation_id:
         forwarded += ["--invocation-id", str(invocation_id)]
 
+    # json-compat output lets _run_fusion re-level each line by its real
+    # severity instead of a single hardcoded level per stream. Request full
+    # verbosity here and let dbt-core's own event system filter by level,
+    # rather than also forwarding a --log-level and double-filtering.
+    forwarded += ["--log-format", "json"]
+
     return base + forwarded
 
 
@@ -340,6 +346,14 @@ def _fusion_subprocess_env() -> dict:
     return env
 
 
+_FUSION_JSON_LEVELS = {
+    "error": EventLevel.ERROR,
+    "warn": EventLevel.WARN,
+    "info": EventLevel.INFO,
+    "debug": EventLevel.DEBUG,
+}
+
+
 def _run_fusion(argv: List[str]) -> None:
     """Run the fusion parser subprocess, capturing stdout/stderr and re-emitting
     each line live through dbt-core's event system as it arrives.
@@ -351,13 +365,24 @@ def _run_fusion(argv: List[str]) -> None:
     something was reading the raw inherited file descriptors directly (true
     for a CLI terminal, not true inside Studio's execution model).
 
-    The fusion parser doesn't yet emit a structured (JSON/OTel) log stream
-    dbt-core can parse, so lines are re-emitted verbatim as Note events —
-    stdout at INFO, stderr at WARN — rather than mapped to fusion's own
-    per-line levels.
-    TODO: once the fusion parser ships that structured log stream and the
-    Python library to decode it lands, replace this raw re-emission with a
-    real parse into properly leveled/structured dbt events.
+    _build_argv requests --log-format json, so each line is normally a JSON
+    object with the fusion-assigned severity at `info.level` and message at
+    `info.msg`; those are re-emitted as a Note at the mapped level rather than
+    the stream's fallback level. json-compat is not a stable, fully-supported
+    fusion contract (schema/fields/level strings may change between fusion
+    releases without notice), and fusion emits plain text before its JSON
+    logger initializes (e.g. CLI-arg errors) or after a panic — so any line
+    that isn't valid JSON, or is missing the fields above, falls back to
+    today's behavior: re-emitted verbatim at the stream's fallback level
+    (stdout at INFO, stderr at WARN).
+
+    On a nonzero exit, raises FusionParserError with just the exit code;
+    the actual failure detail was already streamed live as Note events
+    above, so it isn't duplicated into the exception message.
+    TODO: once the Python library to decode fusion's native OTel log stream
+    lands, replace this json-compat parsing with a real parse into properly
+    leveled/structured dbt events (also preserving info.code/info.name,
+    which json-compat exposes but this still discards into a flat Note).
     """
     try:
         proc = subprocess.Popen(
@@ -375,15 +400,19 @@ def _run_fusion(argv: List[str]) -> None:
             f"point to an alternate engine binary."
         ) from e
 
-    tail: Deque[str] = deque(maxlen=_OUTPUT_TAIL_LINES)
-    tail_lock = threading.Lock()
-
-    def _pump(stream, level: EventLevel) -> None:
+    def _pump(stream, fallback_level: EventLevel) -> None:
         for raw_line in stream:
             line = raw_line.rstrip("\n")
-            with tail_lock:
-                tail.append(line)
-            fire_event(Note(msg=line), level=level)
+            level = fallback_level
+            msg = line
+            try:
+                parsed = json.loads(line)
+                info = parsed["info"]
+                msg = info["msg"]
+                level = _FUSION_JSON_LEVELS.get(info.get("level"), fallback_level)
+            except (json.JSONDecodeError, KeyError, TypeError):
+                pass
+            fire_event(Note(msg=msg), level=level)
 
     # Separate threads per stream avoid the deadlock a single blocking
     # readline() would hit if the other stream fills its OS pipe buffer.
@@ -398,10 +427,8 @@ def _run_fusion(argv: List[str]) -> None:
     returncode = proc.wait()
 
     if returncode != 0:
-        with tail_lock:
-            excerpt = "\n".join(tail)
         raise FusionParserError(
-            f"Fusion parser failed (exit {returncode}).\n{excerpt}",
+            f"Fusion parser failed (exit {returncode}); see parser output above.",
             returncode=returncode,
         )
 

--- a/core/dbt/parser/fusion.py
+++ b/core/dbt/parser/fusion.py
@@ -17,9 +17,11 @@ import shutil
 import subprocess
 import sysconfig
 import tempfile
+import threading
 import time
+from collections import deque
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Deque, List, Optional
 
 from dbt.artifacts.exceptions import IncompatibleSchemaError
 from dbt.artifacts.schemas.manifest import WritableManifest
@@ -34,9 +36,16 @@ from dbt.exceptions import (
 from dbt.flags import get_flags
 from dbt_common.events.base_types import EventLevel
 from dbt_common.events.functions import fire_event, get_invocation_id
+from dbt_common.events.types import Note
 
 if TYPE_CHECKING:
     from dbt.config import RuntimeConfig
+
+# Trailing output lines (stdout+stderr, interleaved by arrival order) kept in
+# memory and surfaced in FusionParserError on a nonzero exit, so the failure
+# reason is visible even to a consumer that only sees the raised exception
+# rather than the live event stream (e.g. dbt Studio's error surfacing).
+_OUTPUT_TAIL_LINES = 40
 
 
 def parse_with_fusion(
@@ -332,25 +341,33 @@ def _fusion_subprocess_env() -> dict:
 
 
 def _run_fusion(argv: List[str]) -> None:
-    # Passthrough mode: the fusion parser inherits dbt's stdout/stderr so users
-    # see progress and errors live. This bypasses dbt's event system (no
-    # log-file capture, no --log-format json, no level filtering), but is the
-    # only way to get streaming output without re-parsing the parser's
-    # free-form text.
-    #
-    # TODO: replace with Popen + line-by-line streaming and re-emit through
-    # fire_event once the fusion parser ships its structured (JSON) log stream
-    # and the Python parsing library lands. Sketch:
-    #   proc = subprocess.Popen(argv, stdout=PIPE, stderr=PIPE, text=True, bufsize=1)
-    #   - read stdout/stderr concurrently (threads or selectors; a single
-    #     blocking readline() on one stream deadlocks if the other fills its pipe)
-    #   - parse each line as a structured log record
-    #   - map level/message to a dbt event type and fire_event(...)
-    #   - proc.wait() and check returncode
-    # Until then, capturing-then-printing-at-end would lose streaming (fusion
-    # parsing can take minutes on large projects), so we inherit fds instead.
+    """Run the fusion parser subprocess, capturing stdout/stderr and re-emitting
+    each line live through dbt-core's event system as it arrives.
+
+    Piping (rather than inheriting) the child's fds means its output only
+    reaches the user via fire_event — this is what makes it visible to any
+    consumer of dbt-core's own event stream (e.g. dbt Studio's IDE log
+    capture), which previously only saw the fusion parser's output if
+    something was reading the raw inherited file descriptors directly (true
+    for a CLI terminal, not true inside Studio's execution model).
+
+    The fusion parser doesn't yet emit a structured (JSON/OTel) log stream
+    dbt-core can parse, so lines are re-emitted verbatim as Note events —
+    stdout at INFO, stderr at WARN — rather than mapped to fusion's own
+    per-line levels.
+    TODO: once the fusion parser ships that structured log stream and the
+    Python library to decode it lands, replace this raw re-emission with a
+    real parse into properly leveled/structured dbt events.
+    """
     try:
-        result = subprocess.run(argv, check=False, env=_fusion_subprocess_env())
+        proc = subprocess.Popen(
+            argv,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+            env=_fusion_subprocess_env(),
+        )
     except FileNotFoundError as e:
         raise FusionParserError(
             f"Fusion parser command not found: {argv[0]!r}. "
@@ -358,10 +375,34 @@ def _run_fusion(argv: List[str]) -> None:
             f"point to an alternate engine binary."
         ) from e
 
-    if result.returncode != 0:
+    tail: Deque[str] = deque(maxlen=_OUTPUT_TAIL_LINES)
+    tail_lock = threading.Lock()
+
+    def _pump(stream, level: EventLevel) -> None:
+        for raw_line in stream:
+            line = raw_line.rstrip("\n")
+            with tail_lock:
+                tail.append(line)
+            fire_event(Note(msg=line), level=level)
+
+    # Separate threads per stream avoid the deadlock a single blocking
+    # readline() would hit if the other stream fills its OS pipe buffer.
+    readers = [
+        threading.Thread(target=_pump, args=(proc.stdout, EventLevel.INFO), daemon=True),
+        threading.Thread(target=_pump, args=(proc.stderr, EventLevel.WARN), daemon=True),
+    ]
+    for reader in readers:
+        reader.start()
+    for reader in readers:
+        reader.join()
+    returncode = proc.wait()
+
+    if returncode != 0:
+        with tail_lock:
+            excerpt = "\n".join(tail)
         raise FusionParserError(
-            f"Fusion parser failed (exit {result.returncode}); see parser output above.",
-            returncode=result.returncode,
+            f"Fusion parser failed (exit {returncode}).\n{excerpt}",
+            returncode=returncode,
         )
 
 

--- a/core/dbt/parser/fusion.py
+++ b/core/dbt/parser/fusion.py
@@ -402,7 +402,9 @@ def _run_fusion(argv: List[str]) -> None:
             f"point to an alternate engine binary."
         ) from e
 
-    assert proc.stdout is not None and proc.stderr is not None  # guaranteed by stdout/stderr=PIPE above
+    assert (
+        proc.stdout is not None and proc.stderr is not None
+    )  # guaranteed by stdout/stderr=PIPE above
 
     def _pump(stream, fallback_level: EventLevel) -> None:
         for raw_line in stream:

--- a/core/dbt/parser/fusion.py
+++ b/core/dbt/parser/fusion.py
@@ -390,6 +390,8 @@ def _run_fusion(argv: List[str]) -> None:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             bufsize=1,
             env=_fusion_subprocess_env(),
         )

--- a/core/dbt/parser/fusion.py
+++ b/core/dbt/parser/fusion.py
@@ -17,9 +17,11 @@ import shutil
 import subprocess
 import sysconfig
 import tempfile
+import threading
 import time
+from collections import deque
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Deque, List, Optional
 
 from dbt.artifacts.exceptions import IncompatibleSchemaError
 from dbt.artifacts.schemas.manifest import WritableManifest
@@ -33,9 +35,16 @@ from dbt.exceptions import (
 from dbt.flags import get_flags
 from dbt_common.events.base_types import EventLevel
 from dbt_common.events.functions import fire_event, get_invocation_id
+from dbt_common.events.types import Note
 
 if TYPE_CHECKING:
     from dbt.config import RuntimeConfig
+
+# Trailing output lines (stdout+stderr, interleaved by arrival order) kept in
+# memory and surfaced in FusionParserError on a nonzero exit, so the failure
+# reason is visible even to a consumer that only sees the raised exception
+# rather than the live event stream (e.g. dbt Studio's error surfacing).
+_OUTPUT_TAIL_LINES = 40
 
 
 def parse_with_fusion(
@@ -240,25 +249,33 @@ def _fusion_subprocess_env() -> dict:
 
 
 def _run_fusion(argv: List[str]) -> None:
-    # Passthrough mode: the fusion parser inherits dbt's stdout/stderr so users
-    # see progress and errors live. This bypasses dbt's event system (no
-    # log-file capture, no --log-format json, no level filtering), but is the
-    # only way to get streaming output without re-parsing the parser's
-    # free-form text.
-    #
-    # TODO: replace with Popen + line-by-line streaming and re-emit through
-    # fire_event once the fusion parser ships its structured (JSON) log stream
-    # and the Python parsing library lands. Sketch:
-    #   proc = subprocess.Popen(argv, stdout=PIPE, stderr=PIPE, text=True, bufsize=1)
-    #   - read stdout/stderr concurrently (threads or selectors; a single
-    #     blocking readline() on one stream deadlocks if the other fills its pipe)
-    #   - parse each line as a structured log record
-    #   - map level/message to a dbt event type and fire_event(...)
-    #   - proc.wait() and check returncode
-    # Until then, capturing-then-printing-at-end would lose streaming (fusion
-    # parsing can take minutes on large projects), so we inherit fds instead.
+    """Run the fusion parser subprocess, capturing stdout/stderr and re-emitting
+    each line live through dbt-core's event system as it arrives.
+
+    Piping (rather than inheriting) the child's fds means its output only
+    reaches the user via fire_event — this is what makes it visible to any
+    consumer of dbt-core's own event stream (e.g. dbt Studio's IDE log
+    capture), which previously only saw the fusion parser's output if
+    something was reading the raw inherited file descriptors directly (true
+    for a CLI terminal, not true inside Studio's execution model).
+
+    The fusion parser doesn't yet emit a structured (JSON/OTel) log stream
+    dbt-core can parse, so lines are re-emitted verbatim as Note events —
+    stdout at INFO, stderr at WARN — rather than mapped to fusion's own
+    per-line levels.
+    TODO: once the fusion parser ships that structured log stream and the
+    Python library to decode it lands, replace this raw re-emission with a
+    real parse into properly leveled/structured dbt events.
+    """
     try:
-        result = subprocess.run(argv, check=False, env=_fusion_subprocess_env())
+        proc = subprocess.Popen(
+            argv,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+            env=_fusion_subprocess_env(),
+        )
     except FileNotFoundError as e:
         raise FusionParserError(
             f"Fusion parser command not found: {argv[0]!r}. "
@@ -266,10 +283,34 @@ def _run_fusion(argv: List[str]) -> None:
             f"point to an alternate engine binary."
         ) from e
 
-    if result.returncode != 0:
+    tail: Deque[str] = deque(maxlen=_OUTPUT_TAIL_LINES)
+    tail_lock = threading.Lock()
+
+    def _pump(stream, level: EventLevel) -> None:
+        for raw_line in stream:
+            line = raw_line.rstrip("\n")
+            with tail_lock:
+                tail.append(line)
+            fire_event(Note(msg=line), level=level)
+
+    # Separate threads per stream avoid the deadlock a single blocking
+    # readline() would hit if the other stream fills its OS pipe buffer.
+    readers = [
+        threading.Thread(target=_pump, args=(proc.stdout, EventLevel.INFO), daemon=True),
+        threading.Thread(target=_pump, args=(proc.stderr, EventLevel.WARN), daemon=True),
+    ]
+    for reader in readers:
+        reader.start()
+    for reader in readers:
+        reader.join()
+    returncode = proc.wait()
+
+    if returncode != 0:
+        with tail_lock:
+            excerpt = "\n".join(tail)
         raise FusionParserError(
-            f"Fusion parser failed (exit {result.returncode}); see parser output above.",
-            returncode=result.returncode,
+            f"Fusion parser failed (exit {returncode}).\n{excerpt}",
+            returncode=returncode,
         )
 
 

--- a/tests/unit/parser/test_fusion.py
+++ b/tests/unit/parser/test_fusion.py
@@ -1,9 +1,8 @@
 import json
 import os
-import subprocess
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Optional
+from typing import Iterable, Optional
 from unittest import mock
 
 import pytest
@@ -21,6 +20,8 @@ from dbt.parser.fusion import (
     parse_with_fusion,
     rediscover_adapter_macros,
 )
+from dbt_common.events.base_types import EventLevel
+from dbt_common.events.types import Note
 
 
 def _flags(**overrides):
@@ -39,21 +40,47 @@ def _flags(**overrides):
     return SimpleNamespace(**base)
 
 
-def _fake_parser(manifest_text: Optional[str], returncode: int = 0, stderr: str = ""):
-    """Build a subprocess.run side_effect that writes manifest.json into the
+class _FakePopen:
+    """Stand-in for subprocess.Popen that supplies the attributes _run_fusion
+    reads: iterable text-mode stdout/stderr streams, wait() -> returncode."""
+
+    def __init__(
+        self,
+        argv,
+        returncode: int = 0,
+        stdout_lines: Iterable[str] = (),
+        stderr_lines: Iterable[str] = (),
+    ):
+        self.stdout = iter([line + "\n" for line in stdout_lines])
+        self.stderr = iter([line + "\n" for line in stderr_lines])
+        self.returncode = returncode
+
+    def wait(self) -> int:
+        return self.returncode
+
+
+def _fake_parser(
+    manifest_text: Optional[str],
+    returncode: int = 0,
+    stderr: str = "",
+    stdout_lines: Iterable[str] = (),
+    stderr_lines: Iterable[str] = (),
+):
+    """Build a subprocess.Popen side_effect that writes manifest.json into the
     --target-path argv slot. Pass manifest_text=None to simulate a parser run
     that exits successfully without writing a manifest."""
 
-    def _run(argv, *args, **kwargs):
+    def _popen(argv, *args, **kwargs):
         if manifest_text is not None and returncode == 0:
             target_path = Path(argv[argv.index("--target-path") + 1])
             target_path.mkdir(parents=True, exist_ok=True)
             (target_path / "manifest.json").write_text(manifest_text)
-        return subprocess.CompletedProcess(
-            args=argv, returncode=returncode, stdout="", stderr=stderr
+        lines = stderr_lines or ([stderr] if stderr else ())
+        return _FakePopen(
+            argv, returncode=returncode, stdout_lines=stdout_lines, stderr_lines=lines
         )
 
-    return _run
+    return _popen
 
 
 @pytest.fixture(autouse=True)
@@ -174,7 +201,7 @@ class TestParseWithFusion:
         with mock.patch(
             "dbt.parser.fusion.get_flags",
             return_value=_flags(V2_PARSER="definitely-not-a-real-binary-xyz"),
-        ), mock.patch("dbt.parser.fusion.subprocess.run", side_effect=FileNotFoundError()):
+        ), mock.patch("dbt.parser.fusion.subprocess.Popen", side_effect=FileNotFoundError()):
             with pytest.raises(FusionParserError):
                 parse_with_fusion(self._runtime_config(tmp_path), write=True, write_json=True)
 
@@ -190,7 +217,7 @@ class TestParseWithFusion:
 
         with mock.patch.dict(
             "os.environ", {"DBT_INVOCATION_ENV": "dbt-cloud-prod__host:cloud"}, clear=False
-        ), mock.patch("dbt.parser.fusion.subprocess.run", side_effect=_capture), mock.patch(
+        ), mock.patch("dbt.parser.fusion.subprocess.Popen", side_effect=_capture), mock.patch(
             "dbt.parser.fusion._load_writable_manifest", return_value=mock.MagicMock()
         ), mock.patch(
             "dbt.parser.fusion.Manifest.from_writable_manifest", return_value=mock.MagicMock()
@@ -227,7 +254,7 @@ class TestParseWithFusion:
             "DBT_ENGINE_STATE_API_URL": "https://state.example.com",
         }
         with mock.patch.dict("os.environ", parent_env, clear=False), mock.patch(
-            "dbt.parser.fusion.subprocess.run", side_effect=_capture
+            "dbt.parser.fusion.subprocess.Popen", side_effect=_capture
         ), mock.patch(
             "dbt.parser.fusion._load_writable_manifest", return_value=mock.MagicMock()
         ), mock.patch(
@@ -245,19 +272,70 @@ class TestParseWithFusion:
         assert child_env["DBT_ENGINE_STATE_API_URL"] == "https://state.example.com"
 
     def test_nonzero_exit_raises(self, tmp_path: Path, _patch_fusion_deps):
-        # Passthrough mode: the parser's stderr streams directly to the user,
-        # so the exception only carries the exit code, not the captured stderr.
         with mock.patch(
-            "dbt.parser.fusion.subprocess.run",
+            "dbt.parser.fusion.subprocess.Popen",
             side_effect=_fake_parser(manifest_text=None, returncode=2),
         ):
             with pytest.raises(FusionParserError, match="exit 2"):
                 parse_with_fusion(self._runtime_config(tmp_path), write=True, write_json=True)
 
+    def test_nonzero_exit_error_includes_captured_output(self, tmp_path: Path, _patch_fusion_deps):
+        """Captured stdout/stderr must be embedded in the raised error so the
+        failure reason is visible even to a caller that only sees the exception,
+        not just the live event stream (e.g. dbt Studio's error surfacing)."""
+        with mock.patch(
+            "dbt.parser.fusion.subprocess.Popen",
+            side_effect=_fake_parser(
+                manifest_text=None,
+                returncode=1,
+                stdout_lines=["compiling model foo"],
+                stderr_lines=["panic: division by zero"],
+            ),
+        ):
+            with pytest.raises(FusionParserError, match="panic: division by zero"):
+                parse_with_fusion(self._runtime_config(tmp_path), write=True, write_json=True)
+
+    def test_output_lines_reemitted_as_note_events(self, tmp_path: Path, _patch_fusion_deps):
+        """stdout/stderr lines must be re-emitted through dbt-core's event
+        system (as Note events) so they reach any consumer of that stream
+        (e.g. dbt Studio), not just a raw inherited terminal fd."""
+        events: list = []
+        levels: list = []
+
+        def _capture(event, *args, **kwargs):
+            events.append(event)
+            levels.append(kwargs.get("level"))
+
+        with mock.patch(
+            "dbt.parser.fusion.subprocess.Popen",
+            side_effect=_fake_parser(
+                manifest_text=json.dumps({"metadata": {}}),
+                stdout_lines=["compiling model foo"],
+                stderr_lines=["warning: deprecated config"],
+            ),
+        ), mock.patch(
+            "dbt.parser.fusion._load_writable_manifest", return_value=mock.MagicMock()
+        ), mock.patch(
+            "dbt.parser.fusion.Manifest.from_writable_manifest", return_value=mock.MagicMock()
+        ), mock.patch(
+            "dbt.parser.fusion.fire_event", side_effect=_capture
+        ):
+            parse_with_fusion(self._runtime_config(tmp_path), write=False, write_json=False)
+
+        notes = [(e.msg, lvl) for e, lvl in zip(events, levels) if isinstance(e, Note)]
+        assert (
+            "compiling model foo",
+            EventLevel.INFO,
+        ) in notes
+        assert (
+            "warning: deprecated config",
+            EventLevel.WARN,
+        ) in notes
+
     def test_missing_manifest_after_success_raises(self, tmp_path: Path, _patch_fusion_deps):
         """Parser exits 0 but writes nothing — must raise, not silently load a stale file."""
         with mock.patch(
-            "dbt.parser.fusion.subprocess.run", side_effect=_fake_parser(manifest_text=None)
+            "dbt.parser.fusion.subprocess.Popen", side_effect=_fake_parser(manifest_text=None)
         ):
             with pytest.raises(FusionParserError, match="did not produce"):
                 parse_with_fusion(self._runtime_config(tmp_path), write=True, write_json=True)
@@ -267,14 +345,14 @@ class TestParseWithFusion:
         the fusion handoff — parser writes into a fresh temp dir."""
         (tmp_path / "manifest.json").write_text(json.dumps({"stale": True}))
         with mock.patch(
-            "dbt.parser.fusion.subprocess.run", side_effect=_fake_parser(manifest_text=None)
+            "dbt.parser.fusion.subprocess.Popen", side_effect=_fake_parser(manifest_text=None)
         ):
             with pytest.raises(FusionParserError, match="did not produce"):
                 parse_with_fusion(self._runtime_config(tmp_path), write=True, write_json=True)
 
     def test_invalid_json_raises_schema_error(self, tmp_path: Path, _patch_fusion_deps):
         with mock.patch(
-            "dbt.parser.fusion.subprocess.run", side_effect=_fake_parser("{ not valid json")
+            "dbt.parser.fusion.subprocess.Popen", side_effect=_fake_parser("{ not valid json")
         ):
             with pytest.raises(FusionParserSchemaError):
                 parse_with_fusion(self._runtime_config(tmp_path), write=True, write_json=True)
@@ -285,7 +363,9 @@ class TestParseWithFusion:
         bad_version = json.dumps(
             {"metadata": {"dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v1.json"}}
         )
-        with mock.patch("dbt.parser.fusion.subprocess.run", side_effect=_fake_parser(bad_version)):
+        with mock.patch(
+            "dbt.parser.fusion.subprocess.Popen", side_effect=_fake_parser(bad_version)
+        ):
             with pytest.raises(FusionParserVersionError):
                 parse_with_fusion(self._runtime_config(tmp_path), write=True, write_json=True)
 
@@ -296,7 +376,7 @@ class TestParseWithFusion:
         target = tmp_path / "target"
         target.mkdir()
         with mock.patch(
-            "dbt.parser.fusion.subprocess.run",
+            "dbt.parser.fusion.subprocess.Popen",
             side_effect=_fake_parser(json.dumps({"metadata": {}})),
         ), mock.patch(
             "dbt.parser.fusion._load_writable_manifest",
@@ -319,7 +399,7 @@ class TestParseWithFusion:
         target.mkdir()
         corrected_manifest = mock.MagicMock()
         with mock.patch(
-            "dbt.parser.fusion.subprocess.run",
+            "dbt.parser.fusion.subprocess.Popen",
             side_effect=_fake_parser(json.dumps({"metadata": {}})),
         ), mock.patch(
             "dbt.parser.fusion._load_writable_manifest",
@@ -354,7 +434,7 @@ class TestParseWithFusionTelemetry:
     def test_success_fires_start_and_end_success(self, tmp_path: Path, _patch_fusion_deps):
         events, patch_fire = self._patch_fire_event()
         with patch_fire, mock.patch(
-            "dbt.parser.fusion.subprocess.run",
+            "dbt.parser.fusion.subprocess.Popen",
             side_effect=_fake_parser(json.dumps({"metadata": {}})),
         ), mock.patch(
             "dbt.parser.fusion._load_writable_manifest", return_value=mock.MagicMock()
@@ -395,7 +475,7 @@ class TestParseWithFusionTelemetry:
     ):
         events, patch_fire = self._patch_fire_event()
         with patch_fire, mock.patch(
-            "dbt.parser.fusion.subprocess.run", side_effect=subprocess_side_effect
+            "dbt.parser.fusion.subprocess.Popen", side_effect=subprocess_side_effect
         ):
             with pytest.raises(FusionParserError):
                 parse_with_fusion(self._runtime_config(tmp_path), write=True, write_json=True)
@@ -413,7 +493,7 @@ class TestParseWithFusionTelemetry:
             {"metadata": {"dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v1.json"}}
         )
         with patch_fire, mock.patch(
-            "dbt.parser.fusion.subprocess.run", side_effect=_fake_parser(bad_version)
+            "dbt.parser.fusion.subprocess.Popen", side_effect=_fake_parser(bad_version)
         ):
             with pytest.raises(FusionParserVersionError):
                 parse_with_fusion(self._runtime_config(tmp_path), write=True, write_json=True)

--- a/tests/unit/parser/test_fusion.py
+++ b/tests/unit/parser/test_fusion.py
@@ -40,6 +40,21 @@ def _flags(**overrides):
     return SimpleNamespace(**base)
 
 
+class _FakeStream:
+    """Iterable text-mode stream stand-in that also supports close(), like a
+    real Popen pipe."""
+
+    def __init__(self, lines: Iterable[str]):
+        self._iter = iter(lines)
+        self.closed = False
+
+    def __iter__(self):
+        return self._iter
+
+    def close(self) -> None:
+        self.closed = True
+
+
 class _FakePopen:
     """Stand-in for subprocess.Popen that supplies the attributes _run_fusion
     reads: iterable text-mode stdout/stderr streams, wait() -> returncode."""
@@ -51,8 +66,8 @@ class _FakePopen:
         stdout_lines: Iterable[str] = (),
         stderr_lines: Iterable[str] = (),
     ):
-        self.stdout = iter([line + "\n" for line in stdout_lines])
-        self.stderr = iter([line + "\n" for line in stderr_lines])
+        self.stdout = _FakeStream([line + "\n" for line in stdout_lines])
+        self.stderr = _FakeStream([line + "\n" for line in stderr_lines])
         self.returncode = returncode
 
     def wait(self) -> int:

--- a/tests/unit/parser/test_fusion.py
+++ b/tests/unit/parser/test_fusion.py
@@ -100,7 +100,12 @@ class TestBuildArgv:
             yield
 
     def test_default_command_no_forwards(self):
-        assert _build_argv(_flags()) == ["dbt-core-experimental-parser", "parse"]
+        assert _build_argv(_flags()) == [
+            "dbt-core-experimental-parser",
+            "parse",
+            "--log-format",
+            "json",
+        ]
 
     def test_forwards_all_known_flags(self):
         argv = _build_argv(
@@ -128,16 +133,31 @@ class TestBuildArgv:
         i = argv.index("--vars")
         assert "k" in argv[i + 1] and "v" in argv[i + 1]
 
+    def test_forwards_log_format_json(self):
+        """--log-format json is always forwarded (not user-configurable) so
+        _run_fusion can parse each line's real severity instead of using a
+        single hardcoded level per stream."""
+        argv = _build_argv(_flags())
+        i = argv.index("--log-format")
+        assert argv[i + 1] == "json"
+
     def test_custom_command_split_with_shlex(self):
         argv = _build_argv(_flags(V2_PARSER="uv run dbt-core-experimental-parser parse"))
-        assert argv == ["uv", "run", "dbt-core-experimental-parser", "parse"]
+        assert argv == [
+            "uv",
+            "run",
+            "dbt-core-experimental-parser",
+            "parse",
+            "--log-format",
+            "json",
+        ]
 
     def test_expands_tilde_in_v2_parser_path(self):
         # shlex.split leaves ~ literal; users expect shell-style expansion when
         # pointing --v2-parser at a binary under their home directory.
         home = os.path.expanduser("~")
         argv = _build_argv(_flags(V2_PARSER="~/bin/my-parser parse"))
-        assert argv == [f"{home}/bin/my-parser", "parse"]
+        assert argv == [f"{home}/bin/my-parser", "parse", "--log-format", "json"]
 
     def test_target_path_override_replaces_user_value(self):
         argv = _build_argv(_flags(TARGET_PATH="user/target"), target_path_override="/tmp/handoff")
@@ -279,26 +299,9 @@ class TestParseWithFusion:
             with pytest.raises(FusionParserError, match="exit 2"):
                 parse_with_fusion(self._runtime_config(tmp_path), write=True, write_json=True)
 
-    def test_nonzero_exit_error_includes_captured_output(self, tmp_path: Path, _patch_fusion_deps):
-        """Captured stdout/stderr must be embedded in the raised error so the
-        failure reason is visible even to a caller that only sees the exception,
-        not just the live event stream (e.g. dbt Studio's error surfacing)."""
-        with mock.patch(
-            "dbt.parser.fusion.subprocess.Popen",
-            side_effect=_fake_parser(
-                manifest_text=None,
-                returncode=1,
-                stdout_lines=["compiling model foo"],
-                stderr_lines=["panic: division by zero"],
-            ),
-        ):
-            with pytest.raises(FusionParserError, match="panic: division by zero"):
-                parse_with_fusion(self._runtime_config(tmp_path), write=True, write_json=True)
-
-    def test_output_lines_reemitted_as_note_events(self, tmp_path: Path, _patch_fusion_deps):
-        """stdout/stderr lines must be re-emitted through dbt-core's event
-        system (as Note events) so they reach any consumer of that stream
-        (e.g. dbt Studio), not just a raw inherited terminal fd."""
+    def _run_and_capture_notes(self, tmp_path: Path, stdout_lines=(), stderr_lines=()):
+        """Run parse_with_fusion against fake stdout/stderr lines and return
+        the (msg, level) pairs of every Note event fired."""
         events: list = []
         levels: list = []
 
@@ -310,8 +313,8 @@ class TestParseWithFusion:
             "dbt.parser.fusion.subprocess.Popen",
             side_effect=_fake_parser(
                 manifest_text=json.dumps({"metadata": {}}),
-                stdout_lines=["compiling model foo"],
-                stderr_lines=["warning: deprecated config"],
+                stdout_lines=stdout_lines,
+                stderr_lines=stderr_lines,
             ),
         ), mock.patch(
             "dbt.parser.fusion._load_writable_manifest", return_value=mock.MagicMock()
@@ -322,15 +325,60 @@ class TestParseWithFusion:
         ):
             parse_with_fusion(self._runtime_config(tmp_path), write=False, write_json=False)
 
-        notes = [(e.msg, lvl) for e, lvl in zip(events, levels) if isinstance(e, Note)]
-        assert (
-            "compiling model foo",
-            EventLevel.INFO,
-        ) in notes
-        assert (
-            "warning: deprecated config",
-            EventLevel.WARN,
-        ) in notes
+        return [(e.msg, lvl) for e, lvl in zip(events, levels) if isinstance(e, Note)]
+
+    def test_output_lines_reemitted_as_note_events(self, tmp_path: Path, _patch_fusion_deps):
+        """Non-JSON stdout/stderr lines must still be re-emitted through
+        dbt-core's event system (as Note events) at the stream's fallback
+        level, so they reach any consumer of that stream (e.g. dbt Studio),
+        not just a raw inherited terminal fd. This is the json-compat
+        fallback path: plain-text lines (e.g. pre-JSON-logger clap/panic
+        output) aren't dropped just because they aren't valid JSON."""
+        notes = self._run_and_capture_notes(
+            tmp_path,
+            stdout_lines=["compiling model foo"],
+            stderr_lines=["warning: deprecated config"],
+        )
+        assert ("compiling model foo", EventLevel.INFO) in notes
+        assert ("warning: deprecated config", EventLevel.WARN) in notes
+
+    @pytest.mark.parametrize(
+        "fusion_level, expected_level",
+        [
+            ("error", EventLevel.ERROR),
+            ("warn", EventLevel.WARN),
+            ("info", EventLevel.INFO),
+            ("debug", EventLevel.DEBUG),
+        ],
+    )
+    def test_json_line_reemitted_with_mapped_level(
+        self, tmp_path: Path, _patch_fusion_deps, fusion_level, expected_level
+    ):
+        """A json-compat line's own info.level must override the stream's
+        fallback level (e.g. an "error" on stdout is still fired as ERROR,
+        not silently downgraded to stdout's INFO fallback)."""
+        line = json.dumps({"info": {"level": fusion_level, "msg": "boom"}})
+        notes = self._run_and_capture_notes(tmp_path, stdout_lines=[line])
+        assert ("boom", expected_level) in notes
+
+    def test_json_line_unknown_level_falls_back(self, tmp_path: Path, _patch_fusion_deps):
+        """An info.level string outside the known vocabulary must not raise —
+        json-compat isn't a stable contract, so an unrecognized level falls
+        back to the stream's default rather than crashing the parse."""
+        line = json.dumps({"info": {"level": "trace", "msg": "boom"}})
+        notes = self._run_and_capture_notes(tmp_path, stdout_lines=[line])
+        assert ("boom", EventLevel.INFO) in notes
+
+    def test_non_json_line_falls_back_to_raw_note(self, tmp_path: Path, _patch_fusion_deps):
+        notes = self._run_and_capture_notes(tmp_path, stdout_lines=["not json at all"])
+        assert ("not json at all", EventLevel.INFO) in notes
+
+    def test_json_line_missing_info_or_msg_falls_back(self, tmp_path: Path, _patch_fusion_deps):
+        """json-compat isn't a guaranteed contract; a schema change that drops
+        or renames fields must degrade to the raw line rather than crash."""
+        line = json.dumps({"unexpected": "shape"})
+        notes = self._run_and_capture_notes(tmp_path, stderr_lines=[line])
+        assert (line, EventLevel.WARN) in notes
 
     def test_missing_manifest_after_success_raises(self, tmp_path: Path, _patch_fusion_deps):
         """Parser exits 0 but writes nothing — must raise, not silently load a stale file."""

--- a/tests/unit/parser/test_fusion.py
+++ b/tests/unit/parser/test_fusion.py
@@ -1,9 +1,8 @@
 import json
 import os
-import subprocess
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Optional
+from typing import Iterable, Optional
 from unittest import mock
 
 import pytest
@@ -20,6 +19,8 @@ from dbt.parser.fusion import (
     _serialize_vars,
     parse_with_fusion,
 )
+from dbt_common.events.base_types import EventLevel
+from dbt_common.events.types import Note
 
 
 def _flags(**overrides):
@@ -38,21 +39,47 @@ def _flags(**overrides):
     return SimpleNamespace(**base)
 
 
-def _fake_parser(manifest_text: Optional[str], returncode: int = 0, stderr: str = ""):
-    """Build a subprocess.run side_effect that writes manifest.json into the
+class _FakePopen:
+    """Stand-in for subprocess.Popen that supplies the attributes _run_fusion
+    reads: iterable text-mode stdout/stderr streams, wait() -> returncode."""
+
+    def __init__(
+        self,
+        argv,
+        returncode: int = 0,
+        stdout_lines: Iterable[str] = (),
+        stderr_lines: Iterable[str] = (),
+    ):
+        self.stdout = iter([line + "\n" for line in stdout_lines])
+        self.stderr = iter([line + "\n" for line in stderr_lines])
+        self.returncode = returncode
+
+    def wait(self) -> int:
+        return self.returncode
+
+
+def _fake_parser(
+    manifest_text: Optional[str],
+    returncode: int = 0,
+    stderr: str = "",
+    stdout_lines: Iterable[str] = (),
+    stderr_lines: Iterable[str] = (),
+):
+    """Build a subprocess.Popen side_effect that writes manifest.json into the
     --target-path argv slot. Pass manifest_text=None to simulate a parser run
     that exits successfully without writing a manifest."""
 
-    def _run(argv, *args, **kwargs):
+    def _popen(argv, *args, **kwargs):
         if manifest_text is not None and returncode == 0:
             target_path = Path(argv[argv.index("--target-path") + 1])
             target_path.mkdir(parents=True, exist_ok=True)
             (target_path / "manifest.json").write_text(manifest_text)
-        return subprocess.CompletedProcess(
-            args=argv, returncode=returncode, stdout="", stderr=stderr
+        lines = stderr_lines or ([stderr] if stderr else ())
+        return _FakePopen(
+            argv, returncode=returncode, stdout_lines=stdout_lines, stderr_lines=lines
         )
 
-    return _run
+    return _popen
 
 
 @pytest.fixture(autouse=True)
@@ -171,7 +198,7 @@ class TestParseWithFusion:
         with mock.patch(
             "dbt.parser.fusion.get_flags",
             return_value=_flags(V2_PARSER="definitely-not-a-real-binary-xyz"),
-        ), mock.patch("dbt.parser.fusion.subprocess.run", side_effect=FileNotFoundError()):
+        ), mock.patch("dbt.parser.fusion.subprocess.Popen", side_effect=FileNotFoundError()):
             with pytest.raises(FusionParserError):
                 parse_with_fusion(self._runtime_config(tmp_path), write=True, write_json=True)
 
@@ -187,7 +214,7 @@ class TestParseWithFusion:
 
         with mock.patch.dict(
             "os.environ", {"DBT_INVOCATION_ENV": "dbt-cloud-prod__host:cloud"}, clear=False
-        ), mock.patch("dbt.parser.fusion.subprocess.run", side_effect=_capture), mock.patch(
+        ), mock.patch("dbt.parser.fusion.subprocess.Popen", side_effect=_capture), mock.patch(
             "dbt.parser.fusion._load_writable_manifest", return_value=mock.MagicMock()
         ), mock.patch(
             "dbt.parser.fusion.Manifest.from_writable_manifest", return_value=mock.MagicMock()
@@ -223,7 +250,7 @@ class TestParseWithFusion:
             "DBT_ENGINE_STATE_API_URL": "https://state.example.com",
         }
         with mock.patch.dict("os.environ", parent_env, clear=False), mock.patch(
-            "dbt.parser.fusion.subprocess.run", side_effect=_capture
+            "dbt.parser.fusion.subprocess.Popen", side_effect=_capture
         ), mock.patch(
             "dbt.parser.fusion._load_writable_manifest", return_value=mock.MagicMock()
         ), mock.patch(
@@ -240,19 +267,70 @@ class TestParseWithFusion:
         assert child_env["DBT_ENGINE_STATE_API_URL"] == "https://state.example.com"
 
     def test_nonzero_exit_raises(self, tmp_path: Path, _patch_fusion_deps):
-        # Passthrough mode: the parser's stderr streams directly to the user,
-        # so the exception only carries the exit code, not the captured stderr.
         with mock.patch(
-            "dbt.parser.fusion.subprocess.run",
+            "dbt.parser.fusion.subprocess.Popen",
             side_effect=_fake_parser(manifest_text=None, returncode=2),
         ):
             with pytest.raises(FusionParserError, match="exit 2"):
                 parse_with_fusion(self._runtime_config(tmp_path), write=True, write_json=True)
 
+    def test_nonzero_exit_error_includes_captured_output(self, tmp_path: Path, _patch_fusion_deps):
+        """Captured stdout/stderr must be embedded in the raised error so the
+        failure reason is visible even to a caller that only sees the exception,
+        not just the live event stream (e.g. dbt Studio's error surfacing)."""
+        with mock.patch(
+            "dbt.parser.fusion.subprocess.Popen",
+            side_effect=_fake_parser(
+                manifest_text=None,
+                returncode=1,
+                stdout_lines=["compiling model foo"],
+                stderr_lines=["panic: division by zero"],
+            ),
+        ):
+            with pytest.raises(FusionParserError, match="panic: division by zero"):
+                parse_with_fusion(self._runtime_config(tmp_path), write=True, write_json=True)
+
+    def test_output_lines_reemitted_as_note_events(self, tmp_path: Path, _patch_fusion_deps):
+        """stdout/stderr lines must be re-emitted through dbt-core's event
+        system (as Note events) so they reach any consumer of that stream
+        (e.g. dbt Studio), not just a raw inherited terminal fd."""
+        events: list = []
+        levels: list = []
+
+        def _capture(event, *args, **kwargs):
+            events.append(event)
+            levels.append(kwargs.get("level"))
+
+        with mock.patch(
+            "dbt.parser.fusion.subprocess.Popen",
+            side_effect=_fake_parser(
+                manifest_text=json.dumps({"metadata": {}}),
+                stdout_lines=["compiling model foo"],
+                stderr_lines=["warning: deprecated config"],
+            ),
+        ), mock.patch(
+            "dbt.parser.fusion._load_writable_manifest", return_value=mock.MagicMock()
+        ), mock.patch(
+            "dbt.parser.fusion.Manifest.from_writable_manifest", return_value=mock.MagicMock()
+        ), mock.patch(
+            "dbt.parser.fusion.fire_event", side_effect=_capture
+        ):
+            parse_with_fusion(self._runtime_config(tmp_path), write=False, write_json=False)
+
+        notes = [(e.msg, lvl) for e, lvl in zip(events, levels) if isinstance(e, Note)]
+        assert (
+            "compiling model foo",
+            EventLevel.INFO,
+        ) in notes
+        assert (
+            "warning: deprecated config",
+            EventLevel.WARN,
+        ) in notes
+
     def test_missing_manifest_after_success_raises(self, tmp_path: Path, _patch_fusion_deps):
         """Parser exits 0 but writes nothing — must raise, not silently load a stale file."""
         with mock.patch(
-            "dbt.parser.fusion.subprocess.run", side_effect=_fake_parser(manifest_text=None)
+            "dbt.parser.fusion.subprocess.Popen", side_effect=_fake_parser(manifest_text=None)
         ):
             with pytest.raises(FusionParserError, match="did not produce"):
                 parse_with_fusion(self._runtime_config(tmp_path), write=True, write_json=True)
@@ -262,14 +340,14 @@ class TestParseWithFusion:
         the fusion handoff — parser writes into a fresh temp dir."""
         (tmp_path / "manifest.json").write_text(json.dumps({"stale": True}))
         with mock.patch(
-            "dbt.parser.fusion.subprocess.run", side_effect=_fake_parser(manifest_text=None)
+            "dbt.parser.fusion.subprocess.Popen", side_effect=_fake_parser(manifest_text=None)
         ):
             with pytest.raises(FusionParserError, match="did not produce"):
                 parse_with_fusion(self._runtime_config(tmp_path), write=True, write_json=True)
 
     def test_invalid_json_raises_schema_error(self, tmp_path: Path, _patch_fusion_deps):
         with mock.patch(
-            "dbt.parser.fusion.subprocess.run", side_effect=_fake_parser("{ not valid json")
+            "dbt.parser.fusion.subprocess.Popen", side_effect=_fake_parser("{ not valid json")
         ):
             with pytest.raises(FusionParserSchemaError):
                 parse_with_fusion(self._runtime_config(tmp_path), write=True, write_json=True)
@@ -280,7 +358,9 @@ class TestParseWithFusion:
         bad_version = json.dumps(
             {"metadata": {"dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v1.json"}}
         )
-        with mock.patch("dbt.parser.fusion.subprocess.run", side_effect=_fake_parser(bad_version)):
+        with mock.patch(
+            "dbt.parser.fusion.subprocess.Popen", side_effect=_fake_parser(bad_version)
+        ):
             with pytest.raises(FusionParserVersionError):
                 parse_with_fusion(self._runtime_config(tmp_path), write=True, write_json=True)
 
@@ -291,7 +371,7 @@ class TestParseWithFusion:
         target = tmp_path / "target"
         target.mkdir()
         with mock.patch(
-            "dbt.parser.fusion.subprocess.run",
+            "dbt.parser.fusion.subprocess.Popen",
             side_effect=_fake_parser(json.dumps({"metadata": {}})),
         ), mock.patch(
             "dbt.parser.fusion._load_writable_manifest",
@@ -307,7 +387,7 @@ class TestParseWithFusion:
         target = tmp_path / "target"
         target.mkdir()
         with mock.patch(
-            "dbt.parser.fusion.subprocess.run",
+            "dbt.parser.fusion.subprocess.Popen",
             side_effect=_fake_parser(json.dumps({"metadata": {}})),
         ), mock.patch(
             "dbt.parser.fusion._load_writable_manifest",
@@ -342,7 +422,7 @@ class TestParseWithFusionTelemetry:
     def test_success_fires_start_and_end_success(self, tmp_path: Path, _patch_fusion_deps):
         events, patch_fire = self._patch_fire_event()
         with patch_fire, mock.patch(
-            "dbt.parser.fusion.subprocess.run",
+            "dbt.parser.fusion.subprocess.Popen",
             side_effect=_fake_parser(json.dumps({"metadata": {}})),
         ), mock.patch(
             "dbt.parser.fusion._load_writable_manifest", return_value=mock.MagicMock()
@@ -383,7 +463,7 @@ class TestParseWithFusionTelemetry:
     ):
         events, patch_fire = self._patch_fire_event()
         with patch_fire, mock.patch(
-            "dbt.parser.fusion.subprocess.run", side_effect=subprocess_side_effect
+            "dbt.parser.fusion.subprocess.Popen", side_effect=subprocess_side_effect
         ):
             with pytest.raises(FusionParserError):
                 parse_with_fusion(self._runtime_config(tmp_path), write=True, write_json=True)
@@ -401,7 +481,7 @@ class TestParseWithFusionTelemetry:
             {"metadata": {"dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v1.json"}}
         )
         with patch_fire, mock.patch(
-            "dbt.parser.fusion.subprocess.run", side_effect=_fake_parser(bad_version)
+            "dbt.parser.fusion.subprocess.Popen", side_effect=_fake_parser(bad_version)
         ):
             with pytest.raises(FusionParserVersionError):
                 parse_with_fusion(self._runtime_config(tmp_path), write=True, write_json=True)


### PR DESCRIPTION
## Summary

The fusion (v2) parser subprocess previously inherited dbt-core's stdout/stderr directly ("passthrough mode"), so its output was only visible if something read those raw file descriptors — true for a CLI terminal, not true for consumers that only ingest dbt-core's own structured event stream. This meant fusion parser failures surfaced no diagnostic detail at all to such consumers (just "Fusion parser failed (exit 1); see parser output above", with nothing actually shown above).

- `_run_fusion` now pipes the subprocess's stdout/stderr and streams each line live through `fire_event` as a `Note` event, so the output reaches any consumer of dbt-core's event stream.
- The fusion parser can emit structured JSON per line via `--log-format json`, each carrying its own severity (`info.level`) and message (`info.msg`). `_build_argv` now forwards that flag unconditionally, and `_run_fusion` uses it to re-level each Note event by the line's real severity instead of a single hardcoded level per stream. Any line that isn't valid JSON, or is missing the expected fields, falls back to the previous behavior: re-emitted verbatim at the stream's fallback level (stdout at INFO, stderr at WARN). json-compat isn't a stable fusion contract, and fusion still emits plain text before its JSON logger initializes or after a panic, hence the fallback.
- Live streaming to the console is preserved (lines are emitted as they arrive, not buffered until process exit).
- Dropped the tail excerpt previously embedded in `FusionParserError`'s message on a nonzero exit — the failing lines are already streamed live as Note events before the subprocess exits, so repeating them there just duplicated the same output a second time for any consumer collecting both the event stream and the exception message.

## Out of scope

- A Python library to deserialize fusion's native OTel log format into dbt-core's structured event schema — this fix reuses the existing unstructured `Note` event (re-leveled via json-compat where available) to avoid a dependency on unshipped work.