### PR TITLE
feat(sqlserver): add dbt Fusion (v2) adapter support

### DIFF
--- a/.changes/unreleased/Features-20260803-sqlserver-adapter.yaml
+++ b/.changes/unreleased/Features-20260803-sqlserver-adapter.yaml
@@ -1,0 +1,8 @@
+kind: Features
+body: Add experimental support for the SQL Server adapter (dbt Fusion / v2). Enable
+    with DBT_ALLOW_EXPERIMENTAL_ADAPTERS=true.
+time: 2026-08-03T00:00:00.000000-00:00
+custom:
+    author: axellpadilla
+    issue: "15714"
+    project: dbt-core

--- a/.changes/unreleased/Fixes-20260802-231939-execute-inner-last-batch.yaml
+++ b/.changes/unreleased/Fixes-20260802-231939-execute-inner-last-batch.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Fix a multi-statement query batch returning the result of a trailing no-op cleanup statement (e.g. `DROP VIEW`) instead of the actual result, when the caller requested a fetched result.
+time: 2026-08-02T23:19:39.000000+00:00
+custom:
+    author: "axellpadilla"
+    issue: "15765"
+    project: dbt-core

--- a/crates/dbt-adapter-core/src/lib.rs
+++ b/crates/dbt-adapter-core/src/lib.rs
@@ -65,6 +65,8 @@ pub enum AdapterType {
     Salesforce,
     // Microsoft Fabric DWH
     Fabric,
+    /// Microsoft SQL Server
+    SqlServer,
     /// ClickHouse
     ClickHouse,
     /// Exasol
@@ -111,6 +113,11 @@ pub fn quote_char(adapter_type: AdapterType) -> char {
         Redshift => '"',
         Postgres | Salesforce => '"',
         Fabric => '"',
+        // T-SQL also accepts `[brackets]`, but double quotes match Fabric and
+        // dbt-sqlserver v1, which renders identifiers with dbt-core's default
+        // quote character. They are only identifier delimiters while
+        // QUOTED_IDENTIFIER is ON, so connection init SQL has to set it.
+        SqlServer => '"',
         DuckDB | Alt => '"',
         Athena | Trino | Starburst => '"',
         Datafusion => '"',
@@ -167,6 +174,7 @@ mod tests {
             ("sPark", AdapterType::Spark),
             ("dUckdb", AdapterType::DuckDB),
             ("fAbric", AdapterType::Fabric),
+            ("sQlserver", AdapterType::SqlServer),
             ("cLickhouse", AdapterType::ClickHouse),
             ("aThena", AdapterType::Athena),
             ("sTarburst", AdapterType::Starburst),
@@ -211,6 +219,7 @@ mod tests {
                 (AdapterType::Postgres, "postgresql"),
                 (AdapterType::Salesforce, "salesforce"),
                 (AdapterType::Fabric, "fabric"),
+                (AdapterType::SqlServer, "sqlserver"),
                 (AdapterType::ClickHouse, "clickhouse"),
                 (AdapterType::Exasol, "exasol"),
                 (AdapterType::Athena, "athena"),
@@ -240,6 +249,7 @@ mod tests {
             AdapterType::Postgres,
             AdapterType::Salesforce,
             AdapterType::Fabric,
+            AdapterType::SqlServer,
             AdapterType::DuckDB,
             AdapterType::Alt,
             AdapterType::Athena,

--- a/crates/dbt-adapter-sql/src/ident.rs
+++ b/crates/dbt-adapter-sql/src/ident.rs
@@ -120,6 +120,12 @@ pub fn max_identifier_length(adapter_type: AdapterType) -> Option<NonZero<usize>
             // SAFETY: literal 127 is never 0
             Some(unsafe { NonZero::new_unchecked(127) })
         }
+        SqlServer => {
+            // Regular identifiers are `sysname`, i.e. `nvarchar(128)`.
+            // https://learn.microsoft.com/en-us/sql/relational-databases/databases/database-identifiers
+            // SAFETY: literal 128 is never 0
+            Some(unsafe { NonZero::new_unchecked(128) })
+        }
         Snowflake | Bigquery | Databricks | Spark | DuckDB | Salesforce | Fabric | ClickHouse
         | Exasol | Athena | Starburst | Trino | Datafusion | Dremio | Oracle | Alt => None,
     }
@@ -144,7 +150,7 @@ pub const fn canonical_quote(backend: AdapterType) -> QuotingStyle {
             QuotingStyle::Double
         }
         // https://learn.microsoft.com/en-us/sql/t-sql/statements/set-quoted-identifier-transact-sql?view=sql-server-ver17
-        Fabric => QuotingStyle::Double,
+        Fabric | SqlServer => QuotingStyle::Double,
         // Fabric => QuotingStyle::Bracketed,
         _ => QuotingStyle::Double,
     }
@@ -170,6 +176,7 @@ pub fn is_valid_ident_char(c: char, backend: AdapterType) -> bool {
             | Salesforce
             | DuckDB
             | Fabric
+            | SqlServer
             | ClickHouse
             | Starburst
             | Trino

--- a/crates/dbt-adapter-sql/src/statements.rs
+++ b/crates/dbt-adapter-sql/src/statements.rs
@@ -21,6 +21,7 @@ pub fn is_update_statement(sql: &str, adapter_type: AdapterType) -> bool {
         | AdapterType::Spark
         | AdapterType::DuckDB
         | AdapterType::Fabric
+        | AdapterType::SqlServer
         | AdapterType::Exasol
         | AdapterType::Starburst
         | AdapterType::Athena

--- a/crates/dbt-adapter/src/adapter/adapter_factory.rs
+++ b/crates/dbt-adapter/src/adapter/adapter_factory.rs
@@ -41,6 +41,7 @@ pub fn backend_of(adapter_type: AdapterType) -> Backend {
         AdapterType::DuckDB => Backend::DuckDB,
         AdapterType::Alt => Backend::Alt,
         AdapterType::Fabric => Backend::SQLServer,
+        AdapterType::SqlServer => Backend::SQLServer,
         AdapterType::ClickHouse => Backend::ClickHouse,
         AdapterType::Exasol => Backend::Exasol,
         AdapterType::Starburst => todo!("Starburst"),

--- a/crates/dbt-adapter/src/adapter/adapter_impl.rs
+++ b/crates/dbt-adapter/src/adapter/adapter_impl.rs
@@ -962,7 +962,7 @@ impl AdapterImpl {
             Bigquery => &[Append],
             Databricks => &[Append, Merge, InsertOverwrite, ReplaceWhere],
             Redshift => &[Append, DeleteInsert, Merge, Microbatch],
-            Fabric => &[Append, DeleteInsert, Merge, Microbatch],
+            Fabric | SqlServer => &[Append, DeleteInsert, Merge, Microbatch],
             Salesforce => &[Append, Merge],
             ClickHouse => &[Append, DeleteInsert, InsertOverwrite, Microbatch, Legacy],
             Spark => &[Append, Merge, InsertOverwrite, Microbatch],
@@ -1457,14 +1457,14 @@ impl AdapterImpl {
             }
             Replay(
                 adapter_type @ (Postgres | Redshift | Salesforce | DuckDB | Alt | Spark | Fabric
-                | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion
-                | Dremio | Oracle),
+                | SqlServer | ClickHouse | Exasol | Starburst | Athena | Trino
+                | Datafusion | Dremio | Oracle),
                 _,
             )
             | Impl(
                 adapter_type @ (Postgres | Redshift | Salesforce | DuckDB | Alt | Spark | Fabric
-                | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion
-                | Dremio | Oracle),
+                | SqlServer | ClickHouse | Exasol | Starburst | Athena | Trino
+                | Datafusion | Dremio | Oracle),
                 _,
             ) => Err(AdapterError::new(
                 AdapterErrorKind::Internal,
@@ -1495,8 +1495,8 @@ impl AdapterImpl {
                 self.list_schemas_via_adbc(state, database)
             }
             Snowflake | Databricks | Redshift | Spark | DuckDB | Postgres | Salesforce | Fabric
-            | ClickHouse | Exasol | Athena | Starburst | Trino | Datafusion | Dremio | Oracle
-            | Alt | Bigquery => {
+            | SqlServer | ClickHouse | Exasol | Athena | Starburst | Trino | Datafusion
+            | Dremio | Oracle | Alt | Bigquery => {
                 use crate::macro_exec::execute_macro_wrapper;
                 use minijinja::value::{Kwargs, Value};
 
@@ -1599,7 +1599,7 @@ impl AdapterImpl {
                 Postgres => "nspname",
                 DuckDB => "schema_name",
                 Alt => "schema_name",
-                Fabric => "schema",
+                Fabric | SqlServer => "schema",
                 // https://github.com/ClickHouse/dbt-clickhouse/blob/main/dbt/include/clickhouse/macros/adapters.sql
                 ClickHouse => "name",
                 Exasol => "name",
@@ -1887,8 +1887,8 @@ impl AdapterImpl {
                 )])))
             }
             Postgres | Bigquery | Databricks | Redshift | Salesforce | Spark | DuckDB | Alt
-            | Fabric | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio
-            | Oracle => {
+            | Fabric | SqlServer | ClickHouse | Exasol | Starburst | Athena | Trino
+            | Datafusion | Dremio | Oracle => {
                 let err = format!(
                     "describe_dynamic_table is not supported by the {} adapter",
                     adapter_type
@@ -2305,14 +2305,13 @@ impl AdapterImpl {
             // NOTE: This is the default behavior. If said adapter type does not
             // have a get_columns_in_relation() macro, it will fail with a
             // "macro does not exist" error
-            Athena | ClickHouse | Datafusion | Dremio | DuckDB | Alt | Exasol | Fabric | Oracle
-            | Postgres | Redshift | Salesforce | Snowflake | Spark | Starburst | Trino => {
-                execute_macro(
-                    state,
-                    &[RelationObject::new(relation.to_owned()).into_value()],
-                    "get_columns_in_relation",
-                )
-            }
+            Athena | ClickHouse | Datafusion | Dremio | DuckDB | Alt | Exasol | Fabric
+            | SqlServer | Oracle | Postgres | Redshift | Salesforce | Snowflake | Spark
+            | Starburst | Trino => execute_macro(
+                state,
+                &[RelationObject::new(relation.to_owned()).into_value()],
+                "get_columns_in_relation",
+            ),
         };
 
         macro_result
@@ -2594,8 +2593,8 @@ impl AdapterImpl {
             }
             Impl(
                 Snowflake | Databricks | Redshift | Salesforce | Postgres | Spark | DuckDB | Alt
-                | Fabric | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio
-                | Oracle,
+                | Fabric | SqlServer | ClickHouse | Exasol | Starburst | Athena | Trino
+                | Datafusion | Dremio | Oracle,
                 _,
             ) => {
                 // downcast relation
@@ -2645,7 +2644,8 @@ impl AdapterImpl {
             }
             Impl(
                 Postgres | Bigquery | Databricks | Redshift | Spark | DuckDB | Alt | Fabric
-                | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio | Oracle,
+                | SqlServer | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion
+                | Dremio | Oracle,
                 _,
             ) => {
                 if quote_config.unwrap_or(true) {
@@ -2847,9 +2847,9 @@ impl AdapterImpl {
 
                 Ok(none_value())
             }
-            Postgres | Snowflake | Databricks | Redshift | Salesforce | Spark | Fabric | DuckDB
-            | Alt | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio
-            | Oracle => {
+            Postgres | Snowflake | Databricks | Redshift | Salesforce | Spark | Fabric
+            | SqlServer | DuckDB | Alt | ClickHouse | Exasol | Starburst | Athena | Trino
+            | Datafusion | Dremio | Oracle => {
                 unimplemented!("only available with BigQuery adapter")
             }
         }
@@ -2864,8 +2864,8 @@ impl AdapterImpl {
     ) -> AdapterResult<Vec<String>> {
         match self.adapter_type() {
             Postgres | Snowflake | Databricks | Redshift | Salesforce | Spark | DuckDB | Alt
-            | Fabric | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio
-            | Oracle => {
+            | Fabric | SqlServer | ClickHouse | Exasol | Starburst | Athena | Trino
+            | Datafusion | Dremio | Oracle => {
                 let mut result = vec![];
                 for (_, column) in columns_map {
                     let col_name = if column.quote.unwrap_or(false) {
@@ -3058,6 +3058,14 @@ impl AdapterImpl {
             (Fabric, ForeignKey) => Enforced,
             (Fabric, Custom) => NotSupported,
 
+            // SqlServer
+            (SqlServer, Check) => Enforced,
+            (SqlServer, NotNull) => Enforced,
+            (SqlServer, Unique) => Enforced,
+            (SqlServer, PrimaryKey) => Enforced,
+            (SqlServer, ForeignKey) => Enforced,
+            (SqlServer, Custom) => NotSupported,
+
             // Salesforce
             (
                 Salesforce | Spark | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion
@@ -3168,7 +3176,7 @@ impl AdapterImpl {
         }
 
         match self.adapter_type() {
-            Postgres | Bigquery | DuckDB | Alt => {
+            Postgres | Bigquery | DuckDB | Alt | SqlServer => {
                 let grantee_cols = record_batch.column_values::<StringArray>("grantee")?;
                 let privilege_cols = record_batch.column_values::<StringArray>("privilege_type")?;
 
@@ -3392,8 +3400,8 @@ impl AdapterImpl {
                 Ok(AgateTable::from_record_batch(Arc::new(catalog)))
             }
             Snowflake | Bigquery | Databricks | Spark | DuckDB | Alt | Postgres | Salesforce
-            | Fabric | ClickHouse | Exasol | Athena | Starburst | Trino | Datafusion | Dremio
-            | Oracle => Err(AdapterError::new(
+            | Fabric | SqlServer | ClickHouse | Exasol | Athena | Starburst | Trino
+            | Datafusion | Dremio | Oracle => Err(AdapterError::new(
                 AdapterErrorKind::NotSupported,
                 "build_catalog_from_show_tables_and_svv_columns is only supported for Redshift",
             )),
@@ -3408,8 +3416,8 @@ impl AdapterImpl {
         match self.adapter_type() {
             Bigquery => nest_column_data_types(columns, constraints),
             Postgres | Snowflake | Databricks | Redshift | Salesforce | Spark | DuckDB | Alt
-            | Fabric | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio
-            | Oracle => {
+            | Fabric | SqlServer | ClickHouse | Exasol | Starburst | Athena | Trino
+            | Datafusion | Dremio | Oracle => {
                 unimplemented!("only available with BigQuery adapter")
             }
         }
@@ -3447,8 +3455,8 @@ impl AdapterImpl {
         match self.adapter_type() {
             Bigquery => Ok(Value::from(render_struct_projection(col_name, data_type))),
             Postgres | Snowflake | Databricks | Redshift | Salesforce | Spark | DuckDB | Alt
-            | Fabric | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio
-            | Oracle => {
+            | Fabric | SqlServer | ClickHouse | Exasol | Starburst | Athena | Trino
+            | Datafusion | Dremio | Oracle => {
                 unimplemented!("only available with BigQuery adapter")
             }
         }
@@ -3545,8 +3553,8 @@ impl AdapterImpl {
                 Ok(none_value())
             }
             Postgres | Snowflake | Databricks | Redshift | Salesforce | Spark | DuckDB | Alt
-            | Fabric | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio
-            | Oracle => {
+            | Fabric | SqlServer | ClickHouse | Exasol | Starburst | Athena | Trino
+            | Datafusion | Dremio | Oracle => {
                 unimplemented!("only available with BigQuery adapter")
             }
         }
@@ -3599,8 +3607,8 @@ impl AdapterImpl {
                 Self::parse_dataset_location(&batch)
             }
             Postgres | Snowflake | Databricks | Redshift | Salesforce | Spark | DuckDB | Alt
-            | Fabric | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio
-            | Oracle => {
+            | Fabric | SqlServer | ClickHouse | Exasol | Starburst | Athena | Trino
+            | Datafusion | Dremio | Oracle => {
                 unimplemented!("only available with BigQuery adapter")
             }
         }
@@ -3657,8 +3665,8 @@ impl AdapterImpl {
                 Ok(none_value())
             }
             Postgres | Snowflake | Databricks | Redshift | Salesforce | Spark | DuckDB | Alt
-            | Fabric | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio
-            | Oracle => {
+            | Fabric | SqlServer | ClickHouse | Exasol | Starburst | Athena | Trino
+            | Datafusion | Dremio | Oracle => {
                 unimplemented!("only available with BigQuery adapter")
             }
         }
@@ -3734,7 +3742,8 @@ impl AdapterImpl {
             }
             Salesforce => todo!("load_dataframe() for the Salesforce adapter"),
             Postgres | Snowflake | Databricks | Redshift | Spark | DuckDB | Alt | Fabric
-            | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio | Oracle => {
+            | SqlServer | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion
+            | Dremio | Oracle => {
                 unimplemented!("only available with BigQuery or Salesforce adapter")
             }
         }
@@ -3795,8 +3804,8 @@ impl AdapterImpl {
                 Ok(none_value())
             }
             Postgres | Snowflake | Databricks | Redshift | Salesforce | Spark | DuckDB | Alt
-            | Fabric | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio
-            | Oracle => {
+            | Fabric | SqlServer | ClickHouse | Exasol | Starburst | Athena | Trino
+            | Datafusion | Dremio | Oracle => {
                 unimplemented!("only available with BigQuery adapter")
             }
         }
@@ -3944,8 +3953,8 @@ impl AdapterImpl {
             }
             Impl(
                 adapter_type @ (Snowflake | Bigquery | Databricks | Salesforce | Spark | Fabric
-                | Exasol | Starburst | Athena | Trino | Datafusion | Dremio
-                | Oracle),
+                | SqlServer | Exasol | Starburst | Athena | Trino | Datafusion
+                | Dremio | Oracle),
                 _,
             ) => {
                 unimplemented!(
@@ -4017,8 +4026,8 @@ impl AdapterImpl {
                 }
             }
             adapter_type @ (Postgres | Snowflake | Databricks | Redshift | Salesforce | Spark
-            | DuckDB | Alt | Fabric | ClickHouse | Exasol | Starburst | Athena
-            | Trino | Datafusion | Dremio | Oracle) => {
+            | DuckDB | Alt | Fabric | SqlServer | ClickHouse | Exasol
+            | Starburst | Athena | Trino | Datafusion | Dremio | Oracle) => {
                 unimplemented!(
                     "is_replaceable is only available with BigQuery adapter, not {}",
                     adapter_type
@@ -4082,8 +4091,8 @@ impl AdapterImpl {
                 Ok(Value::from_object(validated_config))
             }
             Postgres | Snowflake | Databricks | Redshift | Salesforce | Spark | DuckDB | Alt
-            | Fabric | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio
-            | Oracle => {
+            | Fabric | SqlServer | ClickHouse | Exasol | Starburst | Athena | Trino
+            | Datafusion | Dremio | Oracle => {
                 unimplemented!("only available with BigQuery adapter")
             }
         }
@@ -4106,8 +4115,8 @@ impl AdapterImpl {
                 adapter_type,
             ),
             Postgres | Snowflake | Databricks | Redshift | Salesforce | Spark | DuckDB | Alt
-            | Fabric | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio
-            | Oracle => {
+            | Fabric | SqlServer | ClickHouse | Exasol | Starburst | Athena | Trino
+            | Datafusion | Dremio | Oracle => {
                 unimplemented!("only available with BigQuery adapter")
             }
         }
@@ -4130,8 +4139,8 @@ impl AdapterImpl {
                 ),
             ),
             Postgres | Snowflake | Databricks | Redshift | Salesforce | Spark | DuckDB | Alt
-            | Fabric | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio
-            | Oracle => {
+            | Fabric | SqlServer | ClickHouse | Exasol | Starburst | Athena | Trino
+            | Datafusion | Dremio | Oracle => {
                 unimplemented!("only available with BigQuery adapter")
             }
         }
@@ -4157,8 +4166,8 @@ impl AdapterImpl {
                 Ok(Value::from_serialize(options))
             }
             Postgres | Snowflake | Databricks | Redshift | Salesforce | Spark | DuckDB | Alt
-            | Fabric | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio
-            | Oracle => Err(minijinja::Error::new(
+            | Fabric | SqlServer | ClickHouse | Exasol | Starburst | Athena | Trino
+            | Datafusion | Dremio | Oracle => Err(minijinja::Error::new(
                 minijinja::ErrorKind::InvalidOperation,
                 "get_common_options is only available with BigQuery adapter",
             )),
@@ -4199,8 +4208,8 @@ impl AdapterImpl {
                 Ok(Value::from(result))
             }
             Postgres | Snowflake | Databricks | Redshift | Salesforce | Spark | DuckDB | Alt
-            | Fabric | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio
-            | Oracle => {
+            | Fabric | SqlServer | ClickHouse | Exasol | Starburst | Athena | Trino
+            | Datafusion | Dremio | Oracle => {
                 unimplemented!("only available with BigQuery adapter")
             }
         }
@@ -4388,8 +4397,8 @@ impl AdapterImpl {
                 Ok(Value::from(result))
             }
             Postgres | Snowflake | Bigquery | Redshift | Salesforce | Spark | DuckDB | Alt
-            | Fabric | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio
-            | Oracle => {
+            | Fabric | SqlServer | ClickHouse | Exasol | Starburst | Athena | Trino
+            | Datafusion | Dremio | Oracle => {
                 unimplemented!("only available with Databricksadapter")
             }
         }
@@ -4545,8 +4554,8 @@ impl AdapterImpl {
             }
 
             Postgres | Snowflake | Bigquery | Redshift | Salesforce | Spark | DuckDB | Alt
-            | Fabric | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio
-            | Oracle => {
+            | Fabric | SqlServer | ClickHouse | Exasol | Starburst | Athena | Trino
+            | Datafusion | Dremio | Oracle => {
                 unimplemented!("only available with Databricks adapter")
             }
         }
@@ -4623,8 +4632,8 @@ impl AdapterImpl {
                 Ok(())
             }
             Postgres | Snowflake | Bigquery | Redshift | Salesforce | Spark | DuckDB | Alt
-            | Fabric | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio
-            | Oracle => {
+            | Fabric | SqlServer | ClickHouse | Exasol | Starburst | Athena | Trino
+            | Datafusion | Dremio | Oracle => {
                 unimplemented!("only available with Databricks adapter")
             }
         }
@@ -4716,8 +4725,8 @@ impl AdapterImpl {
                 Ok(!use_managed_iceberg)
             }
             Postgres | Snowflake | Bigquery | Redshift | Salesforce | Spark | DuckDB | Alt
-            | Fabric | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio
-            | Oracle => {
+            | Fabric | SqlServer | ClickHouse | Exasol | Starburst | Athena | Trino
+            | Datafusion | Dremio | Oracle => {
                 unimplemented!("only available with Databricks adapter")
             }
         }
@@ -5059,8 +5068,8 @@ impl AdapterImpl {
                 Ok(())
             }
             Postgres | Snowflake | Databricks | Redshift | Salesforce | Spark | DuckDB | Alt
-            | Fabric | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio
-            | Oracle => {
+            | Fabric | SqlServer | ClickHouse | Exasol | Starburst | Athena | Trino
+            | Datafusion | Dremio | Oracle => {
                 unimplemented!("only available with BigQuery adapter")
             }
         }
@@ -5439,8 +5448,8 @@ pub(crate) fn adapter_specific_behavior_flags(adapter_type: AdapterType) -> Vec<
             );
             vec![skip_autocommit_transaction_statements, grants_extended]
         }
-        Postgres | Salesforce | Spark | DuckDB | Alt | ClickHouse | Exasol | Starburst | Athena
-        | Trino | Datafusion | Dremio | Oracle => vec![],
+        Postgres | Salesforce | Spark | DuckDB | Alt | SqlServer | ClickHouse | Exasol
+        | Starburst | Athena | Trino | Datafusion | Dremio | Oracle => vec![],
     }
 }
 

--- a/crates/dbt-adapter/src/adapter/adapter_impl.rs
+++ b/crates/dbt-adapter/src/adapter/adapter_impl.rs
@@ -28,6 +28,7 @@ use crate::metadata::postgres::PostgresMetadataAdapter;
 use crate::metadata::redshift::RedshiftMetadataAdapter;
 use crate::metadata::salesforce::SalesforceMetadataAdapter;
 use crate::metadata::snowflake::SnowflakeMetadataAdapter;
+use crate::metadata::sqlserver::SqlServerMetadataAdapter;
 use crate::metadata::{self, CatalogAndSchema, MetadataAdapter};
 use crate::query_ctx::{node_id_from_state, query_ctx_from_state};
 use crate::record_batch::{RecordBatchExt, RenamedColumn};
@@ -731,6 +732,8 @@ impl AdapterImpl {
                         Fabric => {
                             Box::new(FabricMetadataAdapter::new(engine)) as Box<dyn MetadataAdapter>
                         }
+                        SqlServer => Box::new(SqlServerMetadataAdapter::new(engine))
+                            as Box<dyn MetadataAdapter>,
                         ClickHouse => Box::new(ClickHouseMetadataAdapter::new(engine))
                             as Box<dyn MetadataAdapter>,
                         Exasol => return None,
@@ -4269,6 +4272,9 @@ impl AdapterImpl {
             }
             Impl(Fabric, engine) => {
                 fabric::list_relations(engine.as_ref(), query_ctx, conn, db_schema, token)
+            }
+            Impl(SqlServer, engine) => {
+                sqlserver::list_relations(engine.as_ref(), query_ctx, conn, db_schema, token)
             }
             Impl(
                 adapter_type @ (Postgres | Salesforce | ClickHouse | Exasol | Starburst | Athena

--- a/crates/dbt-adapter/src/adapter/adapter_impl.rs
+++ b/crates/dbt-adapter/src/adapter/adapter_impl.rs
@@ -116,6 +116,37 @@ fn try_to_int_col(col: &arrow_array::Float64Array) -> bool {
     })
 }
 
+/// Tracks results from a loop over a multi-statement query batch: the
+/// literal last statement's batch (for `AdapterResponse`'s rows_affected /
+/// query_id, which should always reflect what actually ran last), and
+/// separately the last batch that has columns (for the returned
+/// `AgateTable`, when a result is being fetched) — so a trailing no-op
+/// cleanup statement (e.g. `DROP VIEW`) can't clobber a real result that
+/// came earlier in the batch.
+#[derive(Default)]
+struct LastBatchTracker {
+    last: Option<RecordBatch>,
+    last_with_columns: Option<RecordBatch>,
+}
+
+impl LastBatchTracker {
+    fn record(&mut self, batch: RecordBatch, fetch: bool) {
+        if fetch && batch.num_columns() > 0 {
+            self.last_with_columns = Some(batch.clone());
+        }
+        self.last = Some(batch);
+    }
+
+    fn last(&self) -> Option<&RecordBatch> {
+        self.last.as_ref()
+    }
+
+    /// The batch that should feed the returned `AgateTable`.
+    fn into_fetched(self) -> Option<RecordBatch> {
+        self.last_with_columns.or(self.last)
+    }
+}
+
 fn warn_duplicate_columns(node_id: Option<String>) -> impl FnOnce(&[RenamedColumn<'_>]) {
     use std::fmt::Write;
 
@@ -1058,9 +1089,9 @@ impl AdapterImpl {
             _ => {}
         }
 
-        let mut last_batch = None;
+        let mut tracker = LastBatchTracker::default();
         for sql in statements {
-            last_batch = Some(execute_query_with_retry(
+            let batch = execute_query_with_retry(
                 engine.clone(),
                 state,
                 conn,
@@ -1070,19 +1101,28 @@ impl AdapterImpl {
                 &options,
                 fetch,
                 token.clone(),
-            )?);
+            )?;
+            tracker.record(batch, fetch);
         }
 
-        let last_batch = last_batch.expect("last_batch should never be None");
-
-        let rows_affected = last_batch.rows_affected(self.adapter_type());
+        let rows_affected = tracker
+            .last()
+            .expect("tracker should have recorded at least one batch")
+            .rows_affected(self.adapter_type());
         let mut response = AdapterResponse::new()
             .with_message(format!("SUCCESS {}", rows_affected))
             .with_code("SUCCESS")
             .with_rows_affected(rows_affected);
-        if let Some(query_id) = last_batch.query_id(self.adapter_type()) {
+        if let Some(query_id) = tracker
+            .last()
+            .and_then(|batch| batch.query_id(self.adapter_type()))
+        {
             response = response.with_query_id(query_id);
         }
+
+        let last_batch = tracker
+            .into_fetched()
+            .expect("tracker should have recorded at least one batch");
 
         // Deduplicate column names to match dbt-core's behavior, which renames
         // duplicate columns to `col_2`, `col_3`, etc.
@@ -6388,6 +6428,57 @@ mod tests {
         let schema = Arc::new(Schema::new(vec![Field::new(name, DataType::Utf8, false)]));
         let array = Arc::new(StringArray::from(values)) as ArrayRef;
         Arc::new(RecordBatch::try_new(schema, vec![array]).unwrap())
+    }
+
+    fn empty_batch() -> RecordBatch {
+        RecordBatch::new_empty(Arc::new(Schema::empty()))
+    }
+
+    #[test]
+    fn last_batch_tracker_prefers_last_batch_with_columns_when_fetching() {
+        // Mirrors a CREATE VIEW-based test macro: create view (no result) ->
+        // select count(*) ... (the real result) -> drop view (no result).
+        let real_result = (*record_batch_with_string_column("failures", vec!["0"])).clone();
+
+        let mut tracker = LastBatchTracker::default();
+        tracker.record(empty_batch(), true);
+        tracker.record(real_result.clone(), true);
+        tracker.record(empty_batch(), true);
+
+        assert_eq!(
+            tracker.last().unwrap().num_columns(),
+            0,
+            "the literal last statement's response must still be used for \
+             AdapterResponse (rows_affected/query_id)"
+        );
+        assert_eq!(
+            tracker.into_fetched().unwrap(),
+            real_result,
+            "the returned table must come from the last statement that \
+             actually had columns, not the trailing no-op cleanup statement"
+        );
+    }
+
+    #[test]
+    fn last_batch_tracker_falls_back_to_last_batch_when_nothing_has_columns() {
+        let mut tracker = LastBatchTracker::default();
+        tracker.record(empty_batch(), true);
+        tracker.record(empty_batch(), true);
+
+        assert_eq!(tracker.into_fetched().unwrap().num_columns(), 0);
+    }
+
+    #[test]
+    fn last_batch_tracker_ignores_columns_when_not_fetching() {
+        // fetch=false: even a batch with columns must not be preferred, to
+        // match execute_inner's pre-existing behavior for non-fetch calls.
+        let with_columns = (*record_batch_with_string_column("id", vec!["1"])).clone();
+
+        let mut tracker = LastBatchTracker::default();
+        tracker.record(with_columns, false);
+        tracker.record(empty_batch(), false);
+
+        assert_eq!(tracker.into_fetched().unwrap().num_columns(), 0);
     }
 
     #[test]

--- a/crates/dbt-adapter/src/column/column_builder.rs
+++ b/crates/dbt-adapter/src/column/column_builder.rs
@@ -29,6 +29,7 @@ impl ColumnBuilder {
             Redshift => Ok(Self::build_redshift(field, type_ops)),
             Postgres | Salesforce | DuckDB | Alt => Ok(Self::build_postgres_like(field, type_ops)),
             Fabric => Ok(Self::build_fabric(field, type_ops)),
+            SqlServer => Ok(Self::build_sqlserver(field, type_ops)),
             ClickHouse => Self::build_clickhouse(field, type_ops),
             Exasol => Ok(Self::build_postgres_like(field, type_ops)),
             Starburst => todo!("Starburst"),
@@ -126,6 +127,14 @@ impl ColumnBuilder {
             Datafusion => todo!("Datafusion"),
             Fabric => Column::new(
                 Fabric,
+                name,
+                dtype,
+                char_size,
+                numeric_precision,
+                numeric_scale,
+            ),
+            SqlServer => Column::new(
+                SqlServer,
                 name,
                 dtype,
                 char_size,
@@ -258,6 +267,39 @@ impl ColumnBuilder {
 
         Column::new(
             Fabric,
+            field.name().to_string(),
+            type_name_or_formatted,
+            char_size.map(|p| p as u32),
+            numeric_precision.map(|p| p as u64),
+            numeric_scale.map(|s| s as u64),
+        )
+    }
+
+    fn build_sqlserver(field: &FieldRef, type_ops: &dyn TypeOps) -> Column {
+        use AdapterType::SqlServer;
+        let data_type = field.data_type();
+        let char_size = sql_types::var_size(SqlServer, data_type);
+        let (numeric_precision, numeric_scale) = {
+            let precision_scale = sql_types::numeric_precision_scale(SqlServer, data_type)
+                .ok()
+                .flatten();
+            match precision_scale {
+                Some((p, Some(s))) => (Some(p), Some(s)),
+                Some((p, None)) => (Some(p), None),
+                None => (None, None),
+            }
+        };
+
+        let mut type_name_or_formatted = String::new();
+        if type_ops
+            .format_arrow_type_as_sql(data_type, &mut type_name_or_formatted)
+            .is_err()
+        {
+            type_name_or_formatted = data_type.to_string();
+        }
+
+        Column::new(
+            SqlServer,
             field.name().to_string(),
             type_name_or_formatted,
             char_size.map(|p| p as u32),

--- a/crates/dbt-adapter/src/formatter.rs
+++ b/crates/dbt-adapter/src/formatter.rs
@@ -20,7 +20,7 @@ impl SqlLiteralFormatter {
 
     pub fn format_bool(&self, b: bool) -> String {
         match self.adapter_type {
-            AdapterType::Fabric => {
+            AdapterType::Fabric | AdapterType::SqlServer => {
                 if b {
                     "1".to_string()
                 } else {
@@ -102,7 +102,7 @@ pub fn format_sql_with_bindings(
     let formatter = SqlLiteralFormatter::new(adapter_type);
     let mut result = String::with_capacity(sql.len());
     // this placeholder char is seen from `get_binding_char` macro
-    let binding_char = if adapter_type == AdapterType::Fabric {
+    let binding_char = if matches!(adapter_type, AdapterType::Fabric | AdapterType::SqlServer) {
         "?"
     } else {
         "%s"

--- a/crates/dbt-adapter/src/metadata/get_relation.rs
+++ b/crates/dbt-adapter/src/metadata/get_relation.rs
@@ -1018,6 +1018,13 @@ fn sqlserver_get_relation(
 ) -> AdapterResult<Option<Box<dyn BaseRelation>>> {
     use crate::metadata::sqlserver::{build_get_relation_sql, relation_type_from_table_type};
 
+    if database.is_empty() {
+        return Err(AdapterError::new(
+            AdapterErrorKind::UnexpectedResult,
+            "SQL Server relations require a database to build a three-part name",
+        ));
+    }
+
     let relation = Relation::new_sqlserver(
         Some(database.to_string()),
         Some(schema.to_string()),

--- a/crates/dbt-adapter/src/metadata/get_relation.rs
+++ b/crates/dbt-adapter/src/metadata/get_relation.rs
@@ -76,6 +76,9 @@ pub fn get_relation(
         AdapterType::Fabric => fabric_get_relation(
             adapter, state, ctx, conn, database, schema, identifier, token,
         ),
+        AdapterType::SqlServer => sqlserver_get_relation(
+            adapter, state, ctx, conn, database, schema, identifier, token,
+        ),
         AdapterType::ClickHouse => clickhouse_get_relation(
             adapter, state, ctx, conn, database, schema, identifier, token,
         ),
@@ -1000,6 +1003,53 @@ fn fabric_get_relation(
         relation_type,
         adapter.quoting(),
     ))))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn sqlserver_get_relation(
+    adapter: &AdapterImpl,
+    state: &State,
+    ctx: &QueryCtx,
+    conn: &'_ mut dyn Connection,
+    database: &str,
+    schema: &str,
+    identifier: &str,
+    token: CancellationToken,
+) -> AdapterResult<Option<Box<dyn BaseRelation>>> {
+    use crate::metadata::sqlserver::{build_get_relation_sql, relation_type_from_table_type};
+
+    let relation = Relation::new_sqlserver(
+        Some(database.to_string()),
+        Some(schema.to_string()),
+        Some(identifier.to_string()),
+        None,
+        adapter.quoting(),
+    );
+
+    let sql = build_get_relation_sql(&relation.quoted(database), schema, identifier);
+
+    let batch = adapter
+        .engine()
+        .execute(Some(state), conn, ctx, &sql, token)?;
+
+    if batch.num_rows() == 0 {
+        return Ok(None);
+    }
+
+    let table_types = batch.column_values::<StringArray>("table_type")?;
+    if table_types.len() != 1 {
+        return Err(AdapterError::new(
+            AdapterErrorKind::UnexpectedResult,
+            format!(
+                "Expected exactly one row for SQL Server get_relation, got {}",
+                table_types.len()
+            ),
+        ));
+    }
+
+    let relation_type = relation_type_from_table_type(table_types.value(0));
+
+    Ok(Some(Box::new(relation.with_relation_type(relation_type))))
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/dbt-adapter/src/metadata/mod.rs
+++ b/crates/dbt-adapter/src/metadata/mod.rs
@@ -27,6 +27,7 @@ pub(crate) mod redshift;
 pub(crate) mod salesforce;
 pub mod snowflake; // XXX: temporarily pub before the refactor is complete
 pub(crate) mod spark;
+pub(crate) mod sqlserver;
 pub(crate) mod view_definition;
 
 // Re-export `metadata_adapter` symbols

--- a/crates/dbt-adapter/src/metadata/sqlserver/mod.rs
+++ b/crates/dbt-adapter/src/metadata/sqlserver/mod.rs
@@ -1,0 +1,574 @@
+use crate::adapter::adapter_impl::*;
+use crate::connection::AdapterConnectionFactory;
+use crate::formatter::SqlLiteralFormatter;
+use crate::metadata::{
+    CatalogAndSchema, MetadataAdapter, MetadataFreshness, RelationSchemaPair, RelationVec,
+    create_schemas_if_not_exists,
+};
+use crate::record_batch::RecordBatchExt;
+use crate::relation::Relation;
+use crate::sql_types::{TypeOps, make_arrow_field};
+use crate::{AdapterEngine, AdapterType};
+use arrow_array::{Array, Int32Array, RecordBatch, StringArray};
+use arrow_schema::Schema;
+use dbt_adapter_core::ExecutionPhase;
+use dbt_adbc::{Connection, MapReduce, QueryCtx};
+use dbt_common::cancellation::CancellationToken;
+use dbt_common::{AdapterError, AdapterErrorKind, Cancellable};
+use dbt_common::{AdapterResult, AsyncAdapterResult};
+use dbt_schemas::dbt_types::RelationType;
+use dbt_schemas::schemas::legacy_catalog::{CatalogNodeStats, TableMetadata};
+use dbt_schemas::schemas::{
+    legacy_catalog::{CatalogTable, ColumnMetadata},
+    relations::base::{BaseRelation, RelationPattern},
+};
+use minijinja::State;
+use std::collections::HashMap;
+use std::collections::btree_map::Entry;
+use std::{collections::BTreeMap, sync::Arc};
+
+/// `sp_tables` and `sp_columns` are not usable here, for two reasons measured against
+/// SQL Server 2022:
+///
+/// - They read the connection's current database only. Any other `@table_qualifier`
+///   is error 15250, "The database name component of the object qualifier must be the
+///   name of the current database".
+/// - `@table_name` is a `LIKE` pattern unless `@fUsePattern = 0` is passed, so
+///   `stg_orders` also matches `stgXorders`.
+///
+/// The catalog views take a three-part name, which resolves cross-database without
+/// changing the connection's current database the way `USE` does.
+///
+/// TODO: v1 makes `with (nolock)` overridable by dispatching
+/// `sqlserver__information_schema_hints`; this has no equivalent.
+pub(crate) fn build_list_relations_sql(quoted_database: &str, schema: &str) -> String {
+    let lit_fmt = SqlLiteralFormatter::new(AdapterType::SqlServer);
+    format!(
+        "select \
+            s.name as table_schema, \
+            o.name as table_name, \
+            case o.type when 'V' then 'VIEW' else 'TABLE' end as table_type \
+         from {quoted_database}.sys.objects o with (nolock) \
+         join {quoted_database}.sys.schemas s with (nolock) on o.schema_id = s.schema_id \
+         where o.type in ('U', 'V') and s.name = {} \
+         order by o.name",
+        lit_fmt.format_str(schema),
+    )
+}
+
+/// Relation type of a single object, or no rows when it does not exist.
+pub(crate) fn build_get_relation_sql(
+    quoted_database: &str,
+    schema: &str,
+    identifier: &str,
+) -> String {
+    let lit_fmt = SqlLiteralFormatter::new(AdapterType::SqlServer);
+    format!(
+        "select case o.type when 'V' then 'VIEW' else 'TABLE' end as table_type \
+         from {quoted_database}.sys.objects o with (nolock) \
+         join {quoted_database}.sys.schemas s with (nolock) on o.schema_id = s.schema_id \
+         where s.name = {} and o.name = {} and o.type in ('U', 'V')",
+        lit_fmt.format_str(schema),
+        lit_fmt.format_str(identifier),
+    )
+}
+
+/// Columns of a single relation, in ordinal order.
+///
+/// `max_length`, `precision` and `scale` come back as `smallint` and `tinyint`; the
+/// casts make them a single Arrow type to read.
+pub(crate) fn build_columns_sql(quoted_database: &str, schema: &str, identifier: &str) -> String {
+    let lit_fmt = SqlLiteralFormatter::new(AdapterType::SqlServer);
+    format!(
+        "select \
+            c.name collate database_default as column_name, \
+            t.name collate database_default as data_type, \
+            cast(c.max_length as int) as max_length, \
+            cast(c.precision as int) as numeric_precision, \
+            cast(c.scale as int) as numeric_scale, \
+            case when c.is_nullable = 1 then 'YES' else 'NO' end as is_nullable \
+         from {quoted_database}.sys.columns c with (nolock) \
+         join {quoted_database}.sys.objects o with (nolock) on c.object_id = o.object_id \
+         join {quoted_database}.sys.schemas s with (nolock) on o.schema_id = s.schema_id \
+         join {quoted_database}.sys.types t with (nolock) on c.user_type_id = t.user_type_id \
+         where s.name = {} and o.name = {} \
+         order by c.column_id",
+        lit_fmt.format_str(schema),
+        lit_fmt.format_str(identifier),
+    )
+}
+
+/// Map the `table_type` column produced by [build_list_relations_sql] and
+/// [build_get_relation_sql].
+pub(crate) fn relation_type_from_table_type(table_type: &str) -> Option<RelationType> {
+    match table_type {
+        "TABLE" => Some(RelationType::Table),
+        "VIEW" => Some(RelationType::View),
+        _ => None,
+    }
+}
+
+/// Rebuild the declared type text from the catalog columns.
+///
+/// `sys.types.name` is the bare type name, so `decimal(18,4)` arrives as `decimal`
+/// with the precision and scale in separate columns.
+pub(crate) fn compose_type_text(
+    data_type: &str,
+    max_length: i32,
+    precision: i32,
+    scale: i32,
+) -> String {
+    match data_type {
+        // `max_length` is in bytes, and -1 is the `(max)` spelling.
+        "char" | "varchar" | "binary" | "varbinary" => {
+            if max_length < 0 {
+                format!("{data_type}(max)")
+            } else {
+                format!("{data_type}({max_length})")
+            }
+        }
+        "nchar" | "nvarchar" => {
+            if max_length < 0 {
+                format!("{data_type}(max)")
+            } else {
+                format!("{data_type}({})", max_length / 2)
+            }
+        }
+        "decimal" | "numeric" => format!("{data_type}({precision},{scale})"),
+        // `datetime` also reports a scale, but does not accept one.
+        "datetime2" | "datetimeoffset" | "time" => format!("{data_type}({scale})"),
+        _ => data_type.to_string(),
+    }
+}
+
+fn quoted_database(relation: &dyn BaseRelation) -> AdapterResult<String> {
+    let database = relation.database_as_str()?;
+    if database.is_empty() {
+        return Err(AdapterError::new(
+            AdapterErrorKind::UnexpectedResult,
+            "SQL Server relations require a database to build a three-part name",
+        ));
+    }
+    Ok(relation.quoted(&database))
+}
+
+pub fn list_relations(
+    engine: &dyn AdapterEngine,
+    ctx: &QueryCtx,
+    conn: &'_ mut dyn Connection,
+    db_schema: &CatalogAndSchema,
+    token: CancellationToken,
+) -> AdapterResult<Vec<Arc<dyn BaseRelation>>> {
+    if db_schema.rendered_catalog.is_empty() {
+        return Err(AdapterError::new(
+            AdapterErrorKind::UnexpectedResult,
+            "SQL Server relations require a database to build a three-part name",
+        ));
+    }
+
+    let sql = build_list_relations_sql(&db_schema.rendered_catalog, &db_schema.resolved_schema);
+    let batch = engine.execute(None, conn, ctx, &sql, token)?;
+
+    if batch.num_rows() == 0 {
+        return Ok(Vec::new());
+    }
+
+    let schema_name = batch.column_values::<StringArray>("table_schema")?;
+    let table_name = batch.column_values::<StringArray>("table_name")?;
+    let table_type = batch.column_values::<StringArray>("table_type")?;
+
+    let mut relations = Vec::with_capacity(batch.num_rows());
+    for i in 0..batch.num_rows() {
+        let relation = Arc::new(Relation::new_sqlserver(
+            Some(db_schema.resolved_catalog.clone()),
+            Some(schema_name.value(i).to_string()),
+            Some(table_name.value(i).to_string()),
+            relation_type_from_table_type(table_type.value(i)),
+            engine.quoting(),
+        )) as Arc<dyn BaseRelation>;
+
+        relations.push(relation);
+    }
+
+    Ok(relations)
+}
+
+pub struct SqlServerMetadataAdapter {
+    pub adapter: AdapterImpl,
+}
+
+impl SqlServerMetadataAdapter {
+    pub fn new(engine: Arc<dyn AdapterEngine>) -> Self {
+        let adapter = AdapterImpl::new(engine, None);
+        Self { adapter }
+    }
+}
+
+impl MetadataAdapter for SqlServerMetadataAdapter {
+    fn adapter_type(&self) -> AdapterType {
+        self.adapter.adapter_type()
+    }
+
+    fn build_schemas_from_stats_sql(
+        &self,
+        stats_sql_result: Arc<RecordBatch>,
+    ) -> AdapterResult<BTreeMap<String, CatalogTable>> {
+        if stats_sql_result.num_rows() == 0 {
+            return Ok(BTreeMap::new());
+        }
+
+        let table_catalogs = stats_sql_result.column_values::<StringArray>("table_database")?;
+        let table_schemas = stats_sql_result.column_values::<StringArray>("table_schema")?;
+        let table_names = stats_sql_result.column_values::<StringArray>("table_name")?;
+        let data_types = stats_sql_result.column_values::<StringArray>("table_type")?;
+        let comments = stats_sql_result.column_values::<StringArray>("table_comment")?;
+        let table_owners = stats_sql_result.column_values::<StringArray>("table_owner")?;
+
+        let mut result = BTreeMap::<String, CatalogTable>::new();
+
+        for i in 0..table_catalogs.len() {
+            let catalog = table_catalogs.value(i);
+            let schema = table_schemas.value(i);
+            let table = table_names.value(i);
+            let data_type = data_types.value(i);
+            let comment = comments.value(i);
+            let owner = table_owners.value(i);
+
+            let fully_qualified_name = format!("{catalog}.{schema}.{table}").to_lowercase();
+
+            let entry = result.entry(fully_qualified_name.clone());
+
+            if matches!(entry, Entry::Vacant(_)) {
+                let node_metadata = TableMetadata {
+                    materialization_type: data_type.to_string(),
+                    schema: schema.to_string(),
+                    name: table.to_string(),
+                    database: Some(catalog.to_string()),
+                    comment: match comment {
+                        "" => None,
+                        _ => Some(comment.to_string()),
+                    },
+                    owner: Some(owner.to_string()),
+                };
+
+                let no_stats = CatalogNodeStats {
+                    id: "has_stats".to_string(),
+                    label: "Has Stats?".to_string(),
+                    value: serde_json::Value::Bool(false),
+                    description: Some(
+                        "Indicates whether there are statistics for this table".to_string(),
+                    ),
+                    include: false,
+                };
+
+                let node = CatalogTable {
+                    metadata: node_metadata,
+                    columns: Default::default(),
+                    stats: BTreeMap::from([("has_stats".to_string(), no_stats)]),
+                    unique_id: None,
+                };
+                result.insert(fully_qualified_name.clone(), node);
+            }
+        }
+        Ok(result)
+    }
+
+    fn build_columns_from_get_columns(
+        &self,
+        stats_sql_result: Arc<RecordBatch>,
+    ) -> AdapterResult<BTreeMap<String, BTreeMap<String, ColumnMetadata>>> {
+        if stats_sql_result.num_rows() == 0 {
+            return Ok(BTreeMap::new());
+        }
+
+        let table_catalogs = stats_sql_result.column_values::<StringArray>("table_database")?;
+        let table_schemas = stats_sql_result.column_values::<StringArray>("table_schema")?;
+        let table_names = stats_sql_result.column_values::<StringArray>("table_name")?;
+
+        let column_names = stats_sql_result.column_values::<StringArray>("column_name")?;
+        let column_indices = stats_sql_result.column_values::<Int32Array>("column_index")?;
+        let column_types = stats_sql_result.column_values::<StringArray>("column_type")?;
+        let column_comments = stats_sql_result.column_values::<StringArray>("column_comment")?;
+
+        let mut columns_by_relation = BTreeMap::new();
+
+        for i in 0..table_catalogs.len() {
+            let catalog = table_catalogs.value(i);
+            let schema = table_schemas.value(i);
+            let table = table_names.value(i);
+
+            let fully_qualified_name = format!("{catalog}.{schema}.{table}").to_lowercase();
+
+            let column_name = column_names.value(i);
+            let column_comment = column_comments.value(i);
+
+            let column = ColumnMetadata {
+                name: column_name.to_string(),
+                index: column_indices.value(i).into(),
+                data_type: column_types.value(i).to_string(),
+                comment: match column_comment {
+                    "" => None,
+                    _ => Some(column_comment.to_string()),
+                },
+            };
+
+            columns_by_relation
+                .entry(fully_qualified_name.clone())
+                .or_insert(BTreeMap::new())
+                .insert(column_name.to_string(), column);
+        }
+        Ok(columns_by_relation)
+    }
+
+    fn create_schemas_if_not_exists(
+        &self,
+        state: &State<'_, '_>,
+        catalog_schemas: Vec<(String, String, String)>,
+    ) -> AdapterResult<Vec<(String, String, String, AdapterResult<()>)>> {
+        create_schemas_if_not_exists(&self.adapter, self, state, catalog_schemas)
+    }
+
+    fn list_relations_schemas_inner(
+        &self,
+        unique_id: Option<String>,
+        phase: Option<ExecutionPhase>,
+        relations: &[Arc<dyn BaseRelation>],
+        token: CancellationToken,
+    ) -> AsyncAdapterResult<'_, HashMap<String, AdapterResult<Arc<Schema>>>> {
+        type Acc = HashMap<String, AdapterResult<Arc<Schema>>>;
+
+        let factory = Box::new(AdapterConnectionFactory::new(
+            self.adapter.engine().clone(),
+            self.adapter.engine().threads(),
+        ));
+
+        let adapter = self.adapter.clone();
+        let token_clone = token.clone();
+        let map_f = move |conn: &'_ mut dyn Connection,
+                          relation: &Arc<dyn BaseRelation>|
+              -> AdapterResult<Arc<Schema>> {
+            let sql = build_columns_sql(
+                &quoted_database(relation.as_ref())?,
+                &relation.schema_as_str()?,
+                &relation.identifier_as_str()?,
+            );
+
+            let ctx = QueryCtx::new_metadata().with_desc("Get table schema");
+
+            let ctx = unique_id
+                .iter()
+                .fold(ctx, |ctx, id| ctx.with_node_id(id.clone()));
+
+            let ctx = phase
+                .iter()
+                .fold(ctx, |ctx, phase| ctx.with_phase(phase.as_str()));
+
+            let (_, table) = adapter.query(&ctx, conn, &sql, None, token_clone.clone())?;
+            let batch = table.original_record_batch();
+            let schema = build_schema_from_columns(batch, adapter.engine().type_ops().as_ref())?;
+
+            Ok(schema)
+        };
+
+        let reduce_f = |acc: &mut Acc,
+                        relation: Arc<dyn BaseRelation>,
+                        schema: AdapterResult<Arc<Schema>>|
+         -> Result<(), Cancellable<AdapterError>> {
+            acc.insert(relation.semantic_fqn(), schema);
+            Ok(())
+        };
+        let map_reduce = MapReduce::new(factory, Box::new(map_f), Box::new(reduce_f), None);
+        map_reduce.run(Arc::new(relations.to_vec()), token)
+    }
+
+    fn list_relations_schemas_by_patterns_inner(
+        &self,
+        patterns: &[RelationPattern],
+        _token: CancellationToken,
+    ) -> AsyncAdapterResult<'_, Vec<(String, AdapterResult<RelationSchemaPair>)>> {
+        let _ = patterns;
+
+        todo!()
+    }
+
+    fn freshness_inner(
+        &self,
+        relations: &[Arc<dyn BaseRelation>],
+        _token: CancellationToken,
+    ) -> AsyncAdapterResult<'_, BTreeMap<String, MetadataFreshness>> {
+        let _ = relations;
+
+        todo!()
+    }
+
+    fn list_relations_in_parallel_inner(
+        &self,
+        db_schemas: &[CatalogAndSchema],
+        token: CancellationToken,
+    ) -> AsyncAdapterResult<'_, BTreeMap<CatalogAndSchema, AdapterResult<RelationVec>>> {
+        type Acc = BTreeMap<CatalogAndSchema, AdapterResult<RelationVec>>;
+        let factory = Box::new(AdapterConnectionFactory::new(
+            self.adapter.engine().clone(),
+            self.adapter.engine().threads(),
+        ));
+
+        let adapter = self.adapter.clone();
+        let token_clone = token.clone();
+        let map_f = move |conn: &'_ mut dyn Connection,
+                          db_schema: &CatalogAndSchema|
+              -> AdapterResult<Vec<Arc<dyn BaseRelation>>> {
+            let query_ctx = QueryCtx::default().with_desc("list_relations_in_parallel");
+            adapter.list_relations(&query_ctx, conn, db_schema, token_clone.clone())
+        };
+
+        let reduce_f = move |acc: &mut Acc,
+                             db_schema: CatalogAndSchema,
+                             relations: AdapterResult<Vec<Arc<dyn BaseRelation>>>|
+              -> Result<(), Cancellable<AdapterError>> {
+            match relations {
+                Ok(relations) => {
+                    acc.insert(db_schema, Ok(relations));
+                    Ok(())
+                }
+                Err(e) => Err(Cancellable::Error(e)),
+            }
+        };
+
+        let map_reduce = MapReduce::new(factory, Box::new(map_f), Box::new(reduce_f), None);
+        map_reduce.run(Arc::new(db_schemas.to_vec()), token)
+    }
+}
+
+fn build_schema_from_columns(
+    columns_result: Arc<RecordBatch>,
+    type_ops: &dyn TypeOps,
+) -> AdapterResult<Arc<Schema>> {
+    let column_names = columns_result.column_values::<StringArray>("column_name")?;
+    let data_types = columns_result.column_values::<StringArray>("data_type")?;
+    let max_lengths = columns_result.column_values::<Int32Array>("max_length")?;
+    let precisions = columns_result.column_values::<Int32Array>("numeric_precision")?;
+    let scales = columns_result.column_values::<Int32Array>("numeric_scale")?;
+    let nullability = columns_result.column_values::<StringArray>("is_nullable")?;
+
+    let mut fields = vec![];
+    for i in 0..columns_result.num_rows() {
+        let text_data_type = compose_type_text(
+            data_types.value(i),
+            max_lengths.value(i),
+            precisions.value(i),
+            scales.value(i),
+        );
+        let nullable = nullability.value(i) == "YES";
+
+        let field = make_arrow_field(
+            type_ops,
+            column_names.value(i).to_string(),
+            &text_data_type,
+            Some(nullable),
+            None,
+        )?;
+        fields.push(field);
+    }
+
+    Ok(Arc::new(Schema::new(fields)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_list_relations_sql_is_three_part_and_quotes_the_schema() {
+        let sql = build_list_relations_sql("\"my_db\"", "my_schema");
+
+        assert!(sql.contains("from \"my_db\".sys.objects o"));
+        assert!(sql.contains("join \"my_db\".sys.schemas s"));
+        assert!(sql.contains("s.name = 'my_schema'"));
+        assert!(sql.contains("o.type in ('U', 'V')"));
+    }
+
+    #[test]
+    fn test_get_relation_sql_matches_the_identifier_exactly() {
+        let sql = build_get_relation_sql("\"my_db\"", "my_schema", "stg_orders");
+
+        // `=`, not `like`: sp_tables' pattern matching also returns `stgXorders`.
+        assert!(sql.contains("o.name = 'stg_orders'"));
+        assert!(!sql.to_lowercase().contains("like"));
+    }
+
+    #[test]
+    fn test_single_quotes_in_a_name_are_escaped() {
+        let sql = build_get_relation_sql("\"my_db\"", "o'brien", "x");
+
+        assert!(sql.contains("s.name = 'o''brien'"));
+    }
+
+    #[test]
+    fn test_columns_sql_casts_the_narrow_integer_columns() {
+        let sql = build_columns_sql("\"my_db\"", "my_schema", "my_table");
+
+        assert!(sql.contains("cast(c.max_length as int) as max_length"));
+        assert!(sql.contains("cast(c.precision as int) as numeric_precision"));
+        assert!(sql.contains("cast(c.scale as int) as numeric_scale"));
+        assert!(sql.contains("order by c.column_id"));
+    }
+
+    #[test]
+    fn test_relation_type_from_table_type() {
+        assert_eq!(
+            relation_type_from_table_type("TABLE"),
+            Some(RelationType::Table)
+        );
+        assert_eq!(
+            relation_type_from_table_type("VIEW"),
+            Some(RelationType::View)
+        );
+        assert_eq!(relation_type_from_table_type("SYNONYM"), None);
+    }
+
+    #[test]
+    fn test_compose_type_text_lengths() {
+        assert_eq!(compose_type_text("varchar", 50, 0, 0), "varchar(50)");
+        assert_eq!(compose_type_text("varchar", -1, 0, 0), "varchar(max)");
+        assert_eq!(compose_type_text("binary", 8, 0, 0), "binary(8)");
+        assert_eq!(compose_type_text("varbinary", -1, 0, 0), "varbinary(max)");
+    }
+
+    #[test]
+    fn test_compose_type_text_halves_the_national_lengths() {
+        // sys.columns.max_length is bytes, and nvarchar stores two per character.
+        assert_eq!(compose_type_text("nvarchar", 100, 0, 0), "nvarchar(50)");
+        assert_eq!(compose_type_text("nchar", 20, 0, 0), "nchar(10)");
+        assert_eq!(compose_type_text("nvarchar", -1, 0, 0), "nvarchar(max)");
+    }
+
+    #[test]
+    fn test_compose_type_text_precision_and_scale() {
+        assert_eq!(compose_type_text("decimal", 9, 18, 4), "decimal(18,4)");
+        assert_eq!(compose_type_text("numeric", 5, 9, 3), "numeric(9,3)");
+    }
+
+    #[test]
+    fn test_compose_type_text_scale_only_types() {
+        assert_eq!(compose_type_text("datetime2", 8, 27, 7), "datetime2(7)");
+        assert_eq!(compose_type_text("time", 4, 12, 3), "time(3)");
+        assert_eq!(
+            compose_type_text("datetimeoffset", 8, 29, 2),
+            "datetimeoffset(2)"
+        );
+    }
+
+    #[test]
+    fn test_compose_type_text_leaves_unparameterized_types_alone() {
+        // `datetime` reports scale 3 but rejects `datetime(3)`.
+        assert_eq!(compose_type_text("datetime", 8, 23, 3), "datetime");
+        assert_eq!(compose_type_text("int", 4, 10, 0), "int");
+        assert_eq!(compose_type_text("float", 8, 53, 0), "float");
+        assert_eq!(compose_type_text("real", 4, 24, 0), "real");
+        assert_eq!(compose_type_text("money", 8, 19, 4), "money");
+        assert_eq!(
+            compose_type_text("uniqueidentifier", 16, 0, 0),
+            "uniqueidentifier"
+        );
+    }
+}

--- a/crates/dbt-adapter/src/relation/factory.rs
+++ b/crates/dbt-adapter/src/relation/factory.rs
@@ -16,8 +16,8 @@ pub fn create_static_relation(
 ) -> Option<Value> {
     use AdapterType::*;
     let result = match adapter_type {
-        Snowflake | Databricks | Spark | Fabric | DuckDB | Alt | Exasol | Postgres | Redshift
-        | Salesforce | Bigquery | ClickHouse => {
+        Snowflake | Databricks | Spark | Fabric | SqlServer | DuckDB | Alt | Exasol | Postgres
+        | Redshift | Salesforce | Bigquery | ClickHouse => {
             let relation_type = RelationStatic {
                 adapter_type,
                 quoting,

--- a/crates/dbt-adapter/src/relation/relation_impl.rs
+++ b/crates/dbt-adapter/src/relation/relation_impl.rs
@@ -216,7 +216,7 @@ impl BaseRelationProperties for Relation {
     fn get_database(&self) -> FsResult<String> {
         use AdapterType::*;
         match self.adapter_type {
-            Databricks | Fabric | Postgres | Redshift | Salesforce | Bigquery => {
+            Databricks | Fabric | SqlServer | Postgres | Redshift | Salesforce | Bigquery => {
                 self.path.database.clone().ok_or_else(|| {
                     fs_err!(
                         ErrorCode::InvalidConfig,
@@ -267,7 +267,7 @@ impl BaseRelationProperties for Relation {
             db_str
         } else {
             match self.adapter_type {
-                Fabric | Bigquery => db_str,
+                Fabric | SqlServer | Bigquery => db_str,
                 Salesforce | Snowflake => db_str.to_ascii_uppercase(),
                 _ => db_str.to_ascii_lowercase(),
             }
@@ -277,7 +277,7 @@ impl BaseRelationProperties for Relation {
             schema_str
         } else {
             match self.adapter_type {
-                Fabric | Bigquery => schema_str,
+                Fabric | SqlServer | Bigquery => schema_str,
                 Salesforce | Snowflake => schema_str.to_ascii_uppercase(),
                 _ => schema_str.to_ascii_lowercase(),
             }
@@ -287,7 +287,7 @@ impl BaseRelationProperties for Relation {
             ident_str
         } else {
             match self.adapter_type {
-                Fabric | Bigquery => ident_str,
+                Fabric | SqlServer | Bigquery => ident_str,
                 Salesforce | Snowflake => ident_str.to_ascii_uppercase(),
                 _ => ident_str.to_ascii_lowercase(),
             }
@@ -486,6 +486,18 @@ impl Relation {
         custom_quoting: ResolvedQuoting,
     ) -> Self {
         Self::new(AdapterType::Fabric, database, schema, identifier)
+            .with_relation_type(relation_type)
+            .with_quoting(custom_quoting)
+    }
+
+    pub fn new_sqlserver(
+        database: Option<String>,
+        schema: Option<String>,
+        identifier: Option<String>,
+        relation_type: Option<RelationType>,
+        custom_quoting: ResolvedQuoting,
+    ) -> Self {
+        Self::new(AdapterType::SqlServer, database, schema, identifier)
             .with_relation_type(relation_type)
             .with_quoting(custom_quoting)
     }
@@ -987,7 +999,19 @@ impl BaseRelation for Relation {
     }
 
     fn normalize_component(&self, component: &str) -> String {
+        // SqlServer falls into the `_ => to_lowercase()` arm here, which
+        // folds names that a case-sensitive collation keeps distinct.
         crate::format_ident::default_identifier_case(component, self.adapter_type)
+    }
+
+    fn quoted(&self, s: &str) -> String {
+        let q = self.quote_character();
+        match self.adapter_type {
+            // A delimited SQL Server identifier escapes an embedded delimiter by
+            // doubling it: https://learn.microsoft.com/sql/relational-databases/databases/database-identifiers
+            AdapterType::SqlServer => format!("{q}{}{q}", s.replace(q, &format!("{q}{q}"))),
+            _ => format!("{q}{s}{q}"),
+        }
     }
 
     fn render_self_as_str(&self) -> String {
@@ -2020,6 +2044,90 @@ mod tests {
                 from_supplied.inner().render_self_as_str(),
                 "`my_schema`.`my_table`"
             );
+        }
+    }
+
+    mod sqlserver {
+        use super::*;
+
+        fn relation(database: Option<String>) -> Relation {
+            Relation::new(
+                AdapterType::SqlServer,
+                database,
+                "my_schema".to_string(),
+                "my_table".to_string(),
+            )
+            .with_quoting(DEFAULT_RESOLVED_QUOTING)
+        }
+
+        #[test]
+        fn test_renders_all_three_parts_quoted() {
+            let relation = relation(Some("my_db".to_string()));
+            assert_eq!(
+                relation.render_self_as_str(),
+                "\"my_db\".\"my_schema\".\"my_table\""
+            );
+        }
+
+        #[test]
+        fn test_missing_database_is_an_error() {
+            assert!(relation(None).get_database().is_err());
+        }
+
+        #[test]
+        fn test_embedded_delimiter_is_doubled() {
+            let relation = Relation::new(
+                AdapterType::SqlServer,
+                "my_db".to_string(),
+                "dom\\usr".to_string(),
+                "x\"q".to_string(),
+            )
+            .with_quoting(DEFAULT_RESOLVED_QUOTING);
+
+            assert_eq!(
+                relation.render_self_as_str(),
+                "\"my_db\".\"dom\\usr\".\"x\"\"q\""
+            );
+        }
+
+        /// An unquoted path part keeps the case it was given, as SQL Server stores it.
+        #[test]
+        fn test_canonical_fqn_preserves_case() {
+            let relation = Relation::new(
+                AdapterType::SqlServer,
+                "MyDB".to_string(),
+                "MySchema".to_string(),
+                "MyTable".to_string(),
+            )
+            .with_quoting(Policy::falses());
+
+            let fqn = relation.get_canonical_fqn().unwrap();
+            assert_eq!(fqn.to_string(), "MyDB.MySchema.MyTable");
+        }
+
+        #[test]
+        fn test_try_new_via_static_base_relation() {
+            let relation_type = RelationStatic {
+                adapter_type: AdapterType::SqlServer,
+                quoting: DEFAULT_RESOLVED_QUOTING,
+            };
+            let relation = relation_type
+                .try_new(
+                    Some("my_db".to_string()),
+                    Some("my_schema".to_string()),
+                    Some("my_table".to_string()),
+                    Some(RelationType::Table),
+                    Some(DEFAULT_RESOLVED_QUOTING),
+                    None,
+                )
+                .unwrap();
+
+            let relation = relation.downcast_object::<RelationObject>().unwrap();
+            assert_eq!(
+                relation.inner().render_self_as_str(),
+                "\"my_db\".\"my_schema\".\"my_table\""
+            );
+            assert_eq!(relation.relation_type().unwrap(), RelationType::Table);
         }
     }
 }

--- a/crates/dbt-adapter/src/sql_types.rs
+++ b/crates/dbt-adapter/src/sql_types.rs
@@ -181,6 +181,7 @@ impl TypeOps for DefaultTypeOps {
         match adapter_type {
             Postgres | Salesforce => postgres::try_format_type(data_type, true, out),
             Fabric => fabric::try_format_type(data_type, true, out),
+            SqlServer => sqlserver::try_format_type(data_type, true, out),
             ClickHouse => clickhouse::try_format_type(data_type, true, out),
             _ => {
                 // sdf-specific distinct types are encoded as FixedSizeList(field, 1).
@@ -339,7 +340,7 @@ impl DefaultTypeOps {
             (SqlType::Real | SqlType::HalfFloat, _) => match adapter_type {
                 Bigquery => "float64",
                 Databricks => "float",
-                Fabric => "real",
+                Fabric | SqlServer => "real",
                 _ => "float8",
             },
 
@@ -350,7 +351,7 @@ impl DefaultTypeOps {
                 // Divergence: upstream has an implicit narrowing bug we fix
                 // see https://github.com/microsoft/dbt-fabric/blob/0de219082282724a789b0d1b18509d39899da8e1/dbt/adapters/fabric/fabric_adapter.py#L117
                 // https://learn.microsoft.com/en-us/sql/t-sql/data-types/float-and-real-transact-sql?view=fabric&preserve-view=true
-                Fabric => "float",
+                Fabric | SqlServer => "float",
                 _ => "float8",
             },
 
@@ -369,6 +370,8 @@ impl DefaultTypeOps {
                 (Fabric, _) => "float",
                 (Databricks, 1..) => "double",
                 (Databricks, ..=0) => "bigint",
+                (SqlServer, 1..) => "float",
+                (SqlServer, ..=0) => "int",
                 (_, 1..) => "float8",
                 (_, ..=0) => "integer",
             },
@@ -380,7 +383,7 @@ impl DefaultTypeOps {
             // ## convert_boolean_type()
             (SqlType::Boolean, _) => match adapter_type {
                 Bigquery => "bool",
-                Fabric => "bit",
+                Fabric | SqlServer => "bit",
                 _ => "boolean",
             },
 
@@ -388,7 +391,7 @@ impl DefaultTypeOps {
             (SqlType::Timestamp { .. }, _) => match adapter_type {
                 Bigquery => "datetime",
                 Databricks => "timestamp",
-                Fabric => "datetime2(6)",
+                Fabric | SqlServer => "datetime2(6)",
                 _ => "timestamp without time zone",
             },
 
@@ -398,7 +401,7 @@ impl DefaultTypeOps {
             // ## convert_time_type()
             // Upstream maps Duration and Interval Arrow types to time.
             (SqlType::Interval(_) | SqlType::Time { .. }, _) => match adapter_type {
-                Fabric => "time(6)",
+                Fabric | SqlServer => "time(6)",
                 _ => "time",
             },
 
@@ -411,7 +414,7 @@ impl DefaultTypeOps {
                     // but that information isn't available here
                     // - N = 64 if column is empty
                     // - N = max(16, max_length) if column is not empty
-                    Fabric => "varchar",
+                    Fabric | SqlServer => "varchar",
                     _ => "text",
                 }
             }
@@ -544,6 +547,7 @@ pub const fn get_field_sql_type_metadata_key(adapter_type: AdapterType) -> &'sta
         AdapterType::DuckDB => todo!(),
         AdapterType::Alt => todo!(),
         AdapterType::Fabric => FABRIC_METADATA_SQL_TYPE_KEY,
+        AdapterType::SqlServer => todo!(),
         AdapterType::ClickHouse => CLICKHOUSE_METADATA_SQL_TYPE_KEY,
         AdapterType::Exasol => "DATA_TYPE",
         AdapterType::Starburst => todo!(),
@@ -598,8 +602,8 @@ impl SdfSchemaBuilder {
                 metadata.get(ARROW_FIELD_COMMENT_METADATA_KEY)
             }
             // no evidence that these drivers store comments in metadata, but just in case
-            Postgres | Snowflake | Salesforce | Fabric | ClickHouse | Exasol | Starburst
-            | Athena | Trino | Dremio | Oracle | Datafusion => {
+            Postgres | Snowflake | Salesforce | Fabric | SqlServer | ClickHouse | Exasol
+            | Starburst | Athena | Trino | Dremio | Oracle | Datafusion => {
                 metadata.get(ARROW_FIELD_COMMENT_METADATA_KEY)
             }
         };
@@ -635,8 +639,8 @@ impl SdfSchemaBuilder {
     pub fn build_sdf_schema(self, type_ops: &dyn TypeOps) -> AdapterResult<SdfSchema> {
         use AdapterType::*;
         match self.adapter_type {
-            Bigquery | Redshift | Databricks | Spark | DuckDB | Alt | Fabric | ClickHouse
-            | Exasol | Starburst | Athena | Trino | Dremio | Oracle | Datafusion => {
+            Bigquery | Redshift | Databricks | Spark | DuckDB | Alt | Fabric | SqlServer
+            | ClickHouse | Exasol | Starburst | Athena | Trino | Dremio | Oracle | Datafusion => {
                 let original_fields = self.original.fields();
                 let mut sdf_fields = Vec::with_capacity(original_fields.len());
                 for field in original_fields {
@@ -950,6 +954,78 @@ pub mod fabric {
     }
 }
 
+pub mod sqlserver {
+
+    use arrow_schema::DataType;
+    use std::fmt::Write;
+
+    use crate::AdapterResult;
+    use crate::errors::{AdapterError, AdapterErrorKind};
+
+    const SQLSERVER_MAX_VARCHAR_TYPE: &str = "VARCHAR(MAX)";
+
+    pub fn try_format_type(
+        datatype: &DataType,
+        nullable: bool,
+        out: &mut String,
+    ) -> AdapterResult<()> {
+        match datatype {
+            DataType::Null => out.push_str("INT"),
+            DataType::Boolean => out.push_str("BIT"),
+            DataType::Int8 => out.push_str("SMALLINT"),
+            DataType::Int16 => out.push_str("SMALLINT"),
+            DataType::Int32 => out.push_str("INT"),
+            DataType::Int64 => out.push_str("BIGINT"),
+
+            DataType::UInt8 => out.push_str("SMALLINT"),
+            DataType::UInt16 => out.push_str("INT"),
+            DataType::UInt32 => out.push_str("BIGINT"),
+            DataType::UInt64 => out.push_str("DECIMAL(20,0)"),
+            DataType::Float32 => out.push_str("REAL"),
+            DataType::Float64 => out.push_str("FLOAT"),
+
+            DataType::Timestamp(_, _) => out.push_str("DATETIME2(6)"),
+
+            DataType::Date32 => out.push_str("DATE"),
+
+            DataType::Time32(_) | DataType::Time64(_) => out.push_str("TIME(6)"),
+
+            DataType::Interval(_) => {
+                return Err(AdapterError::new(
+                    AdapterErrorKind::UnsupportedType,
+                    "INTERVAL is not supported in SQL Server",
+                ));
+            }
+            DataType::Binary => out.push_str("VARBINARY(MAX)"),
+            DataType::Utf8 | DataType::Utf8View => out.push_str(SQLSERVER_MAX_VARCHAR_TYPE),
+
+            DataType::List(_) => {
+                return Err(AdapterError::new(
+                    AdapterErrorKind::UnsupportedType,
+                    "ARRAY is not supported in SQL Server",
+                ));
+            }
+
+            DataType::Dictionary(_, value) if value.as_ref() == &DataType::Utf8 => {
+                out.push_str(SQLSERVER_MAX_VARCHAR_TYPE)
+            }
+            DataType::Decimal128(precision, scale) => {
+                write!(out, "DECIMAL({precision}, {scale})").unwrap()
+            }
+            _ => {
+                return Err(AdapterError::new(
+                    AdapterErrorKind::UnsupportedType,
+                    format!("{datatype} is not convertible to sqlserver sql type"),
+                ));
+            }
+        };
+        if !nullable {
+            out.push_str(" NOT NULL");
+        }
+        Ok(())
+    }
+}
+
 pub const fn max_varchar_size(adapter_type: AdapterType) -> Option<usize> {
     use AdapterType::*;
     match adapter_type {
@@ -957,7 +1033,8 @@ pub const fn max_varchar_size(adapter_type: AdapterType) -> Option<usize> {
         Snowflake => Some(16_777_216),
         Redshift => Some(256),
         Postgres | Bigquery | Databricks | Salesforce | Spark | DuckDB | Alt | Fabric
-        | ClickHouse | Exasol | Starburst | Athena | Trino | Dremio | Oracle | Datafusion => None,
+        | SqlServer | ClickHouse | Exasol | Starburst | Athena | Trino | Dremio | Oracle
+        | Datafusion => None,
     }
 }
 
@@ -968,7 +1045,8 @@ pub const fn max_varbinary_size(adapter_type: AdapterType) -> Option<usize> {
         Redshift => Some(65_535),
         // TODO: define limits for more systems
         Postgres | Bigquery | Databricks | Salesforce | Spark | DuckDB | Alt | Fabric
-        | ClickHouse | Exasol | Starburst | Athena | Trino | Dremio | Oracle | Datafusion => None,
+        | SqlServer | ClickHouse | Exasol | Starburst | Athena | Trino | Dremio | Oracle
+        | Datafusion => None,
     }
 }
 
@@ -1303,6 +1381,8 @@ mod tests {
         assert_eq!(convert_floating_type(Postgres), "float8");
         assert_eq!(convert_floating_type(Snowflake), "float8");
         assert_eq!(convert_floating_type(Redshift), "float8");
+        assert_eq!(convert_floating_type(SqlServer), "float");
+        assert_eq!(convert_type(&DataType::Float32, SqlServer), "real");
         let convert_decimal_type =
             |adapter_type| convert_type(&DataType::Decimal32(10, 0), adapter_type);
         assert_eq!(convert_decimal_type(Bigquery), "int64");
@@ -1310,6 +1390,7 @@ mod tests {
         assert_eq!(convert_decimal_type(Postgres), "integer");
         assert_eq!(convert_decimal_type(Snowflake), "integer");
         assert_eq!(convert_decimal_type(Redshift), "integer");
+        assert_eq!(convert_decimal_type(SqlServer), "int");
         let convert_decimal_type =
             |adapter_type| convert_type(&DataType::Decimal128(10, 2), adapter_type);
         assert_eq!(convert_decimal_type(Bigquery), "float64");
@@ -1317,6 +1398,7 @@ mod tests {
         assert_eq!(convert_decimal_type(Postgres), "float8");
         assert_eq!(convert_decimal_type(Snowflake), "float8");
         assert_eq!(convert_decimal_type(Redshift), "float8");
+        assert_eq!(convert_decimal_type(SqlServer), "float");
     }
 
     #[test]
@@ -1327,6 +1409,7 @@ mod tests {
         assert_eq!(convert_boolean_type(Postgres), "boolean");
         assert_eq!(convert_boolean_type(Snowflake), "boolean");
         assert_eq!(convert_boolean_type(Redshift), "boolean");
+        assert_eq!(convert_boolean_type(SqlServer), "bit");
     }
 
     #[test]
@@ -1351,6 +1434,7 @@ mod tests {
             convert_datetime_type(Redshift),
             "timestamp without time zone"
         );
+        assert_eq!(convert_datetime_type(SqlServer), "datetime2(6)");
     }
     const ALL_ADAPTERS: [AdapterType; 5] = [Bigquery, Databricks, Postgres, Snowflake, Redshift];
 
@@ -1361,6 +1445,7 @@ mod tests {
         for adapter_type in ALL_ADAPTERS {
             assert_eq!(convert_date_type(adapter_type), "date");
         }
+        assert_eq!(convert_date_type(SqlServer), "date");
     }
 
     #[test]
@@ -1371,6 +1456,7 @@ mod tests {
         for adapter_type in ALL_ADAPTERS {
             assert_eq!(convert_time_type(adapter_type), "time");
         }
+        assert_eq!(convert_time_type(SqlServer), "time(6)");
     }
 
     #[test]
@@ -1381,5 +1467,52 @@ mod tests {
         assert_eq!(convert_text_type(Postgres), "text");
         assert_eq!(convert_text_type(Snowflake), "text");
         assert_eq!(convert_text_type(Redshift), "text");
+        assert_eq!(convert_text_type(SqlServer), "varchar");
+    }
+
+    #[test]
+    fn sqlserver_try_format_type_formats_native_types() {
+        let mut out = String::new();
+        sqlserver::try_format_type(&DataType::Boolean, false, &mut out).unwrap();
+        assert_eq!(out, "BIT NOT NULL");
+
+        out.clear();
+        sqlserver::try_format_type(&DataType::Int32, true, &mut out).unwrap();
+        assert_eq!(out, "INT");
+
+        out.clear();
+        sqlserver::try_format_type(&DataType::Utf8, true, &mut out).unwrap();
+        assert_eq!(out, "VARCHAR(MAX)");
+
+        out.clear();
+        sqlserver::try_format_type(&DataType::Decimal128(18, 4), true, &mut out).unwrap();
+        assert_eq!(out, "DECIMAL(18, 4)");
+
+        out.clear();
+        sqlserver::try_format_type(
+            &DataType::Timestamp(TimeUnit::Microsecond, None),
+            true,
+            &mut out,
+        )
+        .unwrap();
+        assert_eq!(out, "DATETIME2(6)");
+    }
+
+    #[test]
+    fn sqlserver_try_format_type_rejects_unsupported_arrow_types() {
+        let mut out = String::new();
+        let err = sqlserver::try_format_type(
+            &DataType::Interval(arrow_schema::IntervalUnit::MonthDayNano),
+            true,
+            &mut out,
+        )
+        .expect_err("INTERVAL is not supported in SQL Server");
+        assert_eq!(err.kind(), AdapterErrorKind::UnsupportedType);
+
+        out.clear();
+        let item = Arc::new(Field::new("item", DataType::Int32, true));
+        let err = sqlserver::try_format_type(&DataType::List(item), true, &mut out)
+            .expect_err("ARRAY is not supported in SQL Server");
+        assert_eq!(err.kind(), AdapterErrorKind::UnsupportedType);
     }
 }

--- a/crates/dbt-auth/src/sqlserver/mod.rs
+++ b/crates/dbt-auth/src/sqlserver/mod.rs
@@ -11,16 +11,29 @@ use dbt_adbc::{
 
 const DEFAULT_AUTH: &str = "ActiveDirectoryServicePrincipal";
 const DEFAULT_PORT: &str = "1433";
+const DEFAULT_ENCRYPT: bool = true;
+const DEFAULT_TRUST_CERT: bool = false;
 
-/// Parsed Microsoft Entra authentication settings for SQL Server / Fabric.
+/// Parsed authentication settings for SQL Server / Fabric.
 ///
 /// Each variant maps profile fields onto [`go-mssqldb`](https://github.com/microsoft/go-mssqldb)
 /// connection URI query parameters consumed by the MSSQL ADBC driver. See upstream
 /// [dbt-fabric `fabric_credentials.py`](https://github.com/microsoft/dbt-fabric/blob/main/dbt/adapters/fabric/fabric_credentials.py)
 /// for supported `authentication` profile values.
 #[derive(Debug)]
-#[allow(clippy::enum_variant_names)]
 enum SQLServerAuthIR<'a> {
+    /// Native SQL Server login — a login defined on the server itself, no Entra token.
+    ///
+    /// Profile: `authentication: sql`, `UID`, `PWD`.
+    ///
+    /// URI: `user id={UID}`, `password={PWD}`, no `fedauth`.
+    SqlLogin {
+        /// SQL Server login name (`UID` in profile).
+        user: &'a str,
+        /// SQL Server login password (`PWD` in profile).
+        password: &'a str,
+    },
+
     /// Unattended service-principal auth (default for Fabric).
     ///
     /// Profile: `authentication: ActiveDirectoryServicePrincipal` (alias: `ServicePrincipal`),
@@ -73,6 +86,14 @@ impl<'a> SQLServerAuthIR<'a> {
         // There are quite a few parameters that can be set
         // See: https://github.com/microsoft/go-mssqldb/tree/main?tab=readme-ov-file#connection-parameters-and-dsn
         match self {
+            Self::SqlLogin { user, password } => {
+                if let Some(uri) = builder.uri.as_mut() {
+                    uri.query_pairs_mut()
+                        .append_pair("user id", user)
+                        .append_pair("password", password)
+                        .finish();
+                }
+            }
             Self::ActiveDirectoryServicePrincipal {
                 tenant_id,
                 client_id,
@@ -123,9 +144,15 @@ fn parse_auth<'a>(config: &'a AdapterConfig) -> Result<SQLServerAuthIR<'a>, Auth
     // https://github.com/microsoft/dbt-fabric/blob/0de219082282724a789b0d1b18509d39899da8e1/dbt/adapters/fabric/fabric_credentials.py#L78-L79
     if authentication.eq_ignore_ascii_case("serviceprincipal") {
         authentication = "ActiveDirectoryServicePrincipal";
+    } else if authentication.eq_ignore_ascii_case("sql") {
+        authentication = "sql";
     }
 
     match authentication {
+        "sql" => Ok(SQLServerAuthIR::SqlLogin {
+            user: config.require_str("UID")?,
+            password: config.require_str("PWD")?,
+        }),
         "ActiveDirectoryServicePrincipal" => Ok(SQLServerAuthIR::ActiveDirectoryServicePrincipal {
             tenant_id: config.get_str("tenant_id"),
             client_id: config.require_str("client_id")?,
@@ -141,8 +168,22 @@ fn parse_auth<'a>(config: &'a AdapterConfig) -> Result<SQLServerAuthIR<'a>, Auth
             unimplemented!("authentication method {} not implemented", authentication)
         }
         _ => Err(AuthError::config(format!(
-            "Invalid authentication method: {authentication} must be one of: [ActiveDirectoryServicePrincipal, ActiveDirectoryPassword, environment]"
+            "Invalid authentication method: {authentication} must be one of: [sql, ActiveDirectoryServicePrincipal, ActiveDirectoryPassword, environment]"
         ))),
+    }
+}
+
+/// Reads a profile field that may arrive as a YAML boolean or as its string spelling.
+fn get_flag(config: &AdapterConfig, field: &str, default: bool) -> bool {
+    let Some(value) = config.get_string(field) else {
+        return default;
+    };
+    if value.eq_ignore_ascii_case("true") || value == "1" {
+        true
+    } else if value.eq_ignore_ascii_case("false") || value == "0" {
+        false
+    } else {
+        default
     }
 }
 
@@ -161,21 +202,36 @@ fn apply_connection_args(
     // See: https://github.com/microsoft/go-mssqldb?tab=readme-ov-file#deprecated
     //
     // TODO: we probably want to be a bit smarter about constructing the URI, but this is a start
+    // TODO: named instances (`host\instance`) are rejected here as an invalid domain
     builder.with_parse_uri(format!("sqlserver://{host}:{port}"))?;
 
+    let encrypt = get_flag(config, "encrypt", DEFAULT_ENCRYPT);
+    let trust_cert = get_flag(config, "trust_cert", DEFAULT_TRUST_CERT);
+    let login_timeout = config
+        .get_string("login_timeout")
+        .and_then(|value| value.parse::<i64>().ok())
+        .unwrap_or_default();
+
     if let Some(uri) = builder.uri.as_mut() {
-        uri.query_pairs_mut()
+        let mut pairs = uri.query_pairs_mut();
+        pairs
             .append_pair("database", config.require_str("database")?)
-            .finish();
+            .append_pair("encrypt", if encrypt { "true" } else { "false" })
+            .append_pair(
+                "TrustServerCertificate",
+                if trust_cert { "true" } else { "false" },
+            );
+        // 0 means "driver default", which go-mssqldb spells as an absent parameter.
+        if login_timeout > 0 {
+            pairs.append_pair("connection timeout", &login_timeout.to_string());
+        }
+        pairs.finish();
     }
 
     // TODO: other parameters, i.e.
-    // - connection timeout
     // - dial timeout
-    // - encrypt
     // - app name
     // - log
-    // - retries
     //
     // See: https://github.com/microsoft/go-mssqldb/tree/main?tab=readme-ov-file#less-common-parameters
     Ok(builder)
@@ -203,6 +259,7 @@ impl Auth for SQLServerAuth {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::YmlValue;
     use crate::test_options::uri_value;
     use dbt_test_primitives::assert_contains;
     use dbt_yaml::Mapping;
@@ -211,6 +268,156 @@ mod tests {
         AdapterConfig::new(Mapping::from_iter(
             pairs.into_iter().map(|(k, v)| (k.into(), v.into())),
         ))
+    }
+
+    fn make_typed_config(
+        pairs: impl IntoIterator<Item = (&'static str, YmlValue)>,
+    ) -> AdapterConfig {
+        AdapterConfig::new(Mapping::from_iter(
+            pairs.into_iter().map(|(k, v)| (k.into(), v)),
+        ))
+    }
+
+    #[test]
+    fn test_sql_login() {
+        let config = make_config([
+            ("authentication", "sql"),
+            ("host", "localhost"),
+            ("database", "mydb"),
+            ("UID", "sa"),
+            ("PWD", "hunter2"),
+        ]);
+
+        let outcome = SQLServerAuth.configure(&config).expect("configure");
+        let uri = uri_value(&outcome.builder);
+
+        assert_contains!(&uri, "sqlserver://localhost:1433");
+        assert_contains!(&uri, "user+id=sa");
+        assert_contains!(&uri, "password=hunter2");
+        assert!(!uri.contains("fedauth"), "SQL logins carry no Entra token");
+    }
+
+    #[test]
+    fn test_sql_login_is_case_insensitive() {
+        let config = make_config([
+            ("authentication", "SQL"),
+            ("host", "localhost"),
+            ("database", "mydb"),
+            ("UID", "sa"),
+            ("PWD", "hunter2"),
+        ]);
+
+        let outcome = SQLServerAuth.configure(&config).expect("configure");
+        assert_contains!(&uri_value(&outcome.builder), "user+id=sa");
+    }
+
+    #[test]
+    fn test_sql_login_requires_credentials() {
+        let config = make_config([
+            ("authentication", "sql"),
+            ("host", "localhost"),
+            ("database", "mydb"),
+            ("UID", "sa"),
+        ]);
+
+        SQLServerAuth
+            .configure(&config)
+            .expect_err("a missing PWD is an error, not an empty password");
+    }
+
+    /// Passwords reach the driver through a query parameter, so the reserved
+    /// characters a SQL Server login may legally contain have to survive it.
+    #[test]
+    fn test_sql_login_password_is_encoded() {
+        let config = make_config([
+            ("authentication", "sql"),
+            ("host", "localhost"),
+            ("database", "mydb"),
+            ("UID", "sa"),
+            ("PWD", "p@ss:w/rd?&=#"),
+        ]);
+
+        let outcome = SQLServerAuth.configure(&config).expect("configure");
+        let uri = uri_value(&outcome.builder);
+
+        assert_contains!(&uri, "password=p%40ss%3Aw%2Frd%3F%26%3D%23");
+    }
+
+    #[test]
+    fn test_tls_defaults_to_encrypted_and_verified() {
+        let config = make_config([
+            ("authentication", "environment"),
+            ("host", "myserver.database.windows.net"),
+            ("database", "mydb"),
+        ]);
+
+        let outcome = SQLServerAuth.configure(&config).expect("configure");
+        let uri = uri_value(&outcome.builder);
+
+        assert_contains!(&uri, "encrypt=true");
+        assert_contains!(&uri, "TrustServerCertificate=false");
+    }
+
+    #[test]
+    fn test_tls_settings_from_yaml_booleans() {
+        let config = make_typed_config([
+            ("authentication", "environment".into()),
+            ("host", "localhost".into()),
+            ("database", "mydb".into()),
+            ("encrypt", false.into()),
+            ("trust_cert", true.into()),
+        ]);
+
+        let outcome = SQLServerAuth.configure(&config).expect("configure");
+        let uri = uri_value(&outcome.builder);
+
+        assert_contains!(&uri, "encrypt=false");
+        assert_contains!(&uri, "TrustServerCertificate=true");
+    }
+
+    #[test]
+    fn test_tls_settings_from_string_booleans() {
+        let config = make_config([
+            ("authentication", "environment"),
+            ("host", "localhost"),
+            ("database", "mydb"),
+            ("encrypt", "false"),
+            ("trust_cert", "true"),
+        ]);
+
+        let outcome = SQLServerAuth.configure(&config).expect("configure");
+        let uri = uri_value(&outcome.builder);
+
+        assert_contains!(&uri, "encrypt=false");
+        assert_contains!(&uri, "TrustServerCertificate=true");
+    }
+
+    #[test]
+    fn test_login_timeout_is_applied() {
+        let config = make_typed_config([
+            ("authentication", "environment".into()),
+            ("host", "localhost".into()),
+            ("database", "mydb".into()),
+            ("login_timeout", YmlValue::number(30i64.into())),
+        ]);
+
+        let outcome = SQLServerAuth.configure(&config).expect("configure");
+        assert_contains!(&uri_value(&outcome.builder), "connection+timeout=30");
+    }
+
+    #[test]
+    fn test_login_timeout_zero_is_omitted() {
+        let config = make_typed_config([
+            ("authentication", "environment".into()),
+            ("host", "localhost".into()),
+            ("database", "mydb".into()),
+            ("login_timeout", YmlValue::number(0i64.into())),
+        ]);
+
+        let outcome = SQLServerAuth.configure(&config).expect("configure");
+        let uri = uri_value(&outcome.builder);
+
+        assert!(!uri.contains("timeout"), "{uri}");
     }
 
     #[test]

--- a/crates/dbt-df-providers/src/seed_io.rs
+++ b/crates/dbt-df-providers/src/seed_io.rs
@@ -230,7 +230,8 @@ pub fn infer_seed_column_name_strategy(
             AdapterType::Bigquery
             | AdapterType::Databricks
             | AdapterType::Spark
-            | AdapterType::Fabric,
+            | AdapterType::Fabric
+            | AdapterType::SqlServer,
         ) => InferColumnNameStrategy::Verbatim,
         (false, AdapterType::ClickHouse) => InferColumnNameStrategy::Verbatim,
         (false, AdapterType::Exasol) => InferColumnNameStrategy::Uppercase,

--- a/crates/dbt-init/src/adapter_config/mod.rs
+++ b/crates/dbt-init/src/adapter_config/mod.rs
@@ -6,6 +6,7 @@ pub mod fabric_config;
 pub mod postgres_config;
 pub mod redshift_config;
 pub mod snowflake_config;
+pub mod sqlserver_config;
 
 pub use bigquery_config::setup_bigquery_profile;
 pub use clickhouse_config::setup_clickhouse_profile;
@@ -14,3 +15,4 @@ pub use fabric_config::setup_fabric_profile;
 pub use postgres_config::setup_postgres_profile;
 pub use redshift_config::setup_redshift_profile;
 pub use snowflake_config::setup_snowflake_profile;
+pub use sqlserver_config::setup_sqlserver_profile;

--- a/crates/dbt-init/src/adapter_config/sqlserver_config.rs
+++ b/crates/dbt-init/src/adapter_config/sqlserver_config.rs
@@ -1,0 +1,233 @@
+use crate::adapter_config::common::{ConfigField, ConfigProcessor, FieldValue, InteractiveSetup};
+
+use dbt_common::FsResult;
+use dbt_schemas::schemas::profiles::SqlServerDbConfig;
+use dbt_schemas::schemas::serde::StringOrInteger;
+
+// Index → authentication string. Order is the order the user sees in the select prompt.
+// SQL Server, unlike Fabric, defaults to native SQL auth (v1's `sqlserver_credentials.py`
+// default), and all four methods below are implemented in `dbt-auth/src/sqlserver/mod.rs`
+// (`parse_auth`), so none need to stay commented out pending untested credentials.
+const AUTH_METHODS: &[(&str, &str)] = &[
+    (
+        "sql",
+        "SQL Authentication (native SQL Server login, UID/PWD)",
+    ),
+    (
+        "ActiveDirectoryServicePrincipal",
+        "Active Directory Service Principal",
+    ),
+    ("ActiveDirectoryPassword", "Active Directory Password"),
+    (
+        "environment",
+        "Environment (DefaultAzureCredential env vars, see https://learn.microsoft.com/en-us/python/api/azure-identity/azure.identity.environmentcredential, explain the available combinations of environment variables you can use to authenticate.)",
+    ),
+];
+
+impl InteractiveSetup for SqlServerDbConfig {
+    fn get_fields() -> Vec<ConfigField> {
+        let auth_labels = auth_label_options();
+        // Default to SQL Authentication (matches v1's default and the common
+        // on-prem/Azure SQL Database case of a native login already on hand).
+        let auth_default = auth_index("sql").unwrap_or(0) as usize;
+
+        // Index lookups for auth-dependent fields.
+        let sql_idx = auth_index("sql").unwrap_or(0);
+        let sp_idx = auth_index("ActiveDirectoryServicePrincipal").unwrap_or(0);
+        let adpw_idx = auth_index("ActiveDirectoryPassword").unwrap_or(0);
+
+        vec![
+            // Core connection settings
+            ConfigField::input(
+                "host",
+                "Host (server hostname, e.g. localhost or my-server.database.windows.net)",
+            ),
+            ConfigField::optional_input("port", "Port", Some("1433")),
+            ConfigField::input("database", "Database"),
+            ConfigField::input("schema", "Schema"),
+            // Authentication
+            ConfigField::select(
+                "authentication",
+                "Which authentication method would you like to use?",
+                auth_labels,
+                auth_default,
+            ),
+            // SQL Authentication fields
+            ConfigField::input("user", "Username (SQL Server login)")
+                .when_field_equals("authentication", FieldValue::Integer(sql_idx)),
+            ConfigField::password("password", "Password")
+                .when_field_equals("authentication", FieldValue::Integer(sql_idx)),
+            // Active Directory Service Principal fields
+            ConfigField::input("client_id", "Client ID (app registration)")
+                .when_field_equals("authentication", FieldValue::Integer(sp_idx)),
+            ConfigField::password("client_secret", "Client secret")
+                .when_field_equals("authentication", FieldValue::Integer(sp_idx)),
+            ConfigField::optional_input("tenant_id", "Tenant ID (optional)", None)
+                .when_field_equals("authentication", FieldValue::Integer(sp_idx)),
+            // Active Directory Password fields (`client_id` here is the Entra app used to
+            // request the user's token, not the service-principal identity above — same
+            // struct field, different auth branch).
+            ConfigField::input(
+                "client_id",
+                "Client ID (Entra app registration used to request the user token)",
+            )
+            .when_field_equals("authentication", FieldValue::Integer(adpw_idx)),
+            ConfigField::input("user", "Username (Entra user principal name)")
+                .when_field_equals("authentication", FieldValue::Integer(adpw_idx)),
+            ConfigField::password("password", "Password (Entra user password)")
+                .when_field_equals("authentication", FieldValue::Integer(adpw_idx)),
+            // `environment` needs no additional fields: credentials come from AZURE_* env vars.
+        ]
+    }
+
+    fn set_field(&mut self, field_name: &str, value: FieldValue) -> FsResult<()> {
+        match field_name {
+            "host" => {
+                if let FieldValue::String(s) = value {
+                    self.host = Some(s);
+                }
+            }
+            "port" => match value {
+                FieldValue::String(s) => {
+                    if let Ok(port) = s.parse::<i64>() {
+                        self.port = Some(StringOrInteger::Integer(port));
+                    }
+                }
+                FieldValue::Integer(i) => {
+                    self.port = Some(StringOrInteger::Integer(i));
+                }
+                _ => {}
+            },
+            "database" => {
+                if let FieldValue::String(s) = value {
+                    self.database = Some(s);
+                }
+            }
+            "schema" => {
+                if let FieldValue::String(s) = value {
+                    self.schema = Some(s);
+                }
+            }
+            "authentication" => {
+                if let FieldValue::Integer(i) = value
+                    && let Some((val, _)) = AUTH_METHODS.get(i as usize)
+                {
+                    self.authentication = Some((*val).to_string());
+                }
+            }
+            "user" => {
+                if let FieldValue::String(s) = value {
+                    self.user = Some(s);
+                }
+            }
+            "password" => {
+                if let FieldValue::String(s) = value {
+                    self.password = Some(s);
+                }
+            }
+            "client_id" => {
+                if let FieldValue::String(s) = value {
+                    self.client_id = Some(s);
+                }
+            }
+            "client_secret" => {
+                if let FieldValue::String(s) = value {
+                    self.client_secret = Some(s);
+                }
+            }
+            "tenant_id" => {
+                if let FieldValue::String(s) = value {
+                    self.tenant_id = Some(s);
+                }
+            }
+            _ => {} // Ignore temporary or unrecognized fields
+        }
+        Ok(())
+    }
+
+    fn get_field(&self, field_name: &str) -> Option<FieldValue> {
+        match field_name {
+            "host" => self.host.as_ref().map(|s| FieldValue::String(s.clone())),
+            "port" => self.port.as_ref().map(|v| match v {
+                StringOrInteger::String(s) => FieldValue::String(s.clone()),
+                StringOrInteger::Integer(i) => FieldValue::Integer(*i),
+            }),
+            "database" => self
+                .database
+                .as_ref()
+                .map(|s| FieldValue::String(s.clone())),
+            "schema" => self.schema.as_ref().map(|s| FieldValue::String(s.clone())),
+            "authentication" => self
+                .authentication
+                .as_deref()
+                .and_then(auth_index)
+                .map(FieldValue::Integer),
+            "user" => self.user.as_ref().map(|s| FieldValue::String(s.clone())),
+            "password" => self
+                .password
+                .as_ref()
+                .map(|s| FieldValue::String(s.clone())),
+            "client_id" => self
+                .client_id
+                .as_ref()
+                .map(|s| FieldValue::String(s.clone())),
+            "client_secret" => self
+                .client_secret
+                .as_ref()
+                .map(|s| FieldValue::String(s.clone())),
+            "tenant_id" => self
+                .tenant_id
+                .as_ref()
+                .map(|s| FieldValue::String(s.clone())),
+            _ => None,
+        }
+    }
+
+    fn is_field_set(&self, field_name: &str) -> bool {
+        match field_name {
+            "host" => self.host.is_some(),
+            "port" => self.port.is_some(),
+            "database" => self.database.is_some(),
+            "schema" => self.schema.is_some(),
+            "authentication" => self
+                .authentication
+                .as_deref()
+                .map(auth_index)
+                .is_some_and(|o| o.is_some()),
+            "user" => self.user.is_some(),
+            "password" => self.password.is_some(),
+            "client_id" => self.client_id.is_some(),
+            "client_secret" => self.client_secret.is_some(),
+            "tenant_id" => self.tenant_id.is_some(),
+            _ => false,
+        }
+    }
+}
+
+fn auth_index(value: &str) -> Option<i64> {
+    AUTH_METHODS
+        .iter()
+        .position(|(v, _)| v.eq_ignore_ascii_case(value))
+        .map(|i| i as i64)
+}
+
+fn auth_label_options() -> Vec<&'static str> {
+    AUTH_METHODS.iter().map(|(_, label)| *label).collect()
+}
+
+fn default_sqlserver_config() -> SqlServerDbConfig {
+    SqlServerDbConfig {
+        authentication: Some("sql".to_string()),
+        encrypt: Some(true),
+        trust_cert: Some(false),
+        ..Default::default()
+    }
+}
+
+pub fn setup_sqlserver_profile(
+    existing_config: Option<&SqlServerDbConfig>,
+) -> FsResult<Box<SqlServerDbConfig>> {
+    let default_config = default_sqlserver_config();
+    let config = ConfigProcessor::process_config(existing_config.or(Some(&default_config)))?;
+    Ok(Box::new(config))
+}

--- a/crates/dbt-init/src/profile_setup.rs
+++ b/crates/dbt-init/src/profile_setup.rs
@@ -1,6 +1,7 @@
 use crate::adapter_config::{
     setup_bigquery_profile, setup_clickhouse_profile, setup_databricks_profile,
     setup_fabric_profile, setup_postgres_profile, setup_redshift_profile, setup_snowflake_profile,
+    setup_sqlserver_profile,
 };
 use crate::dbt_cloud_client::{CloudProject, DbtCloudClient, DbtCloudYml};
 use crate::yaml_utils::{
@@ -197,6 +198,7 @@ impl ProfileSetup {
             AdapterType::Postgres,
             AdapterType::Redshift,
             AdapterType::Fabric,
+            AdapterType::SqlServer,
         ]
     }
 
@@ -391,6 +393,13 @@ impl ProfileSetup {
                     _ => None,
                 };
                 DbConfig::Fabric(setup_fabric_profile(fabric_config.map(Box::as_ref))?)
+            }
+            AdapterType::SqlServer => {
+                let sqlserver_config = match existing_config {
+                    Some(DbConfig::SqlServer(config)) => Some(config),
+                    _ => None,
+                };
+                DbConfig::SqlServer(setup_sqlserver_profile(sqlserver_config.map(Box::as_ref))?)
             }
 
             AdapterType::DuckDB => {

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/__init__.py
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/__init__.py
@@ -1,0 +1,3 @@
+import os
+
+PACKAGE_PATH = os.path.dirname(__file__)

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/dbt_project.yml
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/dbt_project.yml
@@ -1,0 +1,6 @@
+name: dbt_sqlserver
+version: 1.0
+
+config-version: 2
+
+macro-paths: ["macros"]

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/adapters/apply_grants.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/adapters/apply_grants.sql
@@ -1,0 +1,71 @@
+{% macro sqlserver__apply_grants(relation, grant_config, should_revoke=True) %}
+    {#-- If grant_config is {} or None, this is a no-op --#}
+    {% if grant_config %}
+        {% if should_revoke %}
+            {#-- We think previous grants may have carried over --#}
+            {#-- Show current grants and calculate diffs --#}
+            {% set current_grants_table = run_query(get_show_grant_sql(relation)) %}
+            {% set current_grants_dict = adapter.standardize_grants_dict(current_grants_table) %}
+            {% set needs_granting = diff_of_two_dicts(grant_config, current_grants_dict) %}
+            {% set needs_revoking = diff_of_two_dicts(current_grants_dict, grant_config) %}
+            {% if not (needs_granting or needs_revoking) %}
+                {{ log('On ' ~ relation ~': All grants are in place, no revocation or granting needed.')}}
+            {% endif %}
+        {% else %}
+            {#-- We don't think there's any chance of previous grants having carried over. --#}
+            {#-- Jump straight to granting what the user has configured. --#}
+            {% set needs_revoking = {} %}
+            {% set needs_granting = grant_config %}
+        {% endif %}
+        {% if needs_granting or needs_revoking %}
+            {% set revoke_statement_list = get_dcl_statement_list(relation, needs_revoking, get_revoke_sql) %}
+
+            {% if config.get('auto_provision_aad_principals', False) %}
+                {% set provision_statement_list = get_dcl_statement_list(relation, needs_granting, get_provision_sql) %}
+            {% else %}
+                {% set provision_statement_list = [] %}
+            {% endif %}
+
+            {% set grant_statement_list = get_dcl_statement_list(relation, needs_granting, get_grant_sql) %}
+            {% set dcl_statement_list = revoke_statement_list + provision_statement_list + grant_statement_list %}
+            {% if dcl_statement_list %}
+                {{ call_dcl_statements(dcl_statement_list) }}
+            {% endif %}
+        {% endif %}
+    {% endif %}
+{% endmacro %}
+
+{% macro sqlserver__get_show_grant_sql(relation) %}
+    select
+        GRANTEE as grantee,
+        PRIVILEGE_TYPE as privilege_type
+    from INFORMATION_SCHEMA.TABLE_PRIVILEGES {{ information_schema_hints() }}
+    where TABLE_CATALOG = '{{ relation.database }}'
+      and TABLE_SCHEMA = '{{ relation.schema }}'
+      and TABLE_NAME = '{{ relation.identifier }}'
+{% endmacro %}
+
+{%- macro sqlserver__get_grant_sql(relation, privilege, grantees) -%}
+    {%- set grantees_safe = [] -%}
+    {%- for grantee in grantees -%}
+        {%- set grantee_safe = adapter.quote(grantee) -%}
+        {%- do grantees_safe.append(grantee_safe) -%}
+    {%- endfor -%}
+    grant {{ privilege }} on {{ relation }} to {{ grantees_safe | join(', ') }}
+{%- endmacro -%}
+
+{%- macro sqlserver__get_revoke_sql(relation, privilege, grantees) -%}
+    {%- set grantees_safe = [] -%}
+    {%- for grantee in grantees -%}
+        {%- set grantee_safe = adapter.quote(grantee) -%}
+        {%- do grantees_safe.append(grantee_safe) -%}
+    {%- endfor -%}
+    revoke {{ privilege }} on {{ relation }} from {{ grantees_safe | join(', ') }}
+{%- endmacro -%}
+
+{% macro get_provision_sql(relation, privilege, grantees) %}
+    {% for grantee in grantees %}
+        if not exists(select name from sys.database_principals where name = '{{ grantee }}')
+        create user {{ adapter.quote(grantee) }} from external provider;
+    {% endfor %}
+{% endmacro %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/adapters/catalog.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/adapters/catalog.sql
@@ -1,0 +1,321 @@
+{% macro sqlserver__get_catalog(information_schemas, schemas) -%}
+    {% set query_label = get_query_options() %}
+    {%- call statement('catalog', fetch_result=True) -%}
+        {{ get_use_database_sql(information_schemas.database) }}
+        with
+        principals as (
+            select
+                name as principal_name,
+                principal_id as principal_id
+            from
+                sys.database_principals {{ information_schema_hints() }}
+        ),
+
+        schemas as (
+            select
+                name as schema_name,
+                schema_id as schema_id,
+                principal_id as principal_id
+            from
+                sys.schemas {{ information_schema_hints() }}
+        ),
+
+        tables as (
+            select
+                t.object_id,
+                t.name as table_name,
+                t.schema_id as schema_id,
+                t.principal_id as principal_id,
+                'BASE TABLE' as table_type,
+                cast(ep.value as nvarchar(max)) as table_comment
+            from
+                sys.tables as t {{ information_schema_hints() }}
+            left join sys.extended_properties as ep {{ information_schema_hints() }}
+                on ep.class = 1
+               and ep.major_id = t.object_id
+               and ep.minor_id = 0
+               and ep.name = N'MS_Description'
+        ),
+
+        tables_with_metadata as (
+            select
+                object_id,
+                table_name,
+                schema_name,
+                coalesce(tables.principal_id, schemas.principal_id) as owner_principal_id,
+                table_type,
+                table_comment
+            from
+                tables
+            join schemas on tables.schema_id = schemas.schema_id
+        ),
+
+        views as (
+            select
+                v.object_id,
+                v.name as table_name,
+                v.schema_id as schema_id,
+                v.principal_id as principal_id,
+                'VIEW' as table_type,
+                cast(ep.value as nvarchar(max)) as table_comment
+            from
+                sys.views as v {{ information_schema_hints() }}
+            left join sys.extended_properties as ep {{ information_schema_hints() }}
+                on ep.class = 1
+               and ep.major_id = v.object_id
+               and ep.minor_id = 0
+               and ep.name = N'MS_Description'
+        ),
+
+        views_with_metadata as (
+            select
+                object_id,
+                table_name,
+                schema_name,
+                coalesce(views.principal_id, schemas.principal_id) as owner_principal_id,
+                table_type,
+                table_comment
+            from
+                views
+            join schemas on views.schema_id = schemas.schema_id
+        ),
+
+        tables_and_views as (
+            select
+                object_id,
+                table_name,
+                schema_name,
+                principal_name,
+                table_type,
+                table_comment
+            from
+                tables_with_metadata
+            join principals on tables_with_metadata.owner_principal_id = principals.principal_id
+            union all
+            select
+                object_id,
+                table_name,
+                schema_name,
+                principal_name,
+                table_type,
+                table_comment
+            from
+                views_with_metadata
+            join principals on views_with_metadata.owner_principal_id = principals.principal_id
+        ),
+
+        cols as (
+            select
+                c.object_id,
+                c.name as column_name,
+                c.column_id as column_index,
+                t.name as column_type,
+                cast(ep.value as nvarchar(max)) as column_comment
+            from sys.columns as c {{ information_schema_hints() }}
+            left join sys.types as t {{ information_schema_hints() }}
+                on c.user_type_id = t.user_type_id
+            left join sys.extended_properties as ep {{ information_schema_hints() }}
+                on ep.class = 1
+               and ep.major_id = c.object_id
+               and ep.minor_id = c.column_id
+               and ep.name = N'MS_Description'
+        )
+
+        select
+            DB_NAME() as table_database,
+            tv.schema_name as table_schema,
+            tv.table_name,
+            tv.table_type,
+            tv.table_comment,
+            tv.principal_name as table_owner,
+            cols.column_name,
+            cols.column_index,
+            cols.column_type,
+            cols.column_comment
+        from tables_and_views tv
+        join cols on tv.object_id = cols.object_id
+        where ({%- for schema in schemas -%}
+            upper(tv.schema_name) = upper('{{ schema }}'){%- if not loop.last %} or {% endif -%}
+        {%- endfor -%})
+
+        order by column_index
+        {{ query_label }}
+
+        {%- endcall -%}
+
+    {{ return(load_result('catalog').table) }}
+
+{%- endmacro %}
+
+{% macro sqlserver__get_catalog_relations(information_schema, relations) -%}
+    {% set query_label = get_query_options() %}
+    {%- set distinct_databases = relations | map(attribute='database') | unique | list -%}
+
+    {%- if distinct_databases | length == 1 -%}
+        {%- call statement('catalog', fetch_result=True) -%}
+            {{ get_use_database_sql(distinct_databases[0]) }}
+            with
+            principals as (
+                select
+                    name as principal_name,
+                    principal_id as principal_id
+                from
+                    sys.database_principals {{ information_schema_hints() }}
+            ),
+
+            schemas as (
+                select
+                    name as schema_name,
+                    schema_id as schema_id,
+                    principal_id as principal_id
+                from
+                    sys.schemas {{ information_schema_hints() }}
+            ),
+
+            tables as (
+                select
+                    t.object_id,
+                    t.name as table_name,
+                    t.schema_id as schema_id,
+                    t.principal_id as principal_id,
+                    'BASE TABLE' as table_type,
+                    cast(ep.value as nvarchar(max)) as table_comment
+                from
+                    sys.tables as t {{ information_schema_hints() }}
+                left join sys.extended_properties as ep {{ information_schema_hints() }}
+                    on ep.class = 1
+                   and ep.major_id = t.object_id
+                   and ep.minor_id = 0
+                   and ep.name = N'MS_Description'
+            ),
+
+            tables_with_metadata as (
+                select
+                    object_id,
+                    table_name,
+                    schema_name,
+                    coalesce(tables.principal_id, schemas.principal_id) as owner_principal_id,
+                    table_type,
+                    table_comment
+                from
+                    tables
+                join schemas on tables.schema_id = schemas.schema_id
+            ),
+
+            views as (
+                select
+                    v.object_id,
+                    v.name as table_name,
+                    v.schema_id as schema_id,
+                    v.principal_id as principal_id,
+                    'VIEW' as table_type,
+                    cast(ep.value as nvarchar(max)) as table_comment
+                from
+                    sys.views as v {{ information_schema_hints() }}
+                left join sys.extended_properties as ep {{ information_schema_hints() }}
+                    on ep.class = 1
+                   and ep.major_id = v.object_id
+                   and ep.minor_id = 0
+                   and ep.name = N'MS_Description'
+            ),
+
+            views_with_metadata as (
+                select
+                    object_id,
+                    table_name,
+                    schema_name,
+                    coalesce(views.principal_id, schemas.principal_id) as owner_principal_id,
+                    table_type,
+                    table_comment
+                from
+                    views
+                join schemas on views.schema_id = schemas.schema_id
+            ),
+
+            tables_and_views as (
+                select
+                    object_id,
+                    table_name,
+                    schema_name,
+                    principal_name,
+                    table_type,
+                    table_comment
+                from
+                    tables_with_metadata
+                join principals on tables_with_metadata.owner_principal_id = principals.principal_id
+                union all
+                select
+                    object_id,
+                    table_name,
+                    schema_name,
+                    principal_name,
+                    table_type,
+                    table_comment
+                from
+                    views_with_metadata
+                join principals on views_with_metadata.owner_principal_id = principals.principal_id
+            ),
+
+            cols as (
+                select
+                    c.object_id,
+                    c.name as column_name,
+                    c.column_id as column_index,
+                    t.name as column_type,
+                    cast(ep.value as nvarchar(max)) as column_comment
+                from sys.columns as c {{ information_schema_hints() }}
+                left join sys.types as t {{ information_schema_hints() }}
+                    on c.user_type_id = t.user_type_id
+                left join sys.extended_properties as ep {{ information_schema_hints() }}
+                    on ep.class = 1
+                and ep.major_id = c.object_id
+                and ep.minor_id = c.column_id
+                and ep.name = N'MS_Description'
+            )
+
+            select
+                DB_NAME() as table_database,
+                tv.schema_name as table_schema,
+                tv.table_name,
+                tv.table_type,
+                tv.table_comment,
+                tv.principal_name as table_owner,
+                cols.column_name,
+                cols.column_index,
+                cols.column_type,
+                cols.column_comment
+            from tables_and_views tv
+            join cols on tv.object_id = cols.object_id
+            where (
+                {%- for relation in relations -%}
+                    {% if relation.schema and relation.identifier %}
+                        (
+                            upper(tv.schema_name) = upper('{{ relation.schema }}')
+                            and upper(tv.table_name) = upper('{{ relation.identifier }}')
+                        )
+                    {% elif relation.schema %}
+                        (
+                            upper(tv.schema_name) = upper('{{ relation.schema }}')
+                        )
+                    {% else %}
+                        {% do exceptions.raise_compiler_error(
+                            '`get_catalog_relations` requires a list of relations, each with a schema'
+                        ) %}
+                    {% endif %}
+
+                    {%- if not loop.last %} or {% endif -%}
+                {%- endfor -%}
+            )
+
+            order by column_index
+            {{ query_label }}
+
+        {%- endcall -%}
+        {{ return(load_result('catalog').table) }}
+    {% else %}
+        {% do exceptions.raise_compiler_error(
+            '`get_catalog_relations` can catalog one database at a time'
+        ) %}
+    {% endif %}
+
+{%- endmacro %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/adapters/columns.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/adapters/columns.sql
@@ -1,0 +1,114 @@
+{% macro sqlserver__select_starts_with_cte(select_sql) %}
+    {#-- Strip comments first so a leading comment does not hide the CTE --#}
+    {%- set select_sql_stripped = modules.re.sub('(?s)/\\*.*?\\*/|--[^\n]*\n', '', select_sql) -%}
+    {{ return(select_sql_stripped.strip().lower().startswith('with')) }}
+{% endmacro %}
+
+{% macro sqlserver__get_empty_subquery_sql(select_sql, select_sql_header=none) %}
+    {% if sqlserver__select_starts_with_cte(select_sql) %}
+        {{ select_sql }}
+    {% else -%}
+        select * from (
+        {{ select_sql }}
+    ) dbt_sbq_tmp
+    where 1 = 0
+    {%- endif -%}
+
+{% endmacro %}
+
+{% macro sqlserver__get_columns_in_query(select_sql) %}
+    {% set query_label = get_query_options() %}
+    {% if sqlserver__select_starts_with_cte(select_sql) %}
+        {#-- A query starting with a CTE cannot be wrapped in a subquery; describe its result set instead of executing it (dbt-msft/dbt-sqlserver#698) --#}
+        {% call statement('get_columns_in_query', fetch_result=True, auto_begin=False) -%}
+            exec sp_describe_first_result_set @tsql = N'{{ escape_single_quotes(select_sql) }}'
+        {% endcall %}
+        {{ return(load_result('get_columns_in_query').table.columns['name'].values() | list) }}
+    {% else %}
+        {% call statement('get_columns_in_query', fetch_result=True, auto_begin=False) -%}
+            select TOP 0 * from (
+                {{ select_sql }}
+            ) as __dbt_sbq
+            where 0 = 1
+            {{ query_label }}
+        {% endcall %}
+        {{ return(load_result('get_columns_in_query').table.columns | map(attribute='name') | list) }}
+    {% endif %}
+{% endmacro %}
+
+{% macro sqlserver__alter_column_type(relation, column_name, new_column_type) %}
+
+    {% set prefer_single = config.get('prefer_single_alter_column', false) %}
+
+    {% if prefer_single and relation.type == 'table' %}
+        {% set alter_sql %}
+            alter {{ relation.type }} {{ relation }}
+            alter column "{{ column_name }}" {{ new_column_type }};
+        {%- endset %}
+        {% do run_query(alter_sql) %}
+
+    {% else %}
+        {%- set tmp_column = column_name + "__dbt_alter" -%}
+
+        {% set add_column %}
+            alter {{ relation.type }} {{ relation }}
+            add "{{ tmp_column }}" {{ new_column_type }};
+        {%- endset %}
+        {% set update_column %}
+            update {{ relation }} set "{{ tmp_column }}" = "{{ column_name }}";
+        {%- endset %}
+        {% set drop_column %}
+            alter {{ relation.type }} {{ relation }}
+            drop column "{{ column_name }}";
+        {%- endset %}
+        {% set rename_column %}
+            exec sp_rename '{{ escape_single_quotes(relation.include(database=False)) }}.{{ escape_single_quotes(adapter.quote(tmp_column)) }}', '{{ escape_single_quotes(column_name) }}', 'column'
+        {%- endset %}
+
+        {% do run_query(add_column) %}
+        {% do run_query(update_column) %}
+        {% do run_query(drop_column) %}
+        {% do run_query(rename_column) %}
+    {% endif %}
+
+{% endmacro %}
+
+
+{% macro sqlserver__alter_relation_add_remove_columns(relation, add_columns, remove_columns) %}
+  {% call statement('add_drop_columns') -%}
+    {% if add_columns %}
+        alter {{ relation.type }} {{ relation }}
+        add {% for column in add_columns %}"{{ column.name }}" {{ column.data_type }}{{ ', ' if not loop.last }}{% endfor %};
+    {% endif %}
+
+    {% if remove_columns %}
+        alter {{ relation.type }} {{ relation }}
+        drop column {% for column in remove_columns %}"{{ column.name }}"{{ ',' if not loop.last }}{% endfor %};
+    {% endif %}
+  {%- endcall -%}
+{% endmacro %}
+
+{% macro sqlserver__get_columns_in_relation(relation) -%}
+    {% set query_label = get_query_options() %}
+    {% call statement('get_columns_in_relation', fetch_result=True) %}
+        {{ get_use_database_sql(relation.database) }}
+        select
+            c.name collate database_default as column_name,
+            t.name as data_type,
+            case
+                when (t.name in ('nchar', 'nvarchar', 'sysname') and c.max_length <> -1) then c.max_length / 2
+                else c.max_length
+            end as character_maximum_length,
+            c.precision as numeric_precision,
+            c.scale as numeric_scale
+        from sys.columns c {{ information_schema_hints() }}
+        inner join sys.types t {{ information_schema_hints() }}
+        on c.user_type_id = t.user_type_id
+        where c.object_id = object_id('{{ 'tempdb..' ~ relation.include(database=false, schema=false) if '#' in relation.identifier else relation }}')
+        order by c.column_id
+        {{ query_label }}
+
+    {% endcall %}
+    {% set table = load_result('get_columns_in_relation').table %}
+    {{ return(sql_convert_columns_in_relation(table)) }}
+{% endmacro %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/adapters/indexes.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/adapters/indexes.sql
@@ -1,0 +1,7 @@
+{% macro sqlserver__get_create_index_sql(relation, index_dict) -%}
+  {{ exceptions.raise_compiler_error(
+    "Custom `indexes:` config is not implemented yet in dbt Core v2's SQL Server "
+    "adapter (tracked as a follow-up issue). Remove the indexes config from "
+    ~ relation ~ " to build without it."
+  ) }}
+{%- endmacro %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/adapters/metadata.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/adapters/metadata.sql
@@ -1,0 +1,209 @@
+{% macro get_query_options(parse_options=False) %}
+    {{ log (config.get('query_tag','dbt-sqlserver'))}}
+    {#- Escape single quotes so a query_tag like "it's" can't break out of the LABEL literal. -#}
+    {%- set query_label = escape_single_quotes(config.get('query_tag','dbt-sqlserver')) -%}
+    {%- set query_options = config.get('query_options', {}) -%}
+    {%- set query_options_raw = config.get('query_options_raw', []) -%}
+
+    {%- set options_list = ["LABEL = '" ~ query_label ~ "'"] -%}
+
+    {%- if parse_options -%}
+        {%- set valid_options = [
+            'HASH GROUP', 'ORDER GROUP',
+            'CONCAT UNION', 'HASH UNION', 'MERGE UNION',
+            'LOOP JOIN', 'MERGE JOIN', 'HASH JOIN',
+            'DISABLE_OPTIMIZED_PLAN_FORCING',
+            'EXPAND VIEWS',
+            'FAST',
+            'FORCE ORDER',
+            'FORCE EXTERNALPUSHDOWN', 'DISABLE EXTERNALPUSHDOWN',
+            'FORCE SCALEOUTEXECUTION', 'DISABLE SCALEOUTEXECUTION',
+            'IGNORE_NONCLUSTERED_COLUMNSTORE_INDEX',
+            'KEEP PLAN',
+            'KEEPFIXED PLAN',
+            'MAX_GRANT_PERCENT',
+            'MIN_GRANT_PERCENT',
+            'MAXDOP',
+            'MAXRECURSION',
+            'NO_PERFORMANCE_SPOOL',
+            'OPTIMIZE FOR UNKNOWN',
+            'QUERYTRACEON',
+            'RECOMPILE',
+            'ROBUST PLAN',
+        ] -%}
+        {#- SQL Server uses `OPTION (X = N)` for grant-percent hints, not `OPTION (X N)`. -#}
+        {%- set equals_syntax_options = ['MAX_GRANT_PERCENT', 'MIN_GRANT_PERCENT'] -%}
+
+        {%- for key, value in query_options.items() -%}
+            {%- if key | upper not in valid_options -%}
+                {{ exceptions.raise_compiler_error("Invalid query option: '" ~ key ~ "'. Use query_options_raw for non-standard hints. Allowed: " ~ valid_options | join(', ')) }}
+            {%- endif -%}
+
+            {%- if value is none -%}
+                {%- do options_list.append(key | upper) -%}
+            {%- else -%}
+                {%- if value is not number -%}
+                    {{ exceptions.raise_compiler_error("Query option '" ~ key ~ "' value must be a number, got: '" ~ value ~ "'") }}
+                {%- endif -%}
+                {%- set separator = ' = ' if key | upper in equals_syntax_options else ' ' -%}
+                {#- Render the value verbatim: ints become "1", floats become "12.5".
+                    MAX_GRANT_PERCENT / MIN_GRANT_PERCENT accept decimals 0.0–100.0; integer-only
+                    options will surface a clear SQL Server parse error on invalid decimals. -#}
+                {%- do options_list.append(key | upper ~ separator ~ value) -%}
+            {%- endif -%}
+        {%- endfor -%}
+
+        {#- query_options_raw bypasses the allowlist; users opt in to writing valid SQL Server syntax themselves.
+            Shape-check only: a plain string would be iterated character-by-character into garbage. -#}
+        {%- if query_options_raw is string or query_options_raw is mapping -%}
+            {{ exceptions.raise_compiler_error("query_options_raw must be a list of strings, got: '" ~ query_options_raw ~ "'") }}
+        {%- endif -%}
+        {%- for raw in query_options_raw -%}
+            {%- do options_list.append(raw) -%}
+        {%- endfor -%}
+    {%- endif -%}
+
+    OPTION ({{ options_list | join(', ') }});
+{% endmacro %}
+
+{#- DEPRECATED: backward-compat alias for the pre-1.10 macro.
+
+    Calls to `{{ apply_label() }}` from user macros still resolve and emit
+    a LABEL-only OPTION clause — but apply_label() is no longer the
+    extension point. Adapter macros now call get_query_options() instead,
+    so overriding apply_label() in a project's macros directory will have
+    no effect on adapter-emitted SQL.
+
+    To customise the OPTION clause emitted by adapter macros (table,
+    incremental, snapshot, unit_test), override get_query_options instead. -#}
+{% macro apply_label() %}
+    {{ log (config.get('query_tag','dbt-sqlserver'))}}
+    {%- set query_label = escape_single_quotes(config.get('query_tag','dbt-sqlserver')) -%}
+    OPTION (LABEL = '{{query_label}}');
+{% endmacro %}
+
+{#- Guard for materializations and incremental strategies that cannot emit OPTION clauses.
+    Raises a compiler error if the user has configured query_options/query_options_raw. -#}
+{% macro raise_if_query_options_set(context_label) %}
+    {%- if config.get('query_options') or config.get('query_options_raw') -%}
+        {{ exceptions.raise_compiler_error(
+            "query_options/query_options_raw is not supported on " ~ context_label
+            ~ ". Remove the config or switch to a supported materialization (table, incremental delete+insert, snapshot, unit_test)."
+        ) }}
+    {%- endif -%}
+{% endmacro %}
+
+{% macro default__information_schema_hints() %}{% endmacro %}
+{% macro sqlserver__information_schema_hints() %}with (nolock){% endmacro %}
+
+{% macro information_schema_hints() %}
+    {{ return(adapter.dispatch('information_schema_hints')()) }}
+{% endmacro %}
+
+{% macro sqlserver__information_schema_name(database) -%}
+  information_schema
+{%- endmacro %}
+
+{% macro get_use_database_sql(database) %}
+    {{ return(adapter.dispatch('get_use_database_sql', 'dbt')(database)) }}
+{% endmacro %}
+
+{%- macro sqlserver__get_use_database_sql(database) -%}
+  USE {{ adapter.quote(database | replace('"', '')) }};
+{%- endmacro -%}
+
+{% macro sqlserver__list_schemas(database) %}
+  {% call statement('list_schemas', fetch_result=True, auto_begin=False) -%}
+    {{ get_use_database_sql(database) }}
+    select  name as [schema]
+    from sys.schemas {{ information_schema_hints() }} {{ get_query_options() }}
+  {% endcall %}
+  {{ return(load_result('list_schemas').table) }}
+{% endmacro %}
+
+{% macro sqlserver__check_schema_exists(information_schema, schema) -%}
+  {% call statement('check_schema_exists', fetch_result=True, auto_begin=False) -%}
+    SELECT count(*) as schema_exist FROM sys.schemas WHERE name = '{{ schema }}' {{ get_query_options() }}
+  {%- endcall %}
+  {{ return(load_result('check_schema_exists').table) }}
+{% endmacro %}
+
+{% macro sqlserver__list_relations_without_caching(schema_relation) -%}
+  {% call statement('list_relations_without_caching', fetch_result=True) -%}
+    {{ get_use_database_sql(schema_relation.database) }}
+    declare @schema_id int = schema_id('{{ schema_relation.schema }}');
+    select
+      DB_NAME() as [database],
+      t.name as [name],
+      '{{ schema_relation.schema }}' as [schema],
+      'table' as table_type
+    from sys.tables as t {{ information_schema_hints() }}
+    where t.schema_id = @schema_id
+    union all
+    select
+      DB_NAME() as [database],
+      v.name as [name],
+      '{{ schema_relation.schema }}' as [schema],
+      'view' as table_type
+    from sys.views as v {{ information_schema_hints() }}
+    where v.schema_id = @schema_id
+    {{ get_query_options() }}
+  {% endcall %}
+  {{ return(load_result('list_relations_without_caching').table) }}
+{% endmacro %}
+
+{% macro sqlserver__get_relation_without_caching(schema_relation) -%}
+  {% call statement('get_relation_without_caching', fetch_result=True) -%}
+    {{ get_use_database_sql(schema_relation.database) }}
+    declare @schema_id int = schema_id('{{ schema_relation.schema }}');
+    select
+      DB_NAME() as [database],
+      t.name as [name],
+      '{{ schema_relation.schema }}' as [schema],
+      'table' as table_type
+    from sys.tables as t {{ information_schema_hints() }}
+    where t.schema_id = @schema_id and t.name = '{{ schema_relation.identifier }}'
+    union all
+    select
+      DB_NAME() as [database],
+      v.name as [name],
+      '{{ schema_relation.schema }}' as [schema],
+      'view' as table_type
+    from sys.views as v {{ information_schema_hints() }}
+    where v.schema_id = @schema_id and v.name = '{{ schema_relation.identifier }}'
+    {{ get_query_options() }}
+  {% endcall %}
+  {{ return(load_result('get_relation_without_caching').table) }}
+{% endmacro %}
+
+{% macro get_view_definition_sql(relation) %}
+    {{ return(adapter.dispatch('get_view_definition_sql')(relation)) }}
+{% endmacro %}
+
+{% macro sqlserver__get_view_definition_sql(relation) -%}
+  {%- set object_name = "quotename('" ~ relation.schema ~ "') + '.' + quotename('" ~ relation.identifier ~ "')" -%}
+  {{ get_use_database_sql(relation.database) }}
+  select object_definition(object_id({{ object_name }}, 'V')) as definition
+  where object_id({{ object_name }}, 'V') is not null
+{% endmacro %}
+
+{% macro sqlserver__get_relation_last_modified(information_schema, relations) -%}
+  {%- call statement('last_modified', fetch_result=True) -%}
+        select
+            o.name as [identifier]
+            , s.name as [schema]
+            , o.modify_date as last_modified
+            , current_timestamp as snapshotted_at
+        from sys.objects o {{ information_schema_hints() }}
+        inner join sys.schemas s {{ information_schema_hints() }} on o.schema_id = s.schema_id and [type] = 'U'
+        where (
+            {%- for relation in relations -%}
+            (upper(s.name) = upper('{{ relation.schema }}') and
+                upper(o.name) = upper('{{ relation.identifier }}')){%- if not loop.last %} or {% endif -%}
+            {%- endfor -%}
+        )
+        {{ get_query_options() }}
+  {%- endcall -%}
+  {{ return(load_result('last_modified')) }}
+
+{% endmacro %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/adapters/persist_docs.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/adapters/persist_docs.sql
@@ -1,0 +1,137 @@
+{% macro sqlserver__alter_relation_comment(relation, relation_comment) -%}
+    {%- set escaped_comment = (relation_comment or '') | replace("'", "''") -%}
+    {%- set relation_name = relation.identifier | replace("'", "''") -%}
+    {%- set schema_name = relation.schema | replace("'", "''") -%}
+
+    declare @relation_schema sysname = N'{{ schema_name }}';
+    declare @relation_name sysname = N'{{ relation_name }}';
+    declare @relation_comment nvarchar(3750) = N'{{ escaped_comment }}';
+    declare @relation_type nvarchar(128);
+
+    select
+        @relation_type =
+            case
+                when obj.[type] = 'V' then N'VIEW'
+                when obj.[type] = 'U' then N'TABLE'
+            end
+    from sys.objects as obj {{ information_schema_hints() }}
+    inner join sys.schemas as sch {{ information_schema_hints() }}
+        on sch.schema_id = obj.schema_id
+    where sch.name = @relation_schema
+      and obj.name = @relation_name
+      and obj.[type] in ('U', 'V');
+
+    if @relation_type is not null
+    begin
+        if exists (
+            select 1
+            from sys.extended_properties as ep {{ information_schema_hints() }}
+            inner join sys.objects as obj {{ information_schema_hints() }}
+                on obj.object_id = ep.major_id
+            inner join sys.schemas as sch {{ information_schema_hints() }}
+                on sch.schema_id = obj.schema_id
+            where ep.class = 1
+              and ep.minor_id = 0
+              and ep.name = N'MS_Description'
+              and sch.name = @relation_schema
+              and obj.name = @relation_name
+              and obj.[type] in ('U', 'V')
+        )
+        begin
+            exec sys.sp_updateextendedproperty
+                @name = N'MS_Description',
+                @value = @relation_comment,
+                @level0type = N'SCHEMA',
+                @level0name = @relation_schema,
+                @level1type = @relation_type,
+                @level1name = @relation_name;
+        end
+        else
+        begin
+            exec sys.sp_addextendedproperty
+                @name = N'MS_Description',
+                @value = @relation_comment,
+                @level0type = N'SCHEMA',
+                @level0name = @relation_schema,
+                @level1type = @relation_type,
+                @level1name = @relation_name;
+        end
+    end;
+{%- endmacro %}
+
+
+{% macro sqlserver__alter_column_comment(relation, column_dict) -%}
+    {%- set relation_name = relation.identifier | replace("'", "''") -%}
+    {%- set schema_name = relation.schema | replace("'", "''") -%}
+
+    {%- for column_name, column_config in column_dict.items() %}
+        {%- set escaped_column_name = column_name | replace("'", "''") -%}
+        {%- set escaped_comment = (column_config.get('description') or '') | replace("'", "''") -%}
+
+    declare @schema_{{ loop.index }} sysname = N'{{ schema_name }}';
+    declare @relation_{{ loop.index }} sysname = N'{{ relation_name }}';
+    declare @column_{{ loop.index }} sysname = N'{{ escaped_column_name }}';
+    declare @comment_{{ loop.index }} nvarchar(3750) = N'{{ escaped_comment }}';
+    declare @relation_type_{{ loop.index }} nvarchar(128);
+
+    select
+        @relation_type_{{ loop.index }} =
+            case
+                when obj.[type] = 'V' then N'VIEW'
+                when obj.[type] = 'U' then N'TABLE'
+            end
+    from sys.objects as obj {{ information_schema_hints() }}
+    inner join sys.schemas as sch {{ information_schema_hints() }}
+        on sch.schema_id = obj.schema_id
+    inner join sys.columns as col {{ information_schema_hints() }}
+        on col.object_id = obj.object_id
+    where sch.name = @schema_{{ loop.index }}
+      and obj.name = @relation_{{ loop.index }}
+      and col.name = @column_{{ loop.index }}
+      and obj.[type] in ('U', 'V');
+
+    if @relation_type_{{ loop.index }} is not null
+    begin
+        if exists (
+            select 1
+            from sys.extended_properties as ep {{ information_schema_hints() }}
+            inner join sys.objects as obj {{ information_schema_hints() }}
+                on obj.object_id = ep.major_id
+            inner join sys.schemas as sch {{ information_schema_hints() }}
+                on sch.schema_id = obj.schema_id
+            inner join sys.columns as col {{ information_schema_hints() }}
+                on col.object_id = ep.major_id
+               and col.column_id = ep.minor_id
+            where ep.class = 1
+              and ep.name = N'MS_Description'
+              and sch.name = @schema_{{ loop.index }}
+              and obj.name = @relation_{{ loop.index }}
+              and col.name = @column_{{ loop.index }}
+              and obj.[type] in ('U', 'V')
+        )
+        begin
+            exec sys.sp_updateextendedproperty
+                @name = N'MS_Description',
+                @value = @comment_{{ loop.index }},
+                @level0type = N'SCHEMA',
+                @level0name = @schema_{{ loop.index }},
+                @level1type = @relation_type_{{ loop.index }},
+                @level1name = @relation_{{ loop.index }},
+                @level2type = N'COLUMN',
+                @level2name = @column_{{ loop.index }};
+        end
+        else
+        begin
+            exec sys.sp_addextendedproperty
+                @name = N'MS_Description',
+                @value = @comment_{{ loop.index }},
+                @level0type = N'SCHEMA',
+                @level0name = @schema_{{ loop.index }},
+                @level1type = @relation_type_{{ loop.index }},
+                @level1name = @relation_{{ loop.index }},
+                @level2type = N'COLUMN',
+                @level2name = @column_{{ loop.index }};
+        end
+    end;
+    {%- endfor %}
+{%- endmacro %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/adapters/relation.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/adapters/relation.sql
@@ -1,0 +1,62 @@
+{% macro sqlserver__make_temp_relation(base_relation, suffix='__dbt_temp') %}
+    {%- set temp_identifier = base_relation.identifier ~ suffix -%}
+    {%- set temp_relation = base_relation.incorporate(
+                                path={"identifier": temp_identifier}) -%}
+
+    {{ return(temp_relation) }}
+{% endmacro %}
+
+{% macro sqlserver__get_drop_sql(relation) -%}
+  {% if relation.type == 'view' -%}
+      {#- auto_begin=false, matching dbt-adapters' own relations/drop.sql: a
+          read-only lookup must not open the ambient transaction. This is the
+          first statement of the temp-relation build (create.sql ->
+          adapter.drop_relation), so with the default auto_begin=True it held
+          that build's sys.sysschobjs X locks until the materialization
+          committed, deadlocking a concurrent worker (error 1205). -#}
+      {% call statement('find_references', fetch_result=true, auto_begin=false) %}
+        {{ get_use_database_sql(relation.database) }}
+        select
+            sch.name as schema_name,
+            obj.name as view_name
+        from sys.sql_expression_dependencies refs {{ information_schema_hints() }}
+        inner join sys.objects obj {{ information_schema_hints() }}
+        on refs.referencing_id = obj.object_id
+        inner join sys.schemas sch {{ information_schema_hints() }}
+        on obj.schema_id = sch.schema_id
+        where refs.referenced_database_name = '{{ relation.database }}'
+        and refs.referenced_schema_name = '{{ relation.schema }}'
+        and refs.referenced_entity_name = '{{ relation.identifier }}'
+        and obj.type = 'V'
+        {{ get_query_options() }}
+      {% endcall %}
+      {% set references = load_result('find_references')['data'] %}
+      {% for reference in references -%}
+        -- dropping referenced view {{ reference[0] }}.{{ reference[1] }}
+        {% do adapter.drop_relation
+          (api.Relation.create(
+            identifier = reference[1], schema = reference[0], database = relation.database, type='view'
+          ))%}
+      {% endfor %}
+    {% elif relation.type == 'table'%}
+      {% set object_id_type = 'U' %}
+    {%- else -%}
+        {{ exceptions.raise_not_implemented('Invalid relation being dropped: ' ~ relation) }}
+    {% endif %}
+    {{ get_use_database_sql(relation.database) }}
+    EXEC('DROP {{ relation.type }} IF EXISTS {{ relation.include(database=False) }};');
+{% endmacro %}
+
+{% macro sqlserver__rename_relation(from_relation, to_relation) -%}
+  {% call statement('rename_relation') -%}
+     {{ get_use_database_sql(from_relation.database) }}
+      {#- @objname takes a quoted, qualified name; @newname must stay bare -#}
+      EXEC sp_rename '{{ escape_single_quotes(from_relation.include(database=False)) }}', '{{ escape_single_quotes(to_relation.identifier) }}'
+  {%- endcall %}
+{% endmacro %}
+
+{% macro sqlserver__truncate_relation(relation) -%}
+  {% call statement('truncate_relation') -%}
+        truncate table {{ relation }}
+    {%- endcall %}
+{% endmacro %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/adapters/schema.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/adapters/schema.sql
@@ -1,0 +1,42 @@
+{% macro sqlserver__create_schema(relation) -%}
+  {% call statement('create_schema') -%}
+    {{ get_use_database_sql(relation.database) }}
+    IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = '{{ relation.schema }}')
+    BEGIN
+    EXEC('CREATE SCHEMA {{ adapter.quote(relation.schema) }}')
+    END
+  {% endcall %}
+{% endmacro %}
+
+{% macro sqlserver__create_schema_with_authorization(relation, schema_authorization) -%}
+  {% call statement('create_schema') -%}
+    {{ get_use_database_sql(relation.database) }}
+    IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = '{{ relation.schema }}')
+    BEGIN
+    EXEC('CREATE SCHEMA {{ adapter.quote(relation.schema) }} AUTHORIZATION {{ adapter.quote(schema_authorization) }}')
+    END
+  {% endcall %}
+{% endmacro %}
+
+{% macro sqlserver__drop_schema(relation) -%}
+  {%- set relations_in_schema = list_relations_without_caching(relation) %}
+
+  {% for row in relations_in_schema %}
+    {%- set schema_relation = api.Relation.create(database=relation.database,
+                                               schema=relation.schema,
+                                               identifier=row[1],
+                                               type=row[3]
+                                               ) -%}
+    {% do adapter.drop_relation(schema_relation) %}
+  {%- endfor %}
+
+  {% call statement('drop_schema') -%}
+    {{ get_use_database_sql(relation.database) }}
+    EXEC('DROP SCHEMA IF EXISTS {{ relation.schema }}')
+  {% endcall %}
+{% endmacro %}
+
+{% macro sqlserver__drop_schema_named(schema_name) %}
+  {% set schema_relation = api.Relation.create(schema=schema_name, database=target.database) %}
+  {{ adapter.drop_schema(schema_relation) }}
+{% endmacro %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/adapters/show.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/adapters/show.sql
@@ -1,0 +1,12 @@
+{% macro sqlserver__get_limit_sql(sql, limit) %}
+    {%- if limit == -1 or limit is none -%}
+        {{ sql }}
+    {#- Special processing if the last non-blank line starts with order by -#}
+    {%- elif sql.strip().splitlines()[-1].strip().lower().startswith('order by') -%}
+        {{ sql }}
+        offset 0 rows  fetch first {{ limit }} rows only
+    {%- else -%}
+        {{ sql }}
+        order by (select null) offset 0 rows fetch first {{ limit }} rows only
+    {%- endif -%}
+{% endmacro %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/adapters/validate_sql.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/adapters/validate_sql.sql
@@ -1,0 +1,6 @@
+{% macro sqlserver__validate_sql(sql) -%}
+  {% call statement('validate_sql') -%}
+    {{ sql }}
+  {% endcall %}
+  {{ return(load_result('validate_sql')) }}
+{% endmacro %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/materializations/hooks.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/materializations/hooks.sql
@@ -1,0 +1,19 @@
+{% macro run_hooks(hooks, inside_transaction=True) %}
+  {% for hook in hooks | selectattr('transaction', 'equalto', inside_transaction)  %}
+    {% if not inside_transaction and loop.first %}
+      {% call statement(auto_begin=inside_transaction) %}
+        {#- guarded, not a bare COMMIT: nothing guarantees a transaction is
+            open here. A bare one appeared safe only because some earlier
+            statement had auto-begun one (find_references, until relation.sql
+            stopped doing that); with @@TRANCOUNT = 0 it raises Msg 3902. -#}
+        if @@trancount > 0 commit;
+      {% endcall %}
+    {% endif %}
+    {% set rendered = render(hook.get('sql')) | trim %}
+    {% if (rendered | length) > 0 %}
+      {% call statement(auto_begin=inside_transaction) %}
+        {{ rendered }}
+      {% endcall %}
+    {% endif %}
+  {% endfor %}
+{% endmacro %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/materializations/models/incremental/incremental.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/materializations/models/incremental/incremental.sql
@@ -1,0 +1,141 @@
+{% materialization incremental, adapter='sqlserver' -%}
+
+  -- relations
+  {%- set existing_relation = load_cached_relation(this) -%}
+  {%- set target_relation = this.incorporate(type='table') -%}
+  {%- set temp_relation = make_temp_relation(target_relation)-%}
+  {%- set intermediate_relation = make_intermediate_relation(target_relation)-%}
+  {%- set backup_relation_type = 'table' if existing_relation is none else existing_relation.type -%}
+  {%- set backup_relation = make_backup_relation(target_relation, backup_relation_type) -%}
+
+  -- configs
+  {%- set unique_key = config.get('unique_key') -%}
+  {%- set full_refresh_mode = (should_full_refresh()  or existing_relation.is_view) -%}
+  {%- set on_schema_change = incremental_validate_on_schema_change(config.get('on_schema_change'), default='ignore') -%}
+  {%- set full_refresh_build = config.get('full_refresh_build', 'heap_then_index') -%}
+  {%- if full_refresh_build == 'prebuilt' -%}
+    {{ exceptions.raise_compiler_error(
+      "full_refresh_build='prebuilt' is not implemented yet in dbt Core v2's SQL Server "
+      "adapter (tracked as a follow-up issue). Use the default 'heap_then_index'."
+    ) }}
+  {%- elif full_refresh_build != 'heap_then_index' -%}
+    {{ exceptions.raise_compiler_error(
+      "Invalid full_refresh_build '" ~ full_refresh_build ~ "'. Only 'heap_then_index' (default) is supported."
+    ) }}
+  {%- endif -%}
+
+  -- the temp_ and backup_ relations should not already exist in the database; get_relation
+  -- will return None in that case. Otherwise, we get a relation that we can drop
+  -- later, before we try to use this name for the current operation. This has to happen before
+  -- BEGIN, in a separate transaction
+  {%- set preexisting_intermediate_relation = load_cached_relation(intermediate_relation)-%}
+  {%- set preexisting_backup_relation = load_cached_relation(backup_relation) -%}
+   -- grab current tables grants config for comparison later on
+  {% set grant_config = config.get('grants') %}
+  {{ drop_relation_if_exists(preexisting_intermediate_relation) }}
+  {{ drop_relation_if_exists(preexisting_backup_relation) }}
+
+  {{ run_hooks(pre_hooks, inside_transaction=False) }}
+
+  -- `BEGIN` happens here:
+  {{ run_hooks(pre_hooks, inside_transaction=True) }}
+
+  {% set to_drop = [] %}
+  {% set need_swap = false %}
+  {#- true only where the statement('main') batch below carries create_table_as
+      DDL, i.e. the fresh-create / full-refresh branches. The incremental
+      branch's strategy DML stays transactional, so it leaves this false. -#}
+  {% set build_sql_is_create_table_as = false %}
+
+  {% if existing_relation is none %}
+    {% set build_sql = get_create_table_as_sql(False, target_relation, sql) %}
+    {% set build_sql_is_create_table_as = true %}
+  {% elif full_refresh_mode %}
+    {% set build_sql = get_create_table_as_sql(False, intermediate_relation, sql) %}
+    {% set build_sql_is_create_table_as = true %}
+    {% set need_swap = true %}
+  {% else %}
+
+    {#- The temp build is all catalog DDL (CREATE OR ALTER VIEW / SELECT *
+        INTO / DROP VIEW) and must not share the ambient transaction with the
+        strategy DML: held to commit, its sysschobjs X keylocks deadlock a
+        second worker. Nothing opens a transaction here - run_query never
+        auto-begins, and find_references (relation.sql) no longer does either -
+        so each statement autocommits and drops its catalog locks as it
+        finishes. The strategy DML below still runs transactionally, via
+        statement('main')'s default auto_begin through to adapter.commit(). -#}
+    {% do run_query(get_create_table_as_sql(True, temp_relation, sql)) %}
+
+    {% set contract_config = config.get('contract') %}
+    {% if not contract_config or not contract_config.enforced %}
+      {% set expansion_max_rows = config.get('column_type_expansion_max_rows', 1000000) %}
+      {% do adapter.expand_target_column_types(
+               from_relation=temp_relation,
+               to_relation=target_relation,
+               max_rows=expansion_max_rows) %}
+    {% endif %}
+    {#-- Process schema changes. Returns dict of changes if successful. Use source columns for upserting/merging --#}
+    {% set dest_columns = process_schema_changes(on_schema_change, temp_relation, existing_relation) %}
+    {% if not dest_columns %}
+      {% set dest_columns = adapter.get_columns_in_relation(existing_relation) %}
+    {% endif %}
+
+    {#-- Get the incremental_strategy, the macro to use for the strategy, and build the sql --#}
+    {% set incremental_strategy = config.get('incremental_strategy') or 'default' %}
+    {% set incremental_predicates = config.get('predicates', none) or config.get('incremental_predicates', none) %}
+    {% set strategy_sql_macro_func = adapter.get_incremental_strategy_macro(context, incremental_strategy) %}
+    {% set strategy_arg_dict = ({'target_relation': target_relation, 'temp_relation': temp_relation, 'unique_key': unique_key, 'dest_columns': dest_columns, 'incremental_predicates': incremental_predicates }) %}
+    {% set build_sql = strategy_sql_macro_func(strategy_arg_dict) %}
+
+    {% do to_drop.append(temp_relation) %}
+  {% endif %}
+
+  {% if build_sql_is_create_table_as %}
+    {#- This batch is create_table_as catalog DDL, so letting statement() open
+        the ambient transaction would hold its sysschobjs X keylocks until
+        adapter.commit() and deadlock a second worker. -#}
+    {% call statement("main", auto_begin=False) %}
+        {{ build_sql }}
+    {% endcall %}
+    {#- Reopen the ambient transaction the batch above declined to start, so
+        the swap and the tail (grants/persist_docs/indexes/post-hooks) keep
+        their semantics and adapter.commit() below has a matching BEGIN
+        rather than raising Msg 3902. -#}
+    {% do adapter.commit_if_open() %}
+    {% do adapter.begin_if_closed() %}
+    {{ build_model_constraints(target_relation) }}
+  {% else %}
+    {% call statement("main") %}
+        {{ build_sql }}
+    {% endcall %}
+  {% endif %}
+
+  {% if need_swap %}
+      {% do adapter.rename_relation(target_relation, backup_relation) %}
+      {% do adapter.rename_relation(intermediate_relation, target_relation) %}
+      {% do to_drop.append(backup_relation) %}
+  {% endif %}
+
+  {% set should_revoke = should_revoke(existing_relation, full_refresh_mode) %}
+  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
+
+  {% do persist_docs(target_relation, model) %}
+
+  {% if build_sql_is_create_table_as %}
+    {% do create_indexes(target_relation) %}
+  {% endif %}
+
+  {{ run_hooks(post_hooks, inside_transaction=True) }}
+
+  -- `COMMIT` happens here
+  {% do adapter.commit() %}
+
+  {% for rel in to_drop %}
+      {% do adapter.drop_relation(rel) %}
+  {% endfor %}
+
+  {{ run_hooks(post_hooks, inside_transaction=False) }}
+
+  {{ return({'relations': [target_relation]}) }}
+
+{%- endmaterialization %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/materializations/models/incremental/incremental_strategies.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/materializations/models/incremental/incremental_strategies.sql
@@ -1,0 +1,11 @@
+{% macro sqlserver__get_incremental_default_sql(arg_dict) %}
+
+    {% if arg_dict["unique_key"] %}
+        -- Merge strategy: emits a MERGE statement via get_incremental_merge_sql
+        {% do return(get_incremental_merge_sql(arg_dict)) %}
+    {% else %}
+        -- Incremental Append will insert data into target table.
+        {% do return(get_incremental_append_sql(arg_dict)) %}
+    {% endif %}
+
+{% endmacro %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/materializations/models/incremental/merge.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/materializations/models/incremental/merge.sql
@@ -1,0 +1,95 @@
+{% macro sqlserver__get_merge_sql(target, source, unique_key, dest_columns, incremental_predicates=none) %}
+  {{ default__get_merge_sql(target, source, unique_key, dest_columns, incremental_predicates) }}
+  {{ get_query_options(parse_options=True) }}
+{% endmacro %}
+
+{% macro sqlserver__get_insert_overwrite_merge_sql(target, source, dest_columns, predicates, include_sql_header) %}
+  {{ default__get_insert_overwrite_merge_sql(target, source, dest_columns, predicates, include_sql_header) }};
+{% endmacro %}
+
+{% macro sqlserver__get_delete_insert_merge_sql(target, source, unique_key, dest_columns, incremental_predicates=none) %}
+
+    {% set query_label = get_query_options(parse_options=True) %}
+    {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute="name")) -%}
+
+    {% if unique_key %}
+        {% if unique_key is sequence and unique_key is not string %}
+            SET NOCOUNT ON;
+            delete from {{ target }}
+            where exists (
+                select null
+                from {{ source }}
+                where
+                {% for key in unique_key %}
+                    {{ source }}.{{ key }} = {{ target }}.{{ key }}
+                    {{ "and " if not loop.last }}
+                {% endfor %}
+            )
+            {% if incremental_predicates %}
+                {% for predicate in incremental_predicates %}
+                    and {{ predicate }}
+                {% endfor %}
+            {% endif %}
+            {{ query_label }}
+            SET NOCOUNT OFF;
+        {% else %}
+            SET NOCOUNT ON;
+            delete from {{ target }}
+            where (
+                {{ unique_key }}) in (
+                select ({{ unique_key }})
+                from {{ source }}
+            )
+            {%- if incremental_predicates %}
+                {% for predicate in incremental_predicates %}
+                    and {{ predicate }}
+                {% endfor %}
+            {%- endif -%}
+            {{ query_label }}
+            SET NOCOUNT OFF;
+        {% endif %}
+    {% endif %}
+
+    insert into {{ target }} ({{ dest_cols_csv }})
+    (
+        select {{ dest_cols_csv }}
+        from {{ source }}
+    ){{ query_label }}
+{% endmacro %}
+
+{% macro sqlserver__get_incremental_microbatch_sql(arg_dict) %}
+    {%- set target = arg_dict["target_relation"] -%}
+    {%- set source = arg_dict["temp_relation"] -%}
+    {%- set dest_columns = arg_dict["dest_columns"] -%}
+    {%- set incremental_predicates = [] if arg_dict.get('incremental_predicates') is none else arg_dict.get('incremental_predicates') -%}
+    {%- set query_label = get_query_options(parse_options=True) -%}
+
+    {#-- Add additional incremental_predicates to filter for batch --#}
+    {% if model.config.get("__dbt_internal_microbatch_event_time_start") -%}
+    {{ log("incremental append event start time > DBT_INTERNAL_TARGET." ~ model.config.event_time ~ " >= cast('" ~ model.config.__dbt_internal_microbatch_event_time_start ~ "' as datetimeoffset)") }}
+        {% do incremental_predicates.append("DBT_INTERNAL_TARGET." ~ model.config.event_time ~ " >= cast('" ~ model.config.__dbt_internal_microbatch_event_time_start ~ "' as datetimeoffset)") %}
+    {% endif %}
+    {% if model.config.__dbt_internal_microbatch_event_time_end -%}
+    {{ log("incremental append event end time < DBT_INTERNAL_TARGET." ~ model.config.event_time ~ " < cast('" ~ model.config.__dbt_internal_microbatch_event_time_end ~ "' as datetimeoffset)") }}
+        {% do incremental_predicates.append("DBT_INTERNAL_TARGET." ~ model.config.event_time ~ " < cast('" ~ model.config.__dbt_internal_microbatch_event_time_end ~ "' as datetimeoffset)") %}
+    {% endif %}
+    {% do arg_dict.update({'incremental_predicates': incremental_predicates}) %}
+
+    SET NOCOUNT ON;
+    delete DBT_INTERNAL_TARGET from {{ target }} AS DBT_INTERNAL_TARGET
+    where (
+    {% for predicate in incremental_predicates %}
+        {%- if not loop.first %}and {% endif -%} {{ predicate }}
+    {% endfor %}
+    )
+    {{ query_label }}
+    SET NOCOUNT OFF;
+
+    {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute="name")) -%}
+    insert into {{ target }} ({{ dest_cols_csv }})
+    (
+        select {{ dest_cols_csv }}
+        from {{ source }}
+    )
+    {{ query_label }}
+{% endmacro %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/materializations/models/table/columns_spec_ddl.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/materializations/models/table/columns_spec_ddl.sql
@@ -1,0 +1,30 @@
+{% macro build_columns_constraints(relation) %}
+    {{ return(adapter.dispatch('build_columns_constraints', 'dbt')(relation)) }}
+{% endmacro %}
+
+{% macro sqlserver__build_columns_constraints(relation) %}
+  {# loop through user_provided_columns to create DDL with data types and constraints #}
+    {%- set raw_column_constraints = adapter.render_raw_columns_constraints(raw_columns=model['columns']) -%}
+    (
+      {% for c in raw_column_constraints -%}
+        {{ c }}{{ "," if not loop.last }}
+      {% endfor %}
+    )
+{% endmacro %}
+
+{% macro build_model_constraints(relation) %}
+    {{ return(adapter.dispatch('build_model_constraints', 'dbt')(relation)) }}
+{% endmacro %}
+
+{% macro sqlserver__build_model_constraints(relation) %}
+  {# loop through user_provided_columns to create DDL with data types and constraints #}
+    {%- set raw_model_constraints = adapter.render_raw_model_constraints(raw_constraints=model['constraints']) -%}
+    {% for c in raw_model_constraints -%}
+      {% set alter_table_script %}
+        alter table {{ relation.include(database=False) }} {{c}};
+      {%endset%}
+      {% call statement('alter_table_add_constraint') -%}
+        {{alter_table_script}}
+      {%- endcall %}
+    {% endfor -%}
+{% endmacro %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/materializations/models/table/create_table_as.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/materializations/models/table/create_table_as.sql
@@ -1,0 +1,95 @@
+{% macro sqlserver__create_clustered_columnstore_index(relation) -%}
+    {#- cci_name embeds the schema, so it must be quoted as an identifier
+        (raw only in the string comparison below) -- issue #409 -#}
+    {%- set cci_name = (relation.schema ~ '_' ~ relation.identifier ~ '_cci') | replace(".", "") | replace(" ", "") -%}
+    {%- set relation_name = relation.include(database=False) -%}
+    {{ get_use_database_sql(relation.database) }}
+    if EXISTS (
+        SELECT *
+        FROM sys.indexes {{ information_schema_hints() }}
+        WHERE name = '{{ escape_single_quotes(cci_name) }}'
+        AND object_id=object_id('{{ escape_single_quotes(relation_name) }}')
+    )
+    DROP index {{ relation_name }}.{{ adapter.quote(cci_name) }}
+    CREATE CLUSTERED COLUMNSTORE INDEX {{ adapter.quote(cci_name) }}
+    ON {{ relation_name }}
+{% endmacro %}
+
+{% macro sqlserver__create_table_as(temporary, relation, sql) -%}
+    {%- set query_label = get_query_options(parse_options=True) -%}
+    {%- set full_refresh_build = config.get('full_refresh_build', 'heap_then_index') -%}
+    {%- if full_refresh_build == 'prebuilt' -%}
+      {{ exceptions.raise_compiler_error(
+        "full_refresh_build='prebuilt' is not implemented yet in dbt Core v2's "
+        "SQL Server adapter (tracked as a follow-up issue). Use the default 'heap_then_index'."
+      ) }}
+    {%- elif full_refresh_build != 'heap_then_index' -%}
+      {{ exceptions.raise_compiler_error(
+        "Invalid full_refresh_build '" ~ full_refresh_build ~ "'. Only 'heap_then_index' (default) is supported."
+      ) }}
+    {%- endif -%}
+    {%- set tmp_relation = relation.incorporate(path={"identifier": relation.identifier ~ '__dbt_tmp_vw'}, type='view') -%}
+
+    {#- Now that the incremental temp build commits standalone (see
+        incremental.sql), a crash can leave a throwaway table behind and the
+        SELECT * INTO below would hit Msg 2714. Drop it first, but only for
+        adapter-generated throwaways: `temporary` covers the incremental
+        __dbt_temp build, the suffix covers the full-refresh / table-refresh
+        __dbt_tmp intermediate. Suffix match is exact, never substring, so a
+        user model named stg__dbt_tmp_x is untouched.
+        Never guard a fresh-create of the real target: dbt has decided that
+        table does not exist, so 2714 must still surface rather than silently
+        destroying an object dbt does not know about. -#}
+    {%- set _ident = relation.identifier -%}
+    {%- set build_into_temp = temporary or _ident.endswith('__dbt_tmp') or _ident.endswith('__dbt_tmp_vw') -%}
+
+    {%- do adapter.drop_relation(tmp_relation) -%}
+    {{ get_use_database_sql(relation.database) }}
+    {{ get_create_view_as_sql(tmp_relation, sql) }}
+
+    {%- set table_name -%}
+        {{ relation }}
+    {%- endset -%}
+
+
+    {%- set contract_config = config.get('contract') -%}
+    {%- set query -%}
+        {% if contract_config.enforced and (not temporary) %}
+            CREATE TABLE {{table_name}}
+            {{ get_assert_columns_equivalent(sql)  }}
+            {{ build_columns_constraints(relation) }}
+            {% set listColumns %}
+                {% for column in model['columns'] %}
+                    {{ adapter.quote(column) }}{{ ", " if not loop.last }}
+                {% endfor %}
+            {%endset%}
+            INSERT INTO {{relation}} WITH (TABLOCK) ({{listColumns}})
+            SELECT {{listColumns}} FROM {{tmp_relation}} {{ query_label }}
+
+        {% else %}
+            {%- if build_into_temp -%}
+            IF OBJECT_ID('{{ escape_single_quotes(relation.include(database=False)) }}', 'U') IS NOT NULL
+                EXEC('DROP TABLE {{ relation }}');
+            {%- endif -%}
+            SELECT * INTO {{ table_name }} FROM {{ tmp_relation }} {{ query_label }}
+        {% endif %}
+    {%- endset -%}
+
+    EXEC('{{- escape_single_quotes(query) -}}')
+
+    {# For some reason drop_relation is not firing. This solves the issue for now. #}
+    EXEC('DROP VIEW IF EXISTS {{ tmp_relation.include(database=False) }}')
+
+
+
+    {% set as_columnstore = config.get('as_columnstore', default=true) %}
+    {% if not temporary and as_columnstore -%}
+        {#-
+        add columnstore index
+        this creates with dbt_temp as its coming from a temporary relation before renaming
+        could alter relation to drop the dbt_temp portion if needed
+        -#}
+        {{ sqlserver__create_clustered_columnstore_index(relation) }}
+   {% endif %}
+
+{% endmacro %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/materializations/models/table/table.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/materializations/models/table/table.sql
@@ -1,0 +1,89 @@
+{% materialization table, adapter='sqlserver' %}
+
+  {%- set existing_relation = load_cached_relation(this) -%}
+  {%- set target_relation = this.incorporate(type='table') %}
+  {%- set intermediate_relation =  make_intermediate_relation(target_relation) -%}
+  -- the intermediate_relation should not already exist in the database; get_relation
+  -- will return None in that case. Otherwise, we get a relation that we can drop
+  -- later, before we try to use this name for the current operation
+  {%- set preexisting_intermediate_relation = load_cached_relation(intermediate_relation) -%}
+  /*
+      See ../view/view.sql for more information about this relation.
+  */
+  {%- set backup_relation_type = 'table' if existing_relation is none else existing_relation.type -%}
+  {%- set backup_relation = make_backup_relation(target_relation, backup_relation_type) -%}
+  -- as above, the backup_relation should not already exist
+  {%- set preexisting_backup_relation = load_cached_relation(backup_relation) -%}
+  -- grab current tables grants config for comparison later on
+  {% set grant_config = config.get('grants') %}
+
+  {%- set table_refresh_method = config.get('table_refresh_method', 'rename') -%}
+  {%- if table_refresh_method == 'dml' -%}
+    {{ exceptions.raise_compiler_error(
+      "table_refresh_method='dml' is not implemented yet in dbt Core v2's SQL Server "
+      "adapter (tracked as a follow-up issue). Use the default 'rename'."
+    ) }}
+  {%- elif table_refresh_method != 'rename' -%}
+    {{ exceptions.raise_compiler_error(
+      "Invalid table_refresh_method '" ~ table_refresh_method ~ "'. Only 'rename' (default) is supported."
+    ) }}
+  {%- endif -%}
+  {%- set full_refresh_build = config.get('full_refresh_build', 'heap_then_index') -%}
+  {%- if full_refresh_build == 'prebuilt' -%}
+    {{ exceptions.raise_compiler_error(
+      "full_refresh_build='prebuilt' is not implemented yet in dbt Core v2's SQL Server "
+      "adapter (tracked as a follow-up issue). Use the default 'heap_then_index'."
+    ) }}
+  {%- elif full_refresh_build != 'heap_then_index' -%}
+    {{ exceptions.raise_compiler_error(
+      "Invalid full_refresh_build '" ~ full_refresh_build ~ "'. Only 'heap_then_index' (default) is supported."
+    ) }}
+  {%- endif -%}
+
+  -- drop the temp relations if they exist already in the database
+  {{ drop_relation_if_exists(preexisting_intermediate_relation) }}
+  {{ drop_relation_if_exists(preexisting_backup_relation) }}
+
+  {{ run_hooks(pre_hooks, inside_transaction=False) }}
+
+  -- `BEGIN` happens here:
+  {{ run_hooks(pre_hooks, inside_transaction=True) }}
+
+  -- build model
+  {% call statement('main') -%}
+    {{ get_create_table_as_sql(False, intermediate_relation, sql) }}
+  {%- endcall %}
+
+  -- cleanup
+  {% if existing_relation is not none %}
+     /* Do the equivalent of rename_if_exists. 'existing_relation' could have been dropped
+        since the variable was first set. */
+    {% set existing_relation = load_cached_relation(existing_relation) %}
+    {% if existing_relation is not none %}
+        {{ adapter.rename_relation(existing_relation, backup_relation) }}
+    {% endif %}
+  {% endif %}
+
+  {{ adapter.rename_relation(intermediate_relation, target_relation) }}
+
+  {% do create_indexes(target_relation) %}
+
+  {{ run_hooks(post_hooks, inside_transaction=True) }}
+
+  {% set should_revoke = should_revoke(existing_relation, full_refresh_mode=True) %}
+  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
+
+  {% do persist_docs(target_relation, model) %}
+
+  {{ build_model_constraints(target_relation) }}
+
+  -- `COMMIT` happens here
+  {{ adapter.commit() }}
+
+  -- finally, drop the existing/backup relation after the commit
+  {{ drop_relation_if_exists(backup_relation) }}
+
+  {{ run_hooks(post_hooks, inside_transaction=False) }}
+
+  {{ return({'relations': [target_relation]}) }}
+{% endmaterialization %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/materializations/models/unit_test/get_fixture_sql.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/materializations/models/unit_test/get_fixture_sql.sql
@@ -1,0 +1,101 @@
+{#
+    dbt-core does not dispatch "get_fixture_sql" or "get_expected_sql", so this file
+    shadows the implementations from the dbt global project
+    (macros/unit_test_sql/get_fixture_sql.sql) - adapter package macros take
+    precedence over the global project. Keep in sync with dbt-core when upgrading.
+
+    To ease a future transition if dbt-core adds adapter.dispatch for these macros,
+    the public wrappers below are intentionally thin. They delegate to the
+    SQL Server-specific implementations (sqlserver__get_fixture_sql and
+    sqlserver__get_expected_sql), which contain the copied/adapted upstream logic.
+
+    When upstream dispatches these macros, the public wrappers can be deleted and
+    the sqlserver__ implementations kept as the dispatched handlers.
+
+    Changes from upstream (see dbt-msft/dbt-sqlserver#698):
+      - sqlserver__get_fixture_sql: the empty-rows branch emits "select top 0"
+        instead of "limit 0", which is not valid T-SQL.
+      - sqlserver__get_expected_sql: the empty-rows branch emits a "select top 0"
+        of typed nulls instead of "select * from dbt_internal_unit_test_actual limit 0".
+        Besides the invalid "limit", sqlserver__get_unit_test_sql wraps the expected
+        SQL in its own view, where that CTE name is out of scope.
+#}
+
+{% macro get_fixture_sql(rows, column_name_to_data_types) %}
+    {{ return(sqlserver__get_fixture_sql(rows, column_name_to_data_types)) }}
+{% endmacro %}
+
+
+{% macro sqlserver__get_fixture_sql(rows, column_name_to_data_types) %}
+-- Fixture for {{ model.name }}
+{% set default_row = {} %}
+
+{%- if not column_name_to_data_types -%}
+{#-- Use defer_relation IFF it is available in the manifest and 'this' is missing from the database --#}
+{%-   set this_or_defer_relation = defer_relation if (defer_relation and not load_relation(this)) else this -%}
+{%-   set columns_in_relation = adapter.get_columns_in_relation(this_or_defer_relation) -%}
+
+{%-   set column_name_to_data_types = {} -%}
+{%-   set column_name_to_quoted = {} -%}
+{%-   for column in columns_in_relation -%}
+
+{#-- This needs to be a case-insensitive comparison --#}
+{%-     do column_name_to_data_types.update({column.name|lower: column.data_type}) -%}
+{%-     do column_name_to_quoted.update({column.name|lower: column.quoted}) -%}
+{%-   endfor -%}
+{%- endif -%}
+
+{%- if not column_name_to_data_types -%}
+    {{ exceptions.raise_compiler_error("Not able to get columns for unit test '" ~ model.name ~ "' from relation " ~ this ~ " because the relation doesn't exist") }}
+{%- endif -%}
+
+{%- for column_name, column_type in column_name_to_data_types.items() -%}
+    {%- do default_row.update({column_name: (safe_cast("null", column_type) | trim )}) -%}
+{%- endfor -%}
+
+{{ validate_fixture_rows(rows, row_number) }}
+
+{%- for row in rows -%}
+{%-   set formatted_row = format_row(row, column_name_to_data_types) -%}
+{%-   set default_row_copy = default_row.copy() -%}
+{%-   do default_row_copy.update(formatted_row) -%}
+select
+{%-   for column_name, column_value in default_row_copy.items() %} {{ column_value }} as {{ column_name_to_quoted[column_name] }}{% if not loop.last -%}, {%- endif %}
+{%-   endfor %}
+{%-   if not loop.last %}
+union all
+{%    endif %}
+{%- endfor -%}
+
+{%- if (rows | length) == 0 -%}
+    select top 0
+    {%- for column_name, column_value in default_row.items() %} {{ column_value }} as {{ column_name_to_quoted[column_name] }}{% if not loop.last -%},{%- endif %}
+    {%- endfor %}
+{%- endif -%}
+{% endmacro %}
+
+
+{% macro get_expected_sql(rows, column_name_to_data_types, column_name_to_quoted) %}
+    {{ return(sqlserver__get_expected_sql(rows, column_name_to_data_types, column_name_to_quoted)) }}
+{% endmacro %}
+
+
+{% macro sqlserver__get_expected_sql(rows, column_name_to_data_types, column_name_to_quoted) %}
+
+{%- if (rows | length) == 0 -%}
+    select top 0
+    {%- for column_name, column_type in column_name_to_data_types.items() %} {{ safe_cast("null", column_type) | trim }} as {{ column_name_to_quoted[column_name] }}{% if not loop.last -%},{%- endif %}
+    {%- endfor %}
+{%- else -%}
+{%- for row in rows -%}
+{%- set formatted_row = format_row(row, column_name_to_data_types) -%}
+select
+{%- for column_name, column_value in formatted_row.items() %} {{ column_value }} as {{ column_name_to_quoted[column_name] }}{% if not loop.last -%}, {%- endif %}
+{%- endfor %}
+{%- if not loop.last %}
+union all
+{% endif %}
+{%- endfor -%}
+{%- endif -%}
+
+{% endmacro %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/materializations/models/view/create_view_as.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/materializations/models/view/create_view_as.sql
@@ -1,0 +1,30 @@
+{% macro sqlserver__create_view_as(relation, sql) -%}
+    {#- Only guard against user-configured view materializations; this macro is also
+        called for intermediate temp views during table/snapshot materializations,
+        where query_options is intended for the *outer* DML and shouldn't trip a guard here. -#}
+    {%- if config.get('materialized') == 'view' -%}
+        {{ raise_if_query_options_set('view materializations (SQL Server does not accept OPTION on CREATE VIEW)') }}
+    {%- endif -%}
+
+    {%- if config.get('sql_header') -%}
+        {{ exceptions.raise_compiler_error(
+            "sql_header is not supported on SQL Server. "
+            "CREATE VIEW must be the first statement in a batch, so sql_header cannot run in the same query. "
+            "Use pre_hooks for pre-model SQL or query_options for session-level SET options (e.g. query_options={'NOCOUNT': 'ON'})."
+        ) }}
+    {%- endif -%}
+
+    {{ get_use_database_sql(relation.database) }}
+    {% set contract_config = config.get('contract') %}
+    {% if contract_config.enforced %}
+        {{ get_assert_columns_equivalent(sql) }}
+    {%- endif %}
+
+    {% set query %}
+        CREATE OR ALTER VIEW {{ relation.include(database=False) }} AS {{ sql }};
+    {% endset %}
+
+    {{ get_use_database_sql(relation.database) }}
+    EXEC('{{- escape_single_quotes(query) -}}')
+
+{% endmacro %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/materializations/models/view/view.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/materializations/models/view/view.sql
@@ -1,0 +1,109 @@
+{%- materialization view, adapter='sqlserver' -%}
+  {%- set existing_relation = load_cached_relation(this) -%}
+  {%- set target_relation = this.incorporate(type='view') -%}
+  {%- set intermediate_relation =  make_intermediate_relation(target_relation) -%}
+
+  -- the intermediate_relation should not already exist in the database; get_relation
+  -- will return None in that case. Otherwise, we get a relation that we can drop
+  -- later, before we try to use this name for the current operation
+  {%- set preexisting_intermediate_relation = load_cached_relation(intermediate_relation) -%}
+  /*
+     This relation (probably) doesn't exist yet. If it does exist, it's a leftover from
+     a previous run, and we're going to try to drop it immediately. At the end of this
+     materialization, we're going to rename the "existing_relation" to this identifier,
+     and then we're going to drop it. In order to make sure we run the correct one of:
+       - drop view ...
+       - drop table ...
+
+     We need to set the type of this relation to be the type of the existing_relation, if it exists,
+     or else "view" as a sane default if it does not. Note that if the existing_relation does not
+     exist, then there is nothing to move out of the way and subsequentally drop. In that case,
+     this relation will be effectively unused.
+  */
+  {%- set backup_relation_type = 'view' if existing_relation is none else existing_relation.type -%}
+  {%- set backup_relation = make_backup_relation(target_relation, backup_relation_type) -%}
+  -- as above, the backup_relation should not already exist
+  {%- set preexisting_backup_relation = load_cached_relation(backup_relation) -%}
+  -- grab current tables grants config for comparison later on
+  {% set grant_config = config.get('grants') %}
+  {% set preserved_grants = {} %}
+  {% set should_skip_view_update = false %}
+  {% set build_sql = none %}
+
+  {% if existing_relation is not none and existing_relation.type != 'view' %}
+    {% set current_grants_table = run_query(get_show_grant_sql(existing_relation)) %}
+    {% set current_grants_dict = adapter.standardize_grants_dict(current_grants_table) %}
+    {% set preserved_grants = {} %}
+    {% for privilege, grantees in diff_of_two_dicts(current_grants_dict, grant_config).items() %}
+      {% if privilege | lower in ['select', 'insert', 'update', 'delete'] %}
+        {% do preserved_grants.update({privilege: grantees}) %}
+      {% endif %}
+    {% endfor %}
+    {% set build_sql = get_create_view_as_sql(intermediate_relation, sql) %}
+  {% elif existing_relation is not none and existing_relation.type == 'view' %}
+    {% set current_view_definition_table = run_query(get_view_definition_sql(existing_relation)) %}
+    {% if current_view_definition_table is not none and current_view_definition_table.rows | length > 0 %}
+      {% set normalized_relation = target_relation.include(database=False) | lower | replace('\n', '') | replace('\r', '') | replace('\t', '') | replace(' ', '') | replace(';', '') %}
+      {% set normalized_sql = sql | lower | replace('\n', '') | replace('\r', '') | replace('\t', '') | replace(' ', '') | replace(';', '') %}
+      {% set normalized_definition = current_view_definition_table.rows[0][0] | lower | replace('\n', '') | replace('\r', '') | replace('\t', '') | replace(' ', '') | replace(';', '') %}
+      {% set should_skip_view_update = normalized_definition.endswith(normalized_sql) %}
+    {% endif %}
+    {% if should_skip_view_update %}
+      {% set build_sql = 'declare @dbt_sqlserver_noop int;' %}
+    {% else %}
+      {% set build_sql = get_create_view_as_sql(target_relation, sql) %}
+    {% endif %}
+  {% else %}
+    {% set build_sql = get_create_view_as_sql(target_relation, sql) %}
+  {% endif %}
+
+  {{ run_hooks(pre_hooks, inside_transaction=False) }}
+
+  -- drop the temp relations if they exist already in the database
+  {{ drop_relation_if_exists(preexisting_intermediate_relation) }}
+  {{ drop_relation_if_exists(preexisting_backup_relation) }}
+
+  -- `BEGIN` happens here:
+  {{ run_hooks(pre_hooks, inside_transaction=True) }}
+
+  {% if existing_relation is not none and existing_relation.type != 'view' %}
+    -- build model
+    {% call statement('main') -%}
+      {{ build_sql }}
+    {%- endcall %}
+
+    -- cleanup
+    -- move the existing relation out of the way
+    {% set existing_relation = load_cached_relation(existing_relation) %}
+    {% if existing_relation is not none %}
+        {{ adapter.rename_relation(existing_relation, backup_relation) }}
+    {% endif %}
+
+    {{ adapter.rename_relation(intermediate_relation, target_relation) }}
+  {% else %}
+    -- build model
+    {% call statement('main') -%}
+      {{ build_sql }}
+    {%- endcall %}
+  {% endif %}
+
+  {% set should_revoke = should_revoke(existing_relation, full_refresh_mode=True) %}
+  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
+
+  {% if preserved_grants %}
+    {% do apply_grants(target_relation, preserved_grants, should_revoke=False) %}
+  {% endif %}
+
+  {% do persist_docs(target_relation, model) %}
+
+  {{ run_hooks(post_hooks, inside_transaction=True) }}
+
+  {{ adapter.commit() }}
+
+  {{ drop_relation_if_exists(backup_relation) }}
+
+  {{ run_hooks(post_hooks, inside_transaction=False) }}
+
+  {{ return({'relations': [target_relation]}) }}
+
+{%- endmaterialization -%}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/materializations/seeds/helpers.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/materializations/seeds/helpers.sql
@@ -1,0 +1,60 @@
+{% macro sqlserver__get_binding_char() %}
+  {{ return('?') }}
+{% endmacro %}
+
+{% macro sqlserver__get_batch_size() %}
+  {{ return(400) }}
+{% endmacro %}
+
+{% macro calc_batch_size(num_columns) %}
+    {#
+        SQL Server allows for a max of 2098 parameters in a single statement.
+        Check if the max_batch_size fits with the number of columns, otherwise
+        reduce the batch size so it fits.
+    #}
+    {% set max_batch_size = get_batch_size() %}
+    {% set calculated_batch = (2098 / num_columns)|int %}
+    {% set batch_size = [max_batch_size, calculated_batch] | min %}
+
+    {{ return(batch_size) }}
+{%  endmacro %}
+
+{% macro sqlserver__load_csv_rows(model, agate_table) %}
+  {% set cols_sql = get_seed_column_quoted_csv(model, agate_table.column_names) %}
+  {% set batch_size = calc_batch_size(agate_table.column_names|length) %}
+  {% set statements = [] %}
+
+  {{ log("Inserting batches of " ~ batch_size ~ " records") }}
+
+  {% for chunk in agate_table.rows | batch(batch_size) %}
+      {% set bindings = [] %}
+      {% set values_clause = [] %}
+
+      {% for row in chunk %}
+          {% set row_values = [] %}
+          {% for column in agate_table.column_names %}
+              {%- set val = row[loop.index0] -%}
+              {%- if val is none -%}
+                  {%- do row_values.append("null") -%}
+              {%- else -%}
+                  {%- do row_values.append(get_binding_char()) -%}
+                  {%- do bindings.append(val) -%}
+              {%- endif -%}
+          {% endfor %}
+          {% do values_clause.append("(" ~ row_values | join(", ") ~ ")") %}
+      {% endfor %}
+
+      {% set sql %}
+          insert into {{ this.render() }} ({{ cols_sql }}) values {{ values_clause | join(", ") }}
+      {% endset %}
+
+      {% do adapter.add_query(sql, bindings=bindings, abridge_sql_log=True) %}
+
+      {% if loop.index0 == 0 %}
+          {% do statements.append(sql) %}
+      {% endif %}
+  {% endfor %}
+
+  {# Return SQL so we can render it out into the compiled files #}
+  {{ return(statements[0]) }}
+{% endmacro %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/materializations/snapshots/helpers.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/materializations/snapshots/helpers.sql
@@ -1,0 +1,189 @@
+{% macro sqlserver__create_columns(relation, columns) %}
+  {% set column_list %}
+    {% for column_entry in columns %}
+      {{column_entry.name}} {{column_entry.data_type}}{{ ", " if not loop.last }}
+    {% endfor %}
+  {% endset %}
+
+  {% set alter_sql %}
+    ALTER TABLE {{ relation }}
+    ADD {{ column_list }}
+  {% endset %}
+
+  {% set results = run_query(alter_sql) %}
+
+{% endmacro %}
+
+{% macro build_snapshot_staging_table(strategy, temp_snapshot_relation, target_relation) %}
+    {% set temp_relation = make_temp_relation(target_relation) %}
+    {{ adapter.drop_relation(temp_relation) }}
+
+    {% set select = snapshot_staging_table(strategy, temp_snapshot_relation, target_relation) %}
+
+    {% set tmp_tble_vw_relation = temp_relation.incorporate(path={"identifier": temp_relation.identifier ~ '__dbt_tmp_vw'}, type='view')-%}
+    -- Dropping temp view relation if it exists
+    {{ adapter.drop_relation(tmp_tble_vw_relation) }}
+
+    {% call statement('build_snapshot_staging_relation') %}
+        {{ get_create_table_as_sql(True, temp_relation, select) }}
+    {% endcall %}
+
+    -- Dropping temp view relation if it exists
+    {{ adapter.drop_relation(tmp_tble_vw_relation) }}
+
+    {% do return(temp_relation) %}
+{% endmacro %}
+
+
+{% macro sqlserver__post_snapshot(staging_relation) %}
+  -- Clean up the snapshot temp table
+  {% do drop_relation_if_exists(staging_relation) %}
+{% endmacro %}
+
+{% macro sqlserver__get_true_sql() %}
+  {{ return('1=1') }}
+{% endmacro %}
+
+{% macro sqlserver__build_snapshot_table(strategy, relation) %}
+    {% set columns = config.get('snapshot_table_column_names') or get_snapshot_table_column_names() %}
+    select *,
+        {{ strategy.scd_id }} as {{ columns.dbt_scd_id }},
+        {{ strategy.updated_at }} as {{ columns.dbt_updated_at }},
+        {{ strategy.updated_at }} as {{ columns.dbt_valid_from }},
+        {{ get_dbt_valid_to_current(strategy, columns) }}
+        {%- if strategy.hard_deletes == 'new_record' -%}
+            , 'False' as {{ columns.dbt_is_deleted }}
+        {% endif -%}
+    from (
+        select * from {{ relation }}
+    ) sbq
+
+{% endmacro %}
+
+{% macro sqlserver__snapshot_staging_table(strategy, temp_snapshot_relation, target_relation) -%}
+
+    {% set columns = config.get('snapshot_table_column_names') or get_snapshot_table_column_names() %}
+
+    with snapshot_query as (
+        select * from {{ temp_snapshot_relation }}
+    ),
+    snapshotted_data as (
+        select *,
+        {{ unique_key_fields(strategy.unique_key) }}
+        from {{ target_relation }}
+        where
+        {% if config.get('dbt_valid_to_current') %}
+            {# Check for either dbt_valid_to_current OR null, in order to correctly update records with nulls #}
+            ( {{ columns.dbt_valid_to }} = {{ config.get('dbt_valid_to_current') }} or {{ columns.dbt_valid_to }} is null)
+        {% else %}
+            {{ columns.dbt_valid_to }} is null
+        {% endif %}
+        {%- if strategy.hard_deletes == 'new_record' -%}
+            and {{ columns.dbt_is_deleted }} = 'False'
+        {% endif -%}
+    ),
+    insertions_source_data as (
+        select *,
+        {{ unique_key_fields(strategy.unique_key) }},
+        {{ strategy.updated_at }} as {{ columns.dbt_updated_at }},
+        {{ strategy.updated_at }} as {{ columns.dbt_valid_from }},
+        {{ get_dbt_valid_to_current(strategy, columns) }},
+        {{ strategy.scd_id }} as {{ columns.dbt_scd_id }}
+        from snapshot_query
+    ),
+    updates_source_data as (
+        select *,
+        {{ unique_key_fields(strategy.unique_key) }},
+        {{ strategy.updated_at }} as {{ columns.dbt_updated_at }},
+        {{ strategy.updated_at }} as {{ columns.dbt_valid_from }},
+        {{ strategy.updated_at }} as {{ columns.dbt_valid_to }}
+        from snapshot_query
+    ),
+    {%- if strategy.hard_deletes == 'invalidate' or strategy.hard_deletes == 'new_record' %}
+        deletes_source_data as (
+            select *, {{ unique_key_fields(strategy.unique_key) }}
+            from snapshot_query
+        ),
+    {% endif %}
+    insertions as (
+        select 'insert' as dbt_change_type, source_data.*
+        {%- if strategy.hard_deletes == 'new_record' -%}
+        ,'False' as {{ columns.dbt_is_deleted }}
+        {%- endif %}
+        from insertions_source_data as source_data
+        left outer join snapshotted_data
+            on {{ unique_key_join_on(strategy.unique_key, "snapshotted_data", "source_data") }}
+            where {{ unique_key_is_null(strategy.unique_key, "snapshotted_data") }}
+            or ({{ unique_key_is_not_null(strategy.unique_key, "snapshotted_data") }} and ({{ strategy.row_changed }}))
+    ),
+    updates as (
+        select 'update' as dbt_change_type, source_data.*,
+        snapshotted_data.{{ columns.dbt_scd_id }}
+        {%- if strategy.hard_deletes == 'new_record' -%}
+        , snapshotted_data.{{ columns.dbt_is_deleted }}
+        {%- endif %}
+        from updates_source_data as source_data
+        join snapshotted_data
+        on {{ unique_key_join_on(strategy.unique_key, "snapshotted_data", "source_data") }}
+        where ({{ strategy.row_changed }})
+    )
+    {%- if strategy.hard_deletes == 'invalidate' or strategy.hard_deletes == 'new_record' %}
+        ,
+        deletes as (
+            select 'delete' as dbt_change_type,
+            source_data.*,
+            {{ snapshot_get_time() }} as {{ columns.dbt_valid_from }},
+            {{ snapshot_get_time() }} as {{ columns.dbt_updated_at }},
+            {{ snapshot_get_time() }} as {{ columns.dbt_valid_to }},
+            snapshotted_data.{{ columns.dbt_scd_id }}
+            {%- if strategy.hard_deletes == 'new_record' -%}
+            , snapshotted_data.{{ columns.dbt_is_deleted }}
+            {%- endif %}
+            from snapshotted_data
+            left join deletes_source_data as source_data
+            on {{ unique_key_join_on(strategy.unique_key, "snapshotted_data", "source_data") }}
+            where {{ unique_key_is_null(strategy.unique_key, "source_data") }}
+        )
+    {%- endif %}
+    {%- if strategy.hard_deletes == 'new_record' %}
+        {%set source_query = "select * from "~temp_snapshot_relation%}
+        {% set source_sql_cols = get_column_schema_from_query(source_query) %}
+        ,
+        deletion_records as (
+
+            select
+            'insert' as dbt_change_type,
+            {%- for col in source_sql_cols -%}
+            snapshotted_data.{{ adapter.quote(col.column) }},
+            {% endfor -%}
+            {%- if strategy.unique_key | is_list -%}
+                {%- for key in strategy.unique_key -%}
+            snapshotted_data.{{ key }} as dbt_unique_key_{{ loop.index }},
+                {% endfor -%}
+            {%- else -%}
+            snapshotted_data.dbt_unique_key as dbt_unique_key,
+            {% endif -%}
+            {{ snapshot_get_time() }} as {{ columns.dbt_valid_from }},
+            {{ snapshot_get_time() }} as {{ columns.dbt_updated_at }},
+            snapshotted_data.{{ columns.dbt_valid_to }} as {{ columns.dbt_valid_to }},
+            snapshotted_data.{{ columns.dbt_scd_id }},
+            'True' as {{ columns.dbt_is_deleted }}
+            from snapshotted_data
+            left join deletes_source_data as source_data
+            on {{ unique_key_join_on(strategy.unique_key, "snapshotted_data", "source_data") }}
+            where {{ unique_key_is_null(strategy.unique_key, "source_data") }}
+        )
+    {%- endif %}
+    select * from insertions
+    union all
+    select * from updates
+    {%- if strategy.hard_deletes == 'invalidate' or strategy.hard_deletes == 'new_record' %}
+        union all
+        select * from deletes
+    {%- endif %}
+    {%- if strategy.hard_deletes == 'new_record' %}
+        union all
+        select * from deletion_records
+    {%- endif %}
+
+{%- endmacro %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/materializations/snapshots/snapshot.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/materializations/snapshots/snapshot.sql
@@ -1,0 +1,126 @@
+{% materialization snapshot, adapter='sqlserver' %}
+
+  {%- set config = model['config'] -%}
+  {%- set target_table = model.get('alias', model.get('name')) -%}
+  {%- set strategy_name = config.get('strategy') -%}
+  {%- set unique_key = config.get('unique_key') %}
+  -- grab current tables grants config for comparison later on
+  {%- set grant_config = config.get('grants') -%}
+
+  {% set target_relation_exists, target_relation = get_or_create_relation(
+          database=model.database,
+          schema=model.schema,
+          identifier=target_table,
+          type='table') -%}
+
+  {%- if not target_relation.is_table -%}
+    {% do exceptions.relation_wrong_type(target_relation, 'table') %}
+  {%- endif -%}
+
+  {{ run_hooks(pre_hooks, inside_transaction=False) }}
+  {{ run_hooks(pre_hooks, inside_transaction=True) }}
+
+  {% set strategy_macro = strategy_dispatch(strategy_name) %}
+  {% set strategy = strategy_macro(model, "snapshotted_data", "source_data", config, target_relation_exists) %}
+
+  {% set temp_snapshot_relation_exists, temp_snapshot_relation = get_or_create_relation(
+          database=model.database,
+          schema=model.schema,
+          identifier=target_table+"_snapshot_staging_temp_view",
+          type='view') -%}
+
+  -- Create a temporary view to manage if user SQl uses CTE
+  {% set temp_snapshot_relation_sql = model['compiled_code'] %}
+  {{ adapter.drop_relation(temp_snapshot_relation) }}
+
+  {% call statement('create temp_snapshot_relation') -%}
+    {{ get_create_view_as_sql(temp_snapshot_relation, temp_snapshot_relation_sql) }}
+  {%- endcall %}
+
+  {% if not target_relation_exists %}
+
+      {% set build_sql = build_snapshot_table(strategy, temp_snapshot_relation) %}
+      {% set build_or_select_sql = build_sql %}
+
+      -- naming a temp relation
+      {% set tmp_relation_view = target_relation.incorporate(path={"identifier": target_relation.identifier ~ '__dbt_tmp_vw'}, type='view')-%}
+      -- SQL server adapter uses temp relation because of lack of CTE support for CTE in CTAS, Insert
+      -- drop temp relation if exists
+      {{ adapter.drop_relation(tmp_relation_view) }}
+      {% set final_sql = get_create_table_as_sql(False, target_relation, build_sql) %}
+      {{ adapter.drop_relation(tmp_relation_view) }}
+
+  {% else %}
+
+      {% set columns = get_snapshot_table_column_names() %}
+      {% set meta = config.get("snapshot_meta_column_names") %}
+      {% if meta %}
+          {% if meta.dbt_valid_from %}{% do columns.update({"dbt_valid_from": meta.dbt_valid_from}) %}{% endif %}
+          {% if meta.dbt_valid_to %}{% do columns.update({"dbt_valid_to": meta.dbt_valid_to}) %}{% endif %}
+          {% if meta.dbt_scd_id %}{% do columns.update({"dbt_scd_id": meta.dbt_scd_id}) %}{% endif %}
+          {% if meta.dbt_updated_at %}{% do columns.update({"dbt_updated_at": meta.dbt_updated_at}) %}{% endif %}
+          {% if meta.dbt_is_deleted %}{% do columns.update({"dbt_is_deleted": meta.dbt_is_deleted}) %}{% endif %}
+      {% endif %}
+      {{ adapter.valid_snapshot_target(target_relation, columns) }}
+      {% set build_or_select_sql = snapshot_staging_table(strategy, temp_snapshot_relation, target_relation) %}
+      {% set staging_table = build_snapshot_staging_table(strategy, temp_snapshot_relation, target_relation) %}
+      -- this may no-op if the database does not require column expansion
+      {% set expansion_max_rows = config.get('column_type_expansion_max_rows', 1000000) %}
+      {% do adapter.expand_target_column_types(from_relation=staging_table,
+                                               to_relation=target_relation,
+                                               max_rows=expansion_max_rows) %}
+
+      {% set remove_columns = ['dbt_change_type', 'DBT_CHANGE_TYPE', 'dbt_unique_key', 'DBT_UNIQUE_KEY'] %}
+      {% if unique_key | is_list %}
+          {% for key in strategy.unique_key %}
+              {{ remove_columns.append('dbt_unique_key_' + loop.index|string) }}
+              {{ remove_columns.append('DBT_UNIQUE_KEY_' + loop.index|string) }}
+          {% endfor %}
+      {% endif %}
+      {% set missing_columns = adapter.get_missing_columns(staging_table, target_relation)
+                                   | rejectattr('name', 'in', remove_columns)
+                                   | list %}
+      {% if missing_columns|length > 0 %}
+        {{log("Missing columns length is: "~ missing_columns|length)}}
+        {% do create_columns(target_relation, missing_columns) %}
+      {% endif %}
+      {% set source_columns = adapter.get_columns_in_relation(staging_table)
+                                   | rejectattr('name', 'in', remove_columns)
+                                   | list %}
+      {% set quoted_source_columns = [] %}
+      {% for column in source_columns %}
+        {% do quoted_source_columns.append(adapter.quote(column.name)) %}
+      {% endfor %}
+      {% set final_sql = snapshot_merge_sql(
+            target = target_relation,
+            source = staging_table,
+            insert_cols = quoted_source_columns
+         )
+      %}
+  {% endif %}
+  {{ check_time_data_types(build_or_select_sql) }}
+  {% call statement('main') %}
+      {{ final_sql }}
+  {% endcall %}
+
+  {{ adapter.drop_relation(temp_snapshot_relation) }}
+  {% set should_revoke = should_revoke(target_relation_exists, full_refresh_mode=False) %}
+  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
+
+  {% do persist_docs(target_relation, model) %}
+
+  {% if not target_relation_exists %}
+    {% do create_indexes(target_relation) %}
+  {% endif %}
+
+  {{ run_hooks(post_hooks, inside_transaction=True) }}
+  {{ adapter.commit() }}
+
+  {% if staging_table is defined %}
+      {% do post_snapshot(staging_table) %}
+  {% endif %}
+
+  {{ run_hooks(post_hooks, inside_transaction=False) }}
+  {{ return({'relations': [target_relation]}) }}
+
+{% endmaterialization %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/materializations/snapshots/snapshot_merge.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/materializations/snapshots/snapshot_merge.sql
@@ -1,0 +1,30 @@
+{% macro sqlserver__snapshot_merge_sql(target, source, insert_cols) %}
+
+  {%- set insert_cols_csv = insert_cols | join(', ') -%}
+  {%- set columns = config.get("snapshot_table_column_names") or get_snapshot_table_column_names() -%}
+  {%- set target_table = target.include(database=False) -%}
+  {%- set source_table = source.include(database=False) -%}
+  {% set target_columns_list = [] %}
+  {% for column in insert_cols %}
+    {% set target_columns_list = target_columns_list.append("DBT_INTERNAL_SOURCE."+column)  %}
+  {% endfor %}
+  {%- set target_columns = target_columns_list | join(', ') -%}
+
+  update DBT_INTERNAL_DEST
+  set {{ columns.dbt_valid_to }} = DBT_INTERNAL_SOURCE.{{ columns.dbt_valid_to }}
+  from {{ target_table }} as DBT_INTERNAL_DEST
+  inner join {{ source_table }} as DBT_INTERNAL_SOURCE
+  on DBT_INTERNAL_SOURCE.{{ columns.dbt_scd_id }} = DBT_INTERNAL_DEST.{{ columns.dbt_scd_id }}
+  where DBT_INTERNAL_SOURCE.dbt_change_type in ('update', 'delete')
+  {% if config.get("dbt_valid_to_current") %}
+    and (DBT_INTERNAL_DEST.{{ columns.dbt_valid_to }} = {{ config.get('dbt_valid_to_current') }} or DBT_INTERNAL_DEST.{{ columns.dbt_valid_to }} is null)
+  {% else %}
+    and DBT_INTERNAL_DEST.{{ columns.dbt_valid_to }} is null
+  {% endif %}
+  {{ get_query_options(parse_options=True) }}
+
+  insert into {{ target_table }} ({{ insert_cols_csv }})
+  select {{target_columns}} from {{ source_table }} as DBT_INTERNAL_SOURCE
+  where  DBT_INTERNAL_SOURCE.dbt_change_type = 'insert'
+  {{ get_query_options(parse_options=True) }}
+{% endmacro %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/materializations/snapshots/strategies.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/materializations/snapshots/strategies.sql
@@ -1,0 +1,5 @@
+{% macro sqlserver__snapshot_hash_arguments(args) %}
+    CONVERT(VARCHAR(32), HashBytes('MD5', {% for arg in args %}
+        coalesce(cast({{ arg }} as varchar(8000)), '') {% if not loop.last %} + '|' + {% endif %}
+    {% endfor %}), 2)
+{% endmacro %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/materializations/tests/helpers.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/materializations/tests/helpers.sql
@@ -1,0 +1,80 @@
+{% macro sqlserver__get_test_sql(main_sql, fail_calc, warn_if, error_if, limit) -%}
+
+  -- Create target schema if it does not
+  {{ get_use_database_sql(target.database) }}
+  IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = '{{ target.schema }}')
+  BEGIN
+    EXEC('CREATE SCHEMA {{ adapter.quote(target.schema) }}')
+  END
+
+  {% set testview_name = "testview_" ~ local_md5(main_sql) ~ "_" ~ (range(1300, 19000) | random) %}
+  {% set testview %}
+    {{ adapter.quote(target.schema) }}.{{ adapter.quote(testview_name) }}
+  {% endset %}
+
+  {% set sql = main_sql.replace("'", "''")%}
+  EXEC('create view {{testview}} as {{ sql }};')
+  select
+    {{ "top (" ~ limit ~ ')' if limit != none }}
+    {{ fail_calc }} as failures,
+    case when {{ fail_calc }} {{ warn_if }}
+      then 'true' else 'false' end as should_warn,
+    case when {{ fail_calc }} {{ error_if }}
+      then 'true' else 'false' end as should_error
+  from (
+    select * from {{testview}}
+  ) dbt_internal_test;
+
+  EXEC('drop view {{testview}};')
+
+{%- endmacro %}
+
+{% macro sqlserver__get_unit_test_sql(main_sql, expected_fixture_sql, expected_column_names) -%}
+
+  {{ get_use_database_sql(target.database) }}
+  IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = '{{ target.schema }}')
+  BEGIN
+  EXEC('CREATE SCHEMA {{ adapter.quote(target.schema) }}')
+  END
+
+  {% set test_view_name = "testview_" ~ local_md5(main_sql) ~ "_" ~ (range(1300, 19000) | random) %}
+  {% set test_view %}
+      {{ adapter.quote(target.schema) }}.{{ adapter.quote(test_view_name) }}
+  {% endset %}
+  {% set test_sql = main_sql.replace("'", "''")%}
+  EXEC('create view {{test_view}} as {{ test_sql }};')
+
+  {% set expected_view_name = "expectedview_" ~ local_md5(expected_fixture_sql) ~ "_" ~ (range(1300, 19000) | random) %}
+  {% set expected_view %}
+      {{ adapter.quote(target.schema) }}.{{ adapter.quote(expected_view_name) }}
+  {% endset %}
+  {% set expected_sql = expected_fixture_sql.replace("'", "''")%}
+  EXEC('create view {{expected_view}} as {{ expected_sql }};')
+
+  -- Build actual result given inputs
+  {% set unittest_sql %}
+  with dbt_internal_unit_test_actual as (
+    select
+      {% for expected_column_name in expected_column_names %}{{expected_column_name}}{% if not loop.last -%},{% endif %}{%- endfor -%}, {{ dbt.string_literal("actual") }} as {{ adapter.quote("actual_or_expected") }}
+    from
+      {{ test_view }}
+  ),
+  -- Build expected result
+  dbt_internal_unit_test_expected as (
+    select
+      {% for expected_column_name in expected_column_names %}{{expected_column_name}}{% if not loop.last -%}, {% endif %}{%- endfor -%}, {{ dbt.string_literal("expected") }} as {{ adapter.quote("actual_or_expected") }}
+    from
+      {{ expected_view }}
+  )
+  -- Union actual and expected results
+  select * from dbt_internal_unit_test_actual
+  union all
+  select * from dbt_internal_unit_test_expected
+  {% endset %}
+
+  EXEC('{{- escape_single_quotes(unittest_sql) -}}')
+
+  EXEC('drop view {{test_view}};')
+  EXEC('drop view {{expected_view}};')
+
+{%- endmacro %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/utils/any_value.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/utils/any_value.sql
@@ -1,0 +1,5 @@
+{% macro sqlserver__any_value(expression) -%}
+
+    min({{ expression }})
+
+{%- endmacro %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/utils/array_construct.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/utils/array_construct.sql
@@ -1,0 +1,3 @@
+{% macro sqlserver__array_construct(inputs, data_type) -%}
+    JSON_ARRAY({{ inputs|join(' , ') }})
+{%- endmacro %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/utils/cast_bool_to_text.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/utils/cast_bool_to_text.sql
@@ -1,0 +1,7 @@
+{% macro sqlserver__cast_bool_to_text(field) %}
+    case {{ field }}
+        when 1 then 'true'
+        when 0 then 'false'
+        else null
+    end
+{% endmacro %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/utils/concat.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/utils/concat.sql
@@ -1,0 +1,7 @@
+{% macro sqlserver__concat(fields) -%}
+    {%- if fields|length < 2 -%}
+        {{ fields[0] }}
+    {%- else -%}
+        concat({{ fields|join(', ') }})
+    {%- endif -%}
+{%- endmacro %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/utils/date_trunc.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/utils/date_trunc.sql
@@ -1,0 +1,3 @@
+{% macro sqlserver__date_trunc(datepart, date) %}
+    CAST(DATEADD({{datepart}}, DATEDIFF({{datepart}}, 0, {{date}}), 0) AS DATE)
+{% endmacro %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/utils/dateadd.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/utils/dateadd.sql
@@ -1,0 +1,9 @@
+{% macro sqlserver__dateadd(datepart, interval, from_date_or_timestamp) %}
+
+    dateadd(
+        {{ datepart }},
+        {{ interval }},
+        cast({{ from_date_or_timestamp }} as datetime2(6))
+        )
+
+{% endmacro %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/utils/get_tables_by_pattern.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/utils/get_tables_by_pattern.sql
@@ -1,0 +1,12 @@
+{% macro sqlserver__get_tables_by_pattern_sql(schema_pattern, table_pattern, exclude='', database=target.database) %}
+
+    select distinct
+        table_schema as {{ adapter.quote('table_schema') }},
+        table_name as {{ adapter.quote('table_name') }},
+        {{ dbt_utils.get_table_types_sql() }}
+    from {{ database }}.INFORMATION_SCHEMA.TABLES
+    where table_schema like '{{ schema_pattern }}'
+    and table_name like '{{ table_pattern }}'
+    and table_name not like '{{ exclude }}'
+
+{% endmacro %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/utils/hash.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/utils/hash.sql
@@ -1,0 +1,3 @@
+{% macro sqlserver__hash(field) %}
+    lower(convert(varchar(50), hashbytes('md5', coalesce(convert(varchar(8000), {{field}}), '')), 2))
+{% endmacro %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/utils/last_day.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/utils/last_day.sql
@@ -1,0 +1,13 @@
+{% macro sqlserver__last_day(date, datepart) -%}
+
+    {%- if datepart == 'quarter' -%}
+    	CAST(DATEADD(QUARTER, DATEDIFF(QUARTER, 0, {{ date }}) + 1, -1) AS DATE)
+    {%- elif datepart == 'month' -%}
+        EOMONTH ( {{ date }})
+    {%- elif datepart == 'year' -%}
+        CAST(DATEADD(YEAR, DATEDIFF(year, 0, {{ date }}) + 1, -1) AS DATE)
+    {%- else -%}
+        {{dbt_utils.default_last_day(date, datepart)}}
+    {%- endif -%}
+
+{%- endmacro %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/utils/length.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/utils/length.sql
@@ -1,0 +1,5 @@
+{% macro sqlserver__length(expression) %}
+
+    len( {{ expression }} )
+
+{%- endmacro -%}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/utils/listagg.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/utils/listagg.sql
@@ -1,0 +1,8 @@
+{% macro sqlserver__listagg(measure, delimiter_text, order_by_clause, limit_num) -%}
+
+    string_agg({{ measure }}, {{ delimiter_text }})
+        {%- if order_by_clause != None %}
+            within group ({{ order_by_clause }})
+        {%- endif %}
+
+{%- endmacro %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/utils/position.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/utils/position.sql
@@ -1,0 +1,8 @@
+{% macro sqlserver__position(substring_text, string_text) %}
+
+    CHARINDEX(
+        {{ substring_text }},
+        {{ string_text }}
+    )
+
+{%- endmacro -%}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/utils/safe_cast.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/utils/safe_cast.sql
@@ -1,0 +1,3 @@
+{% macro sqlserver__safe_cast(field, type) %}
+    try_cast({{field}} as {{type}})
+{% endmacro %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/utils/split_part.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/utils/split_part.sql
@@ -1,0 +1,17 @@
+{#
+	For more information on how this XML trick works with splitting strings, see https://www.sqlservertips.com/sqlservertip/1771/splitting-delimited-strings-using-xml-in-sql-server/
+	On Azure SQL and SQL Server 2019, we can use the string_split function instead of the XML trick.
+	But since we don't know which version of SQL Server the user is using, we'll stick with the XML trick in this adapter.
+	However, since the XML data type is not supported in Synapse, it has to be overridden in that adapter.
+
+    To adjust for negative part numbers, aka 'from the end of the split', we take the position and subtract from last to get the specific part.
+    Since the input is '-1' for the last, '-2' for second last, we add 1 to the part number to get the correct position.
+#}
+
+{% macro sqlserver__split_part(string_text, delimiter_text, part_number) %}
+    {% if part_number >= 0 %}
+        LTRIM(CAST(('<X>'+REPLACE({{ string_text }},{{ delimiter_text }} ,'</X><X>')+'</X>') AS XML).value('(/X)[{{ part_number }}]', 'VARCHAR(128)'))
+    {% else %}
+        LTRIM(CAST(('<X>'+REPLACE({{ string_text }},{{ delimiter_text }} ,'</X><X>')+'</X>') AS XML).value('(/X)[position() = last(){{ part_number }}+1][1]', 'VARCHAR(128)'))
+    {% endif %}
+{% endmacro %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/utils/timestamps.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-sqlserver/macros/utils/timestamps.sql
@@ -1,0 +1,8 @@
+{% macro sqlserver__current_timestamp() -%}
+  CAST(SYSDATETIME() AS DATETIME2(6))
+{%- endmacro %}
+
+{% macro sqlserver__snapshot_string_as_time(timestamp) -%}
+    {%- set result = "CONVERT(DATETIME2(6), '" ~ timestamp ~ "')" -%}
+    {{ return(result) }}
+{%- endmacro %}

--- a/crates/dbt-loader/tests/materializations/mod.rs
+++ b/crates/dbt-loader/tests/materializations/mod.rs
@@ -1,3 +1,4 @@
 mod incremental;
 mod materialized_view;
+mod table;
 mod view;

--- a/crates/dbt-loader/tests/materializations/table.rs
+++ b/crates/dbt-loader/tests/materializations/table.rs
@@ -1,0 +1,178 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use dbt_adapter::relation::RelationObject;
+use dbt_adapter_core::AdapterType;
+use dbt_jinja_utils::mock_object::MockJinjaObject;
+use dbt_schemas::dbt_types::RelationType;
+use minijinja::Value;
+
+use crate::macro_test_harness::MacroTestHarness;
+
+mod sqlserver {
+    use super::*;
+    const ADAPTER: AdapterType = AdapterType::SqlServer;
+
+    fn build_harness() -> MacroTestHarness {
+        let harness = MacroTestHarness::for_adapter(ADAPTER)
+            .load_all_macros()
+            .with_stub_functions()
+            .build()
+            .expect("harness should build");
+
+        let mock = harness.mock();
+        mock.on("quote", |args| {
+            Ok(args.first().cloned().unwrap_or(Value::UNDEFINED))
+        });
+        mock.on("rename_relation", |_| Ok(Value::UNDEFINED));
+        mock.on("drop_relation", |_| Ok(Value::UNDEFINED));
+        mock.on("commit", |_| Ok(Value::UNDEFINED));
+        mock.on("render_raw_model_constraints", |_| {
+            Ok(Value::from(Vec::<Value>::new()))
+        });
+
+        harness
+    }
+
+    /// A `config` mock that always answers `contract`/`indexes` with a
+    /// no-op-safe default (empty), with room for a test to override specific
+    /// keys. `config.get(key, default=...)` uses a keyword arg for `default`
+    /// on some call sites (e.g. dbt-adapters' own `create_indexes`), which
+    /// this harness's generic positional fallback doesn't unwrap correctly -
+    /// so any key a macro iterates or branches on needs its own explicit arm
+    /// here rather than relying on the passthrough default.
+    fn config_mock(overrides: BTreeMap<&'static str, Value>) -> Arc<MockJinjaObject> {
+        let mock = Arc::new(MockJinjaObject::new());
+        mock.on("get", move |args| {
+            let key = args.first().and_then(|v| v.as_str()).unwrap_or("");
+            if let Some(value) = overrides.get(key) {
+                return Ok(value.clone());
+            }
+            match key {
+                "contract" => Ok(Value::from_serialize(BTreeMap::from([(
+                    "enforced".to_string(),
+                    Value::from(false),
+                )]))),
+                "indexes" => Ok(Value::from(Vec::<Value>::new())),
+                // Positional `config.get(key, default)` calls (table_refresh_method,
+                // full_refresh_build, ...) land their default in args[1]; keyword
+                // `default=` calls (dbt-adapters' own create_indexes) don't, which is
+                // why indexes/contract get their own arms above instead of relying
+                // on this.
+                _ => Ok(args.get(1).cloned().unwrap_or(Value::UNDEFINED)),
+            }
+        });
+        mock.on("persist_column_docs", |_| Ok(Value::from(false)));
+        mock.on("persist_relation_docs", |_| Ok(Value::from(false)));
+        mock
+    }
+
+    fn render_table(
+        harness: &MacroTestHarness,
+        ctx: BTreeMap<String, Value>,
+    ) -> dbt_common::FsResult<String> {
+        harness.render("{{ materialization_table_sqlserver() }}", ctx)
+    }
+
+    #[test]
+    fn no_existing_relation_renames_intermediate_into_target() {
+        let harness = build_harness();
+        harness.mock().on("get_relation", |_| Ok(Value::from(())));
+
+        let ctx = harness
+            .materialization_context("my_table", "SELECT id FROM source_table")
+            .relation_type(RelationType::Table)
+            .config(Value::from_dyn_object(config_mock(BTreeMap::new())))
+            .build();
+        render_table(&harness, ctx)
+            .unwrap_or_else(|e| panic!("table materialization failed: {e:?}"));
+
+        // Intermediate -> target only; no existing/backup relation to swap out.
+        assert_eq!(
+            harness
+                .mock()
+                .observed_calls()
+                .to("rename_relation")
+                .count(),
+            1,
+            "expected only the intermediate->target rename"
+        );
+    }
+
+    #[test]
+    fn existing_table_renamed_to_backup_before_swap() {
+        let harness = build_harness();
+        let existing = harness.relation(
+            "TEST_DB",
+            "TEST_SCHEMA",
+            "my_table",
+            Some(RelationType::Table),
+        );
+        harness.mock().on("get_relation", move |_| {
+            Ok(RelationObject::new(Arc::clone(&existing)).into_value())
+        });
+
+        let ctx = harness
+            .materialization_context("my_table", "SELECT id FROM source_table")
+            .relation_type(RelationType::Table)
+            .config(Value::from_dyn_object(config_mock(BTreeMap::new())))
+            .build();
+        render_table(&harness, ctx)
+            .unwrap_or_else(|e| panic!("table materialization failed: {e:?}"));
+
+        // Two renames: existing -> backup, then intermediate -> target.
+        assert_eq!(
+            harness
+                .mock()
+                .observed_calls()
+                .to("rename_relation")
+                .count(),
+            2,
+            "expected existing->backup and intermediate->target renames"
+        );
+    }
+
+    #[test]
+    fn full_refresh_build_prebuilt_raises_compiler_error() {
+        let harness = build_harness();
+        harness.mock().on("get_relation", |_| Ok(Value::from(())));
+
+        let overrides = BTreeMap::from([("full_refresh_build", Value::from("prebuilt"))]);
+        let ctx = harness
+            .materialization_context("my_table", "SELECT id FROM source_table")
+            .relation_type(RelationType::Table)
+            .config(Value::from_dyn_object(config_mock(overrides)))
+            .build();
+
+        let result = render_table(&harness, ctx);
+        assert!(
+            result.is_err(),
+            "full_refresh_build='prebuilt' should raise a compiler error, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn indexes_config_raises_compiler_error() {
+        let harness = build_harness();
+        harness.mock().on("get_relation", |_| Ok(Value::from(())));
+
+        let overrides = BTreeMap::from([(
+            "indexes",
+            Value::from_serialize(vec![BTreeMap::from([(
+                "columns".to_string(),
+                Value::from(vec![Value::from("id")]),
+            )])]),
+        )]);
+        let ctx = harness
+            .materialization_context("my_table", "SELECT id FROM source_table")
+            .relation_type(RelationType::Table)
+            .config(Value::from_dyn_object(config_mock(overrides)))
+            .build();
+
+        let result = render_table(&harness, ctx);
+        assert!(
+            result.is_err(),
+            "a configured `indexes:` should raise a compiler error rather than silently no-op, got: {result:?}"
+        );
+    }
+}

--- a/crates/dbt-schemas/src/schemas/profiles.rs
+++ b/crates/dbt-schemas/src/schemas/profiles.rs
@@ -43,7 +43,7 @@ pub enum DbConfig {
     Bigquery(Box<BigqueryDbConfig>),
     Trino(Box<TrinoDbConfig>),
     Datafusion(Box<DatafusionDbConfig>),
-    // SqlServer,
+    SqlServer(Box<SqlServerDbConfig>),
     // SingleStore,
     Spark(Box<SparkDbConfig>),
     Databricks(Box<DatabricksDbConfig>),
@@ -104,6 +104,7 @@ impl_from_db_config!(Datafusion, DatafusionDbConfig);
 impl_from_db_config!(Databricks, DatabricksDbConfig);
 impl_from_db_config!(DuckDB, DuckDbConfig);
 impl_from_db_config!(Fabric, FabricDbConfig);
+impl_from_db_config!(SqlServer, SqlServerDbConfig);
 impl_from_db_config!(Exasol, ExasolDbConfig);
 impl_from_db_config!(ClickHouse, ClickHouseDbConfig);
 
@@ -123,6 +124,7 @@ impl DbConfig {
             DbConfig::Alt(config) => Some(config.path.as_deref().unwrap_or(":memory:")),
             DbConfig::Spark(config) => config.host.as_deref(),
             DbConfig::Fabric(config) => config.host.as_deref(),
+            DbConfig::SqlServer(config) => config.host.as_deref(),
             DbConfig::Exasol(config) => config.host.as_deref(),
             DbConfig::ClickHouse(config) => config.host.as_deref(),
         }
@@ -273,6 +275,20 @@ impl DbConfig {
                 "trust_cert",
                 "api_url",
             ],
+            DbConfig::SqlServer(_) => &[
+                "host",
+                "port",
+                "database",
+                "schema",
+                "UID",
+                "authentication",
+                "retries",
+                "login_timeout",
+                "query_timeout",
+                "trace_flag",
+                "encrypt",
+                "trust_cert",
+            ],
             DbConfig::Exasol(_) => &[
                 "host",
                 "port",
@@ -340,6 +356,7 @@ impl DbConfig {
             DbConfig::Salesforce(config) => dbt_yaml::to_value(config),
             DbConfig::Spark(config) => dbt_yaml::to_value(config),
             DbConfig::Fabric(config) => dbt_yaml::to_value(config),
+            DbConfig::SqlServer(config) => dbt_yaml::to_value(config),
             DbConfig::DuckDB(config) => dbt_yaml::to_value(config),
             DbConfig::Alt(config) => dbt_yaml::to_value(config),
             DbConfig::Exasol(config) => dbt_yaml::to_value(config),
@@ -360,6 +377,7 @@ impl DbConfig {
             DbConfig::DuckDB(..) => AdapterType::DuckDB,
             DbConfig::Spark(..) => AdapterType::Spark,
             DbConfig::Fabric(..) => AdapterType::Fabric,
+            DbConfig::SqlServer(..) => AdapterType::SqlServer,
             DbConfig::Exasol(..) => AdapterType::Exasol,
             DbConfig::ClickHouse(..) => AdapterType::ClickHouse,
             DbConfig::Alt(..) => AdapterType::Alt,
@@ -379,6 +397,7 @@ impl DbConfig {
             DbConfig::DuckDB(config) => config.database.as_ref(),
             DbConfig::Spark(_) => None,
             DbConfig::Fabric(config) => config.database.as_ref(),
+            DbConfig::SqlServer(config) => config.database.as_ref(),
             DbConfig::Exasol(config) => config.database.as_ref(),
             DbConfig::ClickHouse(config) => config.database.as_ref(),
             DbConfig::Alt(config) => config.database.as_ref(),
@@ -420,6 +439,7 @@ impl DbConfig {
             DbConfig::Alt(config) => config.schema.as_ref(),
             DbConfig::Salesforce(_) => None,
             DbConfig::Fabric(config) => config.schema.as_ref(),
+            DbConfig::SqlServer(config) => config.schema.as_ref(),
             DbConfig::Exasol(config) => config.schema.as_ref(),
             DbConfig::ClickHouse(config) => config.schema.as_ref(),
         }
@@ -438,6 +458,7 @@ impl DbConfig {
             DbConfig::Salesforce(_) => None,
             DbConfig::Spark(_) => None,
             DbConfig::Fabric(_) => None,
+            DbConfig::SqlServer(config) => config.threads.as_ref(),
             DbConfig::Exasol(config) => config.threads.as_ref(),
             DbConfig::ClickHouse(config) => config.threads.as_ref(),
             DbConfig::Alt(config) => config.threads.as_ref(),
@@ -457,6 +478,7 @@ impl DbConfig {
             DbConfig::Salesforce(_) => (),
             DbConfig::Spark(_) => (),
             DbConfig::Fabric(_) => (),
+            DbConfig::SqlServer(config) => config.threads = threads,
             DbConfig::Exasol(config) => config.threads = threads,
             DbConfig::ClickHouse(config) => config.threads = threads,
             DbConfig::Alt(config) => config.threads = threads,
@@ -1283,6 +1305,59 @@ pub struct FabricDbConfig {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default, DbtSchema, Merge)]
 #[merge(strategy = merge_strategies_extend::overwrite_option)]
 #[serde(rename_all = "snake_case")]
+pub struct SqlServerDbConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub driver: Option<String>, // v1 pyodbc only; unused on the ADBC path
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(alias = "server")]
+    pub host: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub port: Option<StringOrInteger>, // default = 1433, applied in dbt-auth
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub database: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "UID", alias = "user", alias = "username")]
+    pub user: Option<String>, // default = None
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "PWD", alias = "pass", alias = "password")]
+    pub password: Option<String>, // default = None
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(alias = "auth")]
+    pub authentication: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tenant_id: Option<String>, // default = None
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(alias = "app_id")]
+    pub client_id: Option<String>, // default = None
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(alias = "app_secret")]
+    pub client_secret: Option<String>, // default = None
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub encrypt: Option<bool>, // default = True  | default value in MS ODBC Driver 18 as well
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(alias = "TrustServerCertificate")]
+    pub trust_cert: Option<bool>, // default = False  | default value in MS ODBC Driver 18 as well
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub login_timeout: Option<i64>, // default = 0
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub query_timeout: Option<i64>, // default = 0
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retries: Option<i64>, // default = 3
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(alias = "schema_auth")]
+    pub schema_authorization: Option<String>, // default = None
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(alias = "SQL_ATTR_TRACE")]
+    pub trace_flag: Option<bool>, // default = False
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub threads: Option<StringOrInteger>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default, DbtSchema, Merge)]
+#[merge(strategy = merge_strategies_extend::overwrite_option)]
+#[serde(rename_all = "snake_case")]
 pub struct ExasolDbConfig {
     pub user: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", alias = "pass")]
@@ -1534,6 +1609,7 @@ pub enum TargetContext {
     DuckDB(DuckDbTargetEnv),
     Spark(SparkTargetEnv),
     Fabric(FabricTargetEnv),
+    SqlServer(SqlServerTargetEnv),
     Exasol(ExasolTargetEnv),
     ClickHouse(ClickHouseTargetEnv),
     // Add other variants as needed
@@ -1707,6 +1783,16 @@ pub struct FabricTargetEnv {
     pub __common__: CommonTargetContext,
     pub authentication: String,
     // TODO: ...
+}
+
+#[derive(Serialize, DbtSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct SqlServerTargetEnv {
+    pub host: Option<String>,
+    pub port: Option<StringOrInteger>,
+    pub user: Option<String>,
+    pub authentication: String,
+    pub __common__: CommonTargetContext,
 }
 
 #[derive(Serialize, DbtSchema)]
@@ -2126,6 +2212,30 @@ impl TryFrom<DbConfig> for TargetContext {
                     authentication,
                 }))
             }
+            DbConfig::SqlServer(config) => {
+                let threads = match config.threads {
+                    Some(StringOrInteger::String(threads)) => Some(
+                        threads
+                            .parse::<u16>()
+                            .map_err(|_| "threads must be a positive integer".to_string())?,
+                    ),
+                    Some(StringOrInteger::Integer(threads)) => Some(threads as u16),
+                    None => None,
+                };
+
+                Ok(TargetContext::SqlServer(SqlServerTargetEnv {
+                    host: config.host,
+                    port: config.port,
+                    user: config.user,
+                    authentication: config.authentication.unwrap_or_default(),
+                    __common__: CommonTargetContext {
+                        database: config.database.ok_or_else(|| missing("database"))?,
+                        schema: config.schema.ok_or_else(|| missing("schema"))?,
+                        type_: adapter_type,
+                        threads,
+                    },
+                }))
+            }
             DbConfig::Exasol(config) => Ok(TargetContext::Exasol(ExasolTargetEnv {
                 host: config.host.clone(),
                 user: config.user.clone(),
@@ -2528,6 +2638,145 @@ extensions:
                 .get(dbt_yaml::Value::from("serverless_work_group"))
                 .and_then(|v| v.as_str()),
             Some("my-workgroup")
+        );
+    }
+
+    #[test]
+    fn test_sqlserver_config_parses() {
+        let config: DbConfig = dbt_yaml::from_str(
+            "type: sqlserver\n\
+             host: sql.prod.internal\n\
+             port: 1433\n\
+             database: analytics\n\
+             schema: dbo\n\
+             UID: alice\n\
+             PWD: hunter2\n\
+             authentication: sql\n\
+             threads: 4\n",
+        )
+        .unwrap();
+
+        let DbConfig::SqlServer(sqlserver_config) = config else {
+            panic!("Expected DbConfig::SqlServer");
+        };
+        assert_eq!(sqlserver_config.host, Some("sql.prod.internal".to_string()));
+        assert_eq!(sqlserver_config.port, Some(StringOrInteger::Integer(1433)));
+        assert_eq!(sqlserver_config.database, Some("analytics".to_string()));
+        assert_eq!(sqlserver_config.schema, Some("dbo".to_string()));
+        assert_eq!(sqlserver_config.user, Some("alice".to_string()));
+        assert_eq!(sqlserver_config.password, Some("hunter2".to_string()));
+        assert_eq!(sqlserver_config.authentication, Some("sql".to_string()));
+        assert_eq!(sqlserver_config.threads, Some(StringOrInteger::Integer(4)));
+    }
+
+    /// A dbt-sqlserver v1 profile uses `_ALIASES` spellings throughout, and
+    /// must land in the same fields as the canonical names above.
+    #[test]
+    fn test_sqlserver_v1_aliases_parse() {
+        let config: DbConfig = dbt_yaml::from_str(
+            "type: sqlserver\n\
+             server: sql.prod.internal\n\
+             database: analytics\n\
+             schema: dbo\n\
+             user: alice\n\
+             password: hunter2\n\
+             auth: ActiveDirectoryServicePrincipal\n\
+             app_id: my-client\n\
+             app_secret: my-secret\n\
+             TrustServerCertificate: true\n\
+             schema_auth: some_owner\n\
+             SQL_ATTR_TRACE: true\n",
+        )
+        .unwrap();
+
+        let DbConfig::SqlServer(sqlserver_config) = config else {
+            panic!("Expected DbConfig::SqlServer");
+        };
+        assert_eq!(sqlserver_config.host, Some("sql.prod.internal".to_string()));
+        assert_eq!(sqlserver_config.user, Some("alice".to_string()));
+        assert_eq!(sqlserver_config.password, Some("hunter2".to_string()));
+        assert_eq!(
+            sqlserver_config.authentication,
+            Some("ActiveDirectoryServicePrincipal".to_string())
+        );
+        assert_eq!(sqlserver_config.client_id, Some("my-client".to_string()));
+        assert_eq!(
+            sqlserver_config.client_secret,
+            Some("my-secret".to_string())
+        );
+        assert_eq!(sqlserver_config.trust_cert, Some(true));
+        assert_eq!(
+            sqlserver_config.schema_authorization,
+            Some("some_owner".to_string())
+        );
+        assert_eq!(sqlserver_config.trace_flag, Some(true));
+    }
+
+    #[test]
+    fn test_sqlserver_adapter_type_and_unique_field() {
+        let config: DbConfig = SqlServerDbConfig {
+            host: Some("sql.prod.internal".to_string()),
+            ..Default::default()
+        }
+        .into();
+
+        assert_eq!(config.adapter_type(), AdapterType::SqlServer);
+        assert_eq!(config.get_unique_field(), Some("sql.prod.internal"));
+    }
+
+    #[test]
+    fn test_sqlserver_target_context() {
+        let config: DbConfig = SqlServerDbConfig {
+            host: Some("sql.prod.internal".to_string()),
+            port: Some(StringOrInteger::Integer(1433)),
+            database: Some("analytics".to_string()),
+            schema: Some("dbo".to_string()),
+            user: Some("alice".to_string()),
+            password: Some("hunter2".to_string()),
+            authentication: Some("sql".to_string()),
+            threads: Some(StringOrInteger::Integer(4)),
+            ..Default::default()
+        }
+        .into();
+
+        let target = TargetContext::try_from(config).expect("sqlserver target context");
+        let TargetContext::SqlServer(target) = target else {
+            panic!("expected sqlserver target context");
+        };
+        assert_eq!(target.host, Some("sql.prod.internal".to_string()));
+        assert_eq!(target.user, Some("alice".to_string()));
+        assert_eq!(target.authentication, "sql");
+        assert_eq!(target.__common__.database, "analytics");
+        assert_eq!(target.__common__.schema, "dbo");
+        assert_eq!(target.__common__.threads, Some(4));
+    }
+
+    /// `to_connection_mapping` filters on serialized names, which `serde(alias)`
+    /// does not affect — so `get_connection_keys` has to spell `host`, not v1's
+    /// `server`, or `dbt debug` shows no host at all.
+    #[test]
+    fn test_sqlserver_connection_mapping_includes_host_and_omits_secrets() {
+        let config: DbConfig = SqlServerDbConfig {
+            host: Some("sql.prod.internal".to_string()),
+            database: Some("analytics".to_string()),
+            schema: Some("dbo".to_string()),
+            user: Some("alice".to_string()),
+            password: Some("hunter2".to_string()),
+            client_secret: Some("my-secret".to_string()),
+            ..Default::default()
+        }
+        .into();
+
+        let mapping = config.to_connection_mapping().expect("connection mapping");
+        let keys: Vec<&str> = mapping.keys().filter_map(|k| k.as_str()).collect();
+
+        assert!(keys.contains(&"host"), "expected host in {keys:?}");
+        assert!(keys.contains(&"database"), "expected database in {keys:?}");
+        assert!(keys.contains(&"UID"), "expected UID in {keys:?}");
+        assert!(!keys.contains(&"PWD"), "PWD leaked into {keys:?}");
+        assert!(
+            !keys.contains(&"client_secret"),
+            "client_secret leaked into {keys:?}"
         );
     }
 

--- a/crates/dbt-schemas/src/schemas/relations/base.rs
+++ b/crates/dbt-schemas/src/schemas/relations/base.rs
@@ -546,7 +546,8 @@ pub trait BaseRelation: BaseRelationProperties + Any + Send + Sync + fmt::Debug 
             | AdapterType::Spark
             | AdapterType::DuckDB
             | AdapterType::Alt
-            | AdapterType::Fabric => (
+            | AdapterType::Fabric
+            | AdapterType::SqlServer => (
                 start.map(|start| format!("{event_time} >= '{start}'")),
                 end.map(|end| format!("{event_time} < '{end}'")),
             ),

--- a/crates/dbt-tasks-sa/src/materialize.rs
+++ b/crates/dbt-tasks-sa/src/materialize.rs
@@ -1295,8 +1295,10 @@ fn get_test_results(table: &AgateTable) -> FsResult<Vec<TestResult>> {
         let should_error = columns.get(2).unwrap().get_item_by_index(0).ok();
 
         let failures_val = failures.and_then(|v| v.as_i64()).unwrap_or(-1);
-        let should_warn_val = should_warn.map(|v| v.is_true()).unwrap_or(false);
-        let should_error_val = should_error.map(|v| v.is_true()).unwrap_or(false);
+        let should_warn_val = should_warn.map(|v| value_to_test_bool(&v)).unwrap_or(false);
+        let should_error_val = should_error
+            .map(|v| value_to_test_bool(&v))
+            .unwrap_or(false);
 
         Ok(vec![TestResult {
             column_name: None,
@@ -1323,11 +1325,11 @@ fn get_column_test_result(
         .unwrap_or(0);
 
     let should_warn = get_cell_value(values, row, should_warn_idx)
-        .map(|v| v.is_true())
+        .map(|v| value_to_test_bool(&v))
         .unwrap_or(false);
 
     let should_error = get_cell_value(values, row, should_error_idx)
-        .map(|v| v.is_true())
+        .map(|v| value_to_test_bool(&v))
         .unwrap_or(false);
 
     TestResult {
@@ -1335,6 +1337,16 @@ fn get_column_test_result(
         failures,
         should_warn,
         should_error,
+    }
+}
+
+/// Interprets a `should_warn`/`should_error` cell as a boolean, parsing
+/// text `'true'`/`'false'` explicitly before falling back to `is_true()`.
+fn value_to_test_bool(v: &Value) -> bool {
+    match v.as_str() {
+        Some(s) if s.eq_ignore_ascii_case("false") => false,
+        Some(s) if s.eq_ignore_ascii_case("true") => true,
+        _ => v.is_true(),
     }
 }
 

--- a/crates/dbt-tasks-sa/src/sql/dialect.rs
+++ b/crates/dbt-tasks-sa/src/sql/dialect.rs
@@ -32,6 +32,7 @@ pub fn sqlparser_dialect_for(adapter_type: AdapterType) -> &'static dyn Dialect 
         // baseline for tokenization (string/comment forms match).
         Spark => &HIVE,
         Fabric => &MSSQL,
+        SqlServer => &MSSQL,
         ClickHouse => &CLICKHOUSE,
         // No close sqlparser match — generic SQL tokenizer is permissive enough
         // for statement splitting.


### PR DESCRIPTION
Closes #15714.

## Summary

Adds `AdapterType::SqlServer` to dbt Fusion: profile config, authentication
(Entra + native SQL login), relation quoting, catalog introspection, SQL
type mapping, the `dbt-adapter` match-arm surface, the vendored macro
package, and an optional `dbt init` wizard. Ships gated behind
`DBT_ALLOW_EXPERIMENTAL_ADAPTERS=true` (not added to
`NON_EXPERIMENTAL_ADAPTERS`), same as every other adapter's initial
landing.

Landed as ten sequential, crate-scoped PRs against a staging branch first
(`sqlserver-v2-port` on [dbt-sqlserver-next/dbt-core](https://github.com/dbt-sqlserver-next/dbt-core),
[#11](https://github.com/dbt-sqlserver-next/dbt-core/pull/11)–[#20](https://github.com/dbt-sqlserver-next/dbt-core/pull/20)) —
registering the adapter type makes every exhaustive `match adapter_type()`
across the workspace non-exhaustive, so it can't land upstream piecemeal
without breaking `main`'s build in between. Individual PR descriptions
below cite the specific v1/live-server evidence behind each call; this
summary groups by decision.

## Decisions worth a reviewer's eye

**Quoting**: `quote_char = '"'` with `QUOTED_IDENTIFIER` confirmed ON by
default on a live SQL Server 2022 (no init SQL needed) — matches `Fabric`
and matches what v1 already renders despite T-SQL also accepting
`[brackets]`. `quoted()` doubles an embedded delimiter for `SqlServer`
specifically (the shared default renders `x"q` as unparseable `"x"q"`);
scoped narrowly rather than fixed in the shared default, which changes
rendering for every quoting adapter.

**Identifier length**: `max_identifier_length = 128`, not v1's 127 — SQL
Server's documented and live-verified limit (`sysname` is `nvarchar(128)`);
v1's 127 traces to a copy-pasted Redshift constant, comment included. A
128-character name that v1 rejects builds here; tracked as a v1-side bug
separately, not changed to match v1.

**Auth**: native SQL login (`authentication: sql`) added as a new top-level
`SQLServerAuthIR` variant alongside the existing Entra flows (service
principal, AD password, environment credential — already implemented and
tested pre-port). `encrypt`/`TrustServerCertificate`/`connection timeout`
ported from v1's own ADBC backend
([dbt-msft/dbt-sqlserver#783](https://github.com/dbt-msft/dbt-sqlserver/pull/783),
same driver), live-verified against a self-signed on-prem instance.
Windows/trusted-connection auth and named-instance hosts (`host\instance`)
are deferred — the latter fails loudly at URI parse rather than shipping an
unverified rewrite.

**Catalog introspection**: uses `sys.objects`/`sys.schemas`/`sys.columns`/`sys.types`
directly rather than `Fabric`'s `sp_tables`/`sp_columns` pattern — measured
against live SQL Server 2022 that those procedures are single-database
(cross-database reads, which SQL Server supports and v1 relies on, error
out) and that `@table_name` is a `LIKE` pattern, not an exact match
(`probe_table` vs `probeXtable`). Both are pre-existing gaps in `Fabric`'s
own module too; not touched here since only the pattern half is verifiable
against a T-SQL engine this checkout can reach, and cross-database is
verifiably impossible for Fabric's model to hit at all. Filed as a
follow-up, not fixed in this PR.

**Type mapping**: `STRING` → `VARCHAR(MAX)` (v1's current native-string
default, not `Fabric`'s byte-capped `VARCHAR(8000)` — SQL Server has no
equivalent cap tracked here); decimal → `float`/`int` keyed by scale,
reproducing v1's threshold rather than `Fabric`'s unconditional `float`.

**Macro package**: 34-file v1 tree vendored, mirroring `dbt-fabric`'s
layout. `indexes:` config, `full_refresh_build: prebuilt`, and
`table_refresh_method: dml` all raise a named compiler error rather than
silently no-op'ing or running a different path. Dynamic data masking and
index reconciliation on persisted tables dropped entirely (no v2 Rust
counterpart to call).

**Not registered**: `adapter_specific_behavior_flags` returns `vec![]` —
v1's five behavior flags (native string types, safe type expansion, dbt
transactions, default schema concat, empty relation aliases) all stay on
their v1 default with no alternate Rust code path yet, so nothing is
declared that the adapter can't actually honor.

## Deferred / explicitly out of scope

- Windows/trusted-connection auth
- Named SQL Server instances (`host\instance`)
- Dynamic data masking
- Index/columnstore materialization config (loud error today, not silent)
- `full_refresh_build: prebuilt`, scalar function materializations, table clone support
- `SET XACT_ABORT ON` connection-init SQL (currently off by default; several
  vendored macros assume it's on — v1 issues it, v2 doesn't yet, and there's
  no per-connection init hook to hang it on)
- Collation-aware case folding (`normalize_component` always folds to
  lowercase; wrong under a case-sensitive collation — matches a known,
  skipped-in-CI v1 defect, not a regression)

None of these were silently dropped — each is cited against the specific
v1 behavior or plan decision it diverges from in the individual Part PRs
(`dbt-sqlserver-next/dbt-core` #11–#20) and in
[`05-open-questions-and-risks.md`](https://github.com/dbt-sqlserver-next/dbt-sqlserver-v2-roadmap/blob/main/plan/05-open-questions-and-risks.md)
in the roadmap repo.

## Verified

- `cargo build -p dbt-adapter-core -p dbt-adapter-sql`: clean
- `cargo nextest run -p dbt-schemas`: 446 passed / 0 failed
- `cargo nextest run -p dbt-auth`: 287 passed / 0 failed
- `cargo test -p dbt-adapter --lib`: 891 passed / 0 failed
- `cargo test -p dbt-loader --test main`: 47 passed / 0 failed (43 pre-existing + 4 new)
- `cargo test -p dbt-init`: 7/7 passing (no regression; no new tests — no
  `adapter_config/*.rs` file in the crate has coverage today, `fabric_config.rs` included)
- `cargo fmt --check` / `cargo clippy --all-targets`: clean throughout
- `cargo build -p dbt-sa-cli`: clean
- End-to-end: clean `dbt build` (seed, run, generic tests, unit tests)
  against a local SQL Server 2022 container and a T-SQL-ported
  [jaffle-shop](https://github.com/dbt-labs/jaffle-shop), plain SQL auth.
  Auth-mode matrix beyond plain SQL (service principal, AD password,
  environment credential) not exercised end-to-end — no Azure AD
  credentials available in this environment; each is unit-tested in
  `dbt-auth` individually.

## Bugs found outside SQL Server's own code, filed separately

Two pre-existing gaps shared with `Fabric` (same T-SQL engine, same
unmodified shared macros), not fixed here: `dbt_utils.expression_is_true`
selects an unaliased literal, which T-SQL rejects from any named derived
table or view; `dbt.date_spine`/`generate_series` nests a `WITH` block
inside another CTE, which T-SQL also rejects, breaking
`metricflow_time_spine`. Roadmap-repo drafts:
`issues/v2-dbt-utils-expression-is-true-unnamed-column-tsql.md`,
`issues/v2-date-spine-nested-cte-tsql.md`.

## Note on two out-of-scope commits in this diff

This branch also carries `16152a55f`/`2343c50b4` (a multi-statement query
batch fix) and `fe6b636df` (a test-boolean-parsing fix) — general dbt
Fusion engine bugs found while smoke-testing this adapter, not part of the
SQL Server port itself. Each is filed and reviewable on its own:
[#15765](https://github.com/dbt-labs/dbt-core/issues/15765)/[#15766](https://github.com/dbt-labs/dbt-core/pull/15766)
for the first, [#15767](https://github.com/dbt-labs/dbt-core/issues/15767)/[#15768](https://github.com/dbt-labs/dbt-core/pull/15768)
for the second. Please review those separately rather than as part of this
adapter's diff; they'll drop out of this branch's history the next time it
syncs with `main` after `#15766` and `#15768` merge.
