### PR TITLE
Fix state:modified not detecting version-level alias changes on versioned models

### DIFF
--- a/.changes/unreleased/Fixes-20260728-120000.yaml
+++ b/.changes/unreleased/Fixes-20260728-120000.yaml
@@ -1,0 +1,9 @@
+kind: Fixes
+body: Fix `state:modified` not detecting alias removal/change on versioned models by
+    recording the version-level `config:` block (e.g. `alias`) in `unrendered_config`,
+    matching dbt-core v1 behavior.
+time: 2026-07-28T12:00:00.000000-05:00
+custom:
+    author: Mohith26
+    issue: "15707"
+    project: dbt-core

--- a/crates/dbt-parser/src/resolve/resolve_models.rs
+++ b/crates/dbt-parser/src/resolve/resolve_models.rs
@@ -13,7 +13,7 @@ use crate::renderer::collect_adapter_identifiers_detect_unsafe;
 use crate::renderer::render_unresolved_sql_files;
 use crate::resolve::resolve_utils::build_unrendered_config;
 use crate::resolve::resolve_utils::err_resource_name_has_spaces;
-use crate::resolve::resolve_utils::extract_config_map;
+use crate::resolve::resolve_utils::extract_schema_yml_config_map;
 use crate::utils::RelationComponents;
 use crate::utils::extract_resource_config_from_raw_project;
 use crate::utils::get_node_fqn;
@@ -256,12 +256,18 @@ pub async fn resolve_models(
     });
 
     // Snapshot raw schema.yml config blocks before render_unresolved_sql_files nulls out
-    // schema_value entries via std::mem::replace. Keyed by model name.
+    // schema_value entries via std::mem::replace. Keyed by model name. For versioned
+    // models, the version-level `config:` block is merged over the model-level one so
+    // per-version overrides (e.g. `alias`) land in `unrendered_config`.
     let raw_schema_yml_configs: BTreeMap<String, BTreeMap<String, dbt_yaml::Value>> =
         models_properties_sans_semantics
             .iter()
             .filter_map(|(key, mpe)| {
-                let config_map = extract_config_map(&mpe.schema_value)?;
+                let version_config = mpe
+                    .version_info
+                    .as_ref()
+                    .and_then(|vi| (*vi.version_config).as_ref());
+                let config_map = extract_schema_yml_config_map(&mpe.schema_value, version_config)?;
                 Some((key.clone(), config_map))
             })
             .collect();

--- a/crates/dbt-parser/src/resolve/resolve_utils.rs
+++ b/crates/dbt-parser/src/resolve/resolve_utils.rs
@@ -405,4 +405,64 @@ mod tests {
             );
         }
     }
+
+    /// Helper: parse a YAML snippet into a `dbt_yaml::Value` for the
+    /// `extract_schema_yml_config_map` tests below.
+    fn yaml(s: &str) -> dbt_yaml::Value {
+        dbt_yaml::from_str(s).unwrap()
+    }
+
+    /// Regression test for dbt-labs/dbt-core#15707: a versioned model's
+    /// version-level `config:` block (e.g. `alias`) must be recorded in the raw
+    /// schema.yml config map feeding `unrendered_config`, otherwise
+    /// `state:modified` cannot detect that the alias was removed or changed.
+    #[test]
+    fn version_level_alias_is_recorded_in_schema_yml_config() {
+        let schema_value = yaml("name: y_v\nlatest_version: 1");
+        let version_config = yaml("alias: aliased_y_v");
+        let config_map =
+            extract_schema_yml_config_map(&schema_value, Some(&version_config)).unwrap();
+        assert_eq!(
+            config_map.get("alias").and_then(|v| v.as_str()),
+            Some("aliased_y_v")
+        );
+    }
+
+    /// Removing the version-level alias (with no model-level `config:`) must
+    /// yield no schema.yml config at all — the before (`alias` present) vs.
+    /// after (absent) difference is what `state:modified` keys off.
+    #[test]
+    fn version_level_alias_removal_yields_no_schema_yml_config() {
+        let schema_value = yaml("name: y_v\nlatest_version: 1");
+        assert!(extract_schema_yml_config_map(&schema_value, None).is_none());
+    }
+
+    /// A version-level `config:` key overrides the model-level one, while
+    /// non-conflicting model-level keys are preserved.
+    #[test]
+    fn version_level_config_overrides_model_level() {
+        let schema_value = yaml("name: y_v\nconfig:\n  alias: model_alias\n  tags: [a]");
+        let version_config = yaml("alias: version_alias");
+        let config_map =
+            extract_schema_yml_config_map(&schema_value, Some(&version_config)).unwrap();
+        assert_eq!(
+            config_map.get("alias").and_then(|v| v.as_str()),
+            Some("version_alias")
+        );
+        assert!(config_map.contains_key("tags"));
+    }
+
+    /// Non-versioned models (no version-level config) keep the previous
+    /// behavior: model-level `config:` is extracted as-is, and models without
+    /// any `config:` block produce no entry.
+    #[test]
+    fn non_versioned_model_schema_yml_config_unchanged() {
+        let schema_value = yaml("name: a\nconfig:\n  alias: aliased_a");
+        let config_map = extract_schema_yml_config_map(&schema_value, None).unwrap();
+        assert_eq!(
+            config_map.get("alias").and_then(|v| v.as_str()),
+            Some("aliased_a")
+        );
+        assert!(extract_schema_yml_config_map(&yaml("name: b"), None).is_none());
+    }
 }

--- a/crates/dbt-parser/src/resolve/resolve_utils.rs
+++ b/crates/dbt-parser/src/resolve/resolve_utils.rs
@@ -41,6 +41,29 @@ pub(crate) fn extract_config_map(
         })
 }
 
+/// Builds the raw schema.yml config map for a model entry, merging the version-level
+/// `config:` block (for versioned models) over the model-level one. This mirrors
+/// dbt-core's versioned model patch construction, so per-version overrides (e.g.
+/// `alias`) are recorded in `unrendered_config` and detected by `state:modified`.
+pub(crate) fn extract_schema_yml_config_map(
+    schema_value: &dbt_yaml::Value,
+    version_config: Option<&dbt_yaml::Value>,
+) -> Option<BTreeMap<String, dbt_yaml::Value>> {
+    let mut config_map = extract_config_map(schema_value).unwrap_or_default();
+    if let Some(mapping) = version_config.and_then(|v| v.as_mapping()) {
+        config_map.extend(
+            mapping
+                .iter()
+                .filter_map(|(k, v)| k.as_str().map(|k| (k.to_string(), v.clone()))),
+        );
+    }
+    if config_map.is_empty() {
+        None
+    } else {
+        Some(config_map)
+    }
+}
+
 /// Builds `unrendered_config` by merging config sources in hierarchical order:
 /// project < root < schema.yml < inline. Each source is merged independently so
 /// that hook key normalization (pre_hook → pre-hook, etc.) applies per-source


### PR DESCRIPTION
Fixes #15707, reported by @jeremyyeo.

When snapshotting raw schema.yml configs for `unrendered_config`, the parser only captured a model's top-level `config:` block. A versioned model's version-level config (for example `alias` inside a `versions:` entry) never landed in `unrendered_config`, and since `state:modified` compares `unrendered_config` for models, removing or changing a version-level alias was invisible to state selection.

The fix merges the version-level `config:` block over the model-level one when building that snapshot, mirroring dbt-core v1's versioned-model patch construction.

Changelog entry added via `.changes/unreleased/`. Four regression tests cover: the alias is recorded, its removal/change is detectable, version keys override model keys, and non-versioned models are unchanged. `cargo test -p dbt-parser --lib`: 272 passed, 0 failed (baseline 268, zero regressions).
