### PR TITLE
feat: include invocation ID in Databricks query comments

### DIFF
--- a/.changes/unreleased/Fixes-20260802-databricks-invocation-id-query-comment.yaml
+++ b/.changes/unreleased/Fixes-20260802-databricks-invocation-id-query-comment.yaml
@@ -2,5 +2,6 @@ kind: Fixes
 body: Include invocation IDs in default Databricks query comments and preserve run-operation connection names
 time: 2026-08-02T06:44:02.000000+00:00
 custom:
+    author: sd-db
     issue: 15689
     project: dbt-core

--- a/.changes/unreleased/Fixes-20260802-databricks-invocation-id-query-comment.yaml
+++ b/.changes/unreleased/Fixes-20260802-databricks-invocation-id-query-comment.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Include invocation IDs in default Databricks query comments and preserve run-operation connection names
+time: 2026-08-02T06:44:02.000000+00:00
+custom:
+    issue: 15689
+    project: dbt-core

--- a/crates/dbt-adapter/src/engine/query_comment.rs
+++ b/crates/dbt-adapter/src/engine/query_comment.rs
@@ -12,19 +12,14 @@ use serde_json::Map as JsonMap;
 use serde_json::Value as JsonValue;
 
 // Reference: https://github.com/dbt-labs/dbt-adapters/blob/317e809abd19026d3784e04281b307c5e6a9d469/dbt-adapters/src/dbt/adapters/contracts/connection.py#L197
-macro_rules! default_query_comment_template {
-    ($additional_fields:literal) => {
-        concat!(
-            "
+const DEFAULT_QUERY_COMMENT: &str = "
 {%- set comment_dict = {} -%}
 {%- do comment_dict.update(
     app='dbt',
     dbt_version=dbt_version,
     profile_name=target.get('profile_name'),
     target_name=target.get('target_name'),
-",
-            $additional_fields,
-            ") -%}
+) -%}
 {%- if node is not none -%}
   {%- do comment_dict.update(
     node_id=node.unique_id,
@@ -34,19 +29,29 @@ macro_rules! default_query_comment_template {
   {%- do comment_dict.update(connection_name=connection_name) -%}
 {%- endif -%}
 {{ return(tojson(comment_dict)) }}
-"
-        )
-    };
-}
-
-const DEFAULT_QUERY_COMMENT: &str = default_query_comment_template!("");
+";
 
 // Databricks includes the command invocation ID in its default query comment.
 // Keep this adapter-specific so the default comments of other adapters remain unchanged.
-const DATABRICKS_QUERY_COMMENT: &str = default_query_comment_template!(
-    "    invocation_id=invocation_id,
-"
-);
+const DATABRICKS_QUERY_COMMENT: &str = "
+{%- set comment_dict = {} -%}
+{%- do comment_dict.update(
+    app='dbt',
+    dbt_version=dbt_version,
+    profile_name=target.get('profile_name'),
+    target_name=target.get('target_name'),
+    invocation_id=invocation_id,
+) -%}
+{%- if node is not none -%}
+  {%- do comment_dict.update(
+    node_id=node.unique_id,
+  ) -%}
+{% else %}
+  {# in the node context, the connection name is the node_id #}
+  {%- do comment_dict.update(connection_name=connection_name) -%}
+{%- endif -%}
+{{ return(tojson(comment_dict)) }}
+";
 
 // Extended default query comment that includes dbt Cloud environment variables when present.
 // Used automatically when any DBT_CLOUD_* environment variable is set.

--- a/crates/dbt-adapter/src/engine/query_comment.rs
+++ b/crates/dbt-adapter/src/engine/query_comment.rs
@@ -12,14 +12,19 @@ use serde_json::Map as JsonMap;
 use serde_json::Value as JsonValue;
 
 // Reference: https://github.com/dbt-labs/dbt-adapters/blob/317e809abd19026d3784e04281b307c5e6a9d469/dbt-adapters/src/dbt/adapters/contracts/connection.py#L197
-const DEFAULT_QUERY_COMMENT: &str = "
+macro_rules! default_query_comment_template {
+    ($additional_fields:literal) => {
+        concat!(
+            "
 {%- set comment_dict = {} -%}
 {%- do comment_dict.update(
     app='dbt',
     dbt_version=dbt_version,
     profile_name=target.get('profile_name'),
     target_name=target.get('target_name'),
-) -%}
+",
+            $additional_fields,
+            ") -%}
 {%- if node is not none -%}
   {%- do comment_dict.update(
     node_id=node.unique_id,
@@ -29,7 +34,19 @@ const DEFAULT_QUERY_COMMENT: &str = "
   {%- do comment_dict.update(connection_name=connection_name) -%}
 {%- endif -%}
 {{ return(tojson(comment_dict)) }}
-";
+"
+        )
+    };
+}
+
+const DEFAULT_QUERY_COMMENT: &str = default_query_comment_template!("");
+
+// Databricks includes the command invocation ID in its default query comment.
+// Keep this adapter-specific so the default comments of other adapters remain unchanged.
+const DATABRICKS_QUERY_COMMENT: &str = default_query_comment_template!(
+    "    invocation_id=invocation_id,
+"
+);
 
 // Extended default query comment that includes dbt Cloud environment variables when present.
 // Used automatically when any DBT_CLOUD_* environment variable is set.
@@ -126,6 +143,8 @@ impl QueryCommentConfig {
                 if use_default {
                     if has_cloud_config(cloud_config) {
                         DEFAULT_QUERY_COMMENT_WITH_CLOUD.to_string()
+                    } else if adapter_type == AdapterType::Databricks {
+                        DATABRICKS_QUERY_COMMENT.to_string()
                     } else {
                         DEFAULT_QUERY_COMMENT.to_string()
                     }
@@ -210,6 +229,10 @@ fn sanitize_label(label: &str) -> String {
 }
 
 #[cfg(test)]
+#[path = "query_comment/databricks_invocation_id_tests.rs"]
+mod databricks_invocation_id_tests;
+
+#[cfg(test)]
 mod tests {
     use dbt_adapter_core::AdapterType;
     use dbt_schemas::schemas::ResolvedCloudConfig;
@@ -217,7 +240,8 @@ mod tests {
     use serde::Deserialize;
 
     use crate::engine::query_comment::{
-        DEFAULT_QUERY_COMMENT, DEFAULT_QUERY_COMMENT_WITH_CLOUD, QueryCommentConfig,
+        DATABRICKS_QUERY_COMMENT, DEFAULT_QUERY_COMMENT, DEFAULT_QUERY_COMMENT_WITH_CLOUD,
+        QueryCommentConfig,
     };
 
     // Env var tests mutate process-wide state, so they must not run in parallel.
@@ -231,11 +255,7 @@ mod tests {
     #[test]
     fn test_empty_query_comment() {
         // Test empty query comment with `use_default`
-        for adapter_type in [
-            AdapterType::Bigquery,
-            AdapterType::Databricks,
-            AdapterType::Redshift,
-        ] {
+        for adapter_type in [AdapterType::Bigquery, AdapterType::Redshift] {
             let config = QueryCommentConfig::from_query_comment(None, adapter_type, true, None);
             let expected_config = QueryCommentConfig {
                 comment: DEFAULT_QUERY_COMMENT.to_string(),
@@ -244,6 +264,15 @@ mod tests {
             };
             assert_configs_equal(&config, &expected_config);
         }
+
+        let config =
+            QueryCommentConfig::from_query_comment(None, AdapterType::Databricks, true, None);
+        let expected_config = QueryCommentConfig {
+            comment: DATABRICKS_QUERY_COMMENT.to_string(),
+            append: false,
+            job_label: false,
+        };
+        assert_configs_equal(&config, &expected_config);
 
         let config =
             QueryCommentConfig::from_query_comment(None, AdapterType::Snowflake, true, None);
@@ -395,7 +424,6 @@ mod tests {
 
         for adapter_type in [
             AdapterType::Bigquery,
-            AdapterType::Databricks,
             AdapterType::Redshift,
             AdapterType::Snowflake,
         ] {
@@ -412,6 +440,19 @@ mod tests {
             };
             assert_configs_equal(&config, &expected_config);
         }
+
+        let config = QueryCommentConfig::from_query_comment(
+            query_comment.clone(),
+            AdapterType::Databricks,
+            true,
+            None,
+        );
+        let expected_config = QueryCommentConfig {
+            comment: DATABRICKS_QUERY_COMMENT.to_string(),
+            append: true,
+            job_label: false,
+        };
+        assert_configs_equal(&config, &expected_config);
 
         let config_str = "append: false";
         let query_comment =
@@ -445,11 +486,7 @@ mod tests {
             QueryComment::deserialize(dbt_yaml::Deserializer::from_str(config_str)).ok();
 
         // This should only work for BigQuery
-        for adapter_type in [
-            AdapterType::Databricks,
-            AdapterType::Redshift,
-            AdapterType::Snowflake,
-        ] {
+        for adapter_type in [AdapterType::Redshift, AdapterType::Snowflake] {
             let config = QueryCommentConfig::from_query_comment(
                 query_comment.clone(),
                 adapter_type,
@@ -463,6 +500,19 @@ mod tests {
             };
             assert_configs_equal(&config, &expected_config);
         }
+
+        let config = QueryCommentConfig::from_query_comment(
+            query_comment.clone(),
+            AdapterType::Databricks,
+            true,
+            None,
+        );
+        let expected_config = QueryCommentConfig {
+            comment: DATABRICKS_QUERY_COMMENT.to_string(),
+            append: false,
+            job_label: false,
+        };
+        assert_configs_equal(&config, &expected_config);
 
         let config = QueryCommentConfig::from_query_comment(
             query_comment,
@@ -565,6 +615,7 @@ mod tests {
             ..Default::default()
         };
         for adapter_type in [
+            AdapterType::Databricks,
             AdapterType::Redshift,
             AdapterType::Snowflake,
             AdapterType::Bigquery,

--- a/crates/dbt-adapter/src/engine/query_comment.rs
+++ b/crates/dbt-adapter/src/engine/query_comment.rs
@@ -143,10 +143,12 @@ impl QueryCommentConfig {
                 if use_default {
                     if has_cloud_config(cloud_config) {
                         DEFAULT_QUERY_COMMENT_WITH_CLOUD.to_string()
-                    } else if adapter_type == AdapterType::Databricks {
-                        DATABRICKS_QUERY_COMMENT.to_string()
                     } else {
-                        DEFAULT_QUERY_COMMENT.to_string()
+                        match adapter_type {
+                            AdapterType::Databricks => DATABRICKS_QUERY_COMMENT,
+                            _ => DEFAULT_QUERY_COMMENT,
+                        }
+                        .to_string()
                     }
                 } else {
                     "".to_string()
@@ -442,7 +444,7 @@ mod tests {
         }
 
         let config = QueryCommentConfig::from_query_comment(
-            query_comment.clone(),
+            query_comment,
             AdapterType::Databricks,
             true,
             None,

--- a/crates/dbt-adapter/src/engine/query_comment.rs
+++ b/crates/dbt-adapter/src/engine/query_comment.rs
@@ -12,14 +12,19 @@ use serde_json::Map as JsonMap;
 use serde_json::Value as JsonValue;
 
 // Reference: https://github.com/dbt-labs/dbt-adapters/blob/317e809abd19026d3784e04281b307c5e6a9d469/dbt-adapters/src/dbt/adapters/contracts/connection.py#L197
-const DEFAULT_QUERY_COMMENT: &str = "
+macro_rules! default_query_comment_template {
+    ($additional_fields:literal) => {
+        concat!(
+            "
 {%- set comment_dict = {} -%}
 {%- do comment_dict.update(
     app='dbt',
     dbt_version=dbt_version,
     profile_name=target.get('profile_name'),
     target_name=target.get('target_name'),
-) -%}
+",
+            $additional_fields,
+            ") -%}
 {%- if node is not none -%}
   {%- do comment_dict.update(
     node_id=node.unique_id,
@@ -29,29 +34,19 @@ const DEFAULT_QUERY_COMMENT: &str = "
   {%- do comment_dict.update(connection_name=connection_name) -%}
 {%- endif -%}
 {{ return(tojson(comment_dict)) }}
-";
+"
+        )
+    };
+}
+
+const DEFAULT_QUERY_COMMENT: &str = default_query_comment_template!("");
 
 // Databricks includes the command invocation ID in its default query comment.
 // Keep this adapter-specific so the default comments of other adapters remain unchanged.
-const DATABRICKS_QUERY_COMMENT: &str = "
-{%- set comment_dict = {} -%}
-{%- do comment_dict.update(
-    app='dbt',
-    dbt_version=dbt_version,
-    profile_name=target.get('profile_name'),
-    target_name=target.get('target_name'),
-    invocation_id=invocation_id,
-) -%}
-{%- if node is not none -%}
-  {%- do comment_dict.update(
-    node_id=node.unique_id,
-  ) -%}
-{% else %}
-  {# in the node context, the connection name is the node_id #}
-  {%- do comment_dict.update(connection_name=connection_name) -%}
-{%- endif -%}
-{{ return(tojson(comment_dict)) }}
-";
+const DATABRICKS_QUERY_COMMENT: &str = default_query_comment_template!(
+    "    invocation_id=invocation_id,
+"
+);
 
 // Extended default query comment that includes dbt Cloud environment variables when present.
 // Used automatically when any DBT_CLOUD_* environment variable is set.

--- a/crates/dbt-adapter/src/engine/query_comment/databricks_invocation_id_tests.rs
+++ b/crates/dbt-adapter/src/engine/query_comment/databricks_invocation_id_tests.rs
@@ -1,0 +1,120 @@
+use std::rc::Rc;
+use std::sync::Arc;
+
+use dbt_adapter_core::AdapterType;
+use minijinja::listener::RenderingEventListener;
+use minijinja::value::Object;
+use minijinja::{Environment, Error, ErrorKind, State, Value, context};
+use serde_json::{Value as JsonValue, json};
+
+use super::QueryCommentConfig;
+
+#[derive(Debug)]
+struct Target;
+
+impl Object for Target {
+    fn call_method(
+        self: &Arc<Self>,
+        _state: &State<'_, '_>,
+        name: &str,
+        args: &[Value],
+        _listeners: &[Rc<dyn RenderingEventListener>],
+    ) -> Result<Value, Error> {
+        if name != "get" {
+            return Err(Error::new(
+                ErrorKind::UnknownMethod,
+                format!("Unknown method on Target: {name}"),
+            ));
+        }
+        Ok(match args.first().and_then(Value::as_str) {
+            Some("profile_name") => Value::from("invocation_id_query_comment"),
+            Some("target_name") => Value::from("conformance"),
+            _ => Value::UNDEFINED,
+        })
+    }
+}
+
+fn render_default_comment(
+    invocation_id: &str,
+    node_id: Option<&str>,
+    connection_name: &str,
+) -> JsonValue {
+    let config = QueryCommentConfig::from_query_comment(None, AdapterType::Databricks, true, None);
+    let mut env = Environment::new();
+    env.add_function("return", |value: Value| value);
+    env.add_function("tojson", |value: Value| -> Result<String, Error> {
+        serde_json::to_string(&value)
+            .map_err(|error| Error::new(ErrorKind::InvalidOperation, error.to_string()))
+    });
+    let node = node_id.map(|unique_id| json!({ "unique_id": unique_id }));
+    let rendered = env
+        .render_str(
+            &config.comment,
+            context! {
+                dbt_version => "2.0.0",
+                target => Value::from_object(Target),
+                invocation_id => invocation_id,
+                node => node,
+                connection_name => connection_name,
+            },
+            &[],
+        )
+        .expect("Databricks default query comment should render");
+    serde_json::from_str(rendered.trim())
+        .expect("Databricks default query comment should render valid JSON")
+}
+
+#[test]
+fn test_databricks_default_query_comment_includes_invocation_id_with_node() {
+    let comment = render_default_comment(
+        "11111111-2222-4333-8444-555555555555",
+        Some("model.invocation_id_query_comment.probe"),
+        "model.invocation_id_query_comment.probe",
+    );
+
+    assert_eq!(
+        comment["invocation_id"],
+        "11111111-2222-4333-8444-555555555555"
+    );
+    assert_eq!(
+        comment["node_id"],
+        "model.invocation_id_query_comment.probe"
+    );
+    assert!(!comment.as_object().unwrap().contains_key("connection_name"));
+}
+
+#[test]
+fn test_databricks_default_query_comment_includes_invocation_id_without_node() {
+    let comment = render_default_comment(
+        "11111111-2222-4333-8444-555555555555",
+        None,
+        "macro_invocation_id_query_comment_non_node",
+    );
+
+    assert_eq!(
+        comment["invocation_id"],
+        "11111111-2222-4333-8444-555555555555"
+    );
+    assert_eq!(
+        comment["connection_name"],
+        "macro_invocation_id_query_comment_non_node"
+    );
+    assert!(!comment.as_object().unwrap().contains_key("node_id"));
+}
+
+#[test]
+fn test_databricks_default_query_comment_reuses_context_invocation_id() {
+    let invocation_id = "11111111-2222-4333-8444-555555555555";
+    let first = render_default_comment(
+        invocation_id,
+        None,
+        "macro_invocation_id_query_comment_non_node",
+    );
+    let second = render_default_comment(
+        invocation_id,
+        None,
+        "macro_invocation_id_query_comment_non_node",
+    );
+
+    assert_eq!(first["invocation_id"], second["invocation_id"]);
+}

--- a/crates/dbt-adapter/src/engine/query_comment/databricks_invocation_id_tests.rs
+++ b/crates/dbt-adapter/src/engine/query_comment/databricks_invocation_id_tests.rs
@@ -1,66 +1,42 @@
-use std::rc::Rc;
-use std::sync::Arc;
+use std::collections::BTreeMap;
 
 use dbt_adapter_core::AdapterType;
-use minijinja::listener::RenderingEventListener;
-use minijinja::value::Object;
-use minijinja::{Environment, Error, ErrorKind, State, Value, context};
-use minijinja_contrib::testing::jinja_assert;
+use minijinja::{Environment, Error, ErrorKind, Value, context};
+use minijinja_contrib::pycompat::unknown_method_callback;
 use serde_json::{Value as JsonValue, json};
 
 use super::QueryCommentConfig;
 
-#[derive(Debug)]
-struct Target;
-
-impl Object for Target {
-    fn call_method(
-        self: &Arc<Self>,
-        _state: &State<'_, '_>,
-        name: &str,
-        args: &[Value],
-        _listeners: &[Rc<dyn RenderingEventListener>],
-    ) -> Result<Value, Error> {
-        if name != "get" {
-            return Err(Error::new(
-                ErrorKind::UnknownMethod,
-                format!("Unknown method on Target: {name}"),
-            ));
-        }
-        Ok(match args.first().and_then(Value::as_str) {
-            Some("profile_name") => Value::from("invocation_id_query_comment"),
-            Some("target_name") => Value::from("conformance"),
-            _ => Value::UNDEFINED,
-        })
-    }
+fn target() -> BTreeMap<String, Value> {
+    BTreeMap::from([
+        (
+            "profile_name".to_string(),
+            Value::from("invocation_id_query_comment"),
+        ),
+        ("target_name".to_string(), Value::from("conformance")),
+    ])
 }
 
 #[test]
-fn test_target_jinja_contract() {
-    jinja_assert(
-        Target,
-        "
-        profile_name: {{ obj.get('profile_name') }}
-        target_name: {{ obj.get('target_name') }}
-        missing_is_undefined: {{ obj.get('missing') is undefined }}
+fn test_target_map_jinja_contract() {
+    let mut env = Environment::new();
+    env.set_unknown_method_callback(unknown_method_callback);
+    let rendered = env
+        .render_str(
+            "
+        profile_name: {{ target.get('profile_name') }}
+        target_name: {{ target.get('target_name') }}
         ",
+            context! { target => target() },
+            &[],
+        )
+        .expect("target map should support Python-compatible get");
+    assert_eq!(
+        rendered,
         "
         profile_name: invocation_id_query_comment
         target_name: conformance
-        missing_is_undefined: True
-        ",
-    );
-
-    let mut env = Environment::new();
-    env.add_global("obj", Value::from_object(Target));
-    let error = env
-        .render_str("{{ obj.unsupported() }}", (), &[])
-        .expect_err("unsupported Target methods should fail in Jinja");
-    assert_eq!(error.kind(), ErrorKind::UnknownMethod);
-    assert!(
-        error
-            .to_string()
-            .contains("Unknown method on Target: unsupported")
+        "
     );
 }
 
@@ -71,6 +47,7 @@ fn render_default_comment(
 ) -> JsonValue {
     let config = QueryCommentConfig::from_query_comment(None, AdapterType::Databricks, true, None);
     let mut env = Environment::new();
+    env.set_unknown_method_callback(unknown_method_callback);
     env.add_function("return", |value: Value| value);
     env.add_function("tojson", |value: Value| -> Result<String, Error> {
         serde_json::to_string(&value)
@@ -82,7 +59,7 @@ fn render_default_comment(
             &config.comment,
             context! {
                 dbt_version => "2.0.0",
-                target => Value::from_object(Target),
+                target => target(),
                 invocation_id => invocation_id,
                 node => node,
                 connection_name => connection_name,

--- a/crates/dbt-adapter/src/engine/query_comment/databricks_invocation_id_tests.rs
+++ b/crates/dbt-adapter/src/engine/query_comment/databricks_invocation_id_tests.rs
@@ -5,6 +5,7 @@ use dbt_adapter_core::AdapterType;
 use minijinja::listener::RenderingEventListener;
 use minijinja::value::Object;
 use minijinja::{Environment, Error, ErrorKind, State, Value, context};
+use minijinja_contrib::testing::jinja_assert;
 use serde_json::{Value as JsonValue, json};
 
 use super::QueryCommentConfig;
@@ -32,6 +33,35 @@ impl Object for Target {
             _ => Value::UNDEFINED,
         })
     }
+}
+
+#[test]
+fn test_target_jinja_contract() {
+    jinja_assert(
+        Target,
+        "
+        profile_name: {{ obj.get('profile_name') }}
+        target_name: {{ obj.get('target_name') }}
+        missing_is_undefined: {{ obj.get('missing') is undefined }}
+        ",
+        "
+        profile_name: invocation_id_query_comment
+        target_name: conformance
+        missing_is_undefined: True
+        ",
+    );
+
+    let mut env = Environment::new();
+    env.add_global("obj", Value::from_object(Target));
+    let error = env
+        .render_str("{{ obj.unsupported() }}", (), &[])
+        .expect_err("unsupported Target methods should fail in Jinja");
+    assert_eq!(error.kind(), ErrorKind::UnknownMethod);
+    assert!(
+        error
+            .to_string()
+            .contains("Unknown method on Target: unsupported")
+    );
 }
 
 fn render_default_comment(

--- a/crates/dbt-tasks-sa/src/run_operation.rs
+++ b/crates/dbt-tasks-sa/src/run_operation.rs
@@ -510,6 +510,10 @@ pub async fn run_operation(
             packages,
         )),
     );
+    run_operation_context.insert(
+        "connection_name".to_owned(),
+        Value::from(format!("macro_{macro_name}")),
+    );
 
     let template = jinja_env.get_template(&template_name)?;
     let state = template.eval_to_state(run_operation_context, &[])?;


### PR DESCRIPTION
Resolves #15689
Related: databricks/dbt-databricks#1378

### Problem

Fusion’s default Databricks query comment does not include the command’s
`invocation_id`. Query history therefore cannot reliably group statements from
the same dbt invocation, and non-node run-operation statements do not retain
dbt-databricks’ connection-name shape.

### Solution

- Add a Databricks-specific default query-comment template containing
  `invocation_id`.
- Preserve dbt Cloud query-comment precedence, explicit overrides, and other
  adapters’ defaults.
- Populate `connection_name` as `macro_<macro_name>` for run-operation
  statements.
- Render and parse the template in tests for node and non-node contexts,
  including reuse of one invocation ID across multiple statements.
- Cover the Jinja object contract used by the query-comment test fixture.

### Validation

- Focused Rust query-comment tests: 4 passed.
- `cargo fmt --all -- --check`.
- Independent dbt-databricks and Fusion live captures passed for node and
  two-statement non-node scenarios.
- Exact ordered feature SQL and warehouse-observation gates passed for both
  scenarios.

### Checklist

- [ ] I have read the contributing guide.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests.
- [ ] This changes a server-visible query comment and may require interface review.
- [x] No Python functions were added or modified.