### PR TITLE
fix(databricks): preserve streaming table configuration on rerun

### DIFF
--- a/.changes/unreleased/Fixes-20260730-databricks-streaming-table-rerun.yaml
+++ b/.changes/unreleased/Fixes-20260730-databricks-streaming-table-rerun.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Preserve complete Databricks streaming-table configuration on rerun and omit empty column comments from create SQL.
+time: 2026-07-30T18:52:26+05:30
+custom:
+    author: sd-db
+    issue: "14612"
+    project: dbt-core

--- a/crates/dbt-adapter/src/column/types.rs
+++ b/crates/dbt-adapter/src/column/types.rs
@@ -1050,13 +1050,20 @@ impl Column {
                 if self._nullable == Some(false) {
                     s.push_str(" NOT NULL");
                 }
-                if let Some(comment) = &self.comment {
+                if let Some(comment) = self.comment_for_create() {
                     let escaped = comment.replace('\\', "\\\\").replace('\'', "\\'");
                     s.push_str(&format!(" COMMENT '{escaped}'"));
                 }
                 s
             }
             _ => unimplemented!("render_for_create is only available for Databricks/Spark"),
+        }
+    }
+
+    fn comment_for_create(&self) -> Option<&str> {
+        match (self._adapter_type, self.comment.as_deref()) {
+            (AdapterType::Databricks, Some("")) => None,
+            (_, comment) => comment,
         }
     }
 
@@ -1287,6 +1294,51 @@ mod tests {
                 "{adapter:?} should double-quote identifiers"
             );
         }
+    }
+
+    #[test]
+    fn databricks_create_column_omits_empty_comment() {
+        let column = Column::new(
+            AdapterType::Databricks,
+            "id".to_string(),
+            "int".to_string(),
+            None,
+            None,
+            None,
+        )
+        .with_comment(Some(String::new()));
+
+        assert_eq!(column.render_for_create(), "`id` int");
+    }
+
+    #[test]
+    fn databricks_create_column_preserves_non_empty_comment() {
+        let column = Column::new(
+            AdapterType::Databricks,
+            "id".to_string(),
+            "int".to_string(),
+            None,
+            None,
+            None,
+        )
+        .with_comment(Some("documented".to_string()));
+
+        assert_eq!(column.render_for_create(), "`id` int COMMENT 'documented'");
+    }
+
+    #[test]
+    fn spark_create_column_preserves_empty_comment() {
+        let column = Column::new(
+            AdapterType::Spark,
+            "id".to_string(),
+            "int".to_string(),
+            None,
+            None,
+            None,
+        )
+        .with_comment(Some(String::new()));
+
+        assert_eq!(column.render_for_create(), "`id` int COMMENT ''");
     }
 
     #[test]

--- a/crates/dbt-adapter/src/column/types.rs
+++ b/crates/dbt-adapter/src/column/types.rs
@@ -1050,7 +1050,13 @@ impl Column {
                 if self._nullable == Some(false) {
                     s.push_str(" NOT NULL");
                 }
-                if let Some(comment) = &self.comment {
+                let comment = match self._adapter_type {
+                    AdapterType::Databricks => {
+                        self.comment.as_ref().filter(|comment| !comment.is_empty())
+                    }
+                    _ => self.comment.as_ref(),
+                };
+                if let Some(comment) = comment {
                     let escaped = comment.replace('\\', "\\\\").replace('\'', "\\'");
                     s.push_str(&format!(" COMMENT '{escaped}'"));
                 }
@@ -1287,6 +1293,51 @@ mod tests {
                 "{adapter:?} should double-quote identifiers"
             );
         }
+    }
+
+    #[test]
+    fn databricks_create_column_omits_empty_comment() {
+        let column = Column::new(
+            AdapterType::Databricks,
+            "id".to_string(),
+            "int".to_string(),
+            None,
+            None,
+            None,
+        )
+        .with_comment(Some(String::new()));
+
+        assert_eq!(column.render_for_create(), "`id` int");
+    }
+
+    #[test]
+    fn databricks_create_column_preserves_non_empty_comment() {
+        let column = Column::new(
+            AdapterType::Databricks,
+            "id".to_string(),
+            "int".to_string(),
+            None,
+            None,
+            None,
+        )
+        .with_comment(Some("documented".to_string()));
+
+        assert_eq!(column.render_for_create(), "`id` int COMMENT 'documented'");
+    }
+
+    #[test]
+    fn spark_create_column_preserves_empty_comment() {
+        let column = Column::new(
+            AdapterType::Spark,
+            "id".to_string(),
+            "int".to_string(),
+            None,
+            None,
+            None,
+        )
+        .with_comment(Some(String::new()));
+
+        assert_eq!(column.render_for_create(), "`id` int COMMENT ''");
     }
 
     #[test]

--- a/crates/dbt-adapter/src/relation/config_v2.rs
+++ b/crates/dbt-adapter/src/relation/config_v2.rs
@@ -233,12 +233,14 @@ impl ComponentConfigChange {
 /// A function that evaluates a set of components that have been changed and returns whether or not
 /// those will require a full refresh
 pub(crate) type RequiresFullRefreshFn = fn(&IndexMap<&'static str, ComponentConfigChange>) -> bool;
+pub(crate) type CompleteChangesetKeyFn = fn(&'static str) -> Option<&'static str>;
 
 #[derive(Debug)]
 pub struct RelationConfig {
     adapter_type: AdapterType,
     components: IndexMap<&'static str, Box<dyn ComponentConfig>>,
     requires_full_refresh_fn: RequiresFullRefreshFn,
+    complete_changeset_key_fn: Option<CompleteChangesetKeyFn>,
 }
 
 impl RelationConfig {
@@ -254,7 +256,16 @@ impl RelationConfig {
                 .map(|cfg| (cfg.type_name(), cfg))
                 .collect(),
             requires_full_refresh_fn,
+            complete_changeset_key_fn: None,
         }
+    }
+
+    fn with_complete_changeset(
+        mut self,
+        complete_changeset_key_fn: Option<CompleteChangesetKeyFn>,
+    ) -> Self {
+        self.complete_changeset_key_fn = complete_changeset_key_fn;
+        self
     }
 
     pub(crate) fn adapter_type(&self) -> AdapterType {
@@ -276,6 +287,53 @@ impl RelationConfig {
             .map(|inner| inner.as_ref())
     }
 
+    fn complete_changeset(
+        &self,
+        mut changes: IndexMap<&'static str, ComponentConfigChange>,
+    ) -> IndexMap<&'static str, ComponentConfigChange> {
+        let Some(changeset_key) = self.complete_changeset_key_fn else {
+            return changes;
+        };
+        if changes.is_empty() {
+            return changes;
+        }
+
+        let mut complete = IndexMap::new();
+        for (type_name, desired_component) in &self.components {
+            let Some(key) = changeset_key(type_name) else {
+                continue;
+            };
+            let change = changes.shift_remove(type_name).unwrap_or_else(|| {
+                ComponentConfigChange::Some(
+                    desired_component
+                        .diff_from(None)
+                        .expect("a desired component with no current state must produce a change"),
+                )
+            });
+            complete.insert(key, change);
+        }
+        complete.extend(changes);
+        complete
+    }
+
+    fn sparse_diff(
+        &self,
+        current_state: &RelationConfig,
+    ) -> IndexMap<&'static str, ComponentConfigChange> {
+        let changed = self.components.iter().filter_map(|(type_name, desired)| {
+            desired
+                .diff_from(current_state.get(type_name))
+                .map(|diff| (*type_name, ComponentConfigChange::Some(diff)))
+        });
+        let dropped = current_state
+            .components
+            .keys()
+            .filter(|type_name| !self.components.contains_key(*type_name))
+            .map(|type_name| (*type_name, ComponentConfigChange::Drop));
+
+        changed.chain(dropped).collect()
+    }
+
     /// Get the diff that takes the current state to the desired state
     pub fn diff(
         desired_state: &RelationConfig,
@@ -283,27 +341,16 @@ impl RelationConfig {
     ) -> RelationComponentConfigChangeSet {
         debug_assert!(desired_state.adapter_type == current_state.adapter_type);
 
-        let mut diffs = IndexMap::new();
+        let diffs = desired_state.sparse_diff(current_state);
 
-        for (type_name, desired_component) in &desired_state.components {
-            let current_component = current_state.get(type_name);
+        let requires_full_refresh = (desired_state.requires_full_refresh_fn)(&diffs);
 
-            if let Some(diff) = desired_component.diff_from(current_component) {
-                let change = ComponentConfigChange::Some(diff);
-                diffs.insert(*type_name, change);
-            }
-        }
+        let diffs = desired_state.complete_changeset(diffs);
 
-        for type_name in current_state.components.keys() {
-            if desired_state.get(type_name).is_none() {
-                diffs.insert(*type_name, ComponentConfigChange::Drop);
-            }
-        }
-
-        RelationComponentConfigChangeSet::new(
+        RelationComponentConfigChangeSet::from_changes(
             desired_state.adapter_type,
             diffs,
-            desired_state.requires_full_refresh_fn,
+            requires_full_refresh,
         )
     }
 }
@@ -437,6 +484,7 @@ pub(crate) struct RelationConfigLoader<'a, R> {
     adapter_type: AdapterType,
     component_loaders: Vec<Box<dyn ComponentConfigLoader<R> + 'a>>,
     requires_full_refresh_fn: RequiresFullRefreshFn,
+    complete_changeset_key_fn: Option<CompleteChangesetKeyFn>,
 }
 
 impl<'a, R> RelationConfigLoader<'a, R> {
@@ -449,7 +497,20 @@ impl<'a, R> RelationConfigLoader<'a, R> {
             adapter_type,
             component_loaders: component_loaders.into_iter().collect(),
             requires_full_refresh_fn,
+            complete_changeset_key_fn: None,
         }
+    }
+
+    /// Include selected desired components when any component changed.
+    ///
+    /// Some adapter renderers rebuild a relation from a changeset and therefore
+    /// need complete desired state rather than only the components that differ.
+    pub(crate) fn with_complete_changeset(
+        mut self,
+        complete_changeset_key_fn: CompleteChangesetKeyFn,
+    ) -> Self {
+        self.complete_changeset_key_fn = Some(complete_changeset_key_fn);
+        self
     }
 
     /// Load the current applied state for the relation and all its components given the remote state
@@ -460,11 +521,10 @@ impl<'a, R> RelationConfigLoader<'a, R> {
             .iter()
             .map(|l| l.from_remote_state(remote_state))
             .collect::<Result<Vec<_>, _>>()?;
-        Ok(RelationConfig::new(
-            self.adapter_type,
-            components,
-            self.requires_full_refresh_fn,
-        ))
+        Ok(
+            RelationConfig::new(self.adapter_type, components, self.requires_full_refresh_fn)
+                .with_complete_changeset(self.complete_changeset_key_fn),
+        )
     }
 
     /// Load the desired relation state from local dbt configs
@@ -478,11 +538,10 @@ impl<'a, R> RelationConfigLoader<'a, R> {
             .iter()
             .map(|l| l.from_local_config(relation_config))
             .collect::<Result<Vec<_>, _>>()?;
-        Ok(RelationConfig::new(
-            self.adapter_type,
-            components,
-            self.requires_full_refresh_fn,
-        ))
+        Ok(
+            RelationConfig::new(self.adapter_type, components, self.requires_full_refresh_fn)
+                .with_complete_changeset(self.complete_changeset_key_fn),
+        )
     }
 }
 
@@ -490,7 +549,7 @@ impl<'a, R> RelationConfigLoader<'a, R> {
 pub struct RelationComponentConfigChangeSet {
     adapter_type: AdapterType,
     changes: IndexMap<&'static str, ComponentConfigChange>,
-    requires_full_refresh_fn: RequiresFullRefreshFn,
+    requires_full_refresh: bool,
 }
 
 impl RelationComponentConfigChangeSet {
@@ -499,10 +558,29 @@ impl RelationComponentConfigChangeSet {
         changes: impl Into<IndexMap<&'static str, ComponentConfigChange>>,
         requires_full_refresh_fn: RequiresFullRefreshFn,
     ) -> Self {
+        let changes = changes.into();
+        let requires_full_refresh = requires_full_refresh_fn(&changes);
+        Self::from_changes(adapter_type, changes, requires_full_refresh)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_with_requires_full_refresh(
+        adapter_type: AdapterType,
+        changes: impl Into<IndexMap<&'static str, ComponentConfigChange>>,
+        requires_full_refresh: bool,
+    ) -> Self {
+        Self::from_changes(adapter_type, changes.into(), requires_full_refresh)
+    }
+
+    fn from_changes(
+        adapter_type: AdapterType,
+        changes: IndexMap<&'static str, ComponentConfigChange>,
+        requires_full_refresh: bool,
+    ) -> Self {
         Self {
             adapter_type,
-            changes: changes.into(),
-            requires_full_refresh_fn,
+            changes,
+            requires_full_refresh,
         }
     }
 
@@ -530,7 +608,7 @@ impl RelationComponentConfigChangeSet {
 
     /// Whether applying this config to an existing table requires a full refresh
     pub fn requires_full_refresh(&self) -> bool {
-        (self.requires_full_refresh_fn)(&self.changes)
+        self.requires_full_refresh
     }
 }
 

--- a/crates/dbt-adapter/src/relation/config_v2.rs
+++ b/crates/dbt-adapter/src/relation/config_v2.rs
@@ -233,12 +233,14 @@ impl ComponentConfigChange {
 /// A function that evaluates a set of components that have been changed and returns whether or not
 /// those will require a full refresh
 pub(crate) type RequiresFullRefreshFn = fn(&IndexMap<&'static str, ComponentConfigChange>) -> bool;
+pub(crate) type CompleteChangesetKeyFn = fn(&'static str) -> Option<&'static str>;
 
 #[derive(Debug)]
 pub struct RelationConfig {
     adapter_type: AdapterType,
     components: IndexMap<&'static str, Box<dyn ComponentConfig>>,
     requires_full_refresh_fn: RequiresFullRefreshFn,
+    complete_changeset_key_fn: Option<CompleteChangesetKeyFn>,
 }
 
 impl RelationConfig {
@@ -254,7 +256,16 @@ impl RelationConfig {
                 .map(|cfg| (cfg.type_name(), cfg))
                 .collect(),
             requires_full_refresh_fn,
+            complete_changeset_key_fn: None,
         }
+    }
+
+    fn with_complete_changeset(
+        mut self,
+        complete_changeset_key_fn: Option<CompleteChangesetKeyFn>,
+    ) -> Self {
+        self.complete_changeset_key_fn = complete_changeset_key_fn;
+        self
     }
 
     pub(crate) fn adapter_type(&self) -> AdapterType {
@@ -276,6 +287,53 @@ impl RelationConfig {
             .map(|inner| inner.as_ref())
     }
 
+    fn complete_changeset(
+        &self,
+        mut changes: IndexMap<&'static str, ComponentConfigChange>,
+    ) -> IndexMap<&'static str, ComponentConfigChange> {
+        let Some(changeset_key) = self.complete_changeset_key_fn else {
+            return changes;
+        };
+        if changes.is_empty() {
+            return changes;
+        }
+
+        let mut complete = IndexMap::new();
+        for (type_name, desired_component) in &self.components {
+            let Some(key) = changeset_key(type_name) else {
+                continue;
+            };
+            let change = changes.shift_remove(type_name).unwrap_or_else(|| {
+                ComponentConfigChange::Some(
+                    desired_component
+                        .diff_from(None)
+                        .expect("a desired component with no current state must produce a change"),
+                )
+            });
+            complete.insert(key, change);
+        }
+        complete.extend(changes);
+        complete
+    }
+
+    fn sparse_diff(
+        &self,
+        current_state: &RelationConfig,
+    ) -> IndexMap<&'static str, ComponentConfigChange> {
+        let changed = self.components.iter().filter_map(|(type_name, desired)| {
+            desired
+                .diff_from(current_state.get(type_name))
+                .map(|diff| (*type_name, ComponentConfigChange::Some(diff)))
+        });
+        let dropped = current_state
+            .components
+            .keys()
+            .filter(|type_name| !self.components.contains_key(*type_name))
+            .map(|type_name| (*type_name, ComponentConfigChange::Drop));
+
+        changed.chain(dropped).collect()
+    }
+
     /// Get the diff that takes the current state to the desired state
     pub fn diff(
         desired_state: &RelationConfig,
@@ -283,27 +341,16 @@ impl RelationConfig {
     ) -> RelationComponentConfigChangeSet {
         debug_assert!(desired_state.adapter_type == current_state.adapter_type);
 
-        let mut diffs = IndexMap::new();
+        let diffs = desired_state.sparse_diff(current_state);
 
-        for (type_name, desired_component) in &desired_state.components {
-            let current_component = current_state.get(type_name);
+        let requires_full_refresh = (desired_state.requires_full_refresh_fn)(&diffs);
 
-            if let Some(diff) = desired_component.diff_from(current_component) {
-                let change = ComponentConfigChange::Some(diff);
-                diffs.insert(*type_name, change);
-            }
-        }
+        let diffs = desired_state.complete_changeset(diffs);
 
-        for type_name in current_state.components.keys() {
-            if desired_state.get(type_name).is_none() {
-                diffs.insert(*type_name, ComponentConfigChange::Drop);
-            }
-        }
-
-        RelationComponentConfigChangeSet::new(
+        RelationComponentConfigChangeSet::from_changes(
             desired_state.adapter_type,
             diffs,
-            desired_state.requires_full_refresh_fn,
+            requires_full_refresh,
         )
     }
 }
@@ -437,6 +484,7 @@ pub(crate) struct RelationConfigLoader<'a, R> {
     adapter_type: AdapterType,
     component_loaders: Vec<Box<dyn ComponentConfigLoader<R> + 'a>>,
     requires_full_refresh_fn: RequiresFullRefreshFn,
+    complete_changeset_key_fn: Option<CompleteChangesetKeyFn>,
 }
 
 impl<'a, R> RelationConfigLoader<'a, R> {
@@ -449,7 +497,25 @@ impl<'a, R> RelationConfigLoader<'a, R> {
             adapter_type,
             component_loaders: component_loaders.into_iter().collect(),
             requires_full_refresh_fn,
+            complete_changeset_key_fn: None,
         }
+    }
+
+    /// Include selected desired components when any component changed.
+    ///
+    /// Some adapter renderers rebuild a relation from a changeset and therefore
+    /// need complete desired state rather than only the components that differ.
+    pub(crate) fn with_complete_changeset(
+        mut self,
+        complete_changeset_key_fn: CompleteChangesetKeyFn,
+    ) -> Self {
+        self.complete_changeset_key_fn = Some(complete_changeset_key_fn);
+        self
+    }
+
+    fn relation_config(&self, components: Vec<Box<dyn ComponentConfig>>) -> RelationConfig {
+        RelationConfig::new(self.adapter_type, components, self.requires_full_refresh_fn)
+            .with_complete_changeset(self.complete_changeset_key_fn)
     }
 
     /// Load the current applied state for the relation and all its components given the remote state
@@ -460,11 +526,7 @@ impl<'a, R> RelationConfigLoader<'a, R> {
             .iter()
             .map(|l| l.from_remote_state(remote_state))
             .collect::<Result<Vec<_>, _>>()?;
-        Ok(RelationConfig::new(
-            self.adapter_type,
-            components,
-            self.requires_full_refresh_fn,
-        ))
+        Ok(self.relation_config(components))
     }
 
     /// Load the desired relation state from local dbt configs
@@ -478,11 +540,7 @@ impl<'a, R> RelationConfigLoader<'a, R> {
             .iter()
             .map(|l| l.from_local_config(relation_config))
             .collect::<Result<Vec<_>, _>>()?;
-        Ok(RelationConfig::new(
-            self.adapter_type,
-            components,
-            self.requires_full_refresh_fn,
-        ))
+        Ok(self.relation_config(components))
     }
 }
 
@@ -490,7 +548,7 @@ impl<'a, R> RelationConfigLoader<'a, R> {
 pub struct RelationComponentConfigChangeSet {
     adapter_type: AdapterType,
     changes: IndexMap<&'static str, ComponentConfigChange>,
-    requires_full_refresh_fn: RequiresFullRefreshFn,
+    requires_full_refresh: bool,
 }
 
 impl RelationComponentConfigChangeSet {
@@ -499,10 +557,29 @@ impl RelationComponentConfigChangeSet {
         changes: impl Into<IndexMap<&'static str, ComponentConfigChange>>,
         requires_full_refresh_fn: RequiresFullRefreshFn,
     ) -> Self {
+        let changes = changes.into();
+        let requires_full_refresh = requires_full_refresh_fn(&changes);
+        Self::from_changes(adapter_type, changes, requires_full_refresh)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_with_requires_full_refresh(
+        adapter_type: AdapterType,
+        changes: impl Into<IndexMap<&'static str, ComponentConfigChange>>,
+        requires_full_refresh: bool,
+    ) -> Self {
+        Self::from_changes(adapter_type, changes.into(), requires_full_refresh)
+    }
+
+    fn from_changes(
+        adapter_type: AdapterType,
+        changes: IndexMap<&'static str, ComponentConfigChange>,
+        requires_full_refresh: bool,
+    ) -> Self {
         Self {
             adapter_type,
-            changes: changes.into(),
-            requires_full_refresh_fn,
+            changes,
+            requires_full_refresh,
         }
     }
 
@@ -530,7 +607,7 @@ impl RelationComponentConfigChangeSet {
 
     /// Whether applying this config to an existing table requires a full refresh
     pub fn requires_full_refresh(&self) -> bool {
-        (self.requires_full_refresh_fn)(&self.changes)
+        self.requires_full_refresh
     }
 }
 

--- a/crates/dbt-adapter/src/relation/databricks/config/components/relation_comment.rs
+++ b/crates/dbt-adapter/src/relation/databricks/config/components/relation_comment.rs
@@ -71,7 +71,11 @@ fn from_local_config(
         .unwrap_or(false);
 
     let comment_str = if persist {
-        relation_config.common().description.clone()
+        relation_config
+            .common()
+            .description
+            .clone()
+            .filter(|comment| !comment.is_empty())
     } else {
         None
     };
@@ -153,5 +157,16 @@ mod tests {
         let comment_config = from_local_config(&model).unwrap();
 
         assert_eq!(comment_config.value, None);
+    }
+
+    #[test]
+    fn test_from_local_config_empty_comment_persist() {
+        let model = create_mock_dbt_model(true, Some(""));
+        let comment_config = from_local_config(&model).unwrap();
+
+        assert_eq!(
+            comment_config.value, None,
+            "v1 normalizes an empty persisted description to no relation comment"
+        );
     }
 }

--- a/crates/dbt-adapter/src/relation/databricks/config/components/tbl_properties.rs
+++ b/crates/dbt-adapter/src/relation/databricks/config/components/tbl_properties.rs
@@ -78,32 +78,25 @@ fn new_component(properties: IndexMap<String, String>) -> TblProperties {
     }
 }
 
-/// Takes the diff between two `TblProperties` by comparing the non-ignored keys.
+/// Takes the asymmetric diff between two `TblProperties`.
 ///
-/// Matches the Python dbt-databricks `TblPropertiesConfig.__eq__` semantics: both dicts are
-/// filtered by `EQ_IGNORE_LIST`, then compared for full equality. If they differ (including
-/// when the current state has extra non-ignored keys absent from the desired state), a diff
-/// is reported. The returned value is the full desired state (matching Python's `get_diff`
-/// which returns `self`).
+/// Matches Python dbt-databricks: properties present only in the current relation are treated as
+/// server-managed and ignored. A diff is reported only when a desired, non-ignored property is
+/// missing from the current relation or has a different value. The full desired state is returned
+/// because consumers render it as the create/refresh clause.
 fn diff(
     desired_state: &IndexMap<String, String>,
     current_state: &IndexMap<String, String>,
 ) -> Option<IndexMap<String, String>> {
-    let filtered_desired: IndexMap<&String, &String> = desired_state
+    let desired_has_changes = desired_state
         .iter()
         .filter(|(k, _)| !EQ_IGNORE_LIST.contains(&k.as_str()))
-        .collect();
+        .any(|(key, value)| current_state.get(key) != Some(value));
 
-    let filtered_current: IndexMap<&String, &String> = current_state
-        .iter()
-        .filter(|(k, _)| !EQ_IGNORE_LIST.contains(&k.as_str()))
-        .collect();
-
-    if filtered_desired == filtered_current {
-        None
-    } else {
-        // Match Python: get_diff returns self (the full desired config)
+    if desired_has_changes {
         Some(desired_state.clone())
+    } else {
+        None
     }
 }
 
@@ -285,16 +278,10 @@ mod tests {
     /// The existing table (SHOW TBLPROPERTIES) has those plus a few other properties
     /// like delta.checkpoint.*, delta.parquet.*, etc.
     ///
-    /// Python dbt-databricks does a full-dict equality check (__eq__) after filtering the ignore
-    /// list from both sides. Since the desired dict (1 key after filtering) differs from the
-    /// current dict (6+ keys), __eq__ returns False, and get_diff returns the desired config.
-    ///
-    /// The Rust diff function currently does per-key comparison and returns None because every
-    /// key present in the desired state matches the current state. This is a behavioral
-    /// divergence — we should match Python and report a diff when the current state has extra
-    /// non-ignored keys not present in the desired state.
+    /// Python dbt-databricks compares `desired.items() - current.items()`, so relation-only
+    /// properties are ignored even when they are not in the explicit Databricks ignore list.
     #[test]
-    fn test_diff_extra_current_keys_should_report_change() {
+    fn test_diff_ignores_extra_current_server_properties() {
         // Desired state: what from_local_config produces from the model config.
         // Note: delta.enableChangeDataFeed is in the model config but will be
         // filtered by EQ_IGNORE_LIST in the diff function.
@@ -322,12 +309,10 @@ mod tests {
             ),
         ]);
 
-        // Python dbt-databricks reports a diff here because the filtered dicts are unequal
-        // (desired has 1 non-ignored key, current has 4 keys). We must match that behavior.
         let result = diff(&desired, &current);
         assert!(
-            result.is_some(),
-            "Expected diff when current state has extra non-ignored keys not in desired state"
+            result.is_none(),
+            "server properties present only on the current relation must not trigger a change"
         );
     }
 

--- a/crates/dbt-adapter/src/relation/databricks/config/relation_types/streaming_table.rs
+++ b/crates/dbt-adapter/src/relation/databricks/config/relation_types/streaming_table.rs
@@ -10,133 +10,54 @@ fn requires_full_refresh(components: &IndexMap<&'static str, ComponentConfigChan
     super::requires_full_refresh(super::MaterializationType::StreamingTable, components)
 }
 
+fn complete_changeset_key(component_type_name: &'static str) -> Option<&'static str> {
+    match component_type_name {
+        components::partition_by::TYPE_NAME => Some("partition_by"),
+        components::relation_comment::TYPE_NAME
+        | components::tbl_properties::TYPE_NAME
+        | components::refresh::TYPE_NAME
+        | components::relation_tags::TYPE_NAME => Some(component_type_name),
+        _ => None,
+    }
+}
+
 /// Create a `RelationConfigLoader` for Databricks streaming tables
 pub(crate) fn new_loader() -> RelationConfigLoader<'static, DatabricksRelationMetadata> {
-    // TODO: missing from Python dbt-databricks:
-    // - liquid clustering
-    // - relation tags
-    let loaders: [Box<dyn ComponentConfigLoader<DatabricksRelationMetadata>>; 5] = [
+    // TODO: liquid clustering is still missing from Python dbt-databricks parity.
+    let loaders: [Box<dyn ComponentConfigLoader<DatabricksRelationMetadata>>; 6] = [
         // Box::new(components::LiquidClusteringLoader),
         Box::new(components::PartitionByLoader),
         Box::new(components::RelationCommentLoader),
         Box::new(components::TblPropertiesLoader),
         Box::new(components::RefreshLoader),
-        // Box::new(components::RelationTagsLoader),
+        Box::new(components::RelationTagsLoader),
         Box::new(components::ColumnMasksLoader),
     ];
 
     RelationConfigLoader::new(AdapterType::Databricks, loaders, requires_full_refresh)
+        .with_complete_changeset(complete_changeset_key)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{new_loader, requires_full_refresh};
+    use super::new_loader;
     use crate::AdapterType;
     use crate::relation::config_v2::{
         ComponentConfigChange, ComponentConfigLoader, RelationComponentConfigChangeSet,
+        RelationConfig,
     };
     use crate::relation::databricks::config::{
         DatabricksRelationMetadata, components,
-        test_helpers::{TestModelConfig, run_test_cases},
+        test_helpers::{TestModelConfig, create_mock_dbt_model, run_test_cases},
     };
     use crate::relation::test_helpers::TestCase;
     use indexmap::IndexMap;
 
-    fn create_test_cases() -> Vec<TestCase<DatabricksRelationMetadata, TestModelConfig>> {
-        vec![
-            TestCase {
-                description: "changing any streaming table components except partition by should not trigger a full refresh",
-                relation_loader: new_loader(),
-                current_state: TestModelConfig {
-                    persist_relation_comments: true,
-                    relation_comment: Some("old comment".to_string()),
-                    cluster_by: vec!["cluster_by_old".to_string()],
-                    cron: Some("* * * * *".to_string()),
-                    time_zone: Some("UTC".to_string()),
-                    tags: IndexMap::from_iter([
-                        ("a_tag".to_string(), "old".to_string()),
-                        ("b_tag".to_string(), "old".to_string()),
-                    ]),
-                    tbl_properties: IndexMap::from_iter([
-                        ("delta.enableRowTracking".to_string(), "false".to_string()),
-                        (
-                            "pipelines.pipelineId".to_string(),
-                            "my_old_pipeline".to_string(),
-                        ),
-                        ("customKey".to_string(), "old".to_string()),
-                    ]),
-                    ..Default::default()
-                },
-                desired_state: TestModelConfig {
-                    persist_relation_comments: true,
-                    relation_comment: Some("new comment".to_string()),
-                    cluster_by: vec!["cluster_by_new".to_string()],
-                    cron: Some("*/60 * * * *".to_string()),
-                    time_zone: Some("UTC".to_string()),
-                    tags: IndexMap::from_iter([
-                        ("a_tag".to_string(), "new".to_string()),
-                        ("b_tag".to_string(), "old".to_string()),
-                    ]),
-                    tbl_properties: IndexMap::from_iter([
-                        // changing these key should not result in anything as these should be ignored
-                        ("delta.enableRowTracking".to_string(), "true".to_string()),
-                        (
-                            "pipelines.pipelineId".to_string(),
-                            "my_new_pipeline".to_string(),
-                        ),
-                        // changing a key not in the ignore list should cause a changeset entry
-                        ("customKey".to_string(), "new".to_string()),
-                        // introducing a new key should also add it to the changeset
-                        ("customKey2".to_string(), "value".to_string()),
-                    ]),
-                    ..Default::default()
-                },
-                expected_changeset: RelationComponentConfigChangeSet::new(
-                    AdapterType::Databricks,
-                    [
-                        // TODO: add liquid clustering to changeset here once that gets implemented
-                        (
-                            components::RefreshLoader.type_name(),
-                            ComponentConfigChange::Some(
-                                components::RefreshLoader::new_component_type_erased(
-                                    Some("*/60 * * * *".to_string()),
-                                    Some("UTC".to_string()),
-                                ),
-                            ),
-                        ),
-                        (
-                            components::RelationCommentLoader.type_name(),
-                            ComponentConfigChange::Some(
-                                components::RelationCommentLoader::new_component_type_erased(Some(
-                                    "new comment".to_string(),
-                                )),
-                            ),
-                        ),
-                        // TODO: re-add tags
-                        // (
-                        //     components::RelationTagsLoader.type_name(),
-                        //     ComponentConfigChange::Some(components::RelationTagsLoader::new_component_type_erased(
-                        //         IndexMap::from_iter([
-                        //             ("a_tag".to_string(), "new".to_string()),
-                        //             ("b_tag".to_string(), "old".to_string()),
-                        //         ]),
-                        //     )),
-                        // ),
-                        (
-                            components::TblPropertiesLoader.type_name(),
-                            ComponentConfigChange::Some(
-                                components::TblPropertiesLoader::new_component_type_erased(
-                                    IndexMap::from_iter([
-                                        ("customKey".to_string(), "new".to_string()),
-                                        ("customKey2".to_string(), "value".to_string()),
-                                    ]),
-                                ),
-                            ),
-                        ),
-                    ],
-                    requires_full_refresh,
-                ),
-                changeset_jinja: "
+    const COMPONENT_CHANGE_JINJA: &str = r#"
+<partition_by>
+    <partition_by>
+    </partition_by>
+</partition_by>
 <comment>
     <comment>
         new comment
@@ -172,7 +93,208 @@ mod tests {
         True
     </is_altered>
 </refresh>
-                    ",
+<tags>
+    <set_tags>
+        <a_tag>
+            new
+        </a_tag>
+        <b_tag>
+            old
+        </b_tag>
+    </set_tags>
+</tags>
+                    "#;
+
+    const PARTITION_CHANGE_JINJA: &str = r#"
+<partition_by>
+    <partition_by>
+        partition_by_new
+    </partition_by>
+</partition_by>
+<comment>
+    <comment>
+        None
+    </comment>
+    <persist>
+        False
+    </persist>
+</comment>
+<tblproperties>
+    <tblproperties>
+    </tblproperties>
+    <pipeline_id>
+        None
+    </pipeline_id>
+</tblproperties>
+<refresh>
+    <cron>
+        None
+    </cron>
+    <time_zone_value>
+        None
+    </time_zone_value>
+    <is_altered>
+        False
+    </is_altered>
+</refresh>
+<tags>
+    <set_tags>
+    </set_tags>
+</tags>
+                    "#;
+
+    fn component_change_current_state() -> TestModelConfig {
+        TestModelConfig {
+            persist_relation_comments: true,
+            relation_comment: Some("old comment".to_string()),
+            cron: Some("* * * * *".to_string()),
+            time_zone: Some("UTC".to_string()),
+            tags: IndexMap::from_iter([
+                ("a_tag".to_string(), "old".to_string()),
+                ("b_tag".to_string(), "old".to_string()),
+            ]),
+            tbl_properties: IndexMap::from_iter([
+                ("delta.enableRowTracking".to_string(), "false".to_string()),
+                (
+                    "pipelines.pipelineId".to_string(),
+                    "my_old_pipeline".to_string(),
+                ),
+                ("customKey".to_string(), "old".to_string()),
+            ]),
+            ..Default::default()
+        }
+    }
+
+    fn component_change_desired_state() -> TestModelConfig {
+        let mut state = component_change_current_state();
+        state.relation_comment = Some("new comment".to_string());
+        state.cron = Some("*/60 * * * *".to_string());
+        state.tags.insert("a_tag".to_string(), "new".to_string());
+        state
+            .tbl_properties
+            .insert("delta.enableRowTracking".to_string(), "true".to_string());
+        state.tbl_properties.insert(
+            "pipelines.pipelineId".to_string(),
+            "my_new_pipeline".to_string(),
+        );
+        state
+            .tbl_properties
+            .insert("customKey".to_string(), "new".to_string());
+        state
+            .tbl_properties
+            .insert("customKey2".to_string(), "value".to_string());
+        state
+    }
+
+    fn expected_component_changeset() -> RelationComponentConfigChangeSet {
+        RelationComponentConfigChangeSet::new_with_requires_full_refresh(
+            AdapterType::Databricks,
+            [
+                (
+                    "partition_by",
+                    ComponentConfigChange::Some(
+                        components::PartitionByLoader::new_component_type_erased(vec![]),
+                    ),
+                ),
+                (
+                    components::RelationCommentLoader.type_name(),
+                    ComponentConfigChange::Some(
+                        components::RelationCommentLoader::new_component_type_erased(Some(
+                            "new comment".to_string(),
+                        )),
+                    ),
+                ),
+                (
+                    components::TblPropertiesLoader.type_name(),
+                    ComponentConfigChange::Some(
+                        components::TblPropertiesLoader::new_component_type_erased(
+                            IndexMap::from_iter([
+                                ("delta.enableRowTracking".to_string(), "true".to_string()),
+                                (
+                                    "pipelines.pipelineId".to_string(),
+                                    "my_new_pipeline".to_string(),
+                                ),
+                                ("customKey".to_string(), "new".to_string()),
+                                ("customKey2".to_string(), "value".to_string()),
+                            ]),
+                        ),
+                    ),
+                ),
+                (
+                    components::RefreshLoader.type_name(),
+                    ComponentConfigChange::Some(
+                        components::RefreshLoader::new_component_type_erased(
+                            Some("*/60 * * * *".to_string()),
+                            Some("UTC".to_string()),
+                        ),
+                    ),
+                ),
+                (
+                    components::RelationTagsLoader.type_name(),
+                    ComponentConfigChange::Some(
+                        components::RelationTagsLoader::new_component_type_erased(
+                            IndexMap::from_iter([
+                                ("a_tag".to_string(), "new".to_string()),
+                                ("b_tag".to_string(), "old".to_string()),
+                            ]),
+                        ),
+                    ),
+                ),
+            ],
+            false,
+        )
+    }
+
+    fn expected_partition_changeset() -> RelationComponentConfigChangeSet {
+        RelationComponentConfigChangeSet::new_with_requires_full_refresh(
+            AdapterType::Databricks,
+            [
+                (
+                    "partition_by",
+                    ComponentConfigChange::Some(
+                        components::PartitionByLoader::new_component_type_erased(vec![
+                            "partition_by_new".to_string(),
+                        ]),
+                    ),
+                ),
+                (
+                    components::RelationCommentLoader.type_name(),
+                    ComponentConfigChange::Some(
+                        components::RelationCommentLoader::new_component_type_erased(None),
+                    ),
+                ),
+                (
+                    components::TblPropertiesLoader.type_name(),
+                    ComponentConfigChange::Some(
+                        components::TblPropertiesLoader::new_component_type_erased(IndexMap::new()),
+                    ),
+                ),
+                (
+                    components::RefreshLoader.type_name(),
+                    ComponentConfigChange::Some(
+                        components::RefreshLoader::new_component_type_erased(None, None),
+                    ),
+                ),
+                (
+                    components::RelationTagsLoader.type_name(),
+                    ComponentConfigChange::Some(
+                        components::RelationTagsLoader::new_component_type_erased(IndexMap::new()),
+                    ),
+                ),
+            ],
+            true,
+        )
+    }
+
+    fn create_test_cases() -> Vec<TestCase<DatabricksRelationMetadata, TestModelConfig>> {
+        vec![
+            TestCase {
+                description: "changing any streaming table components except partition by should not trigger a full refresh",
+                relation_loader: new_loader(),
+                current_state: component_change_current_state(),
+                desired_state: component_change_desired_state(),
+                expected_changeset: expected_component_changeset(),
+                changeset_jinja: COMPONENT_CHANGE_JINJA,
                 requires_full_refresh: false,
             },
             TestCase {
@@ -186,25 +308,8 @@ mod tests {
                     partition_by: vec!["partition_by_new".to_string()],
                     ..Default::default()
                 },
-                expected_changeset: RelationComponentConfigChangeSet::new(
-                    AdapterType::Databricks,
-                    [(
-                        components::PartitionByLoader.type_name(),
-                        ComponentConfigChange::Some(
-                            components::PartitionByLoader::new_component_type_erased(vec![
-                                "partition_by_new".to_string(),
-                            ]),
-                        ),
-                    )],
-                    requires_full_refresh,
-                ),
-                changeset_jinja: "
-<partitioned_by>
-    <partition_by>
-        partition_by_new
-    </partition_by>
-</partitioned_by>
-                    ",
+                expected_changeset: expected_partition_changeset(),
+                changeset_jinja: PARTITION_CHANGE_JINJA,
                 requires_full_refresh: true,
             },
         ]
@@ -213,5 +318,59 @@ mod tests {
     #[test]
     fn test_cases() {
         run_test_cases(create_test_cases());
+    }
+
+    #[test]
+    fn comment_only_diff_carries_supported_v1_desired_components() {
+        let stable_properties =
+            IndexMap::from([("feature_marker".to_string(), "stable".to_string())]);
+        let stable_tags = IndexMap::from([("owner".to_string(), "analytics".to_string())]);
+        let current = create_mock_dbt_model(TestModelConfig {
+            persist_relation_comments: true,
+            relation_comment: Some("old comment".to_string()),
+            tags: stable_tags.clone(),
+            tbl_properties: stable_properties.clone(),
+            ..Default::default()
+        });
+        let desired = create_mock_dbt_model(TestModelConfig {
+            persist_relation_comments: true,
+            relation_comment: Some("updated comment".to_string()),
+            tags: stable_tags,
+            tbl_properties: stable_properties,
+            ..Default::default()
+        });
+        let loader = new_loader();
+        let current = loader
+            .from_local_config(&current)
+            .expect("load current streaming-table config");
+        let desired = loader
+            .from_local_config(&desired)
+            .expect("load desired streaming-table config");
+        let changeset = RelationConfig::diff(&desired, &current);
+
+        assert_eq!(
+            changeset.iter().map(|(name, _)| *name).collect::<Vec<_>>(),
+            vec![
+                "partition_by",
+                "comment",
+                "tblproperties",
+                "refresh",
+                "tags",
+            ],
+            "a partial streaming-table change must carry every supported component consumed by the v1 ALTER renderer",
+        );
+        let ComponentConfigChange::Some(properties) = changeset.get("tblproperties") else {
+            panic!("changeset must carry stable tblproperties");
+        };
+        assert_eq!(
+            properties
+                .to_jinja()
+                .get_attr("tblproperties")
+                .expect("tblproperties component shape")
+                .get_attr("feature_marker")
+                .expect("stable feature marker")
+                .as_str(),
+            Some("stable"),
+        );
     }
 }

--- a/crates/dbt-loader/tests/materializations/mod.rs
+++ b/crates/dbt-loader/tests/materializations/mod.rs
@@ -1,3 +1,4 @@
 mod incremental;
 mod materialized_view;
+mod streaming_table;
 mod view;

--- a/crates/dbt-loader/tests/materializations/streaming_table.rs
+++ b/crates/dbt-loader/tests/materializations/streaming_table.rs
@@ -1,0 +1,133 @@
+use std::collections::{BTreeMap, HashSet};
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use dbt_adapter::relation::RelationObject;
+use dbt_adapter_core::AdapterType;
+use dbt_common::serde_utils::convert_yml_to_value_map;
+use dbt_jinja_utils::{mock_object::MockJinjaObject, phases::run::RunConfig};
+use dbt_schemas::{
+    dbt_types::RelationType,
+    schemas::project::{ModelConfig, ProjectModelConfig},
+};
+use minijinja::Value;
+use minijinja::value::mutable_map::MutableMap;
+
+use crate::macro_test_harness::MacroTestHarness;
+
+fn build_harness() -> MacroTestHarness {
+    let harness = MacroTestHarness::for_adapter(AdapterType::Databricks)
+        .load_all_macros()
+        .with_stub_functions()
+        .with_behavior_flag("use_materialization_v2", false)
+        .build()
+        .expect("harness should build");
+
+    harness.mock().on("clean_sql", |args| {
+        Ok(args.first().cloned().unwrap_or(Value::UNDEFINED))
+    });
+    harness.mock().on("is_uniform", |_| Ok(Value::from(false)));
+    harness
+}
+
+fn omitted_policy_runtime_config() -> RunConfig {
+    let unresolved_config: ProjectModelConfig =
+        dbt_yaml::from_str("__additional_properties__: {}\n")
+            .expect("deserialize project model config with omitted policy");
+    assert!(
+        unresolved_config.on_configuration_change.is_none(),
+        "test input must omit on_configuration_change"
+    );
+    let source_config: ModelConfig = unresolved_config.into();
+    let serialized =
+        dbt_yaml::to_value(&source_config).expect("serialize runtime model config as YAML");
+    let mut model_config = convert_yml_to_value_map(serialized);
+    assert_eq!(
+        model_config
+            .get("on_configuration_change")
+            .and_then(Value::as_str),
+        Some("apply"),
+        "runtime model config must expose the dbt-core default through config.get",
+    );
+    model_config.insert("full_refresh".to_string(), Value::from(false));
+
+    RunConfig {
+        model_config,
+        model: Arc::new(MutableMap::new()),
+        model_compiled_path: PathBuf::new(),
+        valid_keys: HashSet::new(),
+    }
+}
+
+#[test]
+fn omitted_model_config_resolves_to_apply_for_existing_relation() {
+    let harness = build_harness();
+    let change_set = Arc::new(MockJinjaObject::new());
+    change_set.set_attr("requires_full_refresh", Value::from(false));
+    change_set.set_attr(
+        "changes",
+        Value::from_serialize(BTreeMap::from([
+            (
+                "partition_by",
+                Value::from_serialize(BTreeMap::from([("partition_by", Value::UNDEFINED)])),
+            ),
+            (
+                "tblproperties",
+                Value::from_serialize(BTreeMap::from([("tblproperties", Value::UNDEFINED)])),
+            ),
+            (
+                "comment",
+                Value::from_serialize(BTreeMap::from([(
+                    "comment",
+                    Value::from("updated comment"),
+                )])),
+            ),
+            ("refresh", Value::UNDEFINED),
+            ("tags", Value::UNDEFINED),
+        ])),
+    );
+    let changes = Value::from_dyn_object(change_set);
+    let model_config = Arc::new(MockJinjaObject::new());
+    model_config.on("get_changeset", move |_| Ok(changes.clone()));
+    let model_config = Value::from_dyn_object(model_config);
+    harness
+        .mock()
+        .on("get_config_from_model", move |_| Ok(model_config.clone()));
+    harness
+        .mock()
+        .on("get_relation_config", |_| Ok(Value::UNDEFINED));
+
+    let existing = harness.relation(
+        "TEST_DB",
+        "TEST_SCHEMA",
+        "streaming_probe",
+        Some(RelationType::StreamingTable),
+    );
+    let target = harness.relation(
+        "TEST_DB",
+        "TEST_SCHEMA",
+        "streaming_probe",
+        Some(RelationType::StreamingTable),
+    );
+    let ctx = harness
+        .materialization_context("streaming_probe", "SELECT 1")
+        .relation_type(RelationType::StreamingTable)
+        .config(Value::from_object(omitted_policy_runtime_config()))
+        .with("existing", RelationObject::new(existing).into_value())
+        .with("target", RelationObject::new(target).into_value())
+        .build();
+
+    let result = harness
+        .render(
+            "{% set r = streaming_table_get_build_sql(existing, target) %}{{ r }}",
+            ctx,
+        )
+        .expect("resolved omitted policy should exercise the existing-relation apply branch");
+
+    assert!(
+        result
+            .to_uppercase()
+            .contains("CREATE OR REFRESH STREAMING TABLE"),
+        "expected the apply path to render a streaming-table update, got: {result}",
+    );
+}

--- a/crates/dbt-schemas/src/schemas/manifest/manifest_nodes.rs
+++ b/crates/dbt-schemas/src/schemas/manifest/manifest_nodes.rs
@@ -1220,7 +1220,7 @@ impl From<ManifestModelConfig> for ModelConfig {
             full_refresh: config.full_refresh,
             unique_key: config.unique_key,
             on_schema_change: config.on_schema_change,
-            on_configuration_change: config.on_configuration_change,
+            on_configuration_change: Some(config.on_configuration_change.unwrap_or_default()),
             on_error: config.on_error,
             grants: config.grants,
             python_version: config.python_version,

--- a/crates/dbt-schemas/src/schemas/manifest/manifest_nodes.rs
+++ b/crates/dbt-schemas/src/schemas/manifest/manifest_nodes.rs
@@ -1230,7 +1230,7 @@ impl From<ManifestModelConfig> for ModelConfig {
             full_refresh: config.full_refresh,
             unique_key: config.unique_key,
             on_schema_change: config.on_schema_change,
-            on_configuration_change: config.on_configuration_change,
+            on_configuration_change: Some(config.on_configuration_change.unwrap_or_default()),
             on_error: config.on_error,
             grants: config.grants,
             python_version: config.python_version,

--- a/crates/dbt-schemas/src/schemas/project/configs/model_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/model_config.rs
@@ -902,7 +902,7 @@ impl From<ProjectModelConfig> for ModelConfig {
             merge_exclude_columns: config.merge_exclude_columns,
             merge_update_columns: config.merge_update_columns,
             meta: config.meta,
-            on_configuration_change: config.on_configuration_change,
+            on_configuration_change: resolve_configuration_change(config.on_configuration_change),
             on_error: config.on_error,
             on_schema_change: config.on_schema_change,
             packages: Packages(config.packages),
@@ -1051,6 +1051,12 @@ impl From<ProjectModelConfig> for ModelConfig {
             meta_keys_defaults: None,
         }
     }
+}
+
+fn resolve_configuration_change(
+    value: Option<OnConfigurationChange>,
+) -> Option<OnConfigurationChange> {
+    Some(value.unwrap_or_default())
 }
 
 impl From<ModelConfig> for ProjectModelConfig {
@@ -1868,10 +1874,29 @@ fn materialized_eq(a: &Option<DbtMaterialization>, b: &Option<DbtMaterialization
 #[cfg(test)]
 mod tests {
     use super::ModelConfig;
-    use crate::schemas::common::{FreshnessPeriod, UpdatesOn};
+    use crate::schemas::common::{FreshnessPeriod, OnConfigurationChange, UpdatesOn};
     use crate::schemas::manifest::ManifestModelConfig;
     use crate::schemas::project::configs::model_config::ProjectModelConfig;
     use crate::schemas::properties::StatePreClone;
+
+    #[test]
+    fn omitted_on_configuration_change_defaults_to_apply_in_runtime_configs() {
+        let project: ProjectModelConfig =
+            dbt_yaml::from_str("__additional_properties__: {}\n").unwrap();
+        let project_runtime: ModelConfig = project.into();
+        assert_eq!(
+            project_runtime.on_configuration_change,
+            Some(OnConfigurationChange::Apply)
+        );
+
+        let manifest: ManifestModelConfig =
+            dbt_yaml::from_str("__warehouse_specific_config__: {}\n").unwrap();
+        let manifest_runtime: ModelConfig = manifest.into();
+        assert_eq!(
+            manifest_runtime.on_configuration_change,
+            Some(OnConfigurationChange::Apply)
+        );
+    }
 
     #[test]
     fn test_classifiers_merge_in_default_to() {

--- a/crates/dbt-schemas/src/schemas/project/configs/model_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/model_config.rs
@@ -701,7 +701,7 @@ impl From<ProjectModelConfig> for ModelConfig {
             merge_exclude_columns: config.merge_exclude_columns,
             merge_update_columns: config.merge_update_columns,
             meta: config.meta,
-            on_configuration_change: config.on_configuration_change,
+            on_configuration_change: resolve_configuration_change(config.on_configuration_change),
             on_error: config.on_error,
             on_schema_change: config.on_schema_change,
             packages: Packages(config.packages),
@@ -829,6 +829,12 @@ impl From<ProjectModelConfig> for ModelConfig {
             meta_keys_defaults: None,
         }
     }
+}
+
+fn resolve_configuration_change(
+    value: Option<OnConfigurationChange>,
+) -> Option<OnConfigurationChange> {
+    Some(value.unwrap_or_default())
 }
 
 impl From<ModelConfig> for ProjectModelConfig {
@@ -1624,10 +1630,29 @@ fn materialized_eq(a: &Option<DbtMaterialization>, b: &Option<DbtMaterialization
 #[cfg(test)]
 mod tests {
     use super::ModelConfig;
-    use crate::schemas::common::{FreshnessPeriod, UpdatesOn};
+    use crate::schemas::common::{FreshnessPeriod, OnConfigurationChange, UpdatesOn};
     use crate::schemas::manifest::ManifestModelConfig;
     use crate::schemas::project::configs::model_config::ProjectModelConfig;
     use crate::schemas::properties::StatePreClone;
+
+    #[test]
+    fn omitted_on_configuration_change_defaults_to_apply_in_runtime_configs() {
+        let project: ProjectModelConfig =
+            dbt_yaml::from_str("__additional_properties__: {}\n").unwrap();
+        let project_runtime: ModelConfig = project.into();
+        assert_eq!(
+            project_runtime.on_configuration_change,
+            Some(OnConfigurationChange::Apply)
+        );
+
+        let manifest: ManifestModelConfig =
+            dbt_yaml::from_str("__warehouse_specific_config__: {}\n").unwrap();
+        let manifest_runtime: ModelConfig = manifest.into();
+        assert_eq!(
+            manifest_runtime.on_configuration_change,
+            Some(OnConfigurationChange::Apply)
+        );
+    }
 
     #[test]
     fn test_classifiers_merge_in_default_to() {


### PR DESCRIPTION
Resolves #14612.

## Summary

- Default an omitted `on_configuration_change` to `apply`.
- Preserve the complete supported streaming-table configuration when applying a partial change.
- Match dbt-databricks handling of empty relation and column comments.
- Add focused relation, schema, column, and macro regression coverage.

`row_filter` support is tracked separately in #15763.

## Testing

- Focused `dbt-adapter`, `dbt-schemas`, and `dbt-loader` tests
- `cargo fmt` and scoped `cargo clippy`
- Recorder-free live dbt Core v1/Fusion create, unchanged-rerun, and comment-only lifecycle, including ordered SQL, server state, artifacts, and credential scans
