### PR TITLE
fix(duckdb): emit ENDPOINT_TYPE into the catalog ATTACH statement

### DIFF
--- a/.changes/unreleased/Fixes-20260802-204900.yaml
+++ b/.changes/unreleased/Fixes-20260802-204900.yaml
@@ -1,0 +1,9 @@
+kind: Fixes
+body: Emit `ENDPOINT_TYPE` into the DuckDB catalog `ATTACH` statement. `config.duckdb.endpoint_type`
+    was validated by the catalogs.yml v2 schema and then silently discarded, so AWS
+    Glue and Amazon S3 Tables catalogs could not attach.
+time: 2026-08-02T20:49:00.000000+02:00
+custom:
+    author: AndreaBozzo
+    issue: "15725"
+    project: dbt-core

--- a/crates/dbt-adapter/src/engine/duckdb_attach.rs
+++ b/crates/dbt-adapter/src/engine/duckdb_attach.rs
@@ -279,18 +279,22 @@ fn push_default_opts(
     // attach read-write by default; a user-supplied `read_only` config overrides.
     let read_only = duckdb_get_bool(duckdb, "read_only")?.unwrap_or(false);
     opts.push(format!("READ_ONLY {read_only}"));
-    for (config_key, default_clause) in catalog_attach_defaults(catalog_type) {
-        // `endpoint_type` already implies an authorization type inside DuckDB,
-        // which rejects the pair outright ("'authorization_type' can not be
-        // combined with 'endpoint_type'"). Presetting one here would turn a
-        // valid config into a failed ATTACH.
-        if *config_key == "authorization_type" && endpoint_type.is_some() {
-            continue;
-        }
-        if !duckdb_has_key(duckdb, config_key) {
-            opts.push((*default_clause).to_string());
-        }
-    }
+    opts.extend(
+        catalog_attach_defaults(catalog_type)
+            .iter()
+            .filter(|(config_key, _)| {
+                // An explicit user value always wins over dbt's preset.
+                if duckdb_has_key(duckdb, config_key) {
+                    return false;
+                }
+                // `endpoint_type` already implies an authorization type inside
+                // DuckDB, which rejects the pair outright ("'authorization_type'
+                // can not be combined with 'endpoint_type'"). Presetting one
+                // here would turn a valid config into a failed ATTACH.
+                !(*config_key == "authorization_type" && endpoint_type.is_some())
+            })
+            .map(|(_, default_clause)| (*default_clause).to_string()),
+    );
     if duckdb_get_bool(duckdb, "encode_entire_prefix")?.unwrap_or(false) {
         opts.push("ENCODE_ENTIRE_PREFIX true".to_string());
     }

--- a/crates/dbt-adapter/src/engine/duckdb_attach.rs
+++ b/crates/dbt-adapter/src/engine/duckdb_attach.rs
@@ -172,7 +172,37 @@ fn build_duckdb_catalog_attach_stmt(
     let alias = resolve_required_attach_alias(catalog)?;
     let endpoint_type = duckdb_get_str(duckdb, "endpoint_type");
 
+    // Emission order is part of the snapshot contract: connection options, then
+    // user-supplied passthrough options, then dbt's defaults.
     let mut opts = vec!["TYPE ICEBERG".to_string()];
+    push_connection_opts(&mut opts, duckdb, endpoint_type);
+    push_passthrough_opts(&mut opts, duckdb)?;
+    push_default_opts(&mut opts, duckdb, catalog.catalog_type, endpoint_type)?;
+
+    let source = format!(
+        "'{}'",
+        escape_string_literal(
+            resolve_attach_source(catalog, duckdb, endpoint_type),
+            AdapterType::DuckDB
+        )
+    );
+
+    Ok((
+        alias.clone(),
+        format!(
+            "ATTACH IF NOT EXISTS {source} AS {alias} ({})",
+            opts.join(", ")
+        ),
+    ))
+}
+
+/// How DuckDB reaches the catalog: which secret to authenticate with, and where
+/// the REST endpoint lives.
+fn push_connection_opts(
+    opts: &mut Vec<String>,
+    duckdb: &dbt_yaml::Mapping,
+    endpoint_type: Option<&str>,
+) {
     if let Some(secret) = duckdb_get_str(duckdb, "secret") {
         let secret = dbt_adapter_sql::ident::sanitize_identifier(secret, AdapterType::DuckDB);
         if !secret.is_empty() {
@@ -196,7 +226,11 @@ fn build_duckdb_catalog_attach_stmt(
             escape_string_literal(ep, AdapterType::DuckDB)
         ));
     }
+}
 
+/// ATTACH options passed straight through from `config.duckdb`, emitted only
+/// when the user set them.
+fn push_passthrough_opts(opts: &mut Vec<String>, duckdb: &dbt_yaml::Mapping) -> AdapterResult<()> {
     for (key, sql_key) in [
         ("default_region", "DEFAULT_REGION"),
         ("default_schema", "DEFAULT_SCHEMA"),
@@ -229,13 +263,23 @@ fn build_duckdb_catalog_attach_stmt(
             opts.push(format!("{sql_key} {val}"));
         }
     }
+    Ok(())
+}
+
+/// Options dbt supplies on the user's behalf: the read-write default and the
+/// per-catalog-type write-compat presets, each yielding to an explicit user value.
+fn push_default_opts(
+    opts: &mut Vec<String>,
+    duckdb: &dbt_yaml::Mapping,
+    catalog_type: V2CatalogType,
+    endpoint_type: Option<&str>,
+) -> AdapterResult<()> {
     // duckdb's AUTOMATIC access mode resolves to read-only for a remote Iceberg
     // REST catalog, which blocks CREATE/INSERT. dbt writes to its catalogs, so
     // attach read-write by default; a user-supplied `read_only` config overrides.
     let read_only = duckdb_get_bool(duckdb, "read_only")?.unwrap_or(false);
     opts.push(format!("READ_ONLY {read_only}"));
-    // Preset write-compat defaults per catalog type for keys the user did not set.
-    for (config_key, default_clause) in catalog_attach_defaults(catalog.catalog_type) {
+    for (config_key, default_clause) in catalog_attach_defaults(catalog_type) {
         // `endpoint_type` already implies an authorization type inside DuckDB,
         // which rejects the pair outright ("'authorization_type' can not be
         // combined with 'endpoint_type'"). Presetting one here would turn a
@@ -250,10 +294,17 @@ fn build_duckdb_catalog_attach_stmt(
     if duckdb_get_bool(duckdb, "encode_entire_prefix")?.unwrap_or(false) {
         opts.push("ENCODE_ENTIRE_PREFIX true".to_string());
     }
+    Ok(())
+}
 
-    // For Iceberg REST catalogs, source is the warehouse name, not the endpoint
-    // URL.
-    let warehouse = duckdb_get_str(duckdb, "warehouse").unwrap_or_else(|| {
+/// The `ATTACH '<source>'` operand. For Iceberg REST catalogs this is the
+/// warehouse name, not the endpoint URL.
+fn resolve_attach_source<'a>(
+    catalog: &CatalogSpecV2View<'a>,
+    duckdb: &'a dbt_yaml::Mapping,
+    endpoint_type: Option<&str>,
+) -> &'a str {
+    duckdb_get_str(duckdb, "warehouse").unwrap_or_else(|| {
         // Glue reads the source as a catalog path, not a free-form warehouse
         // name, and validates it against its own grammar (':', a 12-digit
         // account id, 'cat1/cat2', ...) — a dbt catalog name fails that check.
@@ -263,19 +314,7 @@ fn build_duckdb_catalog_attach_stmt(
         } else {
             catalog.name
         }
-    });
-    let source = format!(
-        "'{}'",
-        escape_string_literal(warehouse, AdapterType::DuckDB)
-    );
-
-    Ok((
-        alias.clone(),
-        format!(
-            "ATTACH IF NOT EXISTS {source} AS {alias} ({})",
-            opts.join(", ")
-        ),
-    ))
+    })
 }
 
 /// Whether this catalog attaches to AWS Glue, by either route: a `glue` catalog

--- a/crates/dbt-adapter/src/engine/duckdb_attach.rs
+++ b/crates/dbt-adapter/src/engine/duckdb_attach.rs
@@ -170,6 +170,7 @@ fn build_duckdb_catalog_attach_stmt(
     duckdb: &dbt_yaml::Mapping,
 ) -> AdapterResult<(String, String)> {
     let alias = resolve_required_attach_alias(catalog)?;
+    let endpoint_type = duckdb_get_str(duckdb, "endpoint_type");
 
     let mut opts = vec!["TYPE ICEBERG".to_string()];
     if let Some(secret) = duckdb_get_str(duckdb, "secret") {
@@ -177,6 +178,17 @@ fn build_duckdb_catalog_attach_stmt(
         if !secret.is_empty() {
             opts.push(format!("SECRET {secret}"));
         }
+    }
+    // The managed-endpoint shortcut: DuckDB derives ENDPOINT and SIGV4
+    // authorization itself from the endpoint type plus the secret's region
+    // (GLUE) or the warehouse ARN's region (S3_TABLES). Mutually exclusive with
+    // `endpoint` and `authorization_type` — both in our schema and in DuckDB,
+    // which hard-errors on the combination.
+    if let Some(et) = endpoint_type {
+        opts.push(format!(
+            "ENDPOINT_TYPE '{}'",
+            escape_string_literal(et, AdapterType::DuckDB)
+        ));
     }
     if let Some(ep) = duckdb_get_str(duckdb, "endpoint") {
         opts.push(format!(
@@ -224,6 +236,13 @@ fn build_duckdb_catalog_attach_stmt(
     opts.push(format!("READ_ONLY {read_only}"));
     // Preset write-compat defaults per catalog type for keys the user did not set.
     for (config_key, default_clause) in catalog_attach_defaults(catalog.catalog_type) {
+        // `endpoint_type` already implies an authorization type inside DuckDB,
+        // which rejects the pair outright ("'authorization_type' can not be
+        // combined with 'endpoint_type'"). Presetting one here would turn a
+        // valid config into a failed ATTACH.
+        if *config_key == "authorization_type" && endpoint_type.is_some() {
+            continue;
+        }
         if !duckdb_has_key(duckdb, config_key) {
             opts.push((*default_clause).to_string());
         }
@@ -234,7 +253,17 @@ fn build_duckdb_catalog_attach_stmt(
 
     // For Iceberg REST catalogs, source is the warehouse name, not the endpoint
     // URL.
-    let warehouse = duckdb_get_str(duckdb, "warehouse").unwrap_or(catalog.name);
+    let warehouse = duckdb_get_str(duckdb, "warehouse").unwrap_or_else(|| {
+        // Glue reads the source as a catalog path, not a free-form warehouse
+        // name, and validates it against its own grammar (':', a 12-digit
+        // account id, 'cat1/cat2', ...) — a dbt catalog name fails that check.
+        // ':' is Glue's default catalog in the caller's own account.
+        if is_glue_attach(catalog.catalog_type, endpoint_type) {
+            ":"
+        } else {
+            catalog.name
+        }
+    });
     let source = format!(
         "'{}'",
         escape_string_literal(warehouse, AdapterType::DuckDB)
@@ -247,6 +276,15 @@ fn build_duckdb_catalog_attach_stmt(
             opts.join(", ")
         ),
     ))
+}
+
+/// Whether this catalog attaches to AWS Glue, by either route: a `glue` catalog
+/// type pinning its own `endpoint`, or `endpoint_type: GLUE` on any Iceberg REST
+/// catalog. Both land on DuckDB's Glue code path, which reads the ATTACH source
+/// as a Glue catalog path.
+fn is_glue_attach(catalog_type: V2CatalogType, endpoint_type: Option<&str>) -> bool {
+    matches!(catalog_type, V2CatalogType::Glue)
+        || endpoint_type.is_some_and(|et| et.trim().eq_ignore_ascii_case("GLUE"))
 }
 
 fn duckdb_get_str<'a>(duckdb: &'a dbt_yaml::Mapping, key: &str) -> Option<&'a str> {
@@ -301,6 +339,12 @@ fn catalog_attach_defaults(catalog_type: V2CatalogType) -> &'static [(&'static s
             ),
             ("remove_files_on_delete", "REMOVE_FILES_ON_DELETE false"),
         ],
+        // AWS Glue's Iceberg REST endpoint authenticates with SigV4, never
+        // OAuth2 (DuckDB's fallback). `endpoint_type: GLUE` gets SigV4 from
+        // DuckDB itself, but a Glue catalog pinning an explicit `endpoint` —
+        // the only route for regions off the plain amazonaws.com suffix — has
+        // nothing else to supply it.
+        V2CatalogType::Glue => &[("authorization_type", "AUTHORIZATION_TYPE 'SIGV4'")],
         // Databricks Unity Catalog's Iceberg REST endpoint does not support the
         // REST multi-table commit, so default it off; single-table commits work.
         // (Other write-path options are left to DuckDB's defaults pending

--- a/crates/dbt-adapter/src/metadata/duckdb/mod.rs
+++ b/crates/dbt-adapter/src/metadata/duckdb/mod.rs
@@ -410,22 +410,25 @@ pub(crate) struct ExternalIcebergAttach {
 }
 
 /// Catalog types DuckDB reaches through an Iceberg REST `ATTACH ... (TYPE
-/// ICEBERG)`. Horizon and Unity are Iceberg REST services under the hood.
+/// ICEBERG)`. Horizon, Unity, and Glue are Iceberg REST services under the hood.
 /// Single answer to "is this an Iceberg REST-style attachment?" so the ATTACH
 /// composer (`engine::duckdb_attach`) and the metadata routing below can never
 /// disagree about which catalogs need REST-attachment treatment.
 pub(crate) fn attaches_via_iceberg_rest(catalog_type: V2CatalogType) -> bool {
     matches!(
         catalog_type,
-        V2CatalogType::IcebergRest | V2CatalogType::Horizon | V2CatalogType::Unity
+        V2CatalogType::IcebergRest
+            | V2CatalogType::Horizon
+            | V2CatalogType::Unity
+            | V2CatalogType::Glue
     )
 }
 
 /// DuckDB-specific classification of a single v2 catalog spec.
 pub(crate) trait CatalogSpecDuckDbExt {
     /// `Some(..)` iff this catalog is an external Iceberg REST-attached catalog
-    /// (IcebergRest/Horizon/Unity with `table_format: iceberg` and a `duckdb`
-    /// config block), carrying its sanitized `ATTACH` alias.
+    /// (IcebergRest/Horizon/Unity/Glue with `table_format: iceberg` and a
+    /// `duckdb` config block), carrying its sanitized `ATTACH` alias.
     fn external_iceberg_attach(&self) -> Option<ExternalIcebergAttach>;
 
     /// The sanitized DuckDB `ATTACH` alias this catalog resolves to

--- a/crates/dbt-adapter/tests/duckdb_attach.rs
+++ b/crates/dbt-adapter/tests/duckdb_attach.rs
@@ -14,14 +14,18 @@ const SCENARIOS: &[&str] = &[
     "ducklake_full_options",
     "ducklake_minimal",
     "empty_alias_error",
+    "glue_endpoint_type",
+    "glue_explicit_endpoint",
     "horizon_duckdb",
     "horizon_duckdb_user_overrides",
+    "iceberg_rest_endpoint_type_glue",
     "iceberg_rest_full_options",
     "iceberg_rest_minimal",
     "iceberg_rest_string_bool_options",
     "local_filesystem_no_attach",
     "multi_catalog_iceberg_rest",
     "multi_catalog_with_ducklake",
+    "s3_tables_endpoint_type",
     "unity_duckdb",
 ];
 

--- a/crates/dbt-adapter/tests/duckdb_attach_fixtures/glue_endpoint_type/catalogs.yml
+++ b/crates/dbt-adapter/tests/duckdb_attach_fixtures/glue_endpoint_type/catalogs.yml
@@ -1,0 +1,13 @@
+# Scenario: AWS Glue reached through the `endpoint_type: GLUE` shortcut.
+# Exercises: ENDPOINT_TYPE emission; the source defaulting to ':' (Glue's
+# default catalog in the caller's own account) rather than the catalog name,
+# which Glue's catalog-path grammar would reject; and *no* AUTHORIZATION_TYPE,
+# since DuckDB derives SigV4 from the endpoint type and errors on the pair.
+catalogs:
+  - name: aws_glue
+    type: glue
+    table_format: iceberg
+    config:
+      duckdb:
+        endpoint_type: GLUE
+        secret: glue_s3

--- a/crates/dbt-adapter/tests/duckdb_attach_fixtures/glue_endpoint_type/output.snap
+++ b/crates/dbt-adapter/tests/duckdb_attach_fixtures/glue_endpoint_type/output.snap
@@ -1,0 +1,4 @@
+---
+source: crates/dbt-adapter/tests/duckdb_attach.rs
+---
+ATTACH IF NOT EXISTS ':' AS aws_glue (TYPE ICEBERG, SECRET glue_s3, ENDPOINT_TYPE 'GLUE', READ_ONLY false)

--- a/crates/dbt-adapter/tests/duckdb_attach_fixtures/glue_explicit_endpoint/catalogs.yml
+++ b/crates/dbt-adapter/tests/duckdb_attach_fixtures/glue_explicit_endpoint/catalogs.yml
@@ -1,0 +1,16 @@
+# Scenario: AWS Glue pinned to an explicit regional endpoint instead of the
+# `endpoint_type` shortcut — the only route for regions whose endpoint does not
+# use the plain amazonaws.com suffix.
+# Exercises: the Glue AUTHORIZATION_TYPE 'SIGV4' default, which applies here
+# because nothing else supplies it (DuckDB would otherwise fall back to OAuth2);
+# and an explicit `warehouse` (AWS account id) winning over the ':' default.
+catalogs:
+  - name: glue_regional
+    type: glue
+    table_format: iceberg
+    config:
+      duckdb:
+        endpoint: "glue.us-east-1.amazonaws.com/iceberg"
+        warehouse: "123456789012"
+        attach_as: "glue_db"
+        secret: glue_s3

--- a/crates/dbt-adapter/tests/duckdb_attach_fixtures/glue_explicit_endpoint/output.snap
+++ b/crates/dbt-adapter/tests/duckdb_attach_fixtures/glue_explicit_endpoint/output.snap
@@ -1,0 +1,4 @@
+---
+source: crates/dbt-adapter/tests/duckdb_attach.rs
+---
+ATTACH IF NOT EXISTS '123456789012' AS glue_db (TYPE ICEBERG, SECRET glue_s3, ENDPOINT 'glue.us-east-1.amazonaws.com/iceberg', READ_ONLY false, AUTHORIZATION_TYPE 'SIGV4')

--- a/crates/dbt-adapter/tests/duckdb_attach_fixtures/iceberg_rest_endpoint_type_glue/catalogs.yml
+++ b/crates/dbt-adapter/tests/duckdb_attach_fixtures/iceberg_rest_endpoint_type_glue/catalogs.yml
@@ -1,0 +1,15 @@
+# Scenario: the `endpoint_type: GLUE` shortcut on a generic iceberg_rest
+# catalog rather than a `type: glue` one — DuckDB's Glue code path is selected
+# by the endpoint type, not by dbt's catalog type.
+# Exercises: the ':' source default and the suppressed AUTHORIZATION_TYPE apply
+# on this route too, and the Glue-typed SIGV4 default does not leak here.
+catalogs:
+  - name: glue_via_rest
+    type: iceberg_rest
+    table_format: iceberg
+    config:
+      duckdb:
+        endpoint_type: GLUE
+        attach_as: "glue_rest_db"
+        secret: glue_s3
+        default_schema: "analytics"

--- a/crates/dbt-adapter/tests/duckdb_attach_fixtures/iceberg_rest_endpoint_type_glue/output.snap
+++ b/crates/dbt-adapter/tests/duckdb_attach_fixtures/iceberg_rest_endpoint_type_glue/output.snap
@@ -1,0 +1,4 @@
+---
+source: crates/dbt-adapter/tests/duckdb_attach.rs
+---
+ATTACH IF NOT EXISTS ':' AS glue_rest_db (TYPE ICEBERG, SECRET glue_s3, ENDPOINT_TYPE 'GLUE', DEFAULT_SCHEMA 'analytics', READ_ONLY false)

--- a/crates/dbt-adapter/tests/duckdb_attach_fixtures/s3_tables_endpoint_type/catalogs.yml
+++ b/crates/dbt-adapter/tests/duckdb_attach_fixtures/s3_tables_endpoint_type/catalogs.yml
@@ -1,0 +1,15 @@
+# Scenario: Amazon S3 Tables reached through `endpoint_type: S3_TABLES`.
+# Exercises: ENDPOINT_TYPE emission on a non-Glue catalog type, and the table
+# bucket ARN carried through as the ATTACH source — DuckDB parses the region out
+# of that ARN to build the endpoint and sign with SigV4, so neither ENDPOINT nor
+# AUTHORIZATION_TYPE is emitted.
+catalogs:
+  - name: s3_tables_demo
+    type: iceberg_rest
+    table_format: iceberg
+    config:
+      duckdb:
+        endpoint_type: S3_TABLES
+        warehouse: "arn:aws:s3tables:us-east-1:123456789012:bucket/demo-bucket"
+        attach_as: "s3_tables_db"
+        secret: s3_tables_secret

--- a/crates/dbt-adapter/tests/duckdb_attach_fixtures/s3_tables_endpoint_type/output.snap
+++ b/crates/dbt-adapter/tests/duckdb_attach_fixtures/s3_tables_endpoint_type/output.snap
@@ -1,0 +1,4 @@
+---
+source: crates/dbt-adapter/tests/duckdb_attach.rs
+---
+ATTACH IF NOT EXISTS 'arn:aws:s3tables:us-east-1:123456789012:bucket/demo-bucket' AS s3_tables_db (TYPE ICEBERG, SECRET s3_tables_secret, ENDPOINT_TYPE 'S3_TABLES', READ_ONLY false)

--- a/crates/dbt-schemas/src/schemas/dbt_catalogs_v2.rs
+++ b/crates/dbt-schemas/src/schemas/dbt_catalogs_v2.rs
@@ -143,12 +143,12 @@ const LINKED_SNOWFLAKE_FIELDS: &[FieldSpec] = &[
 const DUCKDB_ICEBERG_FIELDS: &[FieldSpec] = &[
     FieldSpec::string("endpoint")
         .non_empty()
-        .doc("Full REST catalog URL. Mutually exclusive with endpoint_type."),
+        .doc("REST catalog URL, with or without a scheme (DuckDB assumes https for SigV4 catalogs and http otherwise, and leaves an explicit scheme alone). Mutually exclusive with endpoint_type."),
     FieldSpec::enumerated("endpoint_type", DUCKDB_ENDPOINT_TYPES)
-        .doc("Managed endpoint type. Mutually exclusive with endpoint."),
+        .doc("Managed AWS endpoint type. DuckDB derives the endpoint URL and SigV4 authorization from it, so it is mutually exclusive with both endpoint and authorization_type."),
     FieldSpec::string("warehouse")
         .non_empty()
-        .doc("S3 warehouse URI. Required when endpoint_type is S3_TABLES."),
+        .doc("Warehouse identifier used as the ATTACH source: the S3 Tables bucket ARN (required when endpoint_type is S3_TABLES), or the Glue catalog path (defaults to ':', the current account's default catalog)."),
     FieldSpec::string("secret")
         .non_empty()
         .doc("Name of a DuckDB secret from profiles.yml to use for authentication."),


### PR DESCRIPTION
Resolves #15725

### Problem

`config.duckdb.endpoint_type` (`GLUE` | `S3_TABLES`) is fully validated by the `catalogs.yml` v2 schema and then never emitted into the `ATTACH` statement. A user's catalog configuration is accepted and silently dropped.

Configuring `endpoint_type: GLUE` today:
1. passes validation,
2. forbids you from setting `authorization_type` yourself (schema rule),
3. produces an ATTACH with no `ENDPOINT`, no `ENDPOINT_TYPE`, and no `AUTHORIZATION_TYPE`.

DuckDB then falls back to its own oauth2 default, which is wrong for both Glue and S3 Tables, and the schema actively prevents working around it.

`ENDPOINT_TYPE` emission existed before the part 1 catalogs stack landed (`dfe9a517c`), which kept the schema-side validation but dropped the builder branch and deleted every Glue fixture — which is why nothing caught the regression.

### Solution

Four parts, all in `build_duckdb_catalog_attach_stmt` unless noted.

**1. Emit `ENDPOINT_TYPE '<value>'` when set.** The direct fix.

**2. Add `V2CatalogType::Glue` to `attaches_via_iceberg_rest`.** Not on the issue's checklist, but a prerequisite: Glue is filtered out of the attach loop entirely, so a `type: glue` catalog emits *no* ATTACH at all and no fixture could observe the emission. Glue is an Iceberg REST service under the hood like Horizon and Unity, so metadata routing follows the same path. Model *writes* against a Glue catalog remain unsupported (#15268) and still produce the existing clear configuration error.

**3. Default the ATTACH source to `':'` on Glue routes.** DuckDB reads the source as a Glue catalog path and validates it against its own grammar — `':'`, a 12-digit account id, `'cat1/cat2'`, etc. ([`SanityCheckGlueWarehouse`](https://github.com/duckdb/duckdb-iceberg/blob/main/src/iceberg_attach.cpp)). The current default, the dbt catalog name, fails that check. `':'` is the caller's own default account catalog. Applies whether Glue is selected by catalog type or by `endpoint_type: GLUE`.

**4. Preset `AUTHORIZATION_TYPE 'SIGV4'` for Glue, suppressed when `endpoint_type` is set.** See the first correction below.

### Two corrections to the issue

I worked from duckdb-iceberg's `iceberg_attach.cpp` rather than the docs, and two checklist items don't hold as written. Flagging them explicitly since a reviewer comparing against the issue will expect otherwise.

**"Give `Glue` a `catalog_attach_defaults` entry with `AUTHORIZATION_TYPE 'SIGV4'`"** — correct, but it must never combine with `endpoint_type`. `S3OrGlueAttachInternal` assigns SIGV4 itself and DuckDB throws `'authorization_type' can not be combined with 'endpoint_type'`. Emitting both would trade a silent misconfiguration for a hard ATTACH failure. The default is what a Glue catalog pinning an explicit `endpoint` needs — the only route for regions off the plain `amazonaws.com` suffix. **`S3_TABLES` needs nothing extra**: `S3TablesAttach` parses the region out of the warehouse ARN and signs with the `s3tables` service name on its own.

This also answers the last checklist item — **the `authorization_type` × `endpoint_type` exclusivity rule mirrors DuckDB's own hard error, so it is still the contract we want.**

**The `https://https://` scheme claim does not reproduce.** `AddHttpHostIfMissing` is a no-op when a scheme is present, and the SigV4 path does `DetectScheme` + `StripScheme`. A full URL works fine. The real subtlety is that a *bare* host defaults to `http://` on the non-SigV4 path. So this PR documents the actual behavior in the `endpoint` doc string rather than normalizing a value DuckDB already handles.

### Tests

Restores the Glue attach fixtures and adds `endpoint_type: S3_TABLES` and `iceberg_rest` + `endpoint_type: GLUE` cases, so emission is snapshot-tested — the previous validation-only tests did not catch this.

```
glue_endpoint_type              ATTACH IF NOT EXISTS ':' AS aws_glue (TYPE ICEBERG, SECRET glue_s3, ENDPOINT_TYPE 'GLUE', READ_ONLY false)
glue_explicit_endpoint          ATTACH IF NOT EXISTS '123456789012' AS glue_db (TYPE ICEBERG, SECRET glue_s3, ENDPOINT 'glue.us-east-1.amazonaws.com/iceberg', READ_ONLY false, AUTHORIZATION_TYPE 'SIGV4')
iceberg_rest_endpoint_type_glue ATTACH IF NOT EXISTS ':' AS glue_rest_db (TYPE ICEBERG, SECRET glue_s3, ENDPOINT_TYPE 'GLUE', DEFAULT_SCHEMA 'analytics', READ_ONLY false)
s3_tables_endpoint_type         ATTACH IF NOT EXISTS 'arn:aws:s3tables:us-east-1:123456789012:bucket/demo-bucket' AS s3_tables_db (TYPE ICEBERG, SECRET s3_tables_secret, ENDPOINT_TYPE 'S3_TABLES', READ_ONLY false)
```

Each of the five behavioral changes was reverted individually and the fixtures fail on each one alone: missing `ENDPOINT_TYPE` (the reported bug), empty output, missing `SIGV4`, a rejected `ENDPOINT_TYPE`+`AUTHORIZATION_TYPE` pair, and `'aws_glue'`/`'glue_via_rest'` as source.

Full `dbt-adapter` (920 tests) and `dbt-schemas` (458 tests) suites pass; clippy and rustfmt clean. **No existing snapshot changed** — the behavior change is confined to Glue and `endpoint_type`.

Note for maintainers: the doc-string edits in `dbt_catalogs_v2.rs` will need the catalogs JSON-schema golden regenerated internally (`GOLDIE_UPDATE=1`), which I can't do from this repo.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
  - Left unchecked deliberately. No `catalogs.yml` keys are added or removed, but the emitted `ATTACH` SQL changes for Glue/`endpoint_type` catalogs, and the `endpoint`/`endpoint_type`/`warehouse` doc strings change, which flows into the catalogs JSON schema. Please confirm whether that needs Product/DX sign-off.
- [x] ~This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.~ N/A — Rust.
