### PR TITLE
feat(dbt-adapter): copy partitions in parallel for BigQuery insert_overwrite

### DIFF
--- a/.changes/unreleased/Under the Hood-20260221-172900.yaml
+++ b/.changes/unreleased/Under the Hood-20260221-172900.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Add BigQuery-only parallel execution path for copy_partitions with bounded concurrency and rate-limit retries, plus supporting adapter tests.
+time: 2026-02-21T17:29:00-08:00
+custom:
+    author: leohoare
+    issue: "14283"
+    project: dbt-fusion

--- a/crates/dbt-adapter/Cargo.toml
+++ b/crates/dbt-adapter/Cargo.toml
@@ -53,6 +53,7 @@ minijinja-contrib = { workspace = true, features = ["datetime", "timezone"] }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
 paste = { workspace = true }
+rand = { workspace = true }
 regex = { workspace = true }
 scc = { workspace = true }
 serde = { workspace = true }

--- a/crates/dbt-adapter/src/adapter/adapter_impl.rs
+++ b/crates/dbt-adapter/src/adapter/adapter_impl.rs
@@ -5015,22 +5015,7 @@ impl AdapterImpl {
         materialization: &str,
         token: CancellationToken,
     ) -> AdapterResult<()> {
-        if self.adapter_type() != Bigquery {
-            return Err(AdapterError::new(
-                AdapterErrorKind::NotSupported,
-                "copy_partitions is only supported for BigQuery adapter",
-            ));
-        }
-        if source_relations.len() != target_relations.len() {
-            return Err(AdapterError::new(
-                AdapterErrorKind::Configuration,
-                format!(
-                    "copy_partitions source/target length mismatch: {} vs {}",
-                    source_relations.len(),
-                    target_relations.len()
-                ),
-            ));
-        }
+        validate_copy_partitions_args(self.adapter_type(), source_relations, target_relations)?;
         if source_relations.is_empty() {
             return Ok(());
         }
@@ -5043,13 +5028,16 @@ impl AdapterImpl {
 
         let write_disposition = bigquery_write_disposition("copy_partitions", materialization)?;
 
-        let mut copy_jobs = Vec::with_capacity(source_relations.len());
-        for (source, target) in source_relations.iter().zip(target_relations) {
-            copy_jobs.push((
-                bigquery_relation_fqn(source)?,
-                bigquery_relation_fqn(target)?,
-            ));
-        }
+        let copy_jobs = source_relations
+            .iter()
+            .zip(target_relations)
+            .map(|(source, target)| {
+                Ok((
+                    bigquery_relation_fqn(source)?,
+                    bigquery_relation_fqn(target)?,
+                ))
+            })
+            .collect::<AdapterResult<Vec<_>>>()?;
 
         // resolve job labels once here: worker threads can't hold `state`
         let mut base_options = self.get_adbc_execute_options(state);
@@ -5082,21 +5070,12 @@ impl AdapterImpl {
             execute_bigquery_copy_job_with_retry(&engine, &ctx, conn, &options, &map_token)
         };
 
-        let reduce_f =
-            |_: &mut (),
-             _copy_job: (String, String),
-             copy_res: Result<(), Cancellable<AdapterError>>| copy_res;
+        type CopyResult = Result<(), Cancellable<AdapterError>>;
+        let reduce_f = |_: &mut (), _job: (String, String), res: CopyResult| res;
 
         let map_reduce = MapReduce::new(factory, Box::new(map_f), Box::new(reduce_f), node_id);
-        run_traced_async_blocking(map_reduce.run(Arc::new(copy_jobs), token)).map_err(|err| {
-            match err {
-                Cancellable::Error(err) => err,
-                Cancellable::Cancelled => AdapterError::new(
-                    AdapterErrorKind::Cancelled,
-                    "copy_partitions operation cancelled",
-                ),
-            }
-        })
+        run_traced_async_blocking(map_reduce.run(Arc::new(copy_jobs), token))
+            .map_err(copy_partitions_run_error)
     }
 
     /// BigQueryAdapter https://github.com/dbt-labs/dbt-adapters/blob/4a00354a497214d9043bf4122810fe2d04de17bb/dbt-bigquery/src/dbt/adapters/bigquery/impl.py#L818
@@ -5937,6 +5916,40 @@ fn bigquery_write_disposition(caller: &str, materialization: &str) -> AdapterRes
             format!("{caller} 'materialization' must be either 'table' or 'incremental'"),
         )),
     }
+}
+
+fn copy_partitions_run_error(err: Cancellable<AdapterError>) -> AdapterError {
+    match err {
+        Cancellable::Error(err) => err,
+        Cancellable::Cancelled => AdapterError::new(
+            AdapterErrorKind::Cancelled,
+            "copy_partitions operation cancelled",
+        ),
+    }
+}
+
+fn validate_copy_partitions_args(
+    adapter_type: AdapterType,
+    source_relations: &[Arc<dyn BaseRelation>],
+    target_relations: &[Arc<dyn BaseRelation>],
+) -> AdapterResult<()> {
+    if adapter_type != Bigquery {
+        return Err(AdapterError::new(
+            AdapterErrorKind::NotSupported,
+            "copy_partitions is only supported for BigQuery adapter",
+        ));
+    }
+    if source_relations.len() != target_relations.len() {
+        return Err(AdapterError::new(
+            AdapterErrorKind::Configuration,
+            format!(
+                "copy_partitions source/target length mismatch: {} vs {}",
+                source_relations.len(),
+                target_relations.len()
+            ),
+        ));
+    }
+    Ok(())
 }
 
 /// Run one BigQuery copy job, retrying rate-limited jobs with backoff.

--- a/crates/dbt-adapter/src/adapter/adapter_impl.rs
+++ b/crates/dbt-adapter/src/adapter/adapter_impl.rs
@@ -1,9 +1,13 @@
 use crate::catalog_relation::CatalogRelation;
 use crate::column::{BigqueryColumnMode, Column, ColumnBuilder};
 use crate::config::AdapterConfig;
-use crate::connection::{ConnectionGuard, borrow_tlocal_connection};
+use crate::connection::{AdapterConnectionFactory, ConnectionGuard, borrow_tlocal_connection};
+use crate::engine::retry::{
+    BIGQUERY_JOB_MAX_RETRIES, bigquery_job_backoff_sleep, is_retryable_bigquery_job_error,
+};
 use crate::engine::{
-    AdapterEngine, AdbcEngine, Options as ExecuteOptions, execute_query_with_retry,
+    AdapterEngine, AdbcEngine, Options as ExecuteOptions, bigquery_job_labels_option,
+    execute_query_with_retry,
 };
 use crate::errors::{
     AdapterError, AdapterErrorKind, adbc_error_to_adapter_error, arrow_error_to_adapter_error,
@@ -52,10 +56,10 @@ use dashmap::DashMap;
 use dbt_adapter_core::AdapterType;
 use dbt_adbc::bigquery::*;
 use dbt_adbc::salesforce::DATA_TRANSFORM_RUN_TIMEOUT;
-use dbt_adbc::{Connection, QueryCtx};
+use dbt_adbc::{Connection, MapReduce, QueryCtx};
 use dbt_agate::AgateTable;
 use dbt_common::behavior_flags::{Behavior, BehaviorFlag};
-use dbt_common::cancellation::CancellationToken;
+use dbt_common::cancellation::{Cancellable, CancellationToken};
 use dbt_common::tracing::dbt_emit::emit_warn_log_message;
 use dbt_common::{ErrorCode, FsResult, unexpected_fs_err};
 use dbt_schema_store::SchemaStoreTrait;
@@ -73,6 +77,7 @@ use dbt_schemas::schemas::properties::ModelConstraint;
 use dbt_schemas::schemas::relations::base::{BaseRelation, ComponentName, Policy};
 use dbt_schemas::schemas::serde::minijinja_value_to_typed_struct;
 use dbt_schemas::schemas::{CommonAttributes, InternalDbtNodeAttributes, InternalDbtNodeWrapper};
+use dbt_tracing::async_tracing::run_traced_async_blocking;
 use dbt_yaml::Value as YmlValue;
 use indexmap::IndexMap;
 use minijinja::dispatch_object::DispatchObject;
@@ -4970,52 +4975,14 @@ impl AdapterImpl {
                 if let Replay(_, replay) = self.inner_adapter() {
                     return replay.replay_copy_table(state, source, dest, &materialization);
                 }
-                let append = materialization == "incremental";
-                let truncate = materialization == "table";
-                if !append && !truncate {
-                    return Err(AdapterError::new(
-                        AdapterErrorKind::Configuration,
-                        "copy_table 'materialization' must be either 'table' or 'incremental'"
-                            .to_string(),
-                    ));
-                }
-
-                let source_fqn = format!(
-                    "{}.{}.{}",
-                    source.database_as_str()?,
-                    source.schema_as_str()?,
-                    source.identifier_as_str()?
-                );
-                let dest_fqn = format!(
-                    "{}.{}.{}",
-                    dest.database_as_str()?,
-                    dest.schema_as_str()?,
-                    dest.identifier_as_str()?
-                );
-
-                // Determine write disposition based on materialization
-                // WRITE_TRUNCATE for table materialization, WRITE_APPEND for incremental
-                let write_disposition = if truncate {
-                    "WRITE_TRUNCATE"
-                } else {
-                    "WRITE_APPEND"
-                };
+                let write_disposition = bigquery_write_disposition("copy_table", &materialization)?;
 
                 let mut options = self.get_adbc_execute_options(state);
-                options.extend(vec![
-                    (
-                        COPY_TABLE_SOURCE.to_string(),
-                        OptionValue::String(source_fqn),
-                    ),
-                    (
-                        COPY_TABLE_DESTINATION.to_string(),
-                        OptionValue::String(dest_fqn),
-                    ),
-                    (
-                        COPY_TABLE_WRITE_DISPOSITION.to_string(),
-                        OptionValue::String(write_disposition.to_string()),
-                    ),
-                ]);
+                options.extend(bigquery_copy_options(
+                    bigquery_relation_fqn(source)?,
+                    bigquery_relation_fqn(dest)?,
+                    write_disposition,
+                ));
 
                 let ctx = query_ctx_from_state(state)?.with_desc("copy_table adapter call");
                 self.engine().execute_with_options(
@@ -5035,6 +5002,121 @@ impl AdapterImpl {
             | Oracle => {
                 unimplemented!("only available with BigQuery adapter")
             }
+        }
+    }
+
+    /// Like [AdapterImpl::copy_table] but copies many partitions concurrently
+    /// through a bounded pool, retrying rate-limited jobs with backoff.
+    pub fn copy_partitions(
+        &self,
+        state: &State,
+        source_relations: &[Arc<dyn BaseRelation>],
+        target_relations: &[Arc<dyn BaseRelation>],
+        materialization: &str,
+        token: CancellationToken,
+    ) -> AdapterResult<()> {
+        if self.adapter_type() != Bigquery {
+            return Err(AdapterError::new(
+                AdapterErrorKind::NotSupported,
+                "copy_partitions is only supported for BigQuery adapter",
+            ));
+        }
+        if source_relations.len() != target_relations.len() {
+            return Err(AdapterError::new(
+                AdapterErrorKind::Configuration,
+                format!(
+                    "copy_partitions source/target length mismatch: {} vs {}",
+                    source_relations.len(),
+                    target_relations.len()
+                ),
+            ));
+        }
+        if source_relations.is_empty() {
+            return Ok(());
+        }
+        if let Replay(_, replay) = self.inner_adapter() {
+            for (source, target) in source_relations.iter().zip(target_relations) {
+                replay.replay_copy_table(state, source, target, materialization)?;
+            }
+            return Ok(());
+        }
+
+        let write_disposition = bigquery_write_disposition("copy_partitions", materialization)?;
+
+        let mut copy_jobs = Vec::with_capacity(source_relations.len());
+        for (source, target) in source_relations.iter().zip(target_relations) {
+            copy_jobs.push((
+                bigquery_relation_fqn(source)?,
+                bigquery_relation_fqn(target)?,
+            ));
+        }
+
+        // resolve job labels once here: worker threads can't hold `state`
+        let mut base_options = self.get_adbc_execute_options(state);
+        let query_comment = self.engine().query_comment().resolve_comment(state)?;
+        base_options.push(bigquery_job_labels_option(
+            self.engine().query_comment(),
+            Some(&query_comment),
+            state,
+        ));
+
+        // shares the global connection budget, like the metadata MapReduce ops
+        let factory = Box::new(AdapterConnectionFactory::new(
+            self.engine().clone(),
+            self.engine().threads(),
+        ));
+
+        let ctx = query_ctx_from_state(state)?.with_desc("copy_partitions adapter call");
+        let node_id = node_id_from_state(state);
+        let engine = self.engine().clone();
+        let map_token = token.clone();
+        let map_f = move |conn: &'_ mut dyn Connection,
+                          (source_fqn, target_fqn): &(String, String)|
+              -> Result<(), Cancellable<AdapterError>> {
+            let mut options = base_options.clone();
+            options.extend(bigquery_copy_options(
+                source_fqn.clone(),
+                target_fqn.clone(),
+                write_disposition,
+            ));
+
+            let mut attempt = 0u32;
+            loop {
+                match engine.execute_with_options(
+                    None,
+                    &ctx,
+                    conn,
+                    "",
+                    options.clone(),
+                    false,
+                    map_token.clone(),
+                ) {
+                    Ok(_) => return Ok(()),
+                    Err(err)
+                        if attempt < BIGQUERY_JOB_MAX_RETRIES
+                            && is_retryable_bigquery_job_error(&err) =>
+                    {
+                        attempt += 1;
+                        bigquery_job_backoff_sleep(attempt, &map_token)?;
+                    }
+                    Err(err) => return Err(Cancellable::Error(err)),
+                }
+            }
+        };
+
+        let reduce_f =
+            |_: &mut (),
+             _copy_job: (String, String),
+             copy_res: Result<(), Cancellable<AdapterError>>| copy_res;
+
+        let map_reduce = MapReduce::new(factory, Box::new(map_f), Box::new(reduce_f), node_id);
+        match run_traced_async_blocking(map_reduce.run(Arc::new(copy_jobs), token)) {
+            Ok(()) => Ok(()),
+            Err(Cancellable::Error(err)) => Err(err),
+            Err(Cancellable::Cancelled) => Err(AdapterError::new(
+                AdapterErrorKind::Cancelled,
+                "copy_partitions operation cancelled",
+            )),
         }
     }
 
@@ -5858,6 +5940,47 @@ pub trait Replayer: fmt::Debug + Send + Sync {
     -> AdapterResult<Option<serde_json::Value>>;
 }
 
+fn bigquery_relation_fqn(relation: &Arc<dyn BaseRelation>) -> AdapterResult<String> {
+    Ok(format!(
+        "{}.{}.{}",
+        relation.database_as_str()?,
+        relation.schema_as_str()?,
+        relation.identifier_as_str()?
+    ))
+}
+
+fn bigquery_write_disposition(caller: &str, materialization: &str) -> AdapterResult<&'static str> {
+    match materialization {
+        "table" => Ok("WRITE_TRUNCATE"),
+        "incremental" => Ok("WRITE_APPEND"),
+        _ => Err(AdapterError::new(
+            AdapterErrorKind::Configuration,
+            format!("{caller} 'materialization' must be either 'table' or 'incremental'"),
+        )),
+    }
+}
+
+fn bigquery_copy_options(
+    source_fqn: String,
+    dest_fqn: String,
+    write_disposition: &str,
+) -> [(String, OptionValue); 3] {
+    [
+        (
+            COPY_TABLE_SOURCE.to_string(),
+            OptionValue::String(source_fqn),
+        ),
+        (
+            COPY_TABLE_DESTINATION.to_string(),
+            OptionValue::String(dest_fqn),
+        ),
+        (
+            COPY_TABLE_WRITE_DISPOSITION.to_string(),
+            OptionValue::String(write_disposition.to_string()),
+        ),
+    ]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -5874,6 +5997,7 @@ mod tests {
     use dbt_adapter_core::AdapterType;
     use dbt_auth::{NoopAuthWarningPrinter, auth_for_backend};
     use dbt_common::AdapterResult;
+    use dbt_common::cancellation::never_cancels;
     use dbt_schemas::schemas::dbt_column::{DbtColumn, DbtColumnRef};
     use dbt_schemas::schemas::relations::base::ComponentName;
     use dbt_schemas::schemas::relations::{DEFAULT_RESOLVED_QUOTING, SNOWFLAKE_RESOLVED_QUOTING};
@@ -7127,5 +7251,62 @@ mod tests {
             parse_from_relation("my_table"),
             Some("my_table".to_string())
         );
+    }
+
+    fn test_relation(adapter_type: AdapterType, identifier: &str) -> Arc<dyn BaseRelation> {
+        Arc::new(Relation::new(
+            adapter_type,
+            "db".to_string(),
+            "schema".to_string(),
+            identifier.to_string(),
+        ))
+    }
+
+    #[test]
+    fn test_copy_partitions_validates_source_target_lengths() {
+        let adapter = AdapterImpl::new(engine(Bigquery), None);
+        let env = Environment::new();
+        let state = State::new_for_env(&env);
+
+        let sources = vec![
+            test_relation(Bigquery, "src_a"),
+            test_relation(Bigquery, "src_b"),
+        ];
+        let targets = vec![test_relation(Bigquery, "dst_a")];
+
+        let err = adapter
+            .copy_partitions(&state, &sources, &targets, "table", never_cancels())
+            .expect_err("expected source/target length mismatch");
+        assert_eq!(err.kind(), AdapterErrorKind::Configuration);
+    }
+
+    #[test]
+    fn test_copy_partitions_non_bigquery_returns_not_supported() {
+        let adapter = AdapterImpl::new(engine(Snowflake), None);
+        let env = Environment::new();
+        let state = State::new_for_env(&env);
+
+        let sources = vec![test_relation(Snowflake, "src_a")];
+        let targets = vec![test_relation(Snowflake, "dst_a")];
+
+        let err = adapter
+            .copy_partitions(&state, &sources, &targets, "table", never_cancels())
+            .expect_err("expected non-bigquery copy_partitions to be not supported");
+        assert_eq!(err.kind(), AdapterErrorKind::NotSupported);
+    }
+
+    #[test]
+    fn test_copy_partitions_rejects_bad_materialization() {
+        let adapter = AdapterImpl::new(engine(Bigquery), None);
+        let env = Environment::new();
+        let state = State::new_for_env(&env);
+
+        let sources = vec![test_relation(Bigquery, "src_a")];
+        let targets = vec![test_relation(Bigquery, "dst_a")];
+
+        let err = adapter
+            .copy_partitions(&state, &sources, &targets, "view", never_cancels())
+            .expect_err("expected invalid materialization to be rejected");
+        assert_eq!(err.kind(), AdapterErrorKind::Configuration);
     }
 }

--- a/crates/dbt-adapter/src/adapter/adapter_impl.rs
+++ b/crates/dbt-adapter/src/adapter/adapter_impl.rs
@@ -5079,29 +5079,7 @@ impl AdapterImpl {
                 target_fqn.clone(),
                 write_disposition,
             ));
-
-            let mut attempt = 0u32;
-            loop {
-                match engine.execute_with_options(
-                    None,
-                    &ctx,
-                    conn,
-                    "",
-                    options.clone(),
-                    false,
-                    map_token.clone(),
-                ) {
-                    Ok(_) => return Ok(()),
-                    Err(err)
-                        if attempt < BIGQUERY_JOB_MAX_RETRIES
-                            && is_retryable_bigquery_job_error(&err) =>
-                    {
-                        attempt += 1;
-                        bigquery_job_backoff_sleep(attempt, &map_token)?;
-                    }
-                    Err(err) => return Err(Cancellable::Error(err)),
-                }
-            }
+            execute_bigquery_copy_job_with_retry(&engine, &ctx, conn, &options, &map_token)
         };
 
         let reduce_f =
@@ -5110,14 +5088,15 @@ impl AdapterImpl {
              copy_res: Result<(), Cancellable<AdapterError>>| copy_res;
 
         let map_reduce = MapReduce::new(factory, Box::new(map_f), Box::new(reduce_f), node_id);
-        match run_traced_async_blocking(map_reduce.run(Arc::new(copy_jobs), token)) {
-            Ok(()) => Ok(()),
-            Err(Cancellable::Error(err)) => Err(err),
-            Err(Cancellable::Cancelled) => Err(AdapterError::new(
-                AdapterErrorKind::Cancelled,
-                "copy_partitions operation cancelled",
-            )),
-        }
+        run_traced_async_blocking(map_reduce.run(Arc::new(copy_jobs), token)).map_err(|err| {
+            match err {
+                Cancellable::Error(err) => err,
+                Cancellable::Cancelled => AdapterError::new(
+                    AdapterErrorKind::Cancelled,
+                    "copy_partitions operation cancelled",
+                ),
+            }
+        })
     }
 
     /// BigQueryAdapter https://github.com/dbt-labs/dbt-adapters/blob/4a00354a497214d9043bf4122810fe2d04de17bb/dbt-bigquery/src/dbt/adapters/bigquery/impl.py#L818
@@ -5957,6 +5936,37 @@ fn bigquery_write_disposition(caller: &str, materialization: &str) -> AdapterRes
             AdapterErrorKind::Configuration,
             format!("{caller} 'materialization' must be either 'table' or 'incremental'"),
         )),
+    }
+}
+
+/// Run one BigQuery copy job, retrying rate-limited jobs with backoff.
+fn execute_bigquery_copy_job_with_retry(
+    engine: &Arc<dyn AdapterEngine>,
+    ctx: &QueryCtx,
+    conn: &mut dyn Connection,
+    options: &ExecuteOptions,
+    token: &CancellationToken,
+) -> Result<(), Cancellable<AdapterError>> {
+    let mut attempt = 0u32;
+    loop {
+        match engine.execute_with_options(
+            None,
+            ctx,
+            conn,
+            "",
+            options.clone(),
+            false,
+            token.clone(),
+        ) {
+            Ok(_) => return Ok(()),
+            Err(err)
+                if attempt < BIGQUERY_JOB_MAX_RETRIES && is_retryable_bigquery_job_error(&err) =>
+            {
+                attempt += 1;
+                bigquery_job_backoff_sleep(attempt, token)?;
+            }
+            Err(err) => return Err(Cancellable::Error(err)),
+        }
     }
 }
 

--- a/crates/dbt-adapter/src/adapter/mod.rs
+++ b/crates/dbt-adapter/src/adapter/mod.rs
@@ -3841,51 +3841,8 @@ impl Adapter {
                     excluded_schemas,
                 )
             }
-            // only available for BigQuery
-            // columns: dict
-            "nest_column_data_types" => self.nest_column_data_types(args),
-            // partition_by: dict, columns: List[Column]
-            // only available for BigQuery
-            "get_struct_select_expression" => {
-                // col_name: string, data_type: string
-                let iter = ArgsIter::new(name, &["col_name", "data_type"], args);
-                let col_name = iter.next_arg::<&str>()?;
-                let data_type = iter.next_arg::<&str>()?;
-                iter.finish()?;
-
-                self.get_struct_select_expression(state, col_name, data_type)
-            }
-            "add_time_ingestion_partition_column" => {
-                self.add_time_ingestion_partition_column(state, args)
-            }
-            // raw_partition_by: Optional[dict]
-            "parse_partition_by" => self.parse_partition_by(state, args),
-            // relation: Optional[BaseRelation], partition_by: Optional[dict], cluster_by: Optional[dict]
-            "is_replaceable" => self.is_replaceable(state, args),
             // schema_relation: BaseRelation
             "list_relations_without_caching" => self.list_relations_without_caching(state, args),
-            // tmp_relation_partitioned: BaseRelation, target_relation_partitioned: BaseRelation, materialization: str
-            "copy_table" => self.copy_table(state, args),
-            // source_relations: List[BaseRelation], target_relations: List[BaseRelation], materialization: str
-            "copy_partitions" => self.copy_partitions(state, args),
-            // relation: BaseRelation, columns: Dict[str, DbtColumn]
-            "update_columns" => self.update_columns(state, args),
-            // database: str, schema: str, identifier: str, description: str
-            "update_table_description" => self.update_table_description(state, args),
-            // relation: BaseRelation, columns: Value
-            "alter_table_add_columns" => self.alter_table_add_columns(state, args),
-            // database: str, schema: str, table_name: str, file_path: str,
-            // agate_table: AgateTable, column_overrides: dict, field_delimiter: str
-            "load_dataframe" => self.load_dataframe(state, args),
-            "upload_file" => self.upload_file(state, args),
-            // relation: BaseRelation
-            "get_bq_table" => self.get_bq_table(state, args),
-            // relation: BaseRelation
-            "describe_relation" => self.describe_relation(state, args),
-            // entity: BaseRelation, entity_type: str, role: Optional[str], grant_target_dict: GrantAccessToTarget
-            "grant_access_to" => self.grant_access_to(state, args),
-            // relation: BaseRelation
-            "get_dataset_location" => self.get_dataset_location(state, args),
             // sql: str
             "get_column_schema_from_query" => self.get_column_schema_from_query(state, args),
             // sql: str
@@ -3896,8 +3853,6 @@ impl Adapter {
             "get_table_options" => self.get_table_options(state, args),
             // config: dict, node: dict
             "get_view_options" => self.get_view_options(state, args),
-            // table: BaseRelation
-            "get_partitions_metadata" => self.get_partitions_metadata(state, args),
             // schema_relation: BaseRelation
             "get_relations_without_caching" => self.get_relations_without_caching(state, args),
             // raw_index: dict
@@ -4131,6 +4086,62 @@ impl Adapter {
                 iter.finish()?;
                 self.render_equals(state, expr1, expr2)
             }
+            _ => self.call_bigquery_method_impl(state, name, args),
+        }
+    }
+
+    /// Dispatch for the BigQuery-specific adapter methods, chained from the
+    /// default arm of [Adapter::call_method_impl].
+    fn call_bigquery_method_impl(
+        self: &Arc<Self>,
+        state: &State,
+        name: &str,
+        args: &[Value],
+    ) -> Result<Value, minijinja::Error> {
+        match name {
+            // columns: dict
+            "nest_column_data_types" => self.nest_column_data_types(args),
+            "get_struct_select_expression" => {
+                // col_name: string, data_type: string
+                let iter = ArgsIter::new(name, &["col_name", "data_type"], args);
+                let col_name = iter.next_arg::<&str>()?;
+                let data_type = iter.next_arg::<&str>()?;
+                iter.finish()?;
+
+                self.get_struct_select_expression(state, col_name, data_type)
+            }
+            // partition_by: dict, columns: List[Column]
+            "add_time_ingestion_partition_column" => {
+                self.add_time_ingestion_partition_column(state, args)
+            }
+            // raw_partition_by: Optional[dict]
+            "parse_partition_by" => self.parse_partition_by(state, args),
+            // relation: Optional[BaseRelation], partition_by: Optional[dict], cluster_by: Optional[dict]
+            "is_replaceable" => self.is_replaceable(state, args),
+            // tmp_relation_partitioned: BaseRelation, target_relation_partitioned: BaseRelation, materialization: str
+            "copy_table" => self.copy_table(state, args),
+            // source_relations: List[BaseRelation], target_relations: List[BaseRelation], materialization: str
+            "copy_partitions" => self.copy_partitions(state, args),
+            // relation: BaseRelation, columns: Dict[str, DbtColumn]
+            "update_columns" => self.update_columns(state, args),
+            // database: str, schema: str, identifier: str, description: str
+            "update_table_description" => self.update_table_description(state, args),
+            // relation: BaseRelation, columns: Value
+            "alter_table_add_columns" => self.alter_table_add_columns(state, args),
+            // database: str, schema: str, table_name: str, file_path: str,
+            // agate_table: AgateTable, column_overrides: dict, field_delimiter: str
+            "load_dataframe" => self.load_dataframe(state, args),
+            "upload_file" => self.upload_file(state, args),
+            // relation: BaseRelation
+            "get_bq_table" => self.get_bq_table(state, args),
+            // relation: BaseRelation
+            "describe_relation" => self.describe_relation(state, args),
+            // entity: BaseRelation, entity_type: str, role: Optional[str], grant_target_dict: GrantAccessToTarget
+            "grant_access_to" => self.grant_access_to(state, args),
+            // relation: BaseRelation
+            "get_dataset_location" => self.get_dataset_location(state, args),
+            // table: BaseRelation
+            "get_partitions_metadata" => self.get_partitions_metadata(state, args),
             _ => Err(minijinja::Error::new(
                 minijinja::ErrorKind::UnknownMethod,
                 format!("Unknown method on adapter object: '{name}'"),

--- a/crates/dbt-adapter/src/adapter/mod.rs
+++ b/crates/dbt-adapter/src/adapter/mod.rs
@@ -2981,6 +2981,53 @@ impl Adapter {
         }
     }
 
+    #[tracing::instrument(skip(self, state), level = "trace")]
+    pub fn copy_partitions(
+        &self,
+        state: &State,
+        args: &[Value],
+    ) -> Result<Value, minijinja::Error> {
+        match &self.inner {
+            Typed { adapter, .. } => {
+                let iter = ArgsIter::new(
+                    "copy_partitions",
+                    &["source_relations", "target_relations", "materialization"],
+                    args,
+                );
+                let source_relations_val = iter.next_arg::<Vec<Value>>()?;
+                let target_relations_val = iter.next_arg::<Vec<Value>>()?;
+                let materialization = iter.next_arg::<&str>()?;
+                iter.finish()?;
+
+                let source_relations = source_relations_val
+                    .iter()
+                    .map(downcast_value_to_dyn_base_relation)
+                    .collect::<Result<Vec<_>, _>>()?;
+                let target_relations = target_relations_val
+                    .iter()
+                    .map(downcast_value_to_dyn_base_relation)
+                    .collect::<Result<Vec<_>, _>>()?;
+
+                for target_relation in &target_relations {
+                    adapter
+                        .engine()
+                        .relation_cache()
+                        .insert_relation(target_relation.clone(), None);
+                }
+
+                adapter.copy_partitions(
+                    state,
+                    &source_relations,
+                    &target_relations,
+                    materialization,
+                    self.cancellation_token.clone(),
+                )?;
+                Ok(none_value())
+            }
+            Parse(_) => Ok(none_value()),
+        }
+    }
+
     #[tracing::instrument(skip(self), level = "trace")]
     pub fn describe_relation(
         &self,
@@ -3819,6 +3866,8 @@ impl Adapter {
             "list_relations_without_caching" => self.list_relations_without_caching(state, args),
             // tmp_relation_partitioned: BaseRelation, target_relation_partitioned: BaseRelation, materialization: str
             "copy_table" => self.copy_table(state, args),
+            // source_relations: List[BaseRelation], target_relations: List[BaseRelation], materialization: str
+            "copy_partitions" => self.copy_partitions(state, args),
             // relation: BaseRelation, columns: Dict[str, DbtColumn]
             "update_columns" => self.update_columns(state, args),
             // database: str, schema: str, identifier: str, description: str

--- a/crates/dbt-adapter/src/engine/adapter_engine.rs
+++ b/crates/dbt-adapter/src/engine/adapter_engine.rs
@@ -229,6 +229,30 @@ fn log_step_duration(label: &str, elapsed: std::time::Duration) {
     tracing::debug!("{label} took {elapsed:?}");
 }
 
+/// Build the BigQuery `QUERY_LABELS` job option from a resolved query comment and state.
+pub(crate) fn bigquery_job_labels_option(
+    query_comment: &QueryCommentConfig,
+    resolved_comment: Option<&str>,
+    state: &State,
+) -> (String, OptionValue) {
+    let mut job_labels = resolved_comment.map_or_else(IndexMap::new, |comment| {
+        query_comment.get_job_labels_from_query_comment(comment)
+    });
+    if let Some(invocation_id_label) = state
+        .lookup("invocation_id", &[])
+        .and_then(|value| value.as_str().map(|label| label.to_owned()))
+    {
+        job_labels.insert("dbt_invocation_id".to_string(), invocation_id_label);
+    }
+
+    let job_labels_json =
+        serde_json::to_string(&job_labels).expect("Should be able to serialize job labels");
+    (
+        QUERY_LABELS.to_owned(),
+        OptionValue::String(job_labels_json),
+    )
+}
+
 /// Default ADBC-based execute_with_options implementation.
 ///
 /// Used by engines whose connections implement the full ADBC protocol
@@ -261,25 +285,10 @@ pub(crate) fn adbc_execute_with_options(
     let adapter_type = engine.adapter_type();
     let mut options = options;
     if let (Some(state), AdapterType::Bigquery) = (state, adapter_type) {
-        let mut job_labels = maybe_query_comment
-            .as_ref()
-            .map_or_else(IndexMap::new, |comment| {
-                engine
-                    .query_comment()
-                    .get_job_labels_from_query_comment(comment)
-            });
-        if let Some(invocation_id_label) = state
-            .lookup("invocation_id", &[])
-            .and_then(|value| value.as_str().map(|label| label.to_owned()))
-        {
-            job_labels.insert("dbt_invocation_id".to_string(), invocation_id_label);
-        }
-
-        let job_label_option =
-            serde_json::to_string(&job_labels).expect("Should be able to serialize job labels");
-        options.push((
-            QUERY_LABELS.to_owned(),
-            OptionValue::String(job_label_option),
+        options.push(bigquery_job_labels_option(
+            engine.query_comment(),
+            maybe_query_comment.as_deref(),
+            state,
         ));
     }
 

--- a/crates/dbt-adapter/src/engine/mod.rs
+++ b/crates/dbt-adapter/src/engine/mod.rs
@@ -15,6 +15,7 @@ use std::{thread, time::Duration};
 mod adapter_engine;
 pub use adapter_engine::AdapterEngine;
 pub use adapter_engine::Options;
+pub(crate) use adapter_engine::bigquery_job_labels_option;
 
 pub mod query_comment;
 pub mod retry;

--- a/crates/dbt-adapter/src/engine/retry.rs
+++ b/crates/dbt-adapter/src/engine/retry.rs
@@ -4,6 +4,8 @@ use dbt_adapter_core::AdapterType;
 use dbt_adbc::Connection;
 use dbt_adbc::duration::parse_duration;
 use dbt_auth::AdapterConfig;
+use dbt_common::AdapterError;
+use dbt_common::cancellation::{Cancellable, CancellationToken};
 
 #[derive(Debug)]
 pub(crate) enum BackoffStrategy {
@@ -241,6 +243,49 @@ fn is_retryable_databricks_error(config: &AdapterConfig, err: &adbc_core::error:
     }
 
     err.message.to_lowercase().contains("retryableerror")
+}
+
+/// Retries per BigQuery job on retryable errors, with backoff via [bigquery_job_backoff_sleep].
+pub(crate) const BIGQUERY_JOB_MAX_RETRIES: u32 = 8;
+const BIGQUERY_JOB_INITIAL_BACKOFF: Duration = Duration::from_secs(1);
+const BIGQUERY_JOB_MAX_BACKOFF_EXP: u32 = 5; // caps backoff at 2^5 = 32s
+
+/// Retryable BigQuery job error reasons, matching the official google-cloud-bigquery client.
+/// Excludes `quotaExceeded`: daily quotas don't recover within a backoff window.
+pub(crate) fn is_retryable_bigquery_job_error(err: &AdapterError) -> bool {
+    let message = err.message().to_ascii_lowercase();
+    [
+        "ratelimitexceeded",
+        "jobratelimitexceeded",
+        "exceeded rate limits",
+        "backenderror",
+        "internalerror",
+    ]
+    .iter()
+    .any(|reason| message.contains(reason))
+}
+
+/// Jittered exponential sleep before the `attempt`-th BigQuery job retry (1-indexed),
+/// waking periodically to honor cancellation.
+pub(crate) fn bigquery_job_backoff_sleep(
+    attempt: u32,
+    token: &CancellationToken,
+) -> Result<(), Cancellable<AdapterError>> {
+    let backoff =
+        BIGQUERY_JOB_INITIAL_BACKOFF * (1u32 << (attempt - 1).min(BIGQUERY_JOB_MAX_BACKOFF_EXP));
+    // jitter in [backoff/2, backoff] spreads out competing workers
+    let jitter = rand::random::<u64>() % (backoff.as_micros() as u64 / 2);
+    let deadline = std::time::Instant::now() + backoff / 2 + Duration::from_micros(jitter);
+    loop {
+        if token.is_cancelled() {
+            return Err(Cancellable::Cancelled);
+        }
+        let now = std::time::Instant::now();
+        if now >= deadline {
+            return Ok(());
+        }
+        std::thread::sleep((deadline - now).min(Duration::from_millis(100)));
+    }
 }
 
 #[cfg(test)]
@@ -559,5 +604,24 @@ mod tests {
         let e = adbc_err(Status::InvalidArguments, "bad config option");
         assert!(!is_retryable_databricks_error(&cfg_default(), &e));
         assert!(is_retryable_databricks_error(&cfg_retry_all(), &e));
+    }
+
+    #[test]
+    fn bigquery_job_error_retryability() {
+        use dbt_common::AdapterErrorKind;
+        let err = |msg: &str| AdapterError::new(AdapterErrorKind::Internal, msg);
+
+        assert!(is_retryable_bigquery_job_error(&err(
+            "Exceeded rate limits: too many table update operations for this table"
+        )));
+        assert!(is_retryable_bigquery_job_error(&err(
+            "jobRateLimitExceeded: retry later"
+        )));
+        assert!(!is_retryable_bigquery_job_error(&err(
+            "quotaExceeded: Your project exceeded quota for copies per project"
+        )));
+        assert!(!is_retryable_bigquery_job_error(&err(
+            "notFound: Table db:schema.t"
+        )));
     }
 }

--- a/crates/dbt-adapter/src/engine/retry.rs
+++ b/crates/dbt-adapter/src/engine/retry.rs
@@ -606,21 +606,26 @@ mod tests {
         assert!(is_retryable_databricks_error(&cfg_retry_all(), &e));
     }
 
-    #[test]
-    fn bigquery_job_error_retryability() {
-        use dbt_common::AdapterErrorKind;
-        let err = |msg: &str| AdapterError::new(AdapterErrorKind::Internal, msg);
+    fn bigquery_err(msg: &str) -> AdapterError {
+        AdapterError::new(dbt_common::AdapterErrorKind::Internal, msg)
+    }
 
-        assert!(is_retryable_bigquery_job_error(&err(
+    #[test]
+    fn bigquery_rate_limit_job_errors_are_retryable() {
+        assert!(is_retryable_bigquery_job_error(&bigquery_err(
             "Exceeded rate limits: too many table update operations for this table"
         )));
-        assert!(is_retryable_bigquery_job_error(&err(
+        assert!(is_retryable_bigquery_job_error(&bigquery_err(
             "jobRateLimitExceeded: retry later"
         )));
-        assert!(!is_retryable_bigquery_job_error(&err(
+    }
+
+    #[test]
+    fn bigquery_permanent_job_errors_are_not_retryable() {
+        assert!(!is_retryable_bigquery_job_error(&bigquery_err(
             "quotaExceeded: Your project exceeded quota for copies per project"
         )));
-        assert!(!is_retryable_bigquery_job_error(&err(
+        assert!(!is_retryable_bigquery_job_error(&bigquery_err(
             "notFound: Table db:schema.t"
         )));
     }

--- a/crates/dbt-adapter/src/time_machine/semantic.rs
+++ b/crates/dbt-adapter/src/time_machine/semantic.rs
@@ -77,6 +77,7 @@ impl SemanticCategory {
             | "expand_target_column_types"
             | "load_dataframe"
             | "copy_table"
+            | "copy_partitions"
             | "update_columns"
             | "update_table_description"
             | "alter_table_add_columns"

--- a/crates/dbt-adapter/src/time_machine/semantic.rs
+++ b/crates/dbt-adapter/src/time_machine/semantic.rs
@@ -32,6 +32,125 @@ pub enum SemanticCategory {
     Pure,
 }
 
+/// Adapter methods that query database state without mutation.
+const METADATA_READ_METHODS: &[&str] = &[
+    "get_relation",
+    "get_columns_in_relation",
+    "list_schemas",
+    "check_schema_exists",
+    "list_relations_without_caching",
+    "get_relations_by_pattern",
+    "get_relations_without_caching",
+    "valid_snapshot_target",
+    "describe_relation",
+    "describe_dynamic_table",
+    "get_column_schema_from_query",
+    "get_columns_in_select_sql",
+    "get_partitions_metadata",
+    "get_bq_table",
+    "get_dataset_location",
+    "get_catalog_integration",
+    "get_relation_config",
+    "compare_dbr_version",
+    "has_dbr_capability",
+    "get_missing_columns",
+    "is_replaceable",
+    "location_exists",
+];
+
+/// Adapter methods that mutate database state (DDL/DML).
+const WRITE_METHODS: &[&str] = &[
+    "execute",
+    "add_query",
+    "drop_relation",
+    "rename_relation",
+    "truncate_relation",
+    "create_schema",
+    "drop_schema",
+    "expand_target_column_types",
+    "load_dataframe",
+    "copy_table",
+    "copy_partitions",
+    "update_columns",
+    "update_table_description",
+    "alter_table_add_columns",
+    "upload_file",
+    "grant_access_to",
+    "submit_python_job",
+    "assert_valid_snapshot_target_given_strategy",
+    "update_tblproperties_for_uniform_iceberg",
+];
+
+/// Adapter methods that only touch the adapter's in-memory relation cache.
+const CACHE_METHODS: &[&str] = &["cache_added", "cache_dropped", "cache_renamed"];
+
+/// Adapter methods that are local computation with no I/O.
+const PURE_METHODS: &[&str] = &[
+    "quote",
+    "quote_as_configured",
+    "quote_seed_column",
+    "render_equals",
+    "convert_type",
+    "build_catalog_from_show_tables_and_svv_columns",
+    "dispatch",
+    "commit",
+    "type",
+    "render_raw_model_constraints",
+    "render_raw_columns_constraints",
+    "get_incremental_strategy_macro",
+    "standardize_grants_dict",
+    "verify_database",
+    "nest_column_data_types",
+    "get_struct_select_expression",
+    "add_time_ingestion_partition_column",
+    "parse_partition_by",
+    "valid_incremental_strategies",
+    "get_persist_doc_columns",
+    "get_column_tags_from_model",
+    "get_config_from_model",
+    "generate_unique_temporary_table_suffix",
+    "parse_columns_and_constraints",
+    "clean_sql",
+    "get_common_options",
+    "get_table_options",
+    "get_view_options",
+    "parse_index",
+    "redact_credentials",
+    "compute_external_path",
+    "get_hard_deletes_behavior",
+    "is_cluster",
+    "is_ducklake",
+    "has_feature",
+    "is_motherduck",
+    "disable_transactions",
+    "build_catalog_relation",
+    "sync_struct_columns",
+    "resolve_file_format",
+    "get_seed_file_path",
+    "is_uniform",
+    "external_root",
+    "external_write_options",
+    "external_read_location",
+    "get_temp_relation_path",
+    "get_clickhouse_cluster_name",
+    "get_clickhouse_local_suffix",
+    "get_clickhouse_local_db_prefix",
+    "clickhouse_db_engine_clause",
+    "is_before_version",
+    "supports_atomic_exchange",
+    "can_exchange",
+    "should_on_cluster",
+    "calculate_incremental_strategy",
+    "validate_incremental_strategy",
+    "get_model_settings",
+    "get_model_query_settings",
+    "filter_settings_by_engine",
+    "get_ch_database",
+    "get_credentials",
+    "get_csv_data",
+    "table_format",
+];
+
 impl SemanticCategory {
     /// Classify a Adapter method by its semantic category.
     ///
@@ -41,128 +160,21 @@ impl SemanticCategory {
     /// - Cache: Only touches adapter's in-memory relation cache
     /// - Pure: Local computation, no I/O at all
     pub fn from_adapter_method(method: &str) -> Self {
-        match method {
-            // Query database state without mutation
-            "get_relation"
-            | "get_columns_in_relation"
-            | "list_schemas"
-            | "check_schema_exists"
-            | "list_relations_without_caching"
-            | "get_relations_by_pattern"
-            | "get_relations_without_caching"
-            | "valid_snapshot_target"
-            | "describe_relation"
-            | "describe_dynamic_table"
-            | "get_column_schema_from_query"
-            | "get_columns_in_select_sql"
-            | "get_partitions_metadata"
-            | "get_bq_table"
-            | "get_dataset_location"
-            | "get_catalog_integration"
-            | "get_relation_config"
-            | "compare_dbr_version"
-            | "has_dbr_capability"
-            | "get_missing_columns"
-            | "is_replaceable"
-            | "location_exists" => SemanticCategory::MetadataRead,
-
-            // Mutate database state (DDL/DML)
-            "execute"
-            | "add_query"
-            | "drop_relation"
-            | "rename_relation"
-            | "truncate_relation"
-            | "create_schema"
-            | "drop_schema"
-            | "expand_target_column_types"
-            | "load_dataframe"
-            | "copy_table"
-            | "copy_partitions"
-            | "update_columns"
-            | "update_table_description"
-            | "alter_table_add_columns"
-            | "upload_file"
-            | "grant_access_to"
-            | "submit_python_job"
-            | "assert_valid_snapshot_target_given_strategy"
-            | "update_tblproperties_for_uniform_iceberg" => SemanticCategory::Write,
-
-            // Internal bookkeeping only
-            "cache_added" | "cache_dropped" | "cache_renamed" => SemanticCategory::Cache,
-
-            // No I/O at all
-            "quote"
-            | "quote_as_configured"
-            | "quote_seed_column"
-            | "render_equals"
-            | "convert_type"
-            | "build_catalog_from_show_tables_and_svv_columns"
-            | "dispatch"
-            | "commit"
-            | "type"
-            | "render_raw_model_constraints"
-            | "render_raw_columns_constraints"
-            | "get_incremental_strategy_macro"
-            | "standardize_grants_dict"
-            | "verify_database"
-            | "nest_column_data_types"
-            | "get_struct_select_expression"
-            | "add_time_ingestion_partition_column"
-            | "parse_partition_by"
-            | "valid_incremental_strategies"
-            | "get_persist_doc_columns"
-            | "get_column_tags_from_model"
-            | "get_config_from_model"
-            | "generate_unique_temporary_table_suffix"
-            | "parse_columns_and_constraints"
-            | "clean_sql"
-            | "get_common_options"
-            | "get_table_options"
-            | "get_view_options"
-            | "parse_index"
-            | "redact_credentials"
-            | "compute_external_path"
-            | "get_hard_deletes_behavior"
-            | "is_cluster"
-            | "is_ducklake"
-            | "has_feature"
-            | "is_motherduck"
-            | "disable_transactions"
-            | "build_catalog_relation"
-            | "sync_struct_columns"
-            | "resolve_file_format"
-            | "get_seed_file_path"
-            | "is_uniform"
-            | "external_root"
-            | "external_write_options"
-            | "external_read_location"
-            | "get_temp_relation_path"
-            | "get_clickhouse_cluster_name"
-            | "get_clickhouse_local_suffix"
-            | "get_clickhouse_local_db_prefix"
-            | "clickhouse_db_engine_clause"
-            | "is_before_version"
-            | "supports_atomic_exchange"
-            | "can_exchange"
-            | "should_on_cluster"
-            | "calculate_incremental_strategy"
-            | "validate_incremental_strategy"
-            | "get_model_settings"
-            | "get_model_query_settings"
-            | "filter_settings_by_engine"
-            | "get_ch_database"
-            | "get_credentials"
-            | "get_csv_data"
-            | "table_format" => SemanticCategory::Pure,
-
-            _ => {
-                debug_assert!(
-                    false,
-                    "time-machine: Unknown adapter method '{}', add it to SemanticCategory::from_adapter_method",
-                    method
-                );
-                SemanticCategory::Write
-            }
+        if METADATA_READ_METHODS.contains(&method) {
+            SemanticCategory::MetadataRead
+        } else if WRITE_METHODS.contains(&method) {
+            SemanticCategory::Write
+        } else if CACHE_METHODS.contains(&method) {
+            SemanticCategory::Cache
+        } else if PURE_METHODS.contains(&method) {
+            SemanticCategory::Pure
+        } else {
+            debug_assert!(
+                false,
+                "time-machine: Unknown adapter method '{}', add it to SemanticCategory::from_adapter_method",
+                method
+            );
+            SemanticCategory::Write
         }
     }
 

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-bigquery/macros/materializations/incremental_strategy/insert_overwrite.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-bigquery/macros/materializations/incremental_strategy/insert_overwrite.sql
@@ -18,6 +18,8 @@
 
 {% macro bq_copy_partitions(tmp_relation, target_relation, partitions, partition_by) %}
 
+  {% set source_partitions = [] %}
+  {% set target_partitions = [] %}
   {% for partition in partitions %}
     {% if partition_by.data_type == 'int64' %}
       {% set partition = partition | as_text %}
@@ -32,8 +34,10 @@
     {% endif %}
     {% set tmp_relation_partitioned = api.Relation.create(database=tmp_relation.database, schema=tmp_relation.schema, identifier=tmp_relation.table ~ '$' ~ partition, type=tmp_relation.type) %}
     {% set target_relation_partitioned = api.Relation.create(database=target_relation.database, schema=target_relation.schema, identifier=target_relation.table ~ '$' ~ partition, type=target_relation.type) %}
-    {% do adapter.copy_table(tmp_relation_partitioned, target_relation_partitioned, "table") %}
+    {% do source_partitions.append(tmp_relation_partitioned) %}
+    {% do target_partitions.append(target_relation_partitioned) %}
   {% endfor %}
+  {% do adapter.copy_partitions(source_partitions, target_partitions, "table") %}
 
 {% endmacro %}
 

--- a/crates/dbt-tracing/src/async_tracing.rs
+++ b/crates/dbt-tracing/src/async_tracing.rs
@@ -62,3 +62,20 @@ where
     tokio::task::block_in_place(move || tokio::runtime::Handle::current().block_on(task))
         .expect("expected to finish task")
 }
+
+/// Run an async task from sync code, reusing the active Tokio runtime if there is one.
+pub fn run_traced_async_blocking<F>(future: F) -> F::Output
+where
+    F: Future + Send + 'static,
+    F::Output: Send + 'static,
+{
+    if tokio::runtime::Handle::try_current().is_ok() {
+        spawn_traced_block_in_place(future)
+    } else {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("expected to build tokio runtime");
+        runtime.block_on(future)
+    }
+}


### PR DESCRIPTION
## What

`bq_copy_partitions` copies partitions one at a time through `adapter.copy_table` — one blocking BigQuery copy job per partition, ~0.5 jobs/s. On models with wide partition ranges the copy step dominates the incremental run: a 96-partition `insert_overwrite` model spends ~3 minutes just copying.

The macro now batches the partitions and hands them to a new `adapter.copy_partitions`, which:

- Fans the copy jobs out through a `MapReduce` pool using `AdapterConnectionFactory` with the profile's `threads`-derived limit, so copy jobs share the global connection budget — a lone model gets the full budget, a busy DAG self-limits.
- Retries rate-limited jobs with jittered exponential backoff (1s doubling to a 32s cap, max 8 attempts), matching the retryable reasons of the official google-cloud-bigquery client (`rateLimitExceeded`, `jobRateLimitExceeded`, `backendError`, `internalError` — deliberately not `quotaExceeded`). The classifier and backoff live in `engine/retry.rs` beside the existing Snowflake classifier.
- Resolves BigQuery job labels once before the fan-out (worker threads can't hold `State`), via a `bigquery_job_labels_option` helper now shared with the engine's normal execute path.

`copy_table` shares the new FQN / write-disposition / copy-option helpers with `copy_partitions` instead of duplicating them.

Resolves #14283.

## Testing

- Unit tests: argument validation, non-BigQuery rejection, invalid materialization, retryable-error classifier. Full dbt-adapter suite passes (925), clippy clean.
- End-to-end with this branch's binary against BigQuery: a 96-partition `insert_overwrite` incremental model completes the copy step in 7.8s (max 47 concurrent copy jobs observed in `INFORMATION_SCHEMA.JOBS_BY_PROJECT`), model total 23.6s.
- Note: copy jobs don't carry `QUERY_LABELS` — the ADBC driver ignores labels on copy operations. Verified this is pre-existing behavior identical to the serial `copy_table` path (production serial copy jobs carry no labels either); the label plumbing here keeps parity and activates if the driver adds support.

## Benchmarks

Real copy jobs against BigQuery, 96 daily partitions into one date-partitioned table (US multi-region):

| concurrency | wall clock | rate | rate-limit errors |
|---|---|---|---|
| serial (current behavior) | 177.7s | 0.54 jobs/s | 0 |
| 4 workers | 39.9s | 2.4 jobs/s | 0 |
| 8 workers | 19.2s | 5.0 jobs/s | 0 |
| 48 workers (shared-budget ceiling) | 5.6s | 17 jobs/s | 0 |

Multi-model load — 6 concurrent models × 180 partitions (1,080 copy jobs) through a shared 48-slot budget: 50s total at 21.6 jobs/s aggregate, zero rate-limit errors, all partitions verified. A sustained probe (4 × 96 back-to-back rounds into the same table, ~12 jobs/s) also produced zero throttling — BigQuery's documented ~5 table-update-ops/10s quota never bit at any tested concurrency, so the retry path is a safety net rather than the expected steady state.
