### PR TITLE
fix(databricks): verify relation cache misses

### DIFF
--- a/.changes/unreleased/Fixes-20260802-071629.yaml
+++ b/.changes/unreleased/Fixes-20260802-071629.yaml
@@ -2,5 +2,6 @@ kind: Fixes
 body: Verify Databricks relation cache misses with a direct lookup so table reruns do not attempt to recreate existing relations.
 time: 2026-08-02T07:16:29.000000+00:00
 custom:
+    author: sd-db
     issue: "14129"
     project: dbt-core

--- a/.changes/unreleased/Fixes-20260802-071629.yaml
+++ b/.changes/unreleased/Fixes-20260802-071629.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Verify Databricks relation cache misses with a direct lookup so table reruns do not attempt to recreate existing relations.
+time: 2026-08-02T07:16:29.000000+00:00
+custom:
+    issue: "14129"
+    project: dbt-core

--- a/crates/dbt-adapter/src/adapter/mod.rs
+++ b/crates/dbt-adapter/src/adapter/mod.rs
@@ -1468,8 +1468,7 @@ impl Adapter {
                                     ),
                                 }
 
-                                self.get_relation_value_from_cache(temp_relation.as_ref())
-                                    .or(Some(none_value()))
+                                self.get_cached_relation_after_listing(temp_relation.as_ref())
                             } else {
                                 None
                             }
@@ -4236,14 +4235,23 @@ impl Object for Adapter {
 }
 
 impl Adapter {
+    fn get_cached_relation_after_listing(&self, temp_relation: &dyn BaseRelation) -> Option<Value> {
+        let cache_result = self.get_relation_value_from_cache(temp_relation);
+        if cache_result.is_some() || self.adapter_type() == AdapterType::Databricks {
+            // Databricks schema listings can lag recent creates.
+            cache_result
+        } else {
+            Some(none_value())
+        }
+    }
+
     fn get_relation_value_from_cache(&self, temp_relation: &dyn BaseRelation) -> Option<Value> {
         let relation_cache = self.engine().relation_cache();
         if let Some(cached_entry) = relation_cache.get_relation(temp_relation) {
             Some(RelationObject::new(cached_entry.relation()).into_value())
-        }
-        // If we have captured the entire schema previously, we can check for non-existence
-        // In these cases, return early with a None value
-        else if relation_cache.contains_full_schema_for_relation(temp_relation) {
+        } else if relation_cache.contains_full_schema_for_relation(temp_relation)
+            && self.adapter_type() != AdapterType::Databricks
+        {
             Some(none_value())
         } else {
             None

--- a/crates/dbt-adapter/src/adapter/tests.rs
+++ b/crates/dbt-adapter/src/adapter/tests.rs
@@ -10,6 +10,7 @@ use dbt_adapter_core::AdapterType;
 use dbt_common::cancellation::never_cancels;
 use dbt_schemas::schemas::relations::{DEFAULT_DBT_QUOTING, DEFAULT_RESOLVED_QUOTING};
 use indexmap::IndexMap;
+use minijinja_contrib::testing::jinja_assert;
 
 /// Helper to call [Adapter::call_method_impl] with jinja-valued arguments.
 fn dispatch_test(
@@ -410,4 +411,56 @@ fn test_get_relation_dispatch_spark_absent_database() {
     )
     .unwrap();
     assert!(!result.is_none() && !result.is_undefined());
+}
+
+#[test]
+fn test_databricks_get_relation_falls_back_after_empty_schema_listing() {
+    let adapter = make_mock_adapter(AdapterType::Databricks);
+    let relation = crate::relation::do_create_relation(
+        AdapterType::Databricks,
+        "my_catalog".to_string(),
+        "my_schema".to_string(),
+        Some("my_table".to_string()),
+        None,
+        DEFAULT_RESOLVED_QUOTING,
+    )
+    .unwrap();
+    let schema = CatalogAndSchema::from(&relation);
+
+    // Model a stale Databricks schema listing.
+    adapter
+        .engine()
+        .relation_cache()
+        .insert_schema(schema, Vec::new());
+
+    jinja_assert(
+        adapter.as_ref().clone(),
+        "{{ obj.get_relation(database='my_catalog', schema='my_schema', identifier='my_table').identifier }}",
+        "my_table",
+    );
+}
+
+#[test]
+fn test_non_databricks_get_relation_trusts_empty_schema_listing() {
+    let adapter = make_mock_adapter(AdapterType::DuckDB);
+    let relation = crate::relation::do_create_relation(
+        AdapterType::DuckDB,
+        "my_catalog".to_string(),
+        "my_schema".to_string(),
+        Some("my_table".to_string()),
+        None,
+        DEFAULT_RESOLVED_QUOTING,
+    )
+    .unwrap();
+    let schema = CatalogAndSchema::from(&relation);
+    adapter
+        .engine()
+        .relation_cache()
+        .insert_schema(schema, Vec::new());
+
+    jinja_assert(
+        adapter.as_ref().clone(),
+        "{{ obj.get_relation(database='my_catalog', schema='my_schema', identifier='my_table') is none }}",
+        "True",
+    );
 }


### PR DESCRIPTION
Follow-up to #15743.

### Problem

Databricks schema listings can temporarily omit a newly created relation. Fusion treated that miss as authoritative and could try to recreate the existing table on rerun.

### Solution

- Fall back to the direct relation lookup for Databricks cache misses.
- Preserve existing negative-cache behavior for other adapters.
- Cover both paths through `adapter.get_relation`.

### Testing

- `cargo test -p dbt-adapter get_relation_ -- --nocapture` — 16 passed
- `cargo test -p dbt-adapter --lib` — 922 passed
- `cargo fmt --all -- --check`
- `cargo clippy -p dbt-adapter --all-targets -- -D warnings`
- Fresh dual-live dbt-databricks/Fusion conformance: all 8 command/capture, ordered SQL, and live-state comparisons passed; all 4 enabled Python artifact checks passed

### Checklist

- [x] I have read the contributing guide and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests.
- [x] This PR has no interface changes.
- [x] No new or modified functions require type annotations.
