### PR TITLE
feat(dbt-jinja-utils): let reset_result_store accept an external ResultStore

### DIFF
--- a/.changes/unreleased/Features-20260727-130954.yaml
+++ b/.changes/unreleased/Features-20260727-130954.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: reset_result_store accepts an optional caller-supplied ResultStore instead of always creating its own — lets embedders read adapter responses back out after rendering without discarding and re-injecting their own store
+time: 2026-07-27T13:09:54.293733+02:00
+custom:
+    author: thejens
+    issue: "14245"
+    project: dbt-core

--- a/crates/dbt-jinja-utils/src/phases/run/run_node_context.rs
+++ b/crates/dbt-jinja-utils/src/phases/run/run_node_context.rs
@@ -278,8 +278,9 @@ pub fn extend_base_context_stateful_fn(
 }
 
 /// Replace the statement-result-store closures (`store_result`/`load_result`/
-/// `store_raw_result`) in an existing run context with a fresh, isolated
-/// [`ResultStore`].
+/// `store_raw_result`) in an existing run context with a [`ResultStore`] —
+/// a fresh, isolated one by default, or a caller-supplied one via
+/// `result_store`.
 ///
 /// `build_run_node_context` bakes a single `ResultStore` into the context. That
 /// store is fine when a context is used once, but microbatch builds the context
@@ -290,10 +291,19 @@ pub fn extend_base_context_stateful_fn(
 /// or `run_query_statement` on Snowflake), so a batch can `load` a result a peer
 /// already consumed and hit `MacroResultAlreadyLoadedError`.
 ///
-/// Calling this on each per-batch context gives every batch its own registry,
-/// mirroring dbt-core where each batch runner builds its own model context.
-pub fn reset_result_store(context: &mut BTreeMap<String, MinijinjaValue>) {
-    let result_store = ResultStore::default();
+/// Calling this on each per-batch context with `result_store: None` gives every
+/// batch its own registry, mirroring dbt-core where each batch runner builds its
+/// own model context. Callers that need to read adapter responses back out
+/// after rendering (e.g. an embedder building its own execution pipeline on
+/// top of these context builders) pass their own `ResultStore` instead, so the
+/// closures baked into the context write into a store they can inspect
+/// afterward — without this, embedders have to allocate and discard a store
+/// they can never observe, then re-inject their own from scratch.
+pub fn reset_result_store(
+    context: &mut BTreeMap<String, MinijinjaValue>,
+    result_store: Option<ResultStore>,
+) {
+    let result_store = result_store.unwrap_or_default();
     context.insert(
         "store_result".to_owned(),
         MinijinjaValue::from_function(result_store.store_result()),

--- a/crates/dbt-tasks-sa/src/runnable/model.rs
+++ b/crates/dbt-tasks-sa/src/runnable/model.rs
@@ -220,7 +220,7 @@ pub fn execute_microbatch_batch(mb_unit: MicrobatchExecUnit, ctx: &TaskRunnerCtx
     // are cloned (Arc) into every batch; with concurrent_batches the batches
     // interleave store/load for the same statement name (e.g.
     // get_columns_in_relation) and collide with MacroResultAlreadyLoadedError.
-    reset_result_store(&mut ctx_for_batch);
+    reset_result_store(&mut ctx_for_batch, None);
 
     if !mb_unit.batch_ctx.is_first() || mb_unit.is_incremental {
         ctx_for_batch.insert(


### PR DESCRIPTION
## Description & motivation

Follow-up to #14245. The original ask there was `Option<ResultStore>` params
on `build_compile_and_run_base_context`/`extend_base_context_stateful_fn`,
but those have since been reshaped by the `OperationCtx` work — the
narrower, still-live gap is `reset_result_store` (added for microbatch
per-batch isolation), which always builds a fresh internal `ResultStore`
whenever it's called. An embedder building its own execution pipeline on top
of these context builders (to read adapter responses back out after
rendering) currently has to let that internal store's data go unread, then
manually re-inject its own `store_result`/`load_result`/`store_raw_result`
closures into the context afterward — allocating and discarding a store it
can never observe.

This changes `reset_result_store` to take `Option<ResultStore>`: `None`
preserves today's behavior exactly (a fresh, isolated store — the microbatch
call site in `dbt-tasks-sa` is updated to pass `None`, unchanged behavior),
`Some(store)` lets a caller supply their own.

## Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md)
- [x] I have run `cargo fmt` and `cargo clippy` on the changed crates (`dbt-jinja-utils`, `dbt-tasks-sa`) with no warnings
- [x] I have added a changelog entry via `changie new`

## Note on authorship

The diagnosis and design here came out of a conversation with Claude (Anthropic), which also drafted the patch — I've reviewed the change and it matches what I'd write by hand, but wanted to be upfront about it, same as I did on the earlier issues in this area (#14550/#14551/#14552).