### PR TITLE
fix(dbt-deps): guard git package URLs against option injection

### DIFF
--- a/.changes/unreleased/Fixes-20260805-000000.yaml
+++ b/.changes/unreleased/Fixes-20260805-000000.yaml
@@ -1,0 +1,8 @@
+kind: Fixes
+body: Terminate git option parsing before the repository URL in `dbt deps` so a
+    package declaring a git URL that starts with `-` (e.g. `--upload-pack=...`)
+    is treated as a repository argument instead of a shell-executed git option.
+time: 2026-08-05T00:00:00.000000+00:00
+custom:
+    author: sunliqiang
+    project: dbt-core

--- a/crates/dbt-deps/src/git_client/generic.rs
+++ b/crates/dbt-deps/src/git_client/generic.rs
@@ -200,15 +200,21 @@ async fn checkout_revision(
         .await;
     }
 
-    run_git(&["fetch", "--depth=1", repo, revision], Some(clone_dir))
-        .await
-        .map_err(|e| match e {
-            GitErr::Io(e) => fs_err!(ErrorCode::GitError, "Error fetching: {e}"),
-            GitErr::Failed { stderr } => {
-                let (code, msg) = parse_git_clone_error(&stderr, repo, Some(revision));
-                fs_err!(code, "{}", msg)
-            }
-        })?;
+    // `--` terminates option parsing so a repo string that starts with `-`
+    // (e.g. `--upload-pack=...`) is treated as a repository argument, not a
+    // git option the shell would execute.
+    run_git(
+        &["fetch", "--depth=1", "--", repo, revision],
+        Some(clone_dir),
+    )
+    .await
+    .map_err(|e| match e {
+        GitErr::Io(e) => fs_err!(ErrorCode::GitError, "Error fetching: {e}"),
+        GitErr::Failed { stderr } => {
+            let (code, msg) = parse_git_clone_error(&stderr, repo, Some(revision));
+            fs_err!(code, "{}", msg)
+        }
+    })?;
 
     run_git(&["checkout", "FETCH_HEAD"], Some(clone_dir))
         .await
@@ -239,7 +245,7 @@ async fn checkout_revision(
 /// Resolve a ref to its 40-char SHA via `git ls-remote`. No rate limit.
 async fn ls_remote_resolve(repo_url: &str, revision: &str) -> FsResult<String> {
     let sanitized = crate::utils::sanitize_git_url(repo_url);
-    let stdout = run_git(&["ls-remote", repo_url, revision], None)
+    let stdout = run_git(&["ls-remote", "--", repo_url, revision], None)
         .await
         .map_err(|e| match e {
             GitErr::Io(e) => fs_err!(ErrorCode::GitError, "git ls-remote failed: {e}"),
@@ -261,4 +267,59 @@ async fn ls_remote_resolve(repo_url: &str, revision: &str) -> FsResult<String> {
         ErrorCode::PackageDownloadFailed,
         "Could not resolve ref '{revision}' via ls-remote"
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn expect_git_success(result: Result<Vec<u8>, GitErr>) {
+        match result {
+            Ok(_) => {}
+            Err(GitErr::Io(e)) => panic!("git command failed: {e}"),
+            Err(GitErr::Failed { stderr }) => panic!("git command failed: {stderr}"),
+        }
+    }
+
+    /// A repo string that starts with `-` must be treated as a repository
+    /// argument (the `--` separator), never as a git option whose value the
+    /// shell would execute. `git` rejects the resulting pathname instead of
+    /// running the payload.
+    #[tokio::test]
+    async fn ls_remote_rejects_option_like_repo_url() {
+        let marker = std::env::temp_dir().join("wb001-option-injection-marker");
+        let _ = std::fs::remove_file(&marker);
+
+        let repo = format!("--upload-pack=touch {}", marker.display());
+        let result = ls_remote_resolve(&repo, "HEAD").await;
+
+        assert!(result.is_err(), "option-like repo URL must not resolve");
+        assert!(
+            !marker.exists(),
+            "git must not execute the injected --upload-pack command"
+        );
+    }
+
+    /// A normal repository URL still resolves through the same `git ls-remote`
+    /// path after the `--` separator is added. Uses a local `file://` repo so
+    /// the test does not depend on network access.
+    #[tokio::test]
+    async fn ls_remote_resolves_valid_repo_url() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let repo = dir.path();
+        expect_git_success(run_git(&["init", repo.to_str().unwrap()], None).await);
+        expect_git_success(
+            run_git(&["config", "user.email", "test@example.com"], Some(repo)).await,
+        );
+        expect_git_success(run_git(&["config", "user.name", "test"], Some(repo)).await);
+        tokiofs::write(repo.join("f.txt"), "hi")
+            .await
+            .expect("write file");
+        expect_git_success(run_git(&["add", "f.txt"], Some(repo)).await);
+        expect_git_success(run_git(&["commit", "-m", "init"], Some(repo)).await);
+
+        let url = format!("file://{}", repo.display());
+        let result = ls_remote_resolve(&url, "HEAD").await;
+        assert!(result.is_ok(), "valid repo URL should resolve: {result:?}");
+    }
 }


### PR DESCRIPTION
A git package URL from `packages.yml` is passed straight into `git fetch` and `git ls-remote` as a positional argument. A URL that starts with `-`, like `--upload-pack=touch /tmp/x`, is parsed by git as an option and the value gets executed through the shell. So a malicious or compromised package dependency can run arbitrary commands when someone runs `dbt deps`.

Added `--` before the repository URL in both calls. Everything after it is treated as a repository/ref argument, never as an option, so the payload can't be executed. Normal URLs are unaffected.

Includes a regression test proving a `-`-prefixed URL is rejected without running its payload, plus a local-repo test that normal URLs still resolve.

### Checklist

- [x] I have read the contributing guide and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes or this PR has already received feedback and approval from Product or DX.
