### PR TITLE
feat(metricflow-sidecar): add async MetricFlow sidecar manager crate

### DIFF
--- a/.changes/unreleased/Under the Hood-20260731-145316.yaml
+++ b/.changes/unreleased/Under the Hood-20260731-145316.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Add async MetricFlow sidecar manager crate for compiling metric queries via the MetricFlow Nuitka sidecar
+time: 2026-07-31T14:53:16.647770-05:00
+custom:
+    author: QMalcolm
+    issue: ""
+    project: dbt-fusion

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ members = [
   "crates/dbt-test-utils",
   "crates/dbt-tui-progress",
   "crates/dbt-metricflow",
+  "crates/dbt-metricflow-sidecar",
   "crates/dbt-sql-keywords",
 
   "crates/dbt-sql/dbt-lexer-bigquery",
@@ -249,6 +250,7 @@ dbt-loader = { path = "crates/dbt-loader" }
 dbt-login = { path = "crates/dbt-login" }
 dbt-main = { path = "crates/dbt-main", default-features = false }
 dbt-metricflow = { path = "crates/dbt-metricflow" }
+dbt-metricflow-sidecar = { path = "crates/dbt-metricflow-sidecar" }
 dbt-parser = { path = "crates/dbt-parser" }
 dbt-platform-auth = { path = "crates/dbt-platform-auth" }
 dbt-pretty-table = { path = "crates/dbt-pretty-table" }

--- a/crates/dbt-metricflow-sidecar/Cargo.toml
+++ b/crates/dbt-metricflow-sidecar/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "dbt-metricflow-sidecar"
+version.workspace = true
+homepage.workspace = true
+repository.workspace = true
+authors.workspace = true
+description.workspace = true
+license.workspace = true
+keywords.workspace = true
+edition.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+dbt-common = { workspace = true }
+dbt-fusion-workspace-hack = { version = "0.1" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+uuid = { workspace = true }
+
+[lib]
+name = "dbt_metricflow_sidecar"
+path = "src/lib.rs"
+doctest = false
+
+[[bin]]
+name = "fake_mf_entry"
+path = "tests/fixtures/fake_mf_entry.rs"

--- a/crates/dbt-metricflow-sidecar/src/lib.rs
+++ b/crates/dbt-metricflow-sidecar/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod manager;
+pub mod messages;

--- a/crates/dbt-metricflow-sidecar/src/manager.rs
+++ b/crates/dbt-metricflow-sidecar/src/manager.rs
@@ -1,0 +1,305 @@
+//! Async manager for one MetricFlow sidecar (`mf_entry`) subprocess.
+//!
+//! Applies the same architectural pattern as Fusion's proprietary
+//! `RunnerManager` (subprocess spawn, NDJSON read/write, request/response
+//! correlation by id via `tokio::oneshot`, a dedicated background reader
+//! task) — reimplemented independently here using only OSS dependencies
+//! already in this workspace, since `RunnerManager` itself lives in a
+//! proprietary crate this repo cannot depend on.
+//!
+//! This manager owns exactly one subprocess and does not pool multiple
+//! instances. `explain()` calls MetricFlow's pure-Python, GIL-bound query
+//! compiler — unlike the DuckDB-backed sidecar `RunnerManager` talks to,
+//! there is no native multi-threading underneath to exploit. Real
+//! concurrency for this workload comes from running multiple
+//! `MetricflowSidecarManager` instances (one process each), not from
+//! multiplexing many in-flight requests onto a single process. This manager
+//! still correlates requests by id — mostly for fairness/interleaving and to
+//! keep the protocol consistent with the pooling model, not because a single
+//! instance is expected to deliver parallel throughput.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::Duration;
+
+use dbt_common::{ErrorCode, FsResult, fs_err};
+use serde::Serialize;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdin, ChildStdout, Command};
+use tokio::sync::{Mutex, oneshot};
+use tokio::task::JoinHandle;
+use tokio::time::timeout;
+use uuid::Uuid;
+
+use crate::messages::{ExplainParams, ReadyMessage, Request, ResponseKind, parse_response_line};
+
+const READY_TIMEOUT: Duration = Duration::from_secs(5);
+
+struct SidecarProcess {
+    #[allow(dead_code)]
+    child: Child,
+    stdin: ChildStdin,
+    #[allow(dead_code)]
+    reader_task: JoinHandle<()>,
+}
+
+/// Manages one `mf_entry` subprocess and its in-flight requests.
+pub struct MetricflowSidecarManager {
+    process: Mutex<Option<SidecarProcess>>,
+    pending: Mutex<HashMap<String, oneshot::Sender<Result<ResponseKind, String>>>>,
+}
+
+impl MetricflowSidecarManager {
+    /// Spawn the sidecar binary at `binary_path` and wait for its ready handshake.
+    #[tracing::instrument(skip_all, fields(binary_path = %binary_path.display()))]
+    pub async fn spawn(binary_path: &Path) -> FsResult<Arc<Self>> {
+        let mut child = Command::new(binary_path)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .map_err(|e| {
+                fs_err!(
+                    ErrorCode::ExecutorFailed,
+                    "failed to spawn mf_entry sidecar: {e}"
+                )
+            })?;
+
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| fs_err!(ErrorCode::ExecutorFailed, "mf_entry stdin unavailable"))?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| fs_err!(ErrorCode::ExecutorFailed, "mf_entry stdout unavailable"))?;
+        // stderr is intentionally not captured here — mf_entry.py redirects library
+        // logging there, and this manager doesn't yet do anything with it. A future
+        // slice could forward it to tracing the way the proprietary RunnerManager does.
+        drop(child.stderr.take());
+
+        let mut stdout = BufReader::new(stdout);
+        let ready = Self::read_ready_message(&mut stdout).await?;
+        if ready.status != "ready" {
+            return Err(fs_err!(
+                ErrorCode::ExecutorFailed,
+                "expected ready status from mf_entry, got: {}",
+                ready.status
+            ));
+        }
+        if ready.protocol_version != 1 {
+            return Err(fs_err!(
+                ErrorCode::ExecutorFailed,
+                "unsupported mf-ipc protocol version: expected 1, got {}",
+                ready.protocol_version
+            ));
+        }
+
+        let manager = Arc::new(Self {
+            process: Mutex::new(None),
+            pending: Mutex::new(HashMap::new()),
+        });
+
+        let reader_manager = Arc::clone(&manager);
+        let reader_task = tokio::spawn(async move { reader_manager.read_loop(stdout).await });
+
+        {
+            let mut guard = manager.process.lock().await;
+            *guard = Some(SidecarProcess {
+                child,
+                stdin,
+                reader_task,
+            });
+        }
+
+        Ok(manager)
+    }
+
+    async fn read_ready_message(stdout: &mut BufReader<ChildStdout>) -> FsResult<ReadyMessage> {
+        let mut line = String::new();
+        timeout(READY_TIMEOUT, stdout.read_line(&mut line))
+            .await
+            .map_err(|_| {
+                fs_err!(
+                    ErrorCode::TaskTimeout,
+                    "timed out waiting for mf_entry ready message"
+                )
+            })?
+            .map_err(|e| {
+                fs_err!(
+                    ErrorCode::IoError,
+                    "failed to read mf_entry ready message: {e}"
+                )
+            })?;
+
+        serde_json::from_str(line.trim()).map_err(|e| {
+            fs_err!(
+                ErrorCode::JsonInvalid,
+                "failed to parse mf_entry ready message: {e}. Got: {line}"
+            )
+        })
+    }
+
+    /// Compile a metric query to SQL without executing it.
+    #[tracing::instrument(skip_all)]
+    pub async fn explain(&self, params: ExplainParams) -> FsResult<String> {
+        match self
+            .submit(Request::explain(new_request_id(), params))
+            .await?
+        {
+            ResponseKind::Explain { sql } => Ok(sql),
+            ResponseKind::Ok => Err(fs_err!(
+                ErrorCode::Unexpected,
+                "explain got an ok response with no sql"
+            )),
+            ResponseKind::Error { error } => Err(fs_err!(
+                ErrorCode::SidecarError,
+                "{}: {}",
+                error.error_type,
+                error.message
+            )),
+        }
+    }
+
+    /// Health check — round trips through the sidecar without touching the manifest/engine.
+    pub async fn ping(&self) -> FsResult<()> {
+        self.submit_ok(Request::ping(new_request_id())).await
+    }
+
+    /// Graceful shutdown request. Waits for the sidecar's ok response; does not
+    /// itself wait for the process to exit (the process is killed on drop regardless).
+    pub async fn shutdown(&self) -> FsResult<()> {
+        self.submit_ok(Request::shutdown(new_request_id())).await
+    }
+
+    async fn submit_ok<P: Serialize>(&self, request: Request<P>) -> FsResult<()> {
+        match self.submit(request).await? {
+            ResponseKind::Ok => Ok(()),
+            ResponseKind::Explain { .. } => Err(fs_err!(
+                ErrorCode::Unexpected,
+                "expected an ok response, got an explain response"
+            )),
+            ResponseKind::Error { error } => Err(fs_err!(
+                ErrorCode::SidecarError,
+                "{}: {}",
+                error.error_type,
+                error.message
+            )),
+        }
+    }
+
+    async fn submit<P: Serialize>(&self, request: Request<P>) -> FsResult<ResponseKind> {
+        let id = request.id.clone();
+        let (tx, rx) = oneshot::channel();
+        {
+            let mut pending = self.pending.lock().await;
+            pending.insert(id.clone(), tx);
+        }
+
+        if let Err(e) = self.write_request(&request).await {
+            let mut pending = self.pending.lock().await;
+            pending.remove(&id);
+            return Err(e);
+        }
+
+        let result = rx.await.map_err(|e| {
+            fs_err!(
+                ErrorCode::ConcurrencyError,
+                "mf_entry closed the response channel for request {id}: {e}"
+            )
+        })?;
+        result.map_err(|e| fs_err!(ErrorCode::SidecarError, "{e}"))
+    }
+
+    async fn write_request<P: Serialize>(&self, request: &Request<P>) -> FsResult<()> {
+        let line = serde_json::to_string(request).map_err(|e| {
+            fs_err!(
+                ErrorCode::JsonInvalid,
+                "failed to serialize mf-ipc request: {e}"
+            )
+        })?;
+
+        let mut guard = self.process.lock().await;
+        let process = guard.as_mut().ok_or_else(|| {
+            fs_err!(
+                ErrorCode::ExecutorFailed,
+                "mf_entry process not initialized"
+            )
+        })?;
+
+        process
+            .stdin
+            .write_all(line.as_bytes())
+            .await
+            .map_err(|e| fs_err!(ErrorCode::IoError, "failed to write mf-ipc request: {e}"))?;
+        process.stdin.write_all(b"\n").await.map_err(|e| {
+            fs_err!(
+                ErrorCode::IoError,
+                "failed to write newline to mf_entry: {e}"
+            )
+        })?;
+        process
+            .stdin
+            .flush()
+            .await
+            .map_err(|e| fs_err!(ErrorCode::IoError, "failed to flush mf-ipc request: {e}"))
+    }
+
+    async fn read_loop(self: Arc<Self>, mut stdout: BufReader<ChildStdout>) {
+        let mut line = String::new();
+        loop {
+            line.clear();
+            match stdout.read_line(&mut line).await {
+                Ok(0) => {
+                    self.drain_pending(
+                        "mf_entry stdout closed (EOF) with requests still in flight",
+                    )
+                    .await;
+                    break;
+                }
+                Ok(_) => {
+                    let trimmed = line.trim();
+                    if trimmed.is_empty() {
+                        continue;
+                    }
+                    match parse_response_line(trimmed) {
+                        Ok((id, kind)) => self.complete(&id, Ok(kind)).await,
+                        Err(e) => tracing::warn!("failed to parse mf-ipc response line: {e}"),
+                    }
+                }
+                Err(e) => {
+                    self.drain_pending(&format!("failed to read mf_entry stdout: {e}"))
+                        .await;
+                    break;
+                }
+            }
+        }
+    }
+
+    async fn complete(&self, id: &str, result: Result<ResponseKind, String>) {
+        let sender = {
+            let mut pending = self.pending.lock().await;
+            pending.remove(id)
+        };
+        match sender {
+            Some(sender) => {
+                let _ = sender.send(result);
+            }
+            None => tracing::warn!("received mf-ipc response for unknown request id {id}"),
+        }
+    }
+
+    async fn drain_pending(&self, message: &str) {
+        let mut pending = self.pending.lock().await;
+        for (_, sender) in pending.drain() {
+            let _ = sender.send(Err(message.to_string()));
+        }
+    }
+}
+
+fn new_request_id() -> String {
+    Uuid::new_v4().to_string()
+}

--- a/crates/dbt-metricflow-sidecar/src/messages.rs
+++ b/crates/dbt-metricflow-sidecar/src/messages.rs
@@ -1,0 +1,177 @@
+//! Wire message types for the mf-ipc v1 protocol.
+//!
+//! Mirrors `sidecar/mf_ipc_protocol.py` in the `metricflow` repo field-for-field.
+//! That file is the source of truth for the wire shape — if the two ever
+//! disagree, trust the Python side and update this file to match, not the
+//! other way around.
+
+use serde::{Deserialize, Serialize};
+
+/// Startup handshake, written once by the sidecar before any request is read.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ReadyMessage {
+    pub status: String,
+    pub metricflow_version: String,
+    pub python_version: String,
+    pub protocol_version: u32,
+}
+
+/// Written instead of [`ReadyMessage`] if manifest pre-loading fails at startup.
+#[derive(Debug, Clone, Deserialize)]
+pub struct StartupErrorMessage {
+    pub status: String,
+    #[serde(rename = "type")]
+    pub error_type: String,
+    pub message: String,
+}
+
+/// Outgoing request envelope. `method` is always a `'static` string literal
+/// per call site (`"explain"`, `"ping"`, `"shutdown"`) — this protocol does not
+/// use serde's tagged-enum convention, so a generic wrapper is simplest.
+#[derive(Debug, Serialize)]
+pub struct Request<P: Serialize> {
+    pub id: String,
+    pub method: &'static str,
+    pub v: u8,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub params: Option<P>,
+}
+
+impl Request<()> {
+    pub fn ping(id: String) -> Self {
+        Self {
+            id,
+            method: "ping",
+            v: 1,
+            params: None,
+        }
+    }
+
+    pub fn shutdown(id: String) -> Self {
+        Self {
+            id,
+            method: "shutdown",
+            v: 1,
+            params: None,
+        }
+    }
+}
+
+impl Request<ExplainParams> {
+    pub fn explain(id: String, params: ExplainParams) -> Self {
+        Self {
+            id,
+            method: "explain",
+            v: 1,
+            params: Some(params),
+        }
+    }
+}
+
+/// Params for the `explain` method.
+///
+/// `sql_engine` is a plain string, not an enum: `mf_entry.py` looks the engine
+/// up by enum *member name* (`SqlEngine["DUCKDB"]`), not by value. This must
+/// stay a string to match the wire contract MetricFlow actually accepts.
+#[derive(Debug, Clone, Serialize)]
+pub struct ExplainParams {
+    pub manifest_path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metric_names: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group_by_names: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub where_constraints: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub order_by_names: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u64>,
+    pub sql_engine: String,
+}
+
+/// The `error` payload of an error response.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ErrorDetail {
+    #[serde(rename = "type")]
+    pub error_type: String,
+    pub message: String,
+    #[serde(default)]
+    pub traceback: Option<String>,
+}
+
+/// A response `id` as it actually appears on the wire. Requests we send
+/// always carry a `String` id (see `Request`), but responses are parsed
+/// defensively since the protocol technically allows `str | int | null`
+/// (e.g. `id: null` for a request that couldn't be parsed at all).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum ResponseId {
+    Str(String),
+    Int(i64),
+}
+
+/// Flat, permissive deserialization target for any response line. Kept
+/// deliberately loose (every field but `id`/`ok` optional) rather than an
+/// untagged enum over `ExplainResponse`/`OkResponse`/`ErrorResponse`: serde's
+/// untagged matching tries variants in declaration order and accepts the
+/// first one that parses, which is a real footgun here since a variant with
+/// only `{id, ok}` would spuriously match a response that also has `sql` or
+/// `error` fields sitting right next to it. Parsing into this struct first
+/// and branching explicitly in `into_kind` makes the discrimination logic
+/// visible instead of implicit in field-declaration order.
+#[derive(Debug, Clone, Deserialize)]
+struct RawResponse {
+    id: Option<ResponseId>,
+    ok: bool,
+    #[serde(default)]
+    sql: Option<String>,
+    #[serde(default)]
+    error: Option<ErrorDetail>,
+}
+
+/// A parsed, unambiguous response to a single request.
+#[derive(Debug, Clone)]
+pub enum ResponseKind {
+    /// `ping` / `shutdown` success.
+    Ok,
+    /// `explain` success.
+    Explain { sql: String },
+    /// Any failed request, regardless of method.
+    Error { error: ErrorDetail },
+}
+
+/// Parse one NDJSON response line into `(id, ResponseKind)`.
+///
+/// Returns `Err` if the line isn't valid JSON, doesn't match the expected
+/// response shape, or its `id` isn't a string (which should never happen for
+/// a response to a request *we* sent, since `Request::id` is always a
+/// `String` — an int or null id here means the sidecar is responding to
+/// something it couldn't associate with our request, e.g. a parse failure
+/// on its end).
+pub fn parse_response_line(line: &str) -> Result<(String, ResponseKind), String> {
+    let raw: RawResponse =
+        serde_json::from_str(line).map_err(|e| format!("invalid response JSON: {e}"))?;
+
+    let id = match raw.id {
+        Some(ResponseId::Str(s)) => s,
+        other => {
+            return Err(format!(
+                "response id is not a string we could have sent: {other:?}"
+            ));
+        }
+    };
+
+    let kind = if raw.ok {
+        match raw.sql {
+            Some(sql) => ResponseKind::Explain { sql },
+            None => ResponseKind::Ok,
+        }
+    } else {
+        match raw.error {
+            Some(error) => ResponseKind::Error { error },
+            None => return Err("ok:false response missing an error payload".to_string()),
+        }
+    };
+
+    Ok((id, kind))
+}

--- a/crates/dbt-metricflow-sidecar/tests/fixtures/fake_mf_entry.rs
+++ b/crates/dbt-metricflow-sidecar/tests/fixtures/fake_mf_entry.rs
@@ -1,0 +1,88 @@
+//! Minimal stand-in for `sidecar/mf_entry.py`, speaking just enough of
+//! mf-ipc v1 to exercise `MetricflowSidecarManager`'s plumbing without any
+//! dependency on Python or a real Nuitka binary.
+//!
+//! Behavior, by `method`:
+//! - `ping` / `shutdown` -> `{"id","ok":true}` (`shutdown` also exits 0 after)
+//! - `explain` with `params.manifest_path == "FORCE_ERROR"` -> a canned error response
+//! - any other `explain` -> a canned `{"id","ok":true,"sql":"SELECT 1"}`
+//! - unrecognised `method` -> a canned error response
+//!
+//! Deliberately parses incoming requests as bare `serde_json::Value` rather
+//! than reusing this crate's own message types: those are one-directional
+//! (`Request<P>` is `Serialize`-only, `ReadyMessage`/`ErrorDetail` are
+//! `Deserialize`-only) since the real client only ever sends requests and
+//! parses responses. This fixture plays the opposite role.
+
+use std::io::{self, BufRead, Write};
+
+use serde_json::{Value, json};
+
+fn main() {
+    let stdout = io::stdout();
+    let mut out = stdout.lock();
+
+    writeln!(
+        out,
+        "{}",
+        json!({
+            "status": "ready",
+            "metricflow_version": "0.0.0-fake",
+            "python_version": "0.0.0-fake",
+            "protocol_version": 1,
+        })
+    )
+    .expect("failed to write ready message");
+    out.flush().expect("failed to flush ready message");
+
+    let stdin = io::stdin();
+    for line in stdin.lock().lines() {
+        let line = line.expect("failed to read stdin line");
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        let request: Value = match serde_json::from_str(&line) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("fake_mf_entry: failed to parse request: {e}");
+                continue;
+            }
+        };
+
+        let id = request.get("id").cloned().unwrap_or(Value::Null);
+        let method = request.get("method").and_then(Value::as_str).unwrap_or("");
+
+        let response = match method {
+            "ping" => json!({"id": id, "ok": true}),
+            "shutdown" => json!({"id": id, "ok": true}),
+            "explain" => {
+                let manifest_path = request
+                    .pointer("/params/manifest_path")
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                if manifest_path == "FORCE_ERROR" {
+                    json!({
+                        "id": id,
+                        "ok": false,
+                        "error": {"type": "TestError", "message": "forced error for testing"},
+                    })
+                } else {
+                    json!({"id": id, "ok": true, "sql": "SELECT 1"})
+                }
+            }
+            other => json!({
+                "id": id,
+                "ok": false,
+                "error": {"type": "UnknownMethod", "message": format!("unknown method: {other}")},
+            }),
+        };
+
+        writeln!(out, "{response}").expect("failed to write response");
+        out.flush().expect("failed to flush response");
+
+        if method == "shutdown" {
+            break;
+        }
+    }
+}

--- a/crates/dbt-metricflow-sidecar/tests/manager_tests.rs
+++ b/crates/dbt-metricflow-sidecar/tests/manager_tests.rs
@@ -1,0 +1,96 @@
+//! Integration tests for `MetricflowSidecarManager`, run against the
+//! `fake_mf_entry` fixture binary (see `tests/fixtures/fake_mf_entry.rs`) —
+//! no dependency on Python or a real Nuitka-compiled `mf_entry` binary.
+
+use std::path::PathBuf;
+
+use dbt_metricflow_sidecar::manager::MetricflowSidecarManager;
+use dbt_metricflow_sidecar::messages::ExplainParams;
+
+fn fixture_binary_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_fake_mf_entry"))
+}
+
+fn explain_params(manifest_path: &str) -> ExplainParams {
+    ExplainParams {
+        manifest_path: manifest_path.to_string(),
+        metric_names: Some(vec!["bookings".to_string()]),
+        group_by_names: Some(vec!["metric_time".to_string()]),
+        where_constraints: None,
+        order_by_names: None,
+        limit: None,
+        sql_engine: "DUCKDB".to_string(),
+    }
+}
+
+#[tokio::test]
+async fn spawn_succeeds_and_ping_round_trips() {
+    let manager = MetricflowSidecarManager::spawn(&fixture_binary_path())
+        .await
+        .expect("spawn should succeed");
+    manager.ping().await.expect("ping should succeed");
+}
+
+#[tokio::test]
+async fn explain_returns_sql() {
+    let manager = MetricflowSidecarManager::spawn(&fixture_binary_path())
+        .await
+        .expect("spawn should succeed");
+    let sql = manager
+        .explain(explain_params("/some/manifest"))
+        .await
+        .expect("explain should succeed");
+    assert_eq!(sql, "SELECT 1");
+}
+
+#[tokio::test]
+async fn explain_surfaces_structured_error() {
+    let manager = MetricflowSidecarManager::spawn(&fixture_binary_path())
+        .await
+        .expect("spawn should succeed");
+    let err = manager
+        .explain(explain_params("FORCE_ERROR"))
+        .await
+        .expect_err("explain should fail");
+    let message = err.to_string();
+    assert!(
+        message.contains("TestError"),
+        "expected TestError in: {message}"
+    );
+    assert!(
+        message.contains("forced error for testing"),
+        "expected error detail in: {message}"
+    );
+}
+
+#[tokio::test]
+async fn concurrent_explain_requests_are_each_answered_correctly() {
+    let manager = MetricflowSidecarManager::spawn(&fixture_binary_path())
+        .await
+        .expect("spawn should succeed");
+
+    let mut handles = Vec::new();
+    for i in 0..8 {
+        let manager = manager.clone();
+        handles.push(tokio::spawn(async move {
+            let params = explain_params(&format!("/manifest-{i}"));
+            manager.explain(params).await
+        }));
+    }
+
+    for handle in handles {
+        let sql = handle
+            .await
+            .expect("task should not panic")
+            .expect("explain should succeed");
+        assert_eq!(sql, "SELECT 1");
+    }
+}
+
+#[tokio::test]
+async fn shutdown_round_trips() {
+    let manager = MetricflowSidecarManager::spawn(&fixture_binary_path())
+        .await
+        .expect("spawn should succeed");
+    manager.shutdown().await.expect("shutdown should succeed");
+}


### PR DESCRIPTION
Resolves #

### Problem

Fusion needs a way to compile metric queries via the MetricFlow Nuitka
sidecar (`mf_entry.py` in the metricflow repo). The existing analogous
sidecar for SQL execution (`RunnerManager`, wrapping dbt-db-runner)
lives entirely in proprietary crates outside this repo — dbt-core has
no path to it at all. `MetricflowClient`/`MetricflowClientFactory`
(`dbt-tasks-core/src/metricflow.rs`) already exist as trait interfaces
here but have zero implementations anywhere, including in the
proprietary crates (verified directly), so there's nothing to break by
building against them later.

### Solution

Add `dbt-metricflow-sidecar`: a standalone async subprocess manager
that reimplements `RunnerManager`'s architecture — spawn, NDJSON
read/write, request/response correlation by id via `tokio::oneshot`, a
dedicated background reader task — using only OSS dependencies already
pinned in this workspace (tokio, serde, uuid). No code is reused from
`RunnerManager`; only the pattern transfers, since the proprietary
crate isn't something this repo can depend on.

Deliberate design choices:
- `messages.rs` mirrors `sidecar/mf_ipc_protocol.py` in the metricflow
  repo field-for-field. `sql_engine` stays a plain `String` rather than
  an enum, matching that file's own reasoning: `mf_entry.py` looks the
  engine up by enum member name, not value.
- Response parsing goes through a permissive intermediate struct
  (`RawResponse`) with explicit branching in `parse_response_line`,
  instead of a `#[serde(untagged)]` enum over the three response
  shapes. Untagged enums try variants in declaration order and accept
  the first structural match — a response with only `{id, ok}` would
  spuriously match before a variant requiring `sql` or `error` got a
  chance to.
- This manager owns exactly one subprocess and does not pool multiple
  instances or multiplex heavily onto one. Unlike the DuckDB-backed
  runner `RunnerManager` talks to, MetricFlow's `explain()` is pure
  Python, GIL-bound — cramming many concurrent requests into one
  process would only buy cooperative interleaving, not real
  throughput. Real concurrency for this workload means running
  multiple manager instances (one process each), which is a pooling
  concern for a later slice, not something this crate does itself.

Tested against a fixture binary (`tests/fixtures/fake_mf_entry.rs`, no
Python dependency, portable in CI) covering spawn, single-request
round trips, structured error propagation, concurrent requests, and
shutdown. Also manually verified end-to-end against the real
Nuitka-compiled `mf_entry.bin` from the metricflow repo: real
`explain()` call, real compiled SQL back.

Not included in this slice, deliberately: extending
`MetricflowClient`/`MetricflowClientFactory` with an explain-style
method, a `MetricflowSidecarFeature` flag on `FeatureStack`, and
filling in the `schema_hydrator.rs`/`task_runner_hooks.rs` TODO stubs.
Each needs its own design pass on what the compilation pipeline
actually hands in and how `explain()`'s output flows downstream.
Pulling in the actual released sidecar binary is also deliberately out
of scope here — the manager takes an arbitrary `binary_path` and has
no coupling to how that binary is acquired; that's a separate,
stacked PR.

### Checklist

- [x] I have read the contributing guide and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes type annotations for new and modified functions.