### PR TITLE
feat(fabric): support ActiveDirectoryAccessToken authentication

### DIFF
--- a/.changes/unreleased/Features-20260805-182006.yaml
+++ b/.changes/unreleased/Features-20260805-182006.yaml
@@ -4,5 +4,5 @@ body: '[dbt-fusion] (fabric) support `authentication: ActiveDirectoryAccessToken
 time: 2026-08-05T18:20:06.218617-07:00
 custom:
     author: mghorpade1
-    issue: ""
+    issue: "15926"
     project: dbt-core

--- a/.changes/unreleased/Features-20260805-182006.yaml
+++ b/.changes/unreleased/Features-20260805-182006.yaml
@@ -1,0 +1,8 @@
+kind: Features
+body: '[dbt-fusion] (fabric) support `authentication: ActiveDirectoryAccessToken`, authenticating
+    with a pre-minted Entra bearer token from the `access_token` profile field'
+time: 2026-08-05T18:20:06.218617-07:00
+custom:
+    author: mghorpade1
+    issue: ""
+    project: dbt-core

--- a/crates/dbt-auth/src/sqlserver/mod.rs
+++ b/crates/dbt-auth/src/sqlserver/mod.rs
@@ -37,6 +37,23 @@ enum SQLServerAuthIR<'a> {
         client_secret: &'a str,
     },
 
+    /// Pre-minted Entra bearer token supplied directly in the profile.
+    ///
+    /// Profile: `authentication: ActiveDirectoryAccessToken`, `access_token`.
+    ///
+    /// URI: `fedauth=ActiveDirectoryServicePrincipalAccessToken`, `password={access_token}`.
+    ///
+    /// Note: the profile name and the `fedauth` value differ on purpose; the driver spells
+    /// this workflow `ActiveDirectoryServicePrincipalAccessToken` and reads the token from
+    /// `password`.
+    ///
+    /// No credential exchange happens: the token is forwarded to the TDS FEDAUTH handshake
+    /// verbatim, so an expired token fails at connection time and is never refreshed.
+    ActiveDirectoryAccessToken {
+        /// Entra bearer token (`access_token` in profile, `password` in URI).
+        access_token: &'a str,
+    },
+
     /// user/password auth via the resource-owner password credentials flow.
     ///
     /// Profile: `authentication: ActiveDirectoryPassword`, `UID`, `PWD`, and `client_id`.
@@ -91,6 +108,16 @@ impl<'a> SQLServerAuthIR<'a> {
                         .finish();
                 }
             }
+            Self::ActiveDirectoryAccessToken { access_token } => {
+                if let Some(uri) = builder.uri.as_mut() {
+                    // go-mssqldb reads the bearer token from `password` and requires no
+                    // `user id` for this workflow.
+                    uri.query_pairs_mut()
+                        .append_pair("fedauth", "ActiveDirectoryServicePrincipalAccessToken")
+                        .append_pair("password", access_token)
+                        .finish();
+                }
+            }
             Self::ActiveDirectoryPassword {
                 client_id,
                 user,
@@ -125,12 +152,30 @@ fn parse_auth<'a>(config: &'a AdapterConfig) -> Result<SQLServerAuthIR<'a>, Auth
         authentication = "ActiveDirectoryServicePrincipal";
     }
 
+    // dbt-fabric matches this method case-insensitively:
+    // `credentials.authentication.lower() == "activedirectoryaccesstoken"`
+    if authentication.eq_ignore_ascii_case("ActiveDirectoryAccessToken") {
+        authentication = "ActiveDirectoryAccessToken";
+    }
+
     match authentication {
         "ActiveDirectoryServicePrincipal" => Ok(SQLServerAuthIR::ActiveDirectoryServicePrincipal {
             tenant_id: config.get_str("tenant_id"),
             client_id: config.require_str("client_id")?,
             client_secret: config.require_str("client_secret")?,
         }),
+        "ActiveDirectoryAccessToken" => {
+            let access_token = config.require_str("access_token")?;
+            // The driver rejects an empty token with a message that names the `password`
+            // URI parameter, which does not exist in the user's profile. Fail earlier with
+            // the profile field name instead.
+            if access_token.is_empty() {
+                return Err(AuthError::config(
+                    "`access_token` must not be empty when using ActiveDirectoryAccessToken authentication",
+                ));
+            }
+            Ok(SQLServerAuthIR::ActiveDirectoryAccessToken { access_token })
+        }
         "ActiveDirectoryPassword" => Ok(SQLServerAuthIR::ActiveDirectoryPassword {
             user: config.require_str("UID")?,
             password: config.require_str("PWD")?,
@@ -141,7 +186,7 @@ fn parse_auth<'a>(config: &'a AdapterConfig) -> Result<SQLServerAuthIR<'a>, Auth
             unimplemented!("authentication method {} not implemented", authentication)
         }
         _ => Err(AuthError::config(format!(
-            "Invalid authentication method: {authentication} must be one of: [ActiveDirectoryServicePrincipal, ActiveDirectoryPassword, environment]"
+            "Invalid authentication method: {authentication} must be one of: [ActiveDirectoryServicePrincipal, ActiveDirectoryAccessToken, ActiveDirectoryPassword, environment]"
         ))),
     }
 }
@@ -333,5 +378,100 @@ mod tests {
         let uri = uri_value(&outcome.builder);
 
         assert_contains!(&uri, "fedauth=ActiveDirectoryServicePrincipal");
+    }
+
+    const FAKE_ACCESS_TOKEN: &str = "eyJ0eXAiOiJKV1QifQ.eyJhdWQiOiJkYiJ9.c2lnbmF0dXJl";
+
+    #[test]
+    fn test_active_directory_access_token() {
+        let config = make_config([
+            ("authentication", "ActiveDirectoryAccessToken"),
+            ("host", "myserver.database.windows.net"),
+            ("database", "mydb"),
+            ("access_token", FAKE_ACCESS_TOKEN),
+        ]);
+
+        let outcome = SQLServerAuth.configure(&config).expect("configure");
+        let uri = uri_value(&outcome.builder);
+
+        assert_contains!(&uri, "sqlserver://myserver.database.windows.net:1433");
+        assert_contains!(&uri, "database=mydb");
+        // dbt-fabric spells the profile value `ActiveDirectoryAccessToken`, but the driver
+        // only understands the go-mssqldb spelling.
+        assert_contains!(&uri, "fedauth=ActiveDirectoryServicePrincipalAccessToken");
+        assert_contains!(&uri, &format!("password={FAKE_ACCESS_TOKEN}"));
+        // This workflow takes no identity parameters.
+        assert!(!uri.contains("user+id"), "unexpected `user id` in {uri}");
+        assert!(
+            !uri.contains("applicationclientid"),
+            "unexpected `applicationclientid` in {uri}"
+        );
+    }
+
+    #[test]
+    fn test_access_token_is_case_insensitive() {
+        // dbt-fabric lowercases `authentication` before comparing.
+        let config = make_config([
+            ("authentication", "activedirectoryaccesstoken"),
+            ("host", "myserver.database.windows.net"),
+            ("database", "mydb"),
+            ("access_token", FAKE_ACCESS_TOKEN),
+        ]);
+
+        let outcome = SQLServerAuth.configure(&config).expect("configure");
+        let uri = uri_value(&outcome.builder);
+
+        assert_contains!(&uri, "fedauth=ActiveDirectoryServicePrincipalAccessToken");
+    }
+
+    #[test]
+    fn test_access_token_missing() {
+        let config = make_config([
+            ("authentication", "ActiveDirectoryAccessToken"),
+            ("host", "myserver.database.windows.net"),
+            ("database", "mydb"),
+        ]);
+
+        let err = SQLServerAuth
+            .configure(&config)
+            .expect_err("missing access_token must fail");
+
+        match err {
+            AuthError::YAML(e) => {
+                assert_contains!(e.to_string(), "missing field `access_token`")
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_access_token_empty() {
+        let config = make_config([
+            ("authentication", "ActiveDirectoryAccessToken"),
+            ("host", "myserver.database.windows.net"),
+            ("database", "mydb"),
+            ("access_token", ""),
+        ]);
+
+        let err = SQLServerAuth
+            .configure(&config)
+            .expect_err("empty access_token must fail");
+
+        assert_contains!(err.msg(), "`access_token` must not be empty");
+    }
+
+    #[test]
+    fn test_invalid_authentication_lists_access_token() {
+        let config = make_config([
+            ("authentication", "NotAnAuthMethod"),
+            ("host", "myserver.database.windows.net"),
+            ("database", "mydb"),
+        ]);
+
+        let err = SQLServerAuth
+            .configure(&config)
+            .expect_err("invalid authentication must fail");
+
+        assert_contains!(err.msg(), "ActiveDirectoryAccessToken");
     }
 }

--- a/crates/dbt-init/src/adapter_config/fabric_config.rs
+++ b/crates/dbt-init/src/adapter_config/fabric_config.rs
@@ -18,10 +18,10 @@ const AUTH_METHODS: &[(&str, &str)] = &[
         "environment",
         "Environment (DefaultAzureCredential env vars, see https://learn.microsoft.com/en-us/python/api/azure-identity/azure.identity.environmentcredential, explain the available combinations of environment variables you can use to authenticate.)",
     ),
-    // (
-    //     "ActiveDirectoryAccessToken",
-    //     "Active Directory Access Token",
-    // ),
+    (
+        "ActiveDirectoryAccessToken",
+        "Active Directory Access Token",
+    ),
     // ("CLI", "Azure CLI"),
     // (
     //     "ActiveDirectoryInteractive",
@@ -40,6 +40,7 @@ impl InteractiveSetup for FabricDbConfig {
 
         // Index lookups for auth-dependent fields.
         let sp_idx = auth_index("ActiveDirectoryServicePrincipal").unwrap_or(0);
+        let token_idx = auth_index("ActiveDirectoryAccessToken").unwrap_or(0);
         // let adpw_idx = auth_index("ActiveDirectoryPassword").unwrap_or(0);
 
         vec![
@@ -64,6 +65,9 @@ impl InteractiveSetup for FabricDbConfig {
                 .when_field_equals("auth_method", FieldValue::Integer(sp_idx)),
             ConfigField::password("client_secret", "Client secret")
                 .when_field_equals("auth_method", FieldValue::Integer(sp_idx)),
+            // Access Token field
+            ConfigField::password("access_token", "Access token")
+                .when_field_equals("auth_method", FieldValue::Integer(token_idx)),
             // TODO: this is supported in `dbt-auth`
             // but it is disabled for now since I didn't find the right credentials to test it
             // Active Directory Password
@@ -115,6 +119,11 @@ impl InteractiveSetup for FabricDbConfig {
                     self.client_secret = Some(s);
                 }
             }
+            "access_token" => {
+                if let FieldValue::String(s) = value {
+                    self.access_token = Some(s);
+                }
+            }
             "user_adpw" => {
                 if let FieldValue::String(s) = value
                     && !s.is_empty()
@@ -157,6 +166,10 @@ impl InteractiveSetup for FabricDbConfig {
                 .client_secret
                 .as_ref()
                 .map(|s| FieldValue::String(s.clone())),
+            "access_token" => self
+                .access_token
+                .as_ref()
+                .map(|s| FieldValue::String(s.clone())),
             "user_adpw" => self.user.as_ref().map(|s| FieldValue::String(s.clone())),
             "password_adpw" => self
                 .password
@@ -179,6 +192,7 @@ impl InteractiveSetup for FabricDbConfig {
             "tenant_id" => self.tenant_id.is_some(),
             "client_id" => self.client_id.is_some(),
             "client_secret" => self.client_secret.is_some(),
+            "access_token" => self.access_token.is_some(),
             "user_adpw" => self.user.is_some(),
             "password_adpw" => self.password.is_some(),
             _ => false,


### PR DESCRIPTION
Adds a fourth Fabric auth method that accepts a pre-minted Entra bearer token from the `access_token` profile field, matching the spelling dbt-fabric already uses.

The profile value is matched case-insensitively. On the wire the URI emits fedauth=ActiveDirectoryServicePrincipalAccessToken with the token in password, which is how go-mssqldb spells this workflow. An empty token is rejected up front so the error names the profile field rather than the driver's internal parameter.

Also surfaces the method in the dbt init wizard, prompting for the token only when that method is selected.

No schema change was required: FabricDbConfig already carried access_token. It is deliberately left out of get_connection_keys() so the token never appears in dbt debug output.

Resolves #15926 

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `action:needs-docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

dbt Fusion's Fabric adapter does not currently support authentication with a
pre-minted Microsoft Entra access token.

Users who obtain tokens externally, such as through a CI/CD pipeline, OAuth
flow, managed token broker, or another identity provider, cannot pass that token
through the `access_token` profile field. They must instead use another
authentication method, such as a service principal with a client secret.

The `dbt init` wizard also does not expose access-token authentication when
creating a Fabric profile.

### Solution

Add support for `authentication: ActiveDirectoryAccessToken` in Fabric profiles.

The implementation:

- Reads the bearer token from the existing `access_token` profile field.
- Maps the profile authentication method to the go-mssqldb
  `ActiveDirectoryServicePrincipalAccessToken` federated authentication mode.
- Passes the token through the driver's `password` connection-string parameter,
  as required by this go-mssqldb authentication flow.
- Rejects an empty or missing token with an error that identifies the
  `access_token` profile field.
- Matches the authentication method case-insensitively for compatibility with
  dbt-fabric.
- Adds the authentication method to the Fabric `dbt init` wizard and prompts
  for an access token only when that method is selected.
- Keeps the access token out of connection/debug output.
- Adds unit tests covering URI generation, case-insensitive matching, missing
  tokens, and empty tokens.

No schema change is required because `FabricDbConfig` already includes the
`access_token` field.

### Validation

- `cargo test -p dbt-auth sqlserver` — 12 tests passed
- `cargo check -p dbt-init` — passed
- Confirmed the generated connection URI works end-to-end against a Fabric
  warehouse through the ADBC MSSQL driver.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
