### PR TITLE
fix(tests): parse should_warn/should_error text before falling back to truthiness

### DIFF
--- a/.changes/unreleased/Fixes-20260803-should-warn-truthiness.yaml
+++ b/.changes/unreleased/Fixes-20260803-should-warn-truthiness.yaml
@@ -1,0 +1,8 @@
+kind: Fixes
+body: Fix should_warn/should_error test result columns being read via generic Jinja
+    truthiness, which reads any non-empty string (including the text 'false') as true.
+time: 2026-08-03T00:10:00.000000-00:00
+custom:
+    author: axellpadilla
+    issue: "15767"
+    project: dbt-core

--- a/crates/dbt-tasks-sa/src/materialize.rs
+++ b/crates/dbt-tasks-sa/src/materialize.rs
@@ -1295,8 +1295,10 @@ fn get_test_results(table: &AgateTable) -> FsResult<Vec<TestResult>> {
         let should_error = columns.get(2).unwrap().get_item_by_index(0).ok();
 
         let failures_val = failures.and_then(|v| v.as_i64()).unwrap_or(-1);
-        let should_warn_val = should_warn.map(|v| v.is_true()).unwrap_or(false);
-        let should_error_val = should_error.map(|v| v.is_true()).unwrap_or(false);
+        let should_warn_val = should_warn.map(|v| value_to_test_bool(&v)).unwrap_or(false);
+        let should_error_val = should_error
+            .map(|v| value_to_test_bool(&v))
+            .unwrap_or(false);
 
         Ok(vec![TestResult {
             column_name: None,
@@ -1323,11 +1325,11 @@ fn get_column_test_result(
         .unwrap_or(0);
 
     let should_warn = get_cell_value(values, row, should_warn_idx)
-        .map(|v| v.is_true())
+        .map(|v| value_to_test_bool(&v))
         .unwrap_or(false);
 
     let should_error = get_cell_value(values, row, should_error_idx)
-        .map(|v| v.is_true())
+        .map(|v| value_to_test_bool(&v))
         .unwrap_or(false);
 
     TestResult {
@@ -1335,6 +1337,16 @@ fn get_column_test_result(
         failures,
         should_warn,
         should_error,
+    }
+}
+
+/// Interprets a `should_warn`/`should_error` cell as a boolean, parsing
+/// text `'true'`/`'false'` explicitly before falling back to `is_true()`.
+fn value_to_test_bool(v: &Value) -> bool {
+    match v.as_str() {
+        Some(s) if s.eq_ignore_ascii_case("false") => false,
+        Some(s) if s.eq_ignore_ascii_case("true") => true,
+        _ => v.is_true(),
     }
 }
 


### PR DESCRIPTION
Resolves #15767

### Problem

`get_test_results`/`get_column_test_result` read the `should_warn`/`should_error`
columns via minijinja's generic `Value::is_true()`, which treats any
non-empty string as `true`. An adapter whose test SQL returns these columns
as text rather than a native boolean (SQL Server has no boolean literal, so
`sqlserver__get_test_sql` emits `'true'`/`'false'`) gets the literal string
`'false'` read as `true` — every generic test reported `should_error`
regardless of the actual failure count.

### Solution

Adds `value_to_test_bool()` to parse recognized `'true'`/`'false'` text
explicitly (case-insensitive) before falling back to `is_true()` for
everything else (real booleans, `0`/`1` integers) — mirroring what v1's
`BaseTestResultData.convert_bool_type()` already does via `strtobool()`
for exactly this case.

Found while smoke-testing an in-progress SQL Server adapter port; the
affected code (`crates/dbt-tasks-sa/src/materialize.rs`) is general engine
code shared by every adapter, not part of that port.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
