### PR TITLE
fix(clickhouse): implement constraint_support in adapter_impl.rs

### DIFF
--- a/.changes/unreleased/Fixes-20260729-172004.yaml
+++ b/.changes/unreleased/Fixes-20260729-172004.yaml
@@ -1,5 +1,5 @@
 kind: Fixes
-body: 'ClickHouse: implement constraint_support (check constraints enforced at the model level; not_null/unique/primary_key/foreign_key marked not supported, matching the legacy Python adapter). Fixes a hard panic when a ClickHouse model declares constraints:.'
+body: 'ClickHouse: implement constraint_support (check constraints enforced at the model level; not_null/unique/primary_key/foreign_key marked not supported, matching the legacy Python adapter). Fixes a hard panic when a ClickHouse model declares a `constraints` block.'
 time: 2026-07-29T17:20:04.090446-04:00
 custom:
     author: jecolvin

--- a/.changes/unreleased/Fixes-20260729-172004.yaml
+++ b/.changes/unreleased/Fixes-20260729-172004.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: 'ClickHouse: implement constraint_support (check constraints enforced at the model level; not_null/unique/primary_key/foreign_key marked not supported, matching the legacy Python adapter). Fixes a hard panic when a ClickHouse model declares constraints:.'
+time: 2026-07-29T17:20:04.090446-04:00
+custom:
+    author: jecolvin
+    issue: "14651"
+    project: dbt-core

--- a/crates/dbt-adapter/src/adapter/adapter_impl.rs
+++ b/crates/dbt-adapter/src/adapter/adapter_impl.rs
@@ -2454,6 +2454,24 @@ impl AdapterImpl {
                 Some(format!("{r} not enforced"))
             }
             (Bigquery, _) => None,
+            // ClickHouse only supports `CHECK` at the table/model level (`CONSTRAINT name
+            // CHECK (expr)`), never inline on an individual column. get_constraint_support
+            // reports Check as Enforced (it genuinely is, at the model level), so it isn't
+            // caught by the NotSupported early-return above; without this arm it would fall
+            // through to the generic renderer and produce invalid inline SQL on a column with
+            // zero warning. Mirrors the legacy Python adapter, which never renders column-level
+            // constraints for ClickHouse and only warns.
+            (ClickHouse, ConstraintType::Check) => {
+                emit_warn_log_message(
+                    ErrorCode::ConstraintNotSupported,
+                    "ClickHouse does not support column-level constraints. Declare `check` \
+                     constraints at the model level (top-level `constraints:` on the model) \
+                     instead of on an individual column."
+                        .to_string(),
+                    None,
+                );
+                None
+            }
             _ => Some(r.trim().to_string()),
         })
     }
@@ -2532,10 +2550,25 @@ impl AdapterImpl {
             (Fabric, ForeignKey) => Enforced,
             (Fabric, Custom) => NotSupported,
 
+            // ClickHouse
+            // https://github.com/ClickHouse/dbt-clickhouse/blob/main/dbt/adapters/clickhouse/impl.py (CONSTRAINT_SUPPORT)
+            // Only `CONSTRAINT name CHECK (expr)` is real, enforced ClickHouse DDL, and only at
+            // the table/model level. ClickHouse has no UNIQUE, no FOREIGN KEY, and no inline
+            // NOT NULL/PRIMARY KEY column-constraint syntax: nullability is expressed via the
+            // Nullable(T) type wrapper (already handled by the column-type machinery, not this
+            // constraint path), and PRIMARY KEY is a separate top-level engine clause driven by
+            // the `primary_key` model config, not the generic constraint renderer.
+            (ClickHouse, Check) => Enforced,
+            (ClickHouse, NotNull) => NotSupported,
+            (ClickHouse, Unique) => NotSupported,
+            (ClickHouse, PrimaryKey) => NotSupported,
+            (ClickHouse, ForeignKey) => NotSupported,
+            (ClickHouse, Custom) => NotSupported,
+
             // Salesforce
             (
-                Salesforce | Spark | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion
-                | Dremio | Oracle,
+                Salesforce | Spark | Exasol | Starburst | Athena | Trino | Datafusion | Dremio
+                | Oracle,
                 _,
             ) => {
                 unimplemented!("constraint support not implemented")
@@ -5378,7 +5411,7 @@ mod tests {
                     ("attach".into(), attach),
                 ])
             }
-            Bigquery | Redshift | Spark | Databricks => Mapping::new(),
+            Bigquery | Redshift | Spark | Databricks | ClickHouse => Mapping::new(),
             _ => unimplemented!("mock config for adapter type {:?}", adapter_type),
         };
         build_engine(adapter_type, config)
@@ -6326,6 +6359,74 @@ mod tests {
             warn_unenforced: None,
         };
         assert!(adapter.render_column_constraint(constraint).is_none());
+    }
+
+    // ClickHouse constraint_support (issue #14651): only `check` is enforced, and only at the
+    // model level. Mirrors the legacy Python adapter's CONSTRAINT_SUPPORT mapping.
+    #[test]
+    fn test_get_constraint_support_clickhouse_check_enforced() {
+        let adapter = AdapterImpl::new(engine(ClickHouse), None);
+        assert_eq!(
+            adapter.get_constraint_support(ConstraintType::Check),
+            ConstraintSupport::Enforced
+        );
+    }
+
+    #[test]
+    fn test_get_constraint_support_clickhouse_not_supported_types() {
+        let adapter = AdapterImpl::new(engine(ClickHouse), None);
+        for ct in [
+            ConstraintType::NotNull,
+            ConstraintType::Unique,
+            ConstraintType::PrimaryKey,
+            ConstraintType::ForeignKey,
+            ConstraintType::Custom,
+        ] {
+            assert_eq!(
+                adapter.get_constraint_support(ct),
+                ConstraintSupport::NotSupported,
+                "expected {ct:?} to be NotSupported for ClickHouse"
+            );
+        }
+    }
+
+    // Regression guard for the bug get_constraint_support(Check) => Enforced would otherwise
+    // introduce: ClickHouse's CHECK syntax only exists at the table/model level, never inline
+    // on a column, so a column-level check constraint must not be rendered as inline SQL.
+    #[test]
+    fn test_render_column_constraint_clickhouse_check_returns_none() {
+        let adapter = AdapterImpl::new(engine(ClickHouse), None);
+        let constraint = Constraint {
+            type_: ConstraintType::Check,
+            expression: Some("x > 0".to_string()),
+            name: None,
+            to: None,
+            to_columns: None,
+            warn_unsupported: None,
+            warn_unenforced: None,
+        };
+        assert!(adapter.render_column_constraint(constraint).is_none());
+    }
+
+    // Model-level rendering is untouched by this change: ClickHouse's generic
+    // render_model_constraint path already produces valid `CONSTRAINT name CHECK (expr)` DDL.
+    #[test]
+    fn test_render_model_constraint_clickhouse_check() {
+        let constraint = ModelConstraint {
+            type_: ConstraintType::Check,
+            expression: Some("x > 0".to_string()),
+            name: Some("my_check".to_string()),
+            to: None,
+            to_columns: None,
+            columns: None,
+            warn_unsupported: None,
+            warn_unenforced: None,
+        };
+        let rendered = crate::render_constraint::render_model_constraint(ClickHouse, constraint);
+        assert_eq!(
+            rendered,
+            Some("constraint my_check check (x > 0)".to_string())
+        );
     }
 
     /// Build a single-column `show databases` style result with the given column

--- a/crates/dbt-adapter/src/adapter/adapter_impl.rs
+++ b/crates/dbt-adapter/src/adapter/adapter_impl.rs
@@ -2552,12 +2552,25 @@ impl AdapterImpl {
 
             // ClickHouse
             // https://github.com/ClickHouse/dbt-clickhouse/blob/main/dbt/adapters/clickhouse/impl.py (CONSTRAINT_SUPPORT)
-            // Only `CONSTRAINT name CHECK (expr)` is real, enforced ClickHouse DDL, and only at
-            // the table/model level. ClickHouse has no UNIQUE, no FOREIGN KEY, and no inline
-            // NOT NULL/PRIMARY KEY column-constraint syntax: nullability is expressed via the
-            // Nullable(T) type wrapper (already handled by the column-type machinery, not this
-            // constraint path), and PRIMARY KEY is a separate top-level engine clause driven by
-            // the `primary_key` model config, not the generic constraint renderer.
+            // Verified directly against a live ClickHouse 26.7 server (not just inferred from
+            // the upstream Python source):
+            //   - CHECK: `CONSTRAINT name CHECK (expr)` is real DDL and is genuinely enforced
+            //     (a violating INSERT is rejected) — but only at the table/model level; there
+            //     is no inline per-column CHECK syntax (SYNTAX_ERROR).
+            //   - UNIQUE: no such column-constraint syntax exists at all (SYNTAX_ERROR).
+            //   - NOT NULL: syntactically accepted, but only as a no-op on an already
+            //     non-nullable type; combining it with Nullable(T) is a hard error
+            //     (ILLEGAL_SYNTAX_FOR_DATA_TYPE). It never enforces anything beyond what the
+            //     type itself already guarantees, so it can't back dbt's not_null semantics.
+            //     Nullability is controlled entirely by the Nullable(T) type wrapper, already
+            //     handled by the column-type machinery, not this constraint path.
+            //   - PRIMARY KEY: the inline column syntax *is* accepted and does get recorded as
+            //     the table's primary key (confirmed via SHOW CREATE TABLE) — but it's a pure
+            //     sparse-index locality hint with zero uniqueness enforcement (inserting a
+            //     duplicate key value succeeds). It's already exposed as a working, distinct
+            //     mechanism via the `primary_key` model config in the vendored macros; routing
+            //     it through this generic path too would misleadingly imply uniqueness.
+            //   - FOREIGN KEY: no such concept in ClickHouse.
             (ClickHouse, Check) => Enforced,
             (ClickHouse, NotNull) => NotSupported,
             (ClickHouse, Unique) => NotSupported,

--- a/crates/dbt-adapter/src/adapter/adapter_impl.rs
+++ b/crates/dbt-adapter/src/adapter/adapter_impl.rs
@@ -2462,14 +2462,18 @@ impl AdapterImpl {
             // zero warning. Mirrors the legacy Python adapter, which never renders column-level
             // constraints for ClickHouse and only warns.
             (ClickHouse, ConstraintType::Check) => {
-                emit_warn_log_message(
-                    ErrorCode::ConstraintNotSupported,
-                    "ClickHouse does not support column-level constraints. Declare `check` \
-                     constraints at the model level (top-level `constraints:` on the model) \
-                     instead of on an individual column."
-                        .to_string(),
-                    None,
-                );
+                // Respect warn_unsupported: false like the standard warn_constraint_support
+                // path does, rather than warning unconditionally.
+                if constraint.warn_unsupported.unwrap_or(true) {
+                    emit_warn_log_message(
+                        ErrorCode::ConstraintNotSupported,
+                        "ClickHouse does not support column-level constraints. Declare `check` \
+                         constraints at the model level (top-level `constraints:` on the model) \
+                         instead of on an individual column."
+                            .to_string(),
+                        None,
+                    );
+                }
                 None
             }
             _ => Some(r.trim().to_string()),

--- a/crates/dbt-adapter/src/adapter/adapter_impl.rs
+++ b/crates/dbt-adapter/src/adapter/adapter_impl.rs
@@ -2462,22 +2462,28 @@ impl AdapterImpl {
             // zero warning. Mirrors the legacy Python adapter, which never renders column-level
             // constraints for ClickHouse and only warns.
             (ClickHouse, ConstraintType::Check) => {
-                // Respect warn_unsupported: false like the standard warn_constraint_support
-                // path does, rather than warning unconditionally.
-                if constraint.warn_unsupported.unwrap_or(true) {
-                    emit_warn_log_message(
-                        ErrorCode::ConstraintNotSupported,
-                        "ClickHouse does not support column-level constraints. Declare `check` \
-                         constraints at the model level (top-level `constraints:` on the model) \
-                         instead of on an individual column."
-                            .to_string(),
-                        None,
-                    );
-                }
-                None
+                Self::warn_and_drop_clickhouse_column_check(constraint.warn_unsupported)
             }
             _ => Some(r.trim().to_string()),
         })
+    }
+
+    /// ClickHouse only supports `CHECK` at the table/model level (`CONSTRAINT name
+    /// CHECK (expr)`), never inline on an individual column — see `render_column_constraint`.
+    /// Warns (respecting `warn_unsupported`, like `warn_constraint_support` does everywhere
+    /// else) and always drops the constraint rather than rendering invalid inline SQL.
+    fn warn_and_drop_clickhouse_column_check(warn_unsupported: Option<bool>) -> Option<String> {
+        if warn_unsupported.unwrap_or(true) {
+            emit_warn_log_message(
+                ErrorCode::ConstraintNotSupported,
+                "ClickHouse does not support column-level constraints. Declare `check` \
+                 constraints at the model level (top-level `constraints:` on the model) \
+                 instead of on an individual column."
+                    .to_string(),
+                None,
+            );
+        }
+        None
     }
 
     /// https://github.com/dbt-labs/dbt-adapters/blob/5379513bad9c75661b990a5ed5f32ac9c62a0758/dbt-adapters/src/dbt/adapters/base/impl.py#L293

--- a/crates/dbt-adapter/src/render_constraint.rs
+++ b/crates/dbt-adapter/src/render_constraint.rs
@@ -124,6 +124,21 @@ pub fn render_model_constraint(
             }
             _ => None,
         },
+        // ClickHouse: `render_raw_model_constraints` already warns via
+        // `warn_constraint_support` before calling this function, using text that says the
+        // constraint "will be ignored" for any NotSupported type. That's only true if this
+        // function actually skips it — otherwise the constraint still gets rendered here and
+        // embedded in the CREATE TABLE column list. PrimaryKey/ForeignKey are safe to still
+        // render as-is even though NotSupported: ClickHouse accepts a bare `primary key (cols)`
+        // item there (it becomes a real, non-unique-enforcing PRIMARY KEY clause) and a bare
+        // `foreign key ... references ...` item there (ClickHouse parses and silently drops
+        // it — a no-op, not an error). But `unique (cols)` in that position is a genuine
+        // SYNTAX_ERROR (verified against a live server) — ClickHouse has no such clause at
+        // all — so it must not be rendered, or the whole CREATE TABLE statement fails.
+        AdapterType::ClickHouse => match constraint.type_ {
+            ConstraintType::Unique => None,
+            _ => Some(rendered),
+        },
         _ => Some(rendered),
     })
 }
@@ -270,6 +285,53 @@ mod tests {
                 None
             ),
             Some(ErrorCode::ConstraintNotEnforced)
+        );
+    }
+
+    fn clickhouse_model_constraint(type_: ConstraintType) -> ModelConstraint {
+        ModelConstraint {
+            type_,
+            expression: None,
+            name: Some("my_constraint".to_string()),
+            to: Some("id".to_string().into()),
+            to_columns: Some(vec!["id".to_string()]),
+            columns: Some(vec!["x".to_string()]),
+            warn_unsupported: None,
+            warn_unenforced: None,
+        }
+    }
+
+    // Regression test: `unique (cols)` in the position ClickHouse embeds model-level
+    // constraints (a bare item in the CREATE TABLE column list) is a real SYNTAX_ERROR,
+    // verified against a live ClickHouse 26.7 server — there is no UNIQUE clause in
+    // ClickHouse at all. Must not be rendered.
+    #[test]
+    fn render_model_constraint_clickhouse_unique_returns_none() {
+        let constraint = clickhouse_model_constraint(ConstraintType::Unique);
+        assert!(render_model_constraint(AdapterType::ClickHouse, constraint).is_none());
+    }
+
+    // `primary key (cols)` in that same position is accepted by ClickHouse and hoisted into
+    // a real `PRIMARY KEY (cols)` clause (confirmed via SHOW CREATE TABLE) — it just doesn't
+    // enforce uniqueness. Valid SQL, so it's fine to still render it.
+    #[test]
+    fn render_model_constraint_clickhouse_primary_key_still_renders() {
+        let constraint = clickhouse_model_constraint(ConstraintType::PrimaryKey);
+        assert_eq!(
+            render_model_constraint(AdapterType::ClickHouse, constraint),
+            Some("constraint my_constraint primary key (x)".to_string())
+        );
+    }
+
+    // `foreign key (cols) references ...` in that position is accepted by ClickHouse's
+    // parser but silently dropped entirely (not even present in SHOW CREATE TABLE) —
+    // confirmed live. A no-op, not an error, so it's fine to still render it.
+    #[test]
+    fn render_model_constraint_clickhouse_foreign_key_still_renders() {
+        let constraint = clickhouse_model_constraint(ConstraintType::ForeignKey);
+        assert_eq!(
+            render_model_constraint(AdapterType::ClickHouse, constraint),
+            Some("constraint my_constraint foreign key (x) references id (id)".to_string())
         );
     }
 }


### PR DESCRIPTION
## Summary

Closes #14651.

`get_constraint_support` currently hits an `unimplemented!()` panic for ClickHouse (grouped with several other not-yet-implemented adapters), which fires the instant a ClickHouse model declares any `constraints:` — blocking dbt contracts (#14581) for ClickHouse entirely.

This ports the mapping from the legacy Python `dbt-clickhouse` adapter's `CONSTRAINT_SUPPORT`, the same way every other arm in this match cites its upstream Python source:

- `check` → **Enforced** — `CONSTRAINT name CHECK (expr)` is real, enforced, table-level ClickHouse DDL.
- `not_null` / `unique` / `primary_key` / `foreign_key` → **NotSupported** — see verification below for why, per type.

## Live verification (not just inferred from the Python source)

I don't have access to any integration/functional test suite for this adapter in this checkout (see Test plan), so I spun up a real ClickHouse 26.7 server (Docker) and verified each classification directly, rather than relying on documentation or the upstream adapter's comments:

| Type | Column-level (inline on a field) | Model-level (top-level `constraints:`) |
|---|---|---|
| **CHECK** | `SYNTAX_ERROR` — no inline column CHECK exists | `CONSTRAINT name CHECK (expr)` — real DDL, genuinely enforced (violating INSERT rejected) |
| **UNIQUE** | `SYNTAX_ERROR` | `SYNTAX_ERROR` — no UNIQUE clause exists in ClickHouse at all |
| **NOT NULL** | Accepted only as a no-op on an already non-nullable type; `ILLEGAL_SYNTAX_FOR_DATA_TYPE` if combined with `Nullable(T)` — never enforces anything | n/a (dbt's contract framework never emits NotNull as a model-level constraint) |
| **PRIMARY KEY** | Accepted, becomes a real `PRIMARY KEY` clause (confirmed via `SHOW CREATE TABLE`) — but zero uniqueness enforcement (duplicate key values insert successfully) | Same: accepted, becomes a real PRIMARY KEY clause, same lack of uniqueness enforcement |
| **FOREIGN KEY** | n/a | Accepted by the parser but silently dropped by ClickHouse entirely (not even present in `SHOW CREATE TABLE`) — a no-op, not an error |

This is why `not_null`/`unique`/`primary_key`/`foreign_key` are all `NotSupported`: none of them back dbt's actual constraint semantics (uniqueness/referential integrity/non-nullability-as-a-constraint), even where the SQL itself doesn't error.

## Two bugs this surfaces and fixes in the same PR

Both are a direct, foreseeable consequence of turning the `unimplemented!()` panic into a real mapping — before this PR, *any* constraint declaration on a ClickHouse model panicked before reaching either code path below, so neither bug was reachable. Fixing both here rather than shipping a change that trades "always panics" for "sometimes still produces invalid SQL" in a different spot.

1. **Column-level CHECK.** `get_constraint_support` reports `Check` as `Enforced` (correct at the model level), so it isn't caught by the existing `NotSupported` early-return in `render_column_constraint`. Without a fix it falls through to the generic renderer and produces an inline `check (<expr>)` on a column — confirmed `SYNTAX_ERROR` live, since ClickHouse's CHECK syntax only exists at the table/model level. Added a ClickHouse arm that warns and drops it instead, matching the legacy Python adapter's behavior of never rendering column-level constraints for ClickHouse.

2. **Model-level UNIQUE.** `render_raw_model_constraints` (`adapter/mod.rs`) warns via `warn_constraint_support` for `NotSupported` types, but doesn't actually skip rendering — it always calls `render_model_constraint`, whose `Unique` arm renders unconditionally for every adapter. So a model-level `unique` constraint would still get embedded in the `CREATE TABLE` column list and hit the real `SYNTAX_ERROR` confirmed above. Added a ClickHouse arm to `render_model_constraint` (mirrors the existing BigQuery arm) that suppresses just `Unique`; `PrimaryKey`/`ForeignKey` are left as-is since they're verified non-fatal (see table above) even though also `NotSupported`.

## Deferred (flagging, not fixing here)

The legacy Python adapter raises `DbtRuntimeError("CHECK Constraint 'name' is required")` if a model-level check constraint has no name. Fusion's shared `render_model_constraint` has no such validation for *any* adapter today — Databricks already has `Check => Enforced` with the same latent gap. Pre-existing, cross-adapter issue, not introduced by this change, so left out of scope here.

Separately: `render_raw_model_constraints`'s warning text ("...and will be ignored") is technically inaccurate for any `NotSupported` type where `render_model_constraint` doesn't special-case the adapter (i.e. every adapter besides BigQuery and, after this PR, ClickHouse's `Unique` case) — the constraint gets rendered anyway. That's a pre-existing, platform-wide inconsistency, not something I'm fixing here since it'd change behavior for every adapter.

## Test plan

I could not find any integration or functional test suite for this adapter (or for Snowflake) in this checkout — no docker-compose/testcontainer setup, no committed record/replay cassettes matching the "17 ClickHouse adapter tests" mentioned in the fusion changelog, nothing under `crates/dbt-adapter/tests/` beyond narrow single-bug repro tests for other adapters. So:

- [x] `cargo build -p dbt-adapter` — confirms both `get_constraint_support` and `render_model_constraint`'s adapter match are exhaustive.
- [x] `cargo test -p dbt-adapter adapter_impl` — 53 passed, including 4 new tests covering `get_constraint_support` (all 6 ConstraintTypes) and column-level rendering (both the Check fix and a model-level regression guard).
- [x] `cargo test -p dbt-adapter render_constraint` — 10 passed, including 3 new tests covering `render_model_constraint` for all three NotSupported types (Unique/PrimaryKey/ForeignKey).
- [x] Every specific claim in the table above was checked against a live ClickHouse 26.7 server via Docker (`CREATE TABLE`, `SHOW CREATE TABLE`, and actual `INSERT` attempts to confirm enforcement or lack thereof) — not just unit-tested. This isn't captured as an automated test in this PR (no live-ClickHouse test harness exists to add it to), so a reviewer with ClickHouse access may want to spot-check independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)