### PR TITLE
fix: align Databricks materialized view tag configuration

### DIFF
--- a/.changes/unreleased/Fixes-20260729-databricks-materialized-view-tags.yaml
+++ b/.changes/unreleased/Fixes-20260729-databricks-materialized-view-tags.yaml
@@ -3,5 +3,5 @@ body: Preserve Databricks materialized view tags when detecting and applying con
 time: 2026-07-29T00:00:00.000000+05:30
 custom:
     author: sd-db
-    issue: ""
+    issue: "15690"
     project: dbt-core

--- a/.changes/unreleased/Fixes-20260729-databricks-materialized-view-tags.yaml
+++ b/.changes/unreleased/Fixes-20260729-databricks-materialized-view-tags.yaml
@@ -2,6 +2,6 @@ kind: Fixes
 body: Preserve Databricks materialized view tags when detecting and applying configuration changes.
 time: 2026-07-29T00:00:00.000000+05:30
 custom:
-    author: ""
+    author: sd-db
     issue: ""
     project: dbt-core

--- a/.changes/unreleased/Fixes-20260729-databricks-materialized-view-tags.yaml
+++ b/.changes/unreleased/Fixes-20260729-databricks-materialized-view-tags.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Preserve Databricks materialized view tags when detecting and applying configuration changes.
+time: 2026-07-29T00:00:00.000000+05:30
+custom:
+    author: ""
+    issue: ""
+    project: dbt-core

--- a/crates/dbt-adapter/src/adapter/adapter_impl.rs
+++ b/crates/dbt-adapter/src/adapter/adapter_impl.rs
@@ -4217,6 +4217,7 @@ impl AdapterImpl {
         state: &State,
         conn: &mut dyn Connection,
         relation: &Arc<dyn BaseRelation>,
+        fetch_relation_tags: bool,
         token: CancellationToken,
     ) -> AdapterResult<RelationConfig> {
         use crate::relation::databricks::config::relation_types;
@@ -4243,7 +4244,13 @@ impl AdapterImpl {
             // In replay mode, adapter calls must go through the replay adapter so they consume
             // the recording stream.
             let metadata_adapter = DatabricksMetadataAdapter::new_from_adapter(self.clone());
-            metadata_adapter.fetch_relation_config_from_remote(state, conn, relation, token)?
+            metadata_adapter.fetch_relation_config_from_remote(
+                state,
+                conn,
+                relation,
+                fetch_relation_tags,
+                token,
+            )?
         };
 
         let config_loader = match relation_type {

--- a/crates/dbt-adapter/src/adapter/mod.rs
+++ b/crates/dbt-adapter/src/adapter/mod.rs
@@ -6,7 +6,9 @@ use crate::errors::into_fs_error;
 use crate::metadata::*;
 use crate::parse::adapter::ParseAdapterState;
 use crate::query_ctx::{node_id_from_state, query_ctx_from_state};
+use crate::relation::config_v2::RelationConfig;
 use crate::relation::databricks::DEFAULT_DATABRICKS_DATABASE;
+use crate::relation::databricks::config::components::relation_tags;
 use crate::relation::factory::create_static_relation;
 use crate::relation::spark::DEFAULT_SPARK_DATABASE;
 use crate::relation::{Relation, RelationObject};
@@ -104,6 +106,12 @@ pub struct Adapter {
     time_machine: Option<TimeMachine>,
     /// Global CLI cancellation token
     cancellation_token: CancellationToken,
+}
+
+fn should_fetch_relation_tags(model_config: Option<&Value>) -> bool {
+    model_config
+        .and_then(|config| config.downcast_object_ref::<RelationConfig>())
+        .is_none_or(relation_tags::requires_server_metadata_for_diff)
 }
 
 impl fmt::Debug for Adapter {
@@ -3186,17 +3194,21 @@ impl Adapter {
     ) -> Result<Value, minijinja::Error> {
         match &self.inner {
             Typed { adapter, .. } => {
-                let iter = ArgsIter::new("get_relation_config", &["relation"], args);
+                let iter =
+                    ArgsIter::new("get_relation_config", &["relation", "model_config"], args);
                 let relation_val = iter.next_arg::<&Value>()?;
                 let relation = downcast_value_to_dyn_base_relation(relation_val)?;
+                let model_config = iter.next_arg::<Option<Value>>()?;
                 iter.finish()?;
 
+                let fetch_relation_tags = should_fetch_relation_tags(model_config.as_ref());
                 let mut conn =
                     adapter.borrow_tlocal_connection(Some(state), node_id_from_state(state))?;
                 let config = adapter.get_relation_config(
                     state,
                     conn.as_mut(),
                     &relation,
+                    fetch_relation_tags,
                     self.cancellation_token.clone(),
                 )?;
                 Ok(Value::from_object(config))
@@ -3618,7 +3630,7 @@ impl Adapter {
                 // needs_information: bool = False
                 let iter = ArgsIter::new(name, &["database", "schema", "identifier"], args);
                 // dbt-core's `BaseAdapter.get_relation`
-                // (~/git/dbt-adapters/dbt-adapters/src/dbt/adapters/base/impl.py:1084)
+                // (dbt-adapters/dbt/adapters/base/impl.py:1084)
                 // declares its args as `str` but does no runtime validation — a
                 // Python `None` (e.g. from `RuntimeConfigObject.get('database')` for
                 // an unset key at compile) flows through `list_relations` and

--- a/crates/dbt-adapter/src/adapter/tests.rs
+++ b/crates/dbt-adapter/src/adapter/tests.rs
@@ -5,13 +5,16 @@ use crate::adapter::Adapter;
 use crate::adapter::adapter_impl::AdapterImpl;
 use crate::relation::config_v2::{ComponentConfigChange, RelationConfig};
 use crate::relation::databricks::config::components::RelationTagsLoader;
+use crate::relation::{Relation, RelationObject};
 use crate::sql_types::DefaultTypeOps;
 use crate::stmt_splitter::DefaultStmtSplitter;
 use dbt_adapter_core::AdapterType;
 
 use dbt_common::cancellation::never_cancels;
+use dbt_schemas::dbt_types::RelationType;
 use dbt_schemas::schemas::relations::{DEFAULT_DBT_QUOTING, DEFAULT_RESOLVED_QUOTING};
 use indexmap::IndexMap;
+use minijinja_contrib::testing::jinja_assert;
 
 fn never_full_refresh(_: &IndexMap<&'static str, ComponentConfigChange>) -> bool {
     false
@@ -36,6 +39,78 @@ fn test_relation_tag_metadata_planning_at_adapter_boundary() {
     assert!(should_fetch_relation_tags(Some(&tagged)));
     assert!(!should_fetch_relation_tags(Some(&empty)));
     assert!(should_fetch_relation_tags(None));
+    assert!(should_fetch_relation_tags(Some(&Value::from(42))));
+}
+
+#[derive(Debug)]
+struct GetRelationConfigFixture {
+    adapter: Arc<Adapter>,
+    relation: Value,
+    tagged: Value,
+    empty: Value,
+}
+
+impl Object for GetRelationConfigFixture {
+    fn get_value(self: &Arc<Self>, key: &Value) -> Option<Value> {
+        match key.as_str()? {
+            "adapter" => Some(Value::from_object(self.adapter.as_ref().clone())),
+            "relation" => Some(self.relation.clone()),
+            "tagged" => Some(self.tagged.clone()),
+            "empty" => Some(self.empty.clone()),
+            _ => None,
+        }
+    }
+}
+
+fn get_relation_config_fixture() -> GetRelationConfigFixture {
+    let relation = Relation::new(
+        AdapterType::Databricks,
+        "main".to_string(),
+        "test_schema".to_string(),
+        "test_mv".to_string(),
+    )
+    .with_relation_type(RelationType::MaterializedView)
+    .with_quoting(DEFAULT_RESOLVED_QUOTING);
+    GetRelationConfigFixture {
+        adapter: make_mock_adapter(AdapterType::Databricks),
+        relation: Value::from_object(RelationObject::new(Arc::new(relation))),
+        tagged: model_config_value(IndexMap::from_iter([(
+            "deployment".to_string(),
+            "DBT".to_string(),
+        )])),
+        empty: model_config_value(IndexMap::new()),
+    }
+}
+
+#[test]
+fn test_get_relation_config_typed_adapter_jinja_value_contract() {
+    let template = r#"
+        {% set tagged = obj.adapter.get_relation_config(obj.relation, obj.tagged) %}
+        {% set empty = obj.adapter.get_relation_config(obj.relation, obj.empty) %}
+        {% set missing = obj.adapter.get_relation_config(obj.relation) %}
+        {% set wrong_type = obj.adapter.get_relation_config(obj.relation, 42) %}
+        {{ tagged is not none and empty is not none and missing is not none and wrong_type is not none }}
+    "#;
+
+    jinja_assert(get_relation_config_fixture(), template, "True");
+}
+
+#[test]
+fn test_get_relation_config_typed_adapter_rejects_excess_jinja_arguments() {
+    let mut env = minijinja::Environment::new();
+    env.add_global("obj", Value::from_object(get_relation_config_fixture()));
+    let error = env
+        .render_str(
+            "{{ obj.adapter.get_relation_config(obj.relation, obj.tagged, 42) }}",
+            BTreeMap::<String, String>::new(),
+            &[],
+        )
+        .unwrap_err();
+
+    assert!(
+        error.to_string().contains("too many arguments"),
+        "unexpected error: {error}"
+    );
 }
 
 /// Helper to call [Adapter::call_method_impl] with jinja-valued arguments.

--- a/crates/dbt-adapter/src/adapter/tests.rs
+++ b/crates/dbt-adapter/src/adapter/tests.rs
@@ -3,6 +3,8 @@ use std::collections::BTreeMap;
 use super::*;
 use crate::adapter::Adapter;
 use crate::adapter::adapter_impl::AdapterImpl;
+use crate::relation::config_v2::{ComponentConfigChange, RelationConfig};
+use crate::relation::databricks::config::components::RelationTagsLoader;
 use crate::sql_types::DefaultTypeOps;
 use crate::stmt_splitter::DefaultStmtSplitter;
 use dbt_adapter_core::AdapterType;
@@ -10,6 +12,31 @@ use dbt_adapter_core::AdapterType;
 use dbt_common::cancellation::never_cancels;
 use dbt_schemas::schemas::relations::{DEFAULT_DBT_QUOTING, DEFAULT_RESOLVED_QUOTING};
 use indexmap::IndexMap;
+
+fn never_full_refresh(_: &IndexMap<&'static str, ComponentConfigChange>) -> bool {
+    false
+}
+
+fn model_config_value(tags: IndexMap<String, String>) -> Value {
+    Value::from_object(RelationConfig::new(
+        AdapterType::Databricks,
+        [RelationTagsLoader::new_component_type_erased(tags)],
+        never_full_refresh,
+    ))
+}
+
+#[test]
+fn test_relation_tag_metadata_planning_at_adapter_boundary() {
+    let tagged = model_config_value(IndexMap::from_iter([(
+        "deployment".to_string(),
+        "DBT".to_string(),
+    )]));
+    let empty = model_config_value(IndexMap::new());
+
+    assert!(should_fetch_relation_tags(Some(&tagged)));
+    assert!(!should_fetch_relation_tags(Some(&empty)));
+    assert!(should_fetch_relation_tags(None));
+}
 
 /// Helper to call [Adapter::call_method_impl] with jinja-valued arguments.
 fn dispatch_test(

--- a/crates/dbt-adapter/src/metadata/databricks/mod.rs
+++ b/crates/dbt-adapter/src/metadata/databricks/mod.rs
@@ -318,36 +318,16 @@ impl DatabricksMetadataAdapter {
         // https://github.com/databricks/dbt-databricks/blob/9e2566fdb56318cb7a59a4492f96c7aaa7af73b0/dbt/adapters/databricks/impl.py#L914-L1021
         match relation_type {
             RelationType::MaterializedView => {
-                for query in materialized_view_metadata_plan(fetch_relation_tags) {
-                    match query {
-                        MaterializedViewMetadataQuery::RelationTags => {
-                            metadata.insert(
-                                DatabricksRelationMetadataKey::InfoSchemaRelationTags,
-                                self.fetch_tags(
-                                    &database,
-                                    &schema,
-                                    &identifier,
-                                    state,
-                                    &mut *conn,
-                                    token.clone(),
-                                )?,
-                            );
-                        }
-                        MaterializedViewMetadataQuery::ViewDescription => {
-                            metadata.insert(
-                                DatabricksRelationMetadataKey::DescribeExtended,
-                                self.get_view_description(
-                                    &database,
-                                    &schema,
-                                    &identifier,
-                                    state,
-                                    &mut *conn,
-                                    token.clone(),
-                                )?,
-                            );
-                        }
-                    }
-                }
+                self.fetch_materialized_view_metadata(
+                    &mut metadata,
+                    fetch_relation_tags,
+                    &database,
+                    &schema,
+                    &identifier,
+                    state,
+                    &mut *conn,
+                    token,
+                )?;
             }
             RelationType::View => {
                 metadata.insert(
@@ -502,6 +482,51 @@ impl DatabricksMetadataAdapter {
         // we might need to query internal delta system tables or expose something via ADBC
 
         Ok((relation_type, metadata))
+    }
+
+    #[expect(clippy::too_many_arguments)]
+    fn fetch_materialized_view_metadata(
+        &self,
+        metadata: &mut DatabricksRelationMetadata,
+        fetch_relation_tags: bool,
+        database: &str,
+        schema: &str,
+        identifier: &str,
+        state: &State,
+        conn: &mut dyn Connection,
+        token: CancellationToken,
+    ) -> AdapterResult<()> {
+        for query in materialized_view_metadata_plan(fetch_relation_tags) {
+            match query {
+                MaterializedViewMetadataQuery::RelationTags => {
+                    metadata.insert(
+                        DatabricksRelationMetadataKey::InfoSchemaRelationTags,
+                        self.fetch_tags(
+                            database,
+                            schema,
+                            identifier,
+                            state,
+                            &mut *conn,
+                            token.clone(),
+                        )?,
+                    );
+                }
+                MaterializedViewMetadataQuery::ViewDescription => {
+                    metadata.insert(
+                        DatabricksRelationMetadataKey::DescribeExtended,
+                        self.get_view_description(
+                            database,
+                            schema,
+                            identifier,
+                            state,
+                            &mut *conn,
+                            token.clone(),
+                        )?,
+                    );
+                }
+            }
+        }
+        Ok(())
     }
 
     // convenience for executing SQL

--- a/crates/dbt-adapter/src/metadata/databricks/mod.rs
+++ b/crates/dbt-adapter/src/metadata/databricks/mod.rs
@@ -50,6 +50,24 @@ pub mod describe_table;
 pub mod schemas;
 pub(crate) mod version;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum MaterializedViewMetadataQuery {
+    RelationTags,
+    ViewDescription,
+}
+
+fn materialized_view_metadata_plan(
+    fetch_relation_tags: bool,
+) -> &'static [MaterializedViewMetadataQuery] {
+    use MaterializedViewMetadataQuery::{RelationTags, ViewDescription};
+
+    if fetch_relation_tags {
+        &[RelationTags, ViewDescription]
+    } else {
+        &[ViewDescription]
+    }
+}
+
 // Reference: https://github.com/databricks/dbt-databricks/blob/92f1442faabe0fce6f0375b95e46ebcbfcea4c67/dbt/include/databricks/macros/adapters/metadata.sql
 pub fn list_relations(
     engine: &dyn AdapterEngine,
@@ -254,6 +272,7 @@ impl DatabricksMetadataAdapter {
         state: &State,
         conn: &mut dyn Connection,
         base_relation: &Arc<dyn BaseRelation>,
+        fetch_relation_tags: bool,
         token: CancellationToken,
     ) -> AdapterResult<(RelationType, DatabricksRelationMetadata)> {
         let relation_type = base_relation.relation_type().ok_or_else(|| {
@@ -299,17 +318,36 @@ impl DatabricksMetadataAdapter {
         // https://github.com/databricks/dbt-databricks/blob/9e2566fdb56318cb7a59a4492f96c7aaa7af73b0/dbt/adapters/databricks/impl.py#L914-L1021
         match relation_type {
             RelationType::MaterializedView => {
-                metadata.insert(
-                    DatabricksRelationMetadataKey::DescribeExtended,
-                    self.get_view_description(
-                        &database,
-                        &schema,
-                        &identifier,
-                        state,
-                        &mut *conn,
-                        token,
-                    )?,
-                );
+                for query in materialized_view_metadata_plan(fetch_relation_tags) {
+                    match query {
+                        MaterializedViewMetadataQuery::RelationTags => {
+                            metadata.insert(
+                                DatabricksRelationMetadataKey::InfoSchemaRelationTags,
+                                self.fetch_tags(
+                                    &database,
+                                    &schema,
+                                    &identifier,
+                                    state,
+                                    &mut *conn,
+                                    token.clone(),
+                                )?,
+                            );
+                        }
+                        MaterializedViewMetadataQuery::ViewDescription => {
+                            metadata.insert(
+                                DatabricksRelationMetadataKey::DescribeExtended,
+                                self.get_view_description(
+                                    &database,
+                                    &schema,
+                                    &identifier,
+                                    state,
+                                    &mut *conn,
+                                    token.clone(),
+                                )?,
+                            );
+                        }
+                    }
+                }
             }
             RelationType::View => {
                 metadata.insert(
@@ -1508,6 +1546,25 @@ mod tests {
     use dbt_schemas::schemas::common::ResolvedQuoting;
     use dbt_schemas::schemas::relations::base::BaseRelation;
     use std::sync::Arc;
+
+    #[test]
+    fn materialized_view_metadata_plan_fetches_tags_when_requested() {
+        assert_eq!(
+            materialized_view_metadata_plan(true),
+            &[
+                MaterializedViewMetadataQuery::RelationTags,
+                MaterializedViewMetadataQuery::ViewDescription,
+            ]
+        );
+    }
+
+    #[test]
+    fn materialized_view_metadata_plan_skips_tags_when_not_requested() {
+        assert_eq!(
+            materialized_view_metadata_plan(false),
+            &[MaterializedViewMetadataQuery::ViewDescription]
+        );
+    }
 
     // Helper function to create a test relation with specific quoting policies
     fn create_test_relation(

--- a/crates/dbt-adapter/src/relation/databricks/config/components/relation_tags.rs
+++ b/crates/dbt-adapter/src/relation/databricks/config/components/relation_tags.rs
@@ -2,7 +2,7 @@
 
 use crate::errors::AdapterResult;
 use crate::relation::config_v2::{
-    ComponentConfig, ComponentConfigLoader, SimpleComponentConfigImpl, diff, impl_loader,
+    ComponentConfig, ComponentConfigLoader, RelationConfig, SimpleComponentConfigImpl, impl_loader,
 };
 use crate::relation::databricks::config::{
     DatabricksRelationMetadata, DatabricksRelationMetadataKey,
@@ -29,10 +29,20 @@ fn to_jinja(v: &IndexMap<String, String>) -> Value {
 fn new_component(tags: IndexMap<String, String>) -> RelationTags {
     RelationTags {
         type_name: TYPE_NAME,
-        diff_fn: diff::desired_state,
+        diff_fn: set_only_diff,
         to_jinja_fn: to_jinja,
         value: tags,
     }
+}
+
+fn set_only_diff(
+    desired_state: &IndexMap<String, String>,
+    current_state: &IndexMap<String, String>,
+) -> Option<IndexMap<String, String>> {
+    desired_state
+        .iter()
+        .any(|(key, value)| current_state.get(key) != Some(value))
+        .then(|| desired_state.clone())
 }
 
 fn from_remote_state(results: &DatabricksRelationMetadata) -> AdapterResult<RelationTags> {
@@ -46,14 +56,31 @@ fn from_remote_state(results: &DatabricksRelationMetadata) -> AdapterResult<Rela
     for row in remote_tags.rows() {
         if let (Ok(tag_name_val), Ok(tag_value_val)) =
             (row.get_item(&Value::from(0)), row.get_item(&Value::from(1)))
-            && let (Some(tag_name), Some(tag_value)) =
-                (tag_name_val.as_str(), tag_value_val.as_str())
+            && let Some(tag_name) = tag_name_val.as_str()
         {
+            let tag_value = if tag_value_val.is_none() {
+                ""
+            } else if let Some(tag_value) = tag_value_val.as_str() {
+                tag_value
+            } else {
+                continue;
+            };
             tags.insert(tag_name.to_string(), tag_value.to_string());
         }
     }
 
     Ok(new_component(tags))
+}
+
+fn yml_scalar_to_string(value: &YmlValue) -> Option<String> {
+    match value {
+        YmlValue::Null(_) => Some(String::new()),
+        YmlValue::Bool(value, _) => Some(if *value { "True" } else { "False" }.to_string()),
+        YmlValue::Number(value, _) => Some(value.to_string()),
+        YmlValue::String(value, _) => Some(value.clone()),
+        YmlValue::Tagged(tagged, _) => yml_scalar_to_string(&tagged.value),
+        YmlValue::Sequence(_, _) | YmlValue::Mapping(_, _) => None,
+    }
 }
 
 fn from_local_config(
@@ -69,8 +96,8 @@ fn from_local_config(
         && let Some(tags_map) = &databricks_attr.databricks_tags
     {
         for (key, value) in tags_map {
-            if let YmlValue::String(value_str, _) = value {
-                tags.insert(key.clone(), value_str.clone());
+            if let Some(value) = yml_scalar_to_string(value) {
+                tags.insert(key.clone(), value);
             }
         }
     }
@@ -86,10 +113,21 @@ impl RelationTagsLoader {
     }
 }
 
+pub(crate) fn requires_server_metadata_for_diff(config: &RelationConfig) -> bool {
+    config
+        .get(TYPE_NAME)
+        .and_then(|component| component.as_any().downcast_ref::<RelationTags>())
+        .is_none_or(|tags| !tags.value.is_empty())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::relation::config_v2::ComponentConfig;
+    use crate::AdapterType;
+    use crate::relation::config_v2::{ComponentConfig, ComponentConfigChange};
+    use crate::relation::databricks::config::test_helpers::{
+        TestModelConfig, create_mock_dbt_model,
+    };
 
     #[test]
     fn test_get_diff_add_or_update() {
@@ -121,5 +159,62 @@ mod tests {
         let diff = RelationTags::diff_from(&config, Some(&config));
 
         assert!(diff.is_none());
+    }
+
+    #[test]
+    fn test_get_diff_configured_removal_is_no_change() {
+        let current = new_component(IndexMap::from_iter([(
+            "deployment".to_string(),
+            "NEXT".to_string(),
+        )]));
+        let desired = new_component(IndexMap::new());
+
+        assert!(RelationTags::diff_from(&desired, Some(&current)).is_none());
+    }
+
+    fn never_full_refresh(_: &IndexMap<&'static str, ComponentConfigChange>) -> bool {
+        false
+    }
+
+    #[test]
+    fn test_server_metadata_requirement_follows_local_tags() {
+        let empty = RelationConfig::new(
+            AdapterType::Databricks,
+            [Box::new(new_component(IndexMap::new())) as Box<dyn ComponentConfig>],
+            never_full_refresh,
+        );
+        let tagged = RelationConfig::new(
+            AdapterType::Databricks,
+            [Box::new(new_component(IndexMap::from_iter([(
+                "deployment".to_string(),
+                "DBT".to_string(),
+            )]))) as Box<dyn ComponentConfig>],
+            never_full_refresh,
+        );
+        let missing = RelationConfig::new(
+            AdapterType::Databricks,
+            Vec::<Box<dyn ComponentConfig>>::new(),
+            never_full_refresh,
+        );
+
+        assert!(!requires_server_metadata_for_diff(&empty));
+        assert!(requires_server_metadata_for_diff(&tagged));
+        assert!(requires_server_metadata_for_diff(&missing));
+    }
+
+    #[test]
+    fn test_local_config_stringifies_scalar_tag_values() {
+        let model = create_mock_dbt_model(TestModelConfig {
+            raw_tags: Some(IndexMap::from_iter([
+                ("priority".to_string(), YmlValue::from(0_i64)),
+                ("enabled".to_string(), YmlValue::from(false)),
+            ])),
+            ..Default::default()
+        });
+
+        let tags = from_local_config(&model).unwrap();
+
+        assert_eq!(tags.value.get("priority"), Some(&"0".to_string()));
+        assert_eq!(tags.value.get("enabled"), Some(&"False".to_string()));
     }
 }

--- a/crates/dbt-adapter/src/relation/databricks/config/components/relation_tags.rs
+++ b/crates/dbt-adapter/src/relation/databricks/config/components/relation_tags.rs
@@ -72,14 +72,69 @@ fn from_remote_state(results: &DatabricksRelationMetadata) -> AdapterResult<Rela
     Ok(new_component(tags))
 }
 
-fn yml_scalar_to_string(value: &YmlValue) -> Option<String> {
+fn python_string_repr(value: &str) -> String {
+    let quote = if value.contains('\'') && !value.contains('"') {
+        '"'
+    } else {
+        '\''
+    };
+    let mut result = String::with_capacity(value.len() + 2);
+    result.push(quote);
+    for character in value.chars() {
+        match character {
+            '\\' => result.push_str("\\\\"),
+            '\n' => result.push_str("\\n"),
+            '\r' => result.push_str("\\r"),
+            '\t' => result.push_str("\\t"),
+            '\u{0008}' => result.push_str("\\b"),
+            '\u{000c}' => result.push_str("\\f"),
+            character if character == quote => {
+                result.push('\\');
+                result.push(character);
+            }
+            character => result.push(character),
+        }
+    }
+    result.push(quote);
+    result
+}
+
+fn yml_value_to_python_repr(value: &YmlValue) -> String {
     match value {
-        YmlValue::Null(_) => Some(String::new()),
-        YmlValue::Bool(value, _) => Some(if *value { "True" } else { "False" }.to_string()),
-        YmlValue::Number(value, _) => Some(value.to_string()),
-        YmlValue::String(value, _) => Some(value.clone()),
-        YmlValue::Tagged(tagged, _) => yml_scalar_to_string(&tagged.value),
-        YmlValue::Sequence(_, _) | YmlValue::Mapping(_, _) => None,
+        YmlValue::Null(_) => "None".to_string(),
+        YmlValue::Bool(value, _) => (if *value { "True" } else { "False" }).to_string(),
+        YmlValue::Number(value, _) => value.to_string(),
+        YmlValue::String(value, _) => python_string_repr(value),
+        YmlValue::Tagged(tagged, _) => yml_value_to_python_repr(&tagged.value),
+        YmlValue::Sequence(values, _) => format!(
+            "[{}]",
+            values
+                .iter()
+                .map(yml_value_to_python_repr)
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+        YmlValue::Mapping(values, _) => format!(
+            "{{{}}}",
+            values
+                .iter()
+                .map(|(key, value)| format!(
+                    "{}: {}",
+                    yml_value_to_python_repr(key),
+                    yml_value_to_python_repr(value)
+                ))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+    }
+}
+
+fn yml_value_to_python_string(value: &YmlValue) -> String {
+    match value {
+        YmlValue::Null(_) => String::new(),
+        YmlValue::String(value, _) => value.clone(),
+        YmlValue::Tagged(tagged, _) => yml_value_to_python_string(&tagged.value),
+        _ => yml_value_to_python_repr(value),
     }
 }
 
@@ -96,9 +151,7 @@ fn from_local_config(
         && let Some(tags_map) = &databricks_attr.databricks_tags
     {
         for (key, value) in tags_map {
-            if let Some(value) = yml_scalar_to_string(value) {
-                tags.insert(key.clone(), value);
-            }
+            tags.insert(key.clone(), yml_value_to_python_string(value));
         }
     }
 
@@ -216,5 +269,29 @@ mod tests {
 
         assert_eq!(tags.value.get("priority"), Some(&"0".to_string()));
         assert_eq!(tags.value.get("enabled"), Some(&"False".to_string()));
+    }
+
+    #[test]
+    fn test_local_config_stringifies_collection_tag_values_like_v1() {
+        let sequence: YmlValue = dbt_yaml::from_str("[1, two, false, null]").unwrap();
+        let mapping: YmlValue = dbt_yaml::from_str("{team: data, active: true}").unwrap();
+        let model = create_mock_dbt_model(TestModelConfig {
+            raw_tags: Some(IndexMap::from_iter([
+                ("sequence".to_string(), sequence),
+                ("mapping".to_string(), mapping),
+            ])),
+            ..Default::default()
+        });
+
+        let tags = from_local_config(&model).unwrap();
+
+        assert_eq!(
+            tags.value.get("sequence"),
+            Some(&"[1, 'two', False, None]".to_string())
+        );
+        assert_eq!(
+            tags.value.get("mapping"),
+            Some(&"{'team': 'data', 'active': True}".to_string())
+        );
     }
 }

--- a/crates/dbt-adapter/src/relation/databricks/config/components/tbl_properties.rs
+++ b/crates/dbt-adapter/src/relation/databricks/config/components/tbl_properties.rs
@@ -17,36 +17,6 @@ pub(crate) const TYPE_NAME: &str = "tblproperties";
 
 const PIPELINE_ID_KEY: &str = "pipelines.pipelineId";
 
-/// All of the following keys are ignoring by the diffing function
-///
-/// These are generally set by databricks and cannot be modified by the user
-const EQ_IGNORE_LIST: [&str; 24] = [
-    PIPELINE_ID_KEY,
-    "delta.enableChangeDataFeed",
-    "delta.minReaderVersion",
-    "delta.minWriterVersion",
-    "pipeline_internal.catalogType",
-    "pipelines.metastore.tableName",
-    "pipeline_internal.enzymeMode",
-    "clusterByAuto",
-    "clusteringColumns",
-    "delta.enableRowTracking",
-    "delta.feature.appendOnly",
-    "delta.feature.changeDataFeed",
-    "delta.feature.checkConstraints",
-    "delta.feature.domainMetadata",
-    "delta.feature.generatedColumns",
-    "delta.feature.invariants",
-    "delta.feature.rowTracking",
-    "delta.rowTracking.materializedRowCommitVersionColumnName",
-    "delta.rowTracking.materializedRowIdColumnName",
-    "spark.internal.pipelines.top_level_entry.user_specified_name",
-    "delta.columnMapping.maxColumnId",
-    "spark.sql.internal.pipelines.parentTableId",
-    "delta.enableDeletionVectors",
-    "delta.feature.deletionVectors",
-];
-
 /// Component for Databricks table properties.
 pub type TblProperties = SimpleComponentConfigImpl<IndexMap<String, String>>;
 
@@ -78,33 +48,20 @@ fn new_component(properties: IndexMap<String, String>) -> TblProperties {
     }
 }
 
-/// Takes the diff between two `TblProperties` by comparing the non-ignored keys.
+/// Matches current dbt-databricks desired-subset semantics.
 ///
-/// Matches the Python dbt-databricks `TblPropertiesConfig.__eq__` semantics: both dicts are
-/// filtered by `EQ_IGNORE_LIST`, then compared for full equality. If they differ (including
-/// when the current state has extra non-ignored keys absent from the desired state), a diff
-/// is reported. The returned value is the full desired state (matching Python's `get_diff`
-/// which returns `self`).
+/// Server-only properties are preserved by ignoring keys that exist only in current state.
+/// The separately rendered pipeline id is not a configurable table property. If any configured
+/// property is absent or has a different value, consumers need the complete desired map.
 fn diff(
     desired_state: &IndexMap<String, String>,
     current_state: &IndexMap<String, String>,
 ) -> Option<IndexMap<String, String>> {
-    let filtered_desired: IndexMap<&String, &String> = desired_state
+    desired_state
         .iter()
-        .filter(|(k, _)| !EQ_IGNORE_LIST.contains(&k.as_str()))
-        .collect();
-
-    let filtered_current: IndexMap<&String, &String> = current_state
-        .iter()
-        .filter(|(k, _)| !EQ_IGNORE_LIST.contains(&k.as_str()))
-        .collect();
-
-    if filtered_desired == filtered_current {
-        None
-    } else {
-        // Match Python: get_diff returns self (the full desired config)
-        Some(desired_state.clone())
-    }
+        .filter(|(key, _)| key.as_str() != PIPELINE_ID_KEY)
+        .any(|(key, value)| current_state.get(key) != Some(value))
+        .then(|| desired_state.clone())
 }
 
 fn from_remote_state(results: &DatabricksRelationMetadata) -> AdapterResult<TblProperties> {
@@ -118,9 +75,7 @@ fn from_remote_state(results: &DatabricksRelationMetadata) -> AdapterResult<TblP
             (row.get_item(&Value::from(0)), row.get_item(&Value::from(1)))
             && let (Some(key_str), Some(value_str)) = (key_val.as_str(), value_val.as_str())
         {
-            if key_str == PIPELINE_ID_KEY || !EQ_IGNORE_LIST.contains(&key_str) {
-                tblproperties.insert(key_str.to_string(), value_str.to_string());
-            }
+            tblproperties.insert(key_str.to_string(), value_str.to_string());
         }
     }
 
@@ -225,24 +180,15 @@ mod tests {
     }
 
     #[test]
-    fn test_diff_changed_databricks_keys() {
-        let prev = IndexMap::from_iter([
-            (
-                "pipelines.pipelineId".to_string(),
-                "pipeline123".to_string(),
-            ),
-            ("delta.enableChangeDataFeed".to_string(), "true".to_string()),
-        ]);
-        let next = IndexMap::from_iter([
-            (
-                "pipelines.pipelineId".to_string(),
-                "pipeline123456".to_string(),
-            ),
-            (
-                "delta.enableChangeDataFeed".to_string(),
-                "false".to_string(),
-            ),
-        ]);
+    fn test_diff_ignores_pipeline_id_change() {
+        let prev = IndexMap::from_iter([(
+            "pipelines.pipelineId".to_string(),
+            "pipeline123".to_string(),
+        )]);
+        let next = IndexMap::from_iter([(
+            "pipelines.pipelineId".to_string(),
+            "pipeline123456".to_string(),
+        )]);
 
         let diff = diff(&next, &prev);
         assert!(diff.is_none());
@@ -279,41 +225,14 @@ mod tests {
         assert_eq!(diff.get("custom.add").unwrap().as_str(), "new");
     }
 
-    /// The model config has tblproperties:
-    ///   {"delta.enableChangeDataFeed": "true", "delta.columnMapping.mode": "name"}
-    ///
-    /// The existing table (SHOW TBLPROPERTIES) has those plus a few other properties
-    /// like delta.checkpoint.*, delta.parquet.*, etc.
-    ///
-    /// Python dbt-databricks does a full-dict equality check (__eq__) after filtering the ignore
-    /// list from both sides. Since the desired dict (1 key after filtering) differs from the
-    /// current dict (6+ keys), __eq__ returns False, and get_diff returns the desired config.
-    ///
-    /// The Rust diff function currently does per-key comparison and returns None because every
-    /// key present in the desired state matches the current state. This is a behavioral
-    /// divergence — we should match Python and report a diff when the current state has extra
-    /// non-ignored keys not present in the desired state.
     #[test]
-    fn test_diff_extra_current_keys_should_report_change() {
-        // Desired state: what from_local_config produces from the model config.
-        // Note: delta.enableChangeDataFeed is in the model config but will be
-        // filtered by EQ_IGNORE_LIST in the diff function.
-        let desired = IndexMap::from_iter([
-            ("delta.enableChangeDataFeed".to_string(), "true".to_string()),
-            ("delta.columnMapping.mode".to_string(), "name".to_string()),
-        ]);
-
-        // Current state: what from_remote_state produces from SHOW TBLPROPERTIES.
-        // from_remote_state already filters EQ_IGNORE_LIST, so delta.enableChangeDataFeed
-        // is NOT here. But extra system properties (not in ignore list) ARE here.
+    fn test_diff_preserves_arbitrary_server_only_properties() {
+        let desired =
+            IndexMap::from_iter([("delta.columnMapping.mode".to_string(), "name".to_string())]);
         let current = IndexMap::from_iter([
             (
-                "delta.checkpoint.writeStatsAsJson".to_string(),
-                "false".to_string(),
-            ),
-            (
-                "delta.checkpoint.writeStatsAsStruct".to_string(),
-                "true".to_string(),
+                "arbitrary.server.only.property".to_string(),
+                "generated".to_string(),
             ),
             ("delta.columnMapping.mode".to_string(), "name".to_string()),
             (
@@ -322,13 +241,33 @@ mod tests {
             ),
         ]);
 
-        // Python dbt-databricks reports a diff here because the filtered dicts are unequal
-        // (desired has 1 non-ignored key, current has 4 keys). We must match that behavior.
-        let result = diff(&desired, &current);
-        assert!(
-            result.is_some(),
-            "Expected diff when current state has extra non-ignored keys not in desired state"
-        );
+        assert!(diff(&desired, &current).is_none());
+    }
+
+    #[test]
+    fn test_diff_compares_explicitly_configured_server_managed_keys() {
+        let desired = IndexMap::from_iter([
+            (
+                "delta.parquet.compression.codec".to_string(),
+                "snappy".to_string(),
+            ),
+            (
+                "io.unitycatalog.tableId".to_string(),
+                "configured-id".to_string(),
+            ),
+        ]);
+        let current = IndexMap::from_iter([
+            (
+                "delta.parquet.compression.codec".to_string(),
+                "zstd".to_string(),
+            ),
+            (
+                "io.unitycatalog.tableId".to_string(),
+                "server-generated-id".to_string(),
+            ),
+        ]);
+
+        assert_eq!(diff(&desired, &current), Some(desired));
     }
 
     #[test]
@@ -344,7 +283,7 @@ mod tests {
         let results = IndexMap::from([(DatabricksRelationMetadataKey::ShowTblProperties, table)]);
         let config = from_remote_state(&results).unwrap();
 
-        assert_eq!(config.value.len(), 4); // Ignores delta properties
+        assert_eq!(config.value.len(), 5);
         assert_eq!(
             config.value.get("streaming.checkpointLocation"),
             Some(&"/tmp/checkpoint".to_string())
@@ -361,7 +300,10 @@ mod tests {
             config.value.get(PIPELINE_ID_KEY),
             Some(&"pipeline123".to_string())
         );
-        assert!(!config.value.contains_key("delta.enableChangeDataFeed"));
+        assert_eq!(
+            config.value.get("delta.enableChangeDataFeed"),
+            Some(&"true".to_string())
+        );
     }
 
     #[test]

--- a/crates/dbt-adapter/src/relation/databricks/config/relation_types/incremental_table.rs
+++ b/crates/dbt-adapter/src/relation/databricks/config/relation_types/incremental_table.rs
@@ -38,7 +38,7 @@ mod tests {
     };
     use crate::relation::databricks::config::{
         DatabricksRelationMetadata, components,
-        test_helpers::{TestModelColumn, TestModelConfig, run_test_cases},
+        test_helpers::{TestModelColumn, TestModelConfig, expected_tbl_properties, run_test_cases},
     };
     use crate::relation::test_helpers::TestCase;
     use dbt_schemas::schemas::common::{Constraint, ConstraintType};
@@ -198,15 +198,10 @@ mod tests {
                         components::TblPropertiesLoader.type_name(),
                         ComponentConfigChange::Some(
                             components::TblPropertiesLoader::new_component_type_erased(
-                                IndexMap::from_iter([
-                                    ("delta.enableRowTracking".to_string(), "true".to_string()),
-                                    (
-                                        "pipelines.pipelineId".to_string(),
-                                        "my_new_pipeline".to_string(),
-                                    ),
-                                    ("customKey".to_string(), "new".to_string()),
-                                    ("customKey2".to_string(), "value".to_string()),
-                                ]),
+                                expected_tbl_properties(
+                                    "my_new_pipeline",
+                                    [("customKey", "new"), ("customKey2", "value")],
+                                ),
                             ),
                         ),
                     ),

--- a/crates/dbt-adapter/src/relation/databricks/config/relation_types/incremental_table.rs
+++ b/crates/dbt-adapter/src/relation/databricks/config/relation_types/incremental_table.rs
@@ -199,6 +199,11 @@ mod tests {
                         ComponentConfigChange::Some(
                             components::TblPropertiesLoader::new_component_type_erased(
                                 IndexMap::from_iter([
+                                    ("delta.enableRowTracking".to_string(), "true".to_string()),
+                                    (
+                                        "pipelines.pipelineId".to_string(),
+                                        "my_new_pipeline".to_string(),
+                                    ),
                                     ("customKey".to_string(), "new".to_string()),
                                     ("customKey2".to_string(), "value".to_string()),
                                 ]),

--- a/crates/dbt-adapter/src/relation/databricks/config/relation_types/materialized_view.rs
+++ b/crates/dbt-adapter/src/relation/databricks/config/relation_types/materialized_view.rs
@@ -38,7 +38,7 @@ mod tests {
     };
     use crate::relation::databricks::config::{
         DatabricksRelationMetadata, components,
-        test_helpers::{TestModelConfig, run_test_cases},
+        test_helpers::{TestModelConfig, expected_tbl_properties, run_test_cases},
     };
     use crate::relation::test_helpers::TestCase;
     use indexmap::IndexMap;
@@ -83,14 +83,10 @@ mod tests {
                             components::TblPropertiesLoader.type_name(),
                             ComponentConfigChange::Some(
                                 components::TblPropertiesLoader::new_component_type_erased(
-                                    IndexMap::from_iter([
-                                        ("delta.enableRowTracking".to_string(), "true".to_string()),
-                                        (
-                                            "pipelines.pipelineId".to_string(),
-                                            "my_old_pipeline".to_string(),
-                                        ),
-                                        ("custom.key".to_string(), "new".to_string()),
-                                    ]),
+                                    expected_tbl_properties(
+                                        "my_old_pipeline",
+                                        [("custom.key", "new")],
+                                    ),
                                 ),
                             ),
                         ),

--- a/crates/dbt-adapter/src/relation/databricks/config/relation_types/materialized_view.rs
+++ b/crates/dbt-adapter/src/relation/databricks/config/relation_types/materialized_view.rs
@@ -14,15 +14,14 @@ fn requires_full_refresh(components: &IndexMap<&'static str, ComponentConfigChan
 pub(crate) fn new_loader() -> RelationConfigLoader<'static, DatabricksRelationMetadata> {
     // TODO: missing from Python dbt-databricks:
     // - liquid clustering
-    // - relation tags
     // - query
-    let loaders: [Box<dyn ComponentConfigLoader<DatabricksRelationMetadata>>; 5] = [
+    let loaders: [Box<dyn ComponentConfigLoader<DatabricksRelationMetadata>>; 6] = [
         // Box::new(components::LiquidClusteringLoader),
         Box::new(components::RelationCommentLoader),
         Box::new(components::PartitionByLoader),
         // Box::new(components::QueryLoader),
         Box::new(components::RefreshLoader),
-        // Box::new(components::RelationTagsLoader),
+        Box::new(components::RelationTagsLoader),
         Box::new(components::TblPropertiesLoader),
         Box::new(components::ColumnMasksLoader),
     ];
@@ -84,10 +83,14 @@ mod tests {
                             components::TblPropertiesLoader.type_name(),
                             ComponentConfigChange::Some(
                                 components::TblPropertiesLoader::new_component_type_erased(
-                                    IndexMap::from_iter([(
-                                        "custom.key".to_string(),
-                                        "new".to_string(),
-                                    )]),
+                                    IndexMap::from_iter([
+                                        ("delta.enableRowTracking".to_string(), "true".to_string()),
+                                        (
+                                            "pipelines.pipelineId".to_string(),
+                                            "my_old_pipeline".to_string(),
+                                        ),
+                                        ("custom.key".to_string(), "new".to_string()),
+                                    ]),
                                 ),
                             ),
                         ),
@@ -139,7 +142,10 @@ mod tests {
                 desired_state: TestModelConfig {
                     cron: Some("*/60 * * * *".to_string()),
                     time_zone: Some("UTC".to_string()),
-                    tags: IndexMap::from_iter([("a_tag".to_string(), "new".to_string())]),
+                    tags: IndexMap::from_iter([
+                        ("z_tag".to_string(), "first".to_string()),
+                        ("a_tag".to_string(), "second".to_string()),
+                    ]),
                     ..Default::default()
                 },
                 expected_changeset: RelationComponentConfigChangeSet::new(
@@ -154,13 +160,17 @@ mod tests {
                                 ),
                             ),
                         ),
-                        // TODO: re-add tags
-                        // (
-                        //     components::RelationTagsLoader.type_name(),
-                        //     ComponentConfigChange::Some(components::RelationTagsLoader::new_component_type_erased(
-                        //         IndexMap::from_iter([("a_tag".to_string(), "new".to_string())]),
-                        //     )),
-                        // ),
+                        (
+                            components::RelationTagsLoader.type_name(),
+                            ComponentConfigChange::Some(
+                                components::RelationTagsLoader::new_component_type_erased(
+                                    IndexMap::from_iter([
+                                        ("z_tag".to_string(), "first".to_string()),
+                                        ("a_tag".to_string(), "second".to_string()),
+                                    ]),
+                                ),
+                            ),
+                        ),
                     ],
                     requires_full_refresh,
                 ),
@@ -176,6 +186,16 @@ mod tests {
         True
     </is_altered>
 </refresh>
+<tags>
+    <set_tags>
+        <z_tag>
+            first
+        </z_tag>
+        <a_tag>
+            second
+        </a_tag>
+    </set_tags>
+</tags>
                     ",
                 requires_full_refresh: false,
             },

--- a/crates/dbt-adapter/src/relation/databricks/config/relation_types/streaming_table.rs
+++ b/crates/dbt-adapter/src/relation/databricks/config/relation_types/streaming_table.rs
@@ -37,7 +37,7 @@ mod tests {
     };
     use crate::relation::databricks::config::{
         DatabricksRelationMetadata, components,
-        test_helpers::{TestModelConfig, run_test_cases},
+        test_helpers::{TestModelConfig, expected_tbl_properties, run_test_cases},
     };
     use crate::relation::test_helpers::TestCase;
     use indexmap::IndexMap;
@@ -126,15 +126,10 @@ mod tests {
                             components::TblPropertiesLoader.type_name(),
                             ComponentConfigChange::Some(
                                 components::TblPropertiesLoader::new_component_type_erased(
-                                    IndexMap::from_iter([
-                                        ("delta.enableRowTracking".to_string(), "true".to_string()),
-                                        (
-                                            "pipelines.pipelineId".to_string(),
-                                            "my_new_pipeline".to_string(),
-                                        ),
-                                        ("customKey".to_string(), "new".to_string()),
-                                        ("customKey2".to_string(), "value".to_string()),
-                                    ]),
+                                    expected_tbl_properties(
+                                        "my_new_pipeline",
+                                        [("customKey", "new"), ("customKey2", "value")],
+                                    ),
                                 ),
                             ),
                         ),

--- a/crates/dbt-adapter/src/relation/databricks/config/relation_types/streaming_table.rs
+++ b/crates/dbt-adapter/src/relation/databricks/config/relation_types/streaming_table.rs
@@ -127,6 +127,11 @@ mod tests {
                             ComponentConfigChange::Some(
                                 components::TblPropertiesLoader::new_component_type_erased(
                                     IndexMap::from_iter([
+                                        ("delta.enableRowTracking".to_string(), "true".to_string()),
+                                        (
+                                            "pipelines.pipelineId".to_string(),
+                                            "my_new_pipeline".to_string(),
+                                        ),
                                         ("customKey".to_string(), "new".to_string()),
                                         ("customKey2".to_string(), "value".to_string()),
                                     ]),

--- a/crates/dbt-adapter/src/relation/databricks/config/relation_types/view.rs
+++ b/crates/dbt-adapter/src/relation/databricks/config/relation_types/view.rs
@@ -143,6 +143,11 @@ mod tests {
                             ComponentConfigChange::Some(
                                 components::TblPropertiesLoader::new_component_type_erased(
                                     IndexMap::from_iter([
+                                        ("delta.enableRowTracking".to_string(), "true".to_string()),
+                                        (
+                                            "pipelines.pipelineId".to_string(),
+                                            "my_new_pipeline".to_string(),
+                                        ),
                                         ("customKey".to_string(), "new".to_string()),
                                         ("customKey2".to_string(), "value".to_string()),
                                     ]),

--- a/crates/dbt-adapter/src/relation/databricks/config/relation_types/view.rs
+++ b/crates/dbt-adapter/src/relation/databricks/config/relation_types/view.rs
@@ -32,7 +32,7 @@ mod tests {
     };
     use crate::relation::databricks::config::{
         DatabricksRelationMetadata, components,
-        test_helpers::{TestModelColumn, TestModelConfig, run_test_cases},
+        test_helpers::{TestModelColumn, TestModelConfig, expected_tbl_properties, run_test_cases},
     };
     use crate::relation::test_helpers::TestCase;
     use indexmap::IndexMap;
@@ -142,15 +142,10 @@ mod tests {
                             components::TblPropertiesLoader.type_name(),
                             ComponentConfigChange::Some(
                                 components::TblPropertiesLoader::new_component_type_erased(
-                                    IndexMap::from_iter([
-                                        ("delta.enableRowTracking".to_string(), "true".to_string()),
-                                        (
-                                            "pipelines.pipelineId".to_string(),
-                                            "my_new_pipeline".to_string(),
-                                        ),
-                                        ("customKey".to_string(), "new".to_string()),
-                                        ("customKey2".to_string(), "value".to_string()),
-                                    ]),
+                                    expected_tbl_properties(
+                                        "my_new_pipeline",
+                                        [("customKey", "new"), ("customKey2", "value")],
+                                    ),
                                 ),
                             ),
                         ),

--- a/crates/dbt-adapter/src/relation/databricks/config/test_helpers.rs
+++ b/crates/dbt-adapter/src/relation/databricks/config/test_helpers.rs
@@ -180,3 +180,23 @@ pub(crate) fn run_test_cases(
 ) {
     test_helpers::run_test_cases(test_cases, create_mock_dbt_model)
 }
+
+pub(crate) fn expected_tbl_properties<K, V>(
+    pipeline_id: &str,
+    custom_properties: impl IntoIterator<Item = (K, V)>,
+) -> IndexMap<String, String>
+where
+    K: Into<String>,
+    V: Into<String>,
+{
+    let mut properties = IndexMap::from_iter([
+        ("delta.enableRowTracking".to_string(), "true".to_string()),
+        ("pipelines.pipelineId".to_string(), pipeline_id.to_string()),
+    ]);
+    properties.extend(
+        custom_properties
+            .into_iter()
+            .map(|(key, value)| (key.into(), value.into())),
+    );
+    properties
+}

--- a/crates/dbt-adapter/src/relation/databricks/config/test_helpers.rs
+++ b/crates/dbt-adapter/src/relation/databricks/config/test_helpers.rs
@@ -40,6 +40,7 @@ pub(crate) struct TestModelConfig {
     #[expect(dead_code)]
     pub query: Option<String>,
     pub relation_comment: Option<String>,
+    pub raw_tags: Option<IndexMap<String, YmlValue>>,
     pub tags: IndexMap<String, String>,
     pub tbl_properties: IndexMap<String, String>,
     pub table_format: Option<String>,
@@ -105,12 +106,12 @@ pub(crate) fn create_mock_dbt_model(cfg: TestModelConfig) -> DbtModel {
             cron: cfg.cron,
             time_zone_value: cfg.time_zone,
         })),
-        databricks_tags: Some(
+        databricks_tags: Some(cfg.raw_tags.unwrap_or_else(|| {
             cfg.tags
                 .into_iter()
                 .map(|(k, v)| (k, YmlValue::from(v)))
-                .collect(),
-        ),
+                .collect()
+        })),
         ..Default::default()
     };
 

--- a/crates/dbt-loader/src/dbt_macro_assets/README.md
+++ b/crates/dbt-loader/src/dbt_macro_assets/README.md
@@ -5,6 +5,9 @@ All adapter macros are currently maintained in:
 
 ## Changelog
 
+### [2026-08-02]
+  - dbt-databricks: commit 50dd33424b97e1c45dff582bbdcbfe4b971e3558 (`relations/tags.sql` whitespace parity; retaining the documented Fusion relation-type rendering divergence)
+
 ### [2026-03-04]
   - dbt-databricks: v1.11.5 (commit 24325a3195171d36972804e545b2ccf967ab575d)
 

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-databricks/macros/relations/config.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-databricks/macros/relations/config.sql
@@ -1,6 +1,6 @@
 {%- macro get_configuration_changes(existing_relation) -%}
-    {%- set existing_config = adapter.get_relation_config(existing_relation) -%}
     {%- set model_config = adapter.get_config_from_model(config.model) -%}
+    {%- set existing_config = adapter.get_relation_config(existing_relation, model_config) -%}
     {%- set configuration_changes = model_config.get_changeset(existing_config) -%}
     {% do return(configuration_changes) %}
 {%- endmacro -%}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-databricks/macros/relations/tags.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-databricks/macros/relations/tags.sql
@@ -31,7 +31,7 @@
 {% macro alter_set_tags(relation, tags) -%}
   {#- DIVERGENCE BEGIN: upstream uses relation.type.render(); we use render_type() Jinja macro instead -#}
   ALTER {{ render_type(relation.type) }} {{ relation.render() }} SET TAGS (
-  {#- DIVERGENCE END -#}
+  {# DIVERGENCE END -#}
     {% for tag in tags -%}
       '{{ tag }}' = '{{ tags[tag] }}' {%- if not loop.last %}, {% endif -%}
     {%- endfor %}

--- a/crates/dbt-loader/tests/materializations/materialized_view.rs
+++ b/crates/dbt-loader/tests/materializations/materialized_view.rs
@@ -262,8 +262,13 @@ mod databricks {
         let a_position = result
             .find("'a_tag' = 'second'")
             .expect("SET TAGS SQL should contain a_tag");
+        let normalized = result.split_whitespace().collect::<Vec<_>>().join(" ");
 
         assert!(result.contains("SET TAGS"));
+        assert!(
+            normalized.contains("SET TAGS ( 'z_tag' = 'first'"),
+            "SET TAGS should preserve the v1 space after the opening parenthesis: {result}"
+        );
         assert!(
             z_position < a_position,
             "configured insertion order must be preserved in SET TAGS SQL: {result}"

--- a/crates/dbt-loader/tests/materializations/materialized_view.rs
+++ b/crates/dbt-loader/tests/materializations/materialized_view.rs
@@ -5,6 +5,7 @@ use dbt_adapter::relation::RelationObject;
 use dbt_adapter_core::AdapterType;
 use dbt_jinja_utils::mock_object::MockJinjaObject;
 use dbt_schemas::dbt_types::RelationType;
+use indexmap::IndexMap;
 use minijinja::Value;
 
 use crate::macro_test_harness::{MacroTestHarness, assert_executed_contains, default_mock_config};
@@ -235,6 +236,37 @@ mod databricks {
         assert!(
             result.to_uppercase().contains("ALTER MATERIALIZED VIEW"),
             "Expected ALTER statement, got: {result}",
+        );
+    }
+
+    #[test]
+    fn alter_tags_preserves_reverse_lexical_config_order() {
+        let h = build_harness();
+        let set_tags = IndexMap::from([
+            ("z_tag".to_string(), Value::from("first")),
+            ("a_tag".to_string(), Value::from("second")),
+        ]);
+        let tags = Value::from_serialize(IndexMap::from([(
+            "set_tags".to_string(),
+            Value::from_serialize(set_tags),
+        )]));
+        let changes = config_changes_mock(
+            false,
+            BTreeMap::from([("refresh", Value::UNDEFINED), ("tags", tags)]),
+        );
+
+        let result = render_alter(&h, changes);
+        let z_position = result
+            .find("'z_tag' = 'first'")
+            .expect("SET TAGS SQL should contain z_tag");
+        let a_position = result
+            .find("'a_tag' = 'second'")
+            .expect("SET TAGS SQL should contain a_tag");
+
+        assert!(result.contains("SET TAGS"));
+        assert!(
+            z_position < a_position,
+            "configured insertion order must be preserved in SET TAGS SQL: {result}"
         );
     }
 

--- a/crates/dbt-schemas/src/lib.rs
+++ b/crates/dbt-schemas/src/lib.rs
@@ -128,6 +128,7 @@ pub mod schemas {
             pub mod common;
             pub mod config_keys;
             pub mod data_test_config;
+            pub(crate) mod databricks;
             pub mod exposure_config;
             pub mod function_config;
             pub mod metric_config;

--- a/crates/dbt-schemas/src/schemas/dbt_column.rs
+++ b/crates/dbt-schemas/src/schemas/dbt_column.rs
@@ -51,7 +51,7 @@ pub struct DbtColumn {
     pub classifiers: Option<Vec<String>>,
     #[serde(
         default,
-        deserialize_with = "crate::schemas::project::configs::common::deserialize_databricks_tags"
+        deserialize_with = "crate::schemas::project::configs::databricks::deserialize_databricks_tags"
     )]
     pub databricks_tags: Option<IndexMap<String, YmlValue>>,
     pub column_mask: Option<ColumnMask>,
@@ -128,7 +128,7 @@ pub struct ColumnProperties {
     pub classifiers: Option<Vec<String>>,
     #[serde(
         default,
-        deserialize_with = "crate::schemas::project::configs::common::deserialize_databricks_tags"
+        deserialize_with = "crate::schemas::project::configs::databricks::deserialize_databricks_tags"
     )]
     pub databricks_tags: Option<IndexMap<String, YmlValue>>,
     pub column_mask: Option<ColumnMask>,
@@ -158,7 +158,7 @@ pub struct VersionColumnProperties {
     pub policy_tags: Option<Vec<String>>,
     #[serde(
         default,
-        deserialize_with = "crate::schemas::project::configs::common::deserialize_databricks_tags"
+        deserialize_with = "crate::schemas::project::configs::databricks::deserialize_databricks_tags"
     )]
     pub databricks_tags: Option<IndexMap<String, YmlValue>>,
     pub column_mask: Option<ColumnMask>,
@@ -199,7 +199,7 @@ pub struct ColumnConfig {
     pub meta: Option<IndexMap<String, YmlValue>>,
     #[serde(
         default,
-        deserialize_with = "crate::schemas::project::configs::common::deserialize_databricks_tags"
+        deserialize_with = "crate::schemas::project::configs::databricks::deserialize_databricks_tags"
     )]
     pub databricks_tags: Option<IndexMap<String, YmlValue>>,
     pub policy_tags: Option<Vec<String>>,

--- a/crates/dbt-schemas/src/schemas/dbt_column.rs
+++ b/crates/dbt-schemas/src/schemas/dbt_column.rs
@@ -1,5 +1,5 @@
 use indexmap::IndexMap;
-use std::{collections::BTreeMap, sync::Arc};
+use std::sync::Arc;
 
 use dbt_common::FsResult;
 use dbt_yaml::{DbtSchema, UntaggedEnumDeserialize};
@@ -49,7 +49,11 @@ pub struct DbtColumn {
     pub tags: Vec<String>,
     pub policy_tags: Option<Vec<String>>,
     pub classifiers: Option<Vec<String>>,
-    pub databricks_tags: Option<BTreeMap<String, YmlValue>>,
+    #[serde(
+        default,
+        deserialize_with = "crate::schemas::project::configs::common::deserialize_databricks_tags"
+    )]
+    pub databricks_tags: Option<IndexMap<String, YmlValue>>,
     pub column_mask: Option<ColumnMask>,
     pub quote: Option<bool>,
     #[serde(default, rename = "config")]
@@ -122,7 +126,11 @@ pub struct ColumnProperties {
     pub granularity: Option<Granularity>,
     pub policy_tags: Option<Vec<String>>,
     pub classifiers: Option<Vec<String>>,
-    pub databricks_tags: Option<BTreeMap<String, YmlValue>>,
+    #[serde(
+        default,
+        deserialize_with = "crate::schemas::project::configs::common::deserialize_databricks_tags"
+    )]
+    pub databricks_tags: Option<IndexMap<String, YmlValue>>,
     pub column_mask: Option<ColumnMask>,
     pub quote: Option<bool>,
     pub config: Option<ColumnConfig>,
@@ -148,7 +156,11 @@ pub struct VersionColumnProperties {
     pub data_tests: Option<Vec<DataTests>>,
     pub granularity: Option<Granularity>,
     pub policy_tags: Option<Vec<String>>,
-    pub databricks_tags: Option<BTreeMap<String, YmlValue>>,
+    #[serde(
+        default,
+        deserialize_with = "crate::schemas::project::configs::common::deserialize_databricks_tags"
+    )]
+    pub databricks_tags: Option<IndexMap<String, YmlValue>>,
     pub column_mask: Option<ColumnMask>,
     pub quote: Option<bool>,
     pub config: Option<ColumnConfig>,
@@ -185,7 +197,11 @@ pub struct ColumnConfig {
     #[serde(default)]
     pub tags: Option<StringOrArrayOfStrings>,
     pub meta: Option<IndexMap<String, YmlValue>>,
-    pub databricks_tags: Option<BTreeMap<String, YmlValue>>,
+    #[serde(
+        default,
+        deserialize_with = "crate::schemas::project::configs::common::deserialize_databricks_tags"
+    )]
+    pub databricks_tags: Option<IndexMap<String, YmlValue>>,
     pub policy_tags: Option<Vec<String>>,
 }
 

--- a/crates/dbt-schemas/src/schemas/nodes.rs
+++ b/crates/dbt-schemas/src/schemas/nodes.rs
@@ -5798,7 +5798,7 @@ pub struct DatabricksAttr {
     pub catalog: Option<String>,
     #[serde(
         default,
-        deserialize_with = "crate::schemas::project::configs::common::deserialize_databricks_tags"
+        deserialize_with = "crate::schemas::project::configs::databricks::deserialize_databricks_tags"
     )]
     pub databricks_tags: Option<IndexMap<String, YmlValue>>,
     pub compression: Option<String>,

--- a/crates/dbt-schemas/src/schemas/nodes.rs
+++ b/crates/dbt-schemas/src/schemas/nodes.rs
@@ -5796,7 +5796,11 @@ pub struct DatabricksAttr {
     pub clustered_by: Option<StringOrArrayOfStrings>,
     pub buckets: Option<i64>,
     pub catalog: Option<String>,
-    pub databricks_tags: Option<BTreeMap<String, YmlValue>>,
+    #[serde(
+        default,
+        deserialize_with = "crate::schemas::project::configs::common::deserialize_databricks_tags"
+    )]
+    pub databricks_tags: Option<IndexMap<String, YmlValue>>,
     pub compression: Option<String>,
     pub databricks_compute: Option<String>,
     pub target_alias: Option<String>,

--- a/crates/dbt-schemas/src/schemas/project/configs/common.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/common.rs
@@ -29,6 +29,31 @@ use crate::schemas::serde::{
     f64_or_string_f64, hours_to_expiration_or_string, u64_or_string_u64,
 };
 
+pub fn deserialize_databricks_tags<'de, D>(
+    deserializer: D,
+) -> Result<Option<IndexMap<String, YmlValue>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum DatabricksTagsInput {
+        Mapping(IndexMap<String, YmlValue>),
+        Other(YmlValue),
+    }
+
+    match Option::<DatabricksTagsInput>::deserialize(deserializer)? {
+        None => Ok(None),
+        Some(DatabricksTagsInput::Mapping(tags)) => Ok(Some(tags)),
+        Some(DatabricksTagsInput::Other(value)) => {
+            let _ = value;
+            Err(serde::de::Error::custom(
+                "databricks_tags must be a dictionary",
+            ))
+        }
+    }
+}
+
 #[track_caller]
 pub fn log_state_mod_diff<I>(unique_id: impl AsRef<str>, node_type: impl AsRef<str>, checks: I)
 where
@@ -369,7 +394,8 @@ pub struct WarehouseSpecificNodeConfig {
     pub clustered_by: Option<StringOrArrayOfStrings>,
     pub buckets: Option<i64>,
     pub catalog: Option<String>,
-    pub databricks_tags: Option<BTreeMap<String, YmlValue>>,
+    #[serde(default, deserialize_with = "deserialize_databricks_tags")]
+    pub databricks_tags: Option<IndexMap<String, YmlValue>>,
     pub compression: Option<String>,
     pub databricks_compute: Option<String>,
     pub target_alias: Option<String>,
@@ -1552,6 +1578,48 @@ pub(crate) fn unrendered_value_eq(a: Option<&YmlValue>, b: Option<&YmlValue>) ->
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_databricks_tags_deserialization_preserves_order() {
+        let mut deserializer =
+            serde_json::Deserializer::from_str(r#"{"z_last":"first","a_first":"second"}"#);
+        let tags = deserialize_databricks_tags(&mut deserializer)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            tags.keys().map(String::as_str).collect::<Vec<_>>(),
+            vec!["z_last", "a_first"]
+        );
+    }
+
+    #[test]
+    fn test_databricks_tags_deserialization_accepts_empty_and_null() {
+        let mut empty_deserializer = serde_json::Deserializer::from_str("{}");
+        let empty = deserialize_databricks_tags(&mut empty_deserializer)
+            .unwrap()
+            .unwrap();
+        assert!(empty.is_empty());
+
+        let mut null_deserializer = serde_json::Deserializer::from_str("null");
+        assert!(
+            deserialize_databricks_tags(&mut null_deserializer)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_databricks_tags_deserialization_rejects_non_mapping() {
+        let mut deserializer = serde_json::Deserializer::from_str(r#"["not","a","mapping"]"#);
+        let error = deserialize_databricks_tags(&mut deserializer).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("databricks_tags must be a dictionary")
+        );
+    }
 
     #[test]
     fn test_array_of_strings_eq_none_and_empty_array() {

--- a/crates/dbt-schemas/src/schemas/project/configs/common.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/common.rs
@@ -29,31 +29,6 @@ use crate::schemas::serde::{
     f64_or_string_f64, hours_to_expiration_or_string, u64_or_string_u64,
 };
 
-pub fn deserialize_databricks_tags<'de, D>(
-    deserializer: D,
-) -> Result<Option<IndexMap<String, YmlValue>>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum DatabricksTagsInput {
-        Mapping(IndexMap<String, YmlValue>),
-        Other(YmlValue),
-    }
-
-    match Option::<DatabricksTagsInput>::deserialize(deserializer)? {
-        None => Ok(None),
-        Some(DatabricksTagsInput::Mapping(tags)) => Ok(Some(tags)),
-        Some(DatabricksTagsInput::Other(value)) => {
-            let _ = value;
-            Err(serde::de::Error::custom(
-                "databricks_tags must be a dictionary",
-            ))
-        }
-    }
-}
-
 #[track_caller]
 pub fn log_state_mod_diff<I>(unique_id: impl AsRef<str>, node_type: impl AsRef<str>, checks: I)
 where
@@ -394,7 +369,10 @@ pub struct WarehouseSpecificNodeConfig {
     pub clustered_by: Option<StringOrArrayOfStrings>,
     pub buckets: Option<i64>,
     pub catalog: Option<String>,
-    #[serde(default, deserialize_with = "deserialize_databricks_tags")]
+    #[serde(
+        default,
+        deserialize_with = "super::databricks::deserialize_databricks_tags"
+    )]
     pub databricks_tags: Option<IndexMap<String, YmlValue>>,
     pub compression: Option<String>,
     pub databricks_compute: Option<String>,
@@ -1578,48 +1556,6 @@ pub(crate) fn unrendered_value_eq(a: Option<&YmlValue>, b: Option<&YmlValue>) ->
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_databricks_tags_deserialization_preserves_order() {
-        let mut deserializer =
-            serde_json::Deserializer::from_str(r#"{"z_last":"first","a_first":"second"}"#);
-        let tags = deserialize_databricks_tags(&mut deserializer)
-            .unwrap()
-            .unwrap();
-
-        assert_eq!(
-            tags.keys().map(String::as_str).collect::<Vec<_>>(),
-            vec!["z_last", "a_first"]
-        );
-    }
-
-    #[test]
-    fn test_databricks_tags_deserialization_accepts_empty_and_null() {
-        let mut empty_deserializer = serde_json::Deserializer::from_str("{}");
-        let empty = deserialize_databricks_tags(&mut empty_deserializer)
-            .unwrap()
-            .unwrap();
-        assert!(empty.is_empty());
-
-        let mut null_deserializer = serde_json::Deserializer::from_str("null");
-        assert!(
-            deserialize_databricks_tags(&mut null_deserializer)
-                .unwrap()
-                .is_none()
-        );
-    }
-
-    #[test]
-    fn test_databricks_tags_deserialization_rejects_non_mapping() {
-        let mut deserializer = serde_json::Deserializer::from_str(r#"["not","a","mapping"]"#);
-        let error = deserialize_databricks_tags(&mut deserializer).unwrap_err();
-
-        assert!(
-            error
-                .to_string()
-                .contains("databricks_tags must be a dictionary")
-        );
-    }
 
     #[test]
     fn test_array_of_strings_eq_none_and_empty_array() {

--- a/crates/dbt-schemas/src/schemas/project/configs/data_test_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/data_test_config.rs
@@ -239,7 +239,7 @@ pub struct ProjectDataTestConfig {
     #[serde(
         default,
         rename = "+databricks_tags",
-        deserialize_with = "super::common::deserialize_databricks_tags"
+        deserialize_with = "super::databricks::deserialize_databricks_tags"
     )]
     pub databricks_tags: Option<IndexMap<String, YmlValue>>,
     #[serde(rename = "+compression")]

--- a/crates/dbt-schemas/src/schemas/project/configs/data_test_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/data_test_config.rs
@@ -236,8 +236,12 @@ pub struct ProjectDataTestConfig {
     pub buckets: Option<i64>,
     #[serde(rename = "+catalog")]
     pub catalog: Option<String>,
-    #[serde(rename = "+databricks_tags")]
-    pub databricks_tags: Option<BTreeMap<String, YmlValue>>,
+    #[serde(
+        default,
+        rename = "+databricks_tags",
+        deserialize_with = "super::common::deserialize_databricks_tags"
+    )]
+    pub databricks_tags: Option<IndexMap<String, YmlValue>>,
     #[serde(rename = "+compression")]
     pub compression: Option<String>,
     #[serde(rename = "+databricks_compute")]

--- a/crates/dbt-schemas/src/schemas/project/configs/databricks.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/databricks.rs
@@ -1,0 +1,75 @@
+use dbt_yaml::Value as YmlValue;
+use indexmap::IndexMap;
+use serde::Deserialize;
+
+pub(crate) fn deserialize_databricks_tags<'de, D>(
+    deserializer: D,
+) -> Result<Option<IndexMap<String, YmlValue>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum DatabricksTagsInput {
+        Mapping(IndexMap<String, YmlValue>),
+        Other(YmlValue),
+    }
+
+    match Option::<DatabricksTagsInput>::deserialize(deserializer)? {
+        None => Ok(None),
+        Some(DatabricksTagsInput::Mapping(tags)) => Ok(Some(tags)),
+        Some(DatabricksTagsInput::Other(value)) => {
+            let _ = value;
+            Err(serde::de::Error::custom(
+                "databricks_tags must be a dictionary",
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::deserialize_databricks_tags;
+
+    #[test]
+    fn preserves_tag_order() {
+        let mut deserializer =
+            serde_json::Deserializer::from_str(r#"{"z_last":"first","a_first":"second"}"#);
+        let tags = deserialize_databricks_tags(&mut deserializer)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            tags.keys().map(String::as_str).collect::<Vec<_>>(),
+            vec!["z_last", "a_first"]
+        );
+    }
+
+    #[test]
+    fn accepts_empty_and_null() {
+        let mut empty_deserializer = serde_json::Deserializer::from_str("{}");
+        let empty = deserialize_databricks_tags(&mut empty_deserializer)
+            .unwrap()
+            .unwrap();
+        assert!(empty.is_empty());
+
+        let mut null_deserializer = serde_json::Deserializer::from_str("null");
+        assert!(
+            deserialize_databricks_tags(&mut null_deserializer)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn rejects_non_mapping() {
+        let mut deserializer = serde_json::Deserializer::from_str(r#"["not","a","mapping"]"#);
+        let error = deserialize_databricks_tags(&mut deserializer).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("databricks_tags must be a dictionary")
+        );
+    }
+}

--- a/crates/dbt-schemas/src/schemas/project/configs/model_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/model_config.rs
@@ -161,7 +161,7 @@ pub struct ProjectModelConfig {
     #[serde(
         default,
         rename = "+databricks_tags",
-        deserialize_with = "super::common::deserialize_databricks_tags"
+        deserialize_with = "super::databricks::deserialize_databricks_tags"
     )]
     pub databricks_tags: Option<IndexMap<String, YmlValue>>,
     #[serde(rename = "+submission_method")]

--- a/crates/dbt-schemas/src/schemas/project/configs/model_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/model_config.rs
@@ -158,8 +158,12 @@ pub struct ProjectModelConfig {
     pub database: Omissible<Option<String>>,
     #[serde(rename = "+databricks_compute")]
     pub databricks_compute: Option<String>,
-    #[serde(rename = "+databricks_tags")]
-    pub databricks_tags: Option<BTreeMap<String, YmlValue>>,
+    #[serde(
+        default,
+        rename = "+databricks_tags",
+        deserialize_with = "super::common::deserialize_databricks_tags"
+    )]
+    pub databricks_tags: Option<IndexMap<String, YmlValue>>,
     #[serde(rename = "+submission_method")]
     pub submission_method: Option<String>,
     #[serde(rename = "+job_cluster_config")]

--- a/crates/dbt-schemas/src/schemas/project/configs/seed_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/seed_config.rs
@@ -224,7 +224,7 @@ pub struct ProjectSeedConfig {
     #[serde(
         default,
         rename = "+databricks_tags",
-        deserialize_with = "super::common::deserialize_databricks_tags"
+        deserialize_with = "super::databricks::deserialize_databricks_tags"
     )]
     pub databricks_tags: Option<IndexMap<String, YmlValue>>,
     #[serde(rename = "+compression")]

--- a/crates/dbt-schemas/src/schemas/project/configs/seed_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/seed_config.rs
@@ -221,8 +221,12 @@ pub struct ProjectSeedConfig {
     pub buckets: Option<i64>,
     #[serde(rename = "+catalog")]
     pub catalog: Option<String>,
-    #[serde(rename = "+databricks_tags")]
-    pub databricks_tags: Option<BTreeMap<String, YmlValue>>,
+    #[serde(
+        default,
+        rename = "+databricks_tags",
+        deserialize_with = "super::common::deserialize_databricks_tags"
+    )]
+    pub databricks_tags: Option<IndexMap<String, YmlValue>>,
     #[serde(rename = "+compression")]
     pub compression: Option<String>,
     #[serde(rename = "+databricks_compute")]

--- a/crates/dbt-schemas/src/schemas/project/configs/snapshot_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/snapshot_config.rs
@@ -271,7 +271,7 @@ pub struct ProjectSnapshotConfig {
     #[serde(
         default,
         rename = "+databricks_tags",
-        deserialize_with = "super::common::deserialize_databricks_tags"
+        deserialize_with = "super::databricks::deserialize_databricks_tags"
     )]
     pub databricks_tags: Option<IndexMap<String, YmlValue>>,
     #[serde(rename = "+file_format")]

--- a/crates/dbt-schemas/src/schemas/project/configs/snapshot_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/snapshot_config.rs
@@ -268,8 +268,12 @@ pub struct ProjectSnapshotConfig {
     pub compression: Option<String>,
     #[serde(rename = "+databricks_compute")]
     pub databricks_compute: Option<String>,
-    #[serde(rename = "+databricks_tags")]
-    pub databricks_tags: Option<BTreeMap<String, YmlValue>>,
+    #[serde(
+        default,
+        rename = "+databricks_tags",
+        deserialize_with = "super::common::deserialize_databricks_tags"
+    )]
+    pub databricks_tags: Option<IndexMap<String, YmlValue>>,
     #[serde(rename = "+file_format")]
     pub file_format: Option<String>,
     #[serde(rename = "+catalog_name")]

--- a/crates/dbt-schemas/src/schemas/project/configs/source_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/source_config.rs
@@ -140,7 +140,7 @@ pub struct ProjectSourceConfig {
     #[serde(
         default,
         rename = "+databricks_tags",
-        deserialize_with = "super::common::deserialize_databricks_tags"
+        deserialize_with = "super::databricks::deserialize_databricks_tags"
     )]
     pub databricks_tags: Option<IndexMap<String, YmlValue>>,
     #[serde(rename = "+compression")]

--- a/crates/dbt-schemas/src/schemas/project/configs/source_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/source_config.rs
@@ -137,8 +137,12 @@ pub struct ProjectSourceConfig {
     pub buckets: Option<i64>,
     #[serde(rename = "+catalog")]
     pub catalog: Option<String>,
-    #[serde(rename = "+databricks_tags")]
-    pub databricks_tags: Option<BTreeMap<String, YmlValue>>,
+    #[serde(
+        default,
+        rename = "+databricks_tags",
+        deserialize_with = "super::common::deserialize_databricks_tags"
+    )]
+    pub databricks_tags: Option<IndexMap<String, YmlValue>>,
     #[serde(rename = "+compression")]
     pub compression: Option<String>,
     #[serde(rename = "+databricks_compute")]

--- a/crates/dbt-schemas/src/schemas/project/configs/unit_test_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/unit_test_config.rs
@@ -192,8 +192,12 @@ pub struct ProjectUnitTestConfig {
     pub buckets: Option<i64>,
     #[serde(rename = "+catalog")]
     pub catalog: Option<String>,
-    #[serde(rename = "+databricks_tags")]
-    pub databricks_tags: Option<BTreeMap<String, YmlValue>>,
+    #[serde(
+        default,
+        rename = "+databricks_tags",
+        deserialize_with = "super::common::deserialize_databricks_tags"
+    )]
+    pub databricks_tags: Option<IndexMap<String, YmlValue>>,
     #[serde(rename = "+compression")]
     pub compression: Option<String>,
     #[serde(rename = "+databricks_compute")]

--- a/crates/dbt-schemas/src/schemas/project/configs/unit_test_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/unit_test_config.rs
@@ -195,7 +195,7 @@ pub struct ProjectUnitTestConfig {
     #[serde(
         default,
         rename = "+databricks_tags",
-        deserialize_with = "super::common::deserialize_databricks_tags"
+        deserialize_with = "super::databricks::deserialize_databricks_tags"
     )]
     pub databricks_tags: Option<IndexMap<String, YmlValue>>,
     #[serde(rename = "+compression")]


### PR DESCRIPTION
Resolves #15690

## Summary

- include Databricks relation tags in materialized-view configuration change detection
- preserve dbt-databricks scalar and collection coercion, insertion order, set-only tag updates,
  desired-subset table-property semantics, and exact `SET TAGS` rendering
- fetch tag metadata only when configured tags require it and preserve the missing-config
  compatibility path
- add focused Adapter Object coverage for the optional `model_config` Jinja boundary
- add schema, adapter-boundary, relation-config, macro-rendering, and full materialized-view lifecycle
  coverage

## Conformance findings

The current-head audit found that server behavior and manifest artifacts already matched current
dbt-databricks, while ordered SQL and adversarial review exposed four supplemental gaps:

- the representative runner needed a narrow, symmetric normalization for the generated schema
  predicate in the retained `system.information_schema.table_tags` lookup
- a Fusion-only Jinja comment trim marker removed the v1 whitespace after `SET TAGS (`
- Fusion dropped collection-valued tags that current dbt-databricks stringifies
- the representative runner classified every seed-node SQL event as setup instead of recognizing
  only the seed staging statements

The collection rendering, Typed Adapter Jinja boundary, macro rendering, and narrow seed exclusions
are now pinned directly. A fresh six-step current-v1 versus Fusion run passes every
command/capture, ordered feature-SQL comparison, live server-state comparison, and manifest
artifact comparison. No successful lifecycle step excludes SQL comparison.

## Verification

- current dbt-databricks unit suite: 1318 passed, 4 skipped
- current dbt-databricks focused live suite: 6 passed
- `cargo test -p dbt-adapter --lib` (884 passed)
- `cargo test -p dbt-schemas --lib` (444 passed, 1 ignored)
- `cargo test -p dbt-state --lib` (121 passed)
- focused Typed Adapter Object optional-model-config Jinja tests (2 passed)
- `cargo test -p dbt-loader materializations::materialized_view -- --nocapture` (6 passed)
- representative-runner negative suite (79 passed)
- fresh dual-live conformance: all 6 lifecycle steps passed SQL, live, and artifact gates
- direct Rust formatting checks for the changed Rust files
- `cargo clippy -p dbt-adapter -p dbt-loader --all-targets -- -D warnings`
- `git diff --check`

## Context

Ports the tagged materialized-view behavior covered by
https://github.com/databricks/dbt-databricks/pull/1424.
