### PR TITLE
Improvements in the OpenTelemetry instrumentation

### DIFF
--- a/.changes/unreleased/Fixes-20260806-120000.yaml
+++ b/.changes/unreleased/Fixes-20260806-120000.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: 'Fix OpenTelemetry hook spans: name them by transaction phase, skip calls that
+    run no hooks, and add node context.'
+time: 2026-08-06T12:00:00.000000-07:00
+custom:
+    Author: tauhid621
+    Issue: "11367"

--- a/.changes/unreleased/Fixes-20260806-120000.yaml
+++ b/.changes/unreleased/Fixes-20260806-120000.yaml
@@ -1,6 +1,6 @@
 kind: Fixes
-body: 'Fix OpenTelemetry hook spans: name them by transaction phase, skip calls that
-    run no hooks, and add node context.'
+body: 'Fix OpenTelemetry hook spans: name them by hook and transaction phase, skip calls
+    that run no hooks, and add node context and status.'
 time: 2026-08-06T12:00:00.000000-07:00
 custom:
     Author: tauhid621

--- a/core/dbt/clients/jinja.py
+++ b/core/dbt/clients/jinja.py
@@ -1,7 +1,7 @@
 import re
 import threading
 from contextlib import contextmanager
-from typing import Any, Dict, List, NoReturn, Optional, Tuple, Union
+from typing import Any, Dict, Generator, List, NoReturn, Optional, Tuple, Union
 
 import jinja2
 import jinja2.ext
@@ -30,9 +30,24 @@ from dbt_common.utils import deep_map_render
 
 SUPPORTED_LANG_ARG = jinja2.nodes.Name("supported_languages", "param")
 
-# Module-level tracer. Inert (creates no spans) until the
-# --snowflake-projects-otel gate opens a span in __call__.
+# Inert until the --snowflake-projects-otel gate opens a span in __call__.
 _TRACER = trace.get_tracer("dbt.runner")
+
+
+def _hook_count(hooks: Any, inside_transaction: bool) -> int:
+    """How many hooks `run_hooks` actually executes in this transaction phase.
+
+    Mirrors the macro's own `selectattr('transaction', ...)` filter: a
+    materialization passes its whole hook list to all four run_hooks calls, so two of
+    them run nothing. Returns 0 for anything that isn't the expected list of
+    mappings, since run_hooks is reachable from user and adapter macros too.
+    """
+    if not isinstance(hooks, (list, tuple)):
+        return 0
+    try:
+        return sum(1 for hook in hooks if hook["transaction"] == inside_transaction)
+    except (TypeError, KeyError, IndexError):
+        return 0
 
 
 class MacroStack(threading.local):
@@ -83,12 +98,30 @@ class MacroGenerator(CallableMacroGenerator):
             finally:
                 self.stack.pop(unique_id)
 
+    @contextmanager
+    def _hook_span(
+        self, args: Tuple[Any, ...], kwargs: Dict[str, Any]
+    ) -> Generator[None, None, None]:
+        inside_transaction = kwargs.get("inside_transaction", args[1] if len(args) > 1 else True)
+        hook_count = _hook_count(args[0] if args else None, inside_transaction)
+        if not hook_count:
+            yield
+            return
+
+        phase = "inside" if inside_transaction else "outside"
+        with _TRACER.start_as_current_span(f"hooks.{phase}_transaction") as span:
+            span.set_attribute("inside_transaction", bool(inside_transaction))
+            span.set_attribute("hook_count", hook_count)
+            unique_id = getattr(self.node, "unique_id", None)
+            if unique_id is not None:
+                span.set_attribute("unique_id", unique_id)
+            yield
+
     # this makes MacroGenerator objects callable like functions
     def __call__(self, *args, **kwargs) -> Any:
         otel_enabled = getattr(get_flags(), "SNOWFLAKE_PROJECTS_OTEL", False)
-        if otel_enabled and self.get_name() == "run_hooks" and args and args[0]:
-            span_name = kwargs["span_name"] if "span_name" in kwargs else "hook_span"
-            with self.track_call(), _TRACER.start_as_current_span(span_name):
+        if otel_enabled and self.get_name() == "run_hooks":
+            with self.track_call(), self._hook_span(args, kwargs):
                 return self.call_macro(*args, **kwargs)
         else:
             with self.track_call():

--- a/core/dbt/clients/jinja.py
+++ b/core/dbt/clients/jinja.py
@@ -10,6 +10,7 @@ import jinja2.nodes
 import jinja2.parser
 import jinja2.sandbox
 from opentelemetry import trace
+from opentelemetry.trace import StatusCode
 
 from dbt.artifacts.resources.types import FunctionLanguage
 from dbt.contracts.graph.nodes import GenericTestNode
@@ -48,6 +49,24 @@ def _hook_count(hooks: Any, inside_transaction: bool) -> int:
         return sum(1 for hook in hooks if hook["transaction"] == inside_transaction)
     except (TypeError, KeyError, IndexError):
         return 0
+
+
+def _hook_span_name(
+    hooks: Any, context: Optional[Dict[str, Any]], inside_transaction: bool
+) -> str:
+    """Name a `run_hooks` span after the phase it is running.
+
+    Nothing in the arguments separates pre-hooks from post-hooks -- both are lists of
+    the same shape -- but every materialization passes the context's `pre_hooks` or
+    `post_hooks` straight through, so identity against the context tells them apart.
+    Equality would not: a node whose pre- and post-hook SQL match satisfies both.
+    Callers that build their own list fall back to the transaction phase alone.
+    """
+    transaction = "inside" if inside_transaction else "outside"
+    for phase in ("pre", "post"):
+        if context is not None and hooks is context.get(f"{phase}_hooks"):
+            return f"hooks.{phase}_hook.{transaction}_transaction"
+    return f"hooks.{transaction}_transaction"
 
 
 class MacroStack(threading.local):
@@ -102,20 +121,24 @@ class MacroGenerator(CallableMacroGenerator):
     def _hook_span(
         self, args: Tuple[Any, ...], kwargs: Dict[str, Any]
     ) -> Generator[None, None, None]:
+        hooks = args[0] if args else None
         inside_transaction = kwargs.get("inside_transaction", args[1] if len(args) > 1 else True)
-        hook_count = _hook_count(args[0] if args else None, inside_transaction)
+        hook_count = _hook_count(hooks, inside_transaction)
         if not hook_count:
             yield
             return
 
-        phase = "inside" if inside_transaction else "outside"
-        with _TRACER.start_as_current_span(f"hooks.{phase}_transaction") as span:
+        span_name = _hook_span_name(hooks, self.context, bool(inside_transaction))
+        with _TRACER.start_as_current_span(span_name) as span:
             span.set_attribute("inside_transaction", bool(inside_transaction))
             span.set_attribute("hook_count", hook_count)
             unique_id = getattr(self.node, "unique_id", None)
             if unique_id is not None:
                 span.set_attribute("unique_id", unique_id)
             yield
+            # Set OK explicitly rather than leaving a successful span UNSET; a hook
+            # that raises leaves the span ERROR via set_status_on_exception.
+            span.set_status(StatusCode.OK)
 
     # this makes MacroGenerator objects callable like functions
     def __call__(self, *args, **kwargs) -> Any:

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -21,7 +21,6 @@ from typing import (
     cast,
 )
 
-from opentelemetry import trace
 from opentelemetry.trace import StatusCode
 
 from dbt import tracking, utils
@@ -1008,9 +1007,6 @@ class RunTask(CompileTask):
         self.batch_map = batch_map
         self.overload_map: Optional[Dict[str, OverloadResults]] = None
         self.original_invocation_started_at: Optional[datetime] = None
-        # Tracer handle is created unconditionally; it is inert (creates no spans)
-        # until the --snowflake-projects-otel gate opens a span via _maybe_span.
-        self.dbt_tracer = trace.get_tracer("dbt.runner")
 
     def raise_on_first_error(self) -> bool:
         return False
@@ -1175,7 +1171,7 @@ class RunTask(CompileTask):
         failed = False
         num_hooks = len(ordered_hooks)
 
-        with self._maybe_span(hook_type) as hook_span:
+        with self._maybe_span(hook_type.value) as hook_span:
             hook_span.set_attribute("hook_type", hook_type.value)
             for idx, hook in enumerate(ordered_hooks, 1):
                 with log_contextvars(node_info=hook.node_info), self._maybe_span(
@@ -1265,6 +1261,11 @@ class RunTask(CompileTask):
                             node_info=hook.node_info,
                         )
                     )
+
+            if not failed:
+                # Match the node and per-hook spans, which set OK explicitly rather
+                # than leaving a successful span UNSET.
+                hook_span.set_status(StatusCode.OK)
 
         if hook_type == RunHookType.Start and ordered_hooks:
             fire_event(Formatting(""))

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -98,10 +98,15 @@ def _rows_affected(adapter_response: Dict[str, Any]) -> Optional[int]:
     # Adapters report -1 for statements with no row count (DDL, and every DBAPI
     # cursor whose rowcount is undefined). Emitting that as a metric reads as a real
     # count, so drop it and leave the attribute off entirely.
-    rows_affected = adapter_response.get("rows_affected")
-    if rows_affected is None or rows_affected < 0:
+    #
+    # The value is not reliably an int -- materialized_view_execute_no_op stores the
+    # string "-1" -- so coerce before comparing, and drop anything that will not
+    # convert rather than let instrumentation break execution.
+    try:
+        rows_affected = int(adapter_response.get("rows_affected"))  # type: ignore[arg-type]
+    except (TypeError, ValueError):
         return None
-    return rows_affected
+    return rows_affected if rows_affected >= 0 else None
 
 
 class GraphRunnableMode(StrEnum):

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -10,8 +10,8 @@ from typing import (
     Any,
     Callable,
     Dict,
+    Generator,
     Iterable,
-    Iterator,
     List,
     Optional,
     Set,
@@ -92,6 +92,16 @@ def _otel_enabled() -> bool:
 def _set_span_attr(span: Span, key: str, value: Any) -> None:
     if value is not None:
         span.set_attribute(key, value)
+
+
+def _rows_affected(adapter_response: Dict[str, Any]) -> Optional[int]:
+    # Adapters report -1 for statements with no row count (DDL, and every DBAPI
+    # cursor whose rowcount is undefined). Emitting that as a metric reads as a real
+    # count, so drop it and leave the attribute off entirely.
+    rows_affected = adapter_response.get("rows_affected")
+    if rows_affected is None or rows_affected < 0:
+        return None
+    return rows_affected
 
 
 class GraphRunnableMode(StrEnum):
@@ -278,7 +288,7 @@ class GraphRunnableTask(ConfiguredTask):
     @contextmanager
     def _node_span(
         self, node_info: Dict[str, Any], parent_context: Optional[Context], links: List[Link]
-    ) -> Iterator[Span]:
+    ) -> Generator[Span, None, None]:
         # When OTel is disabled, yield the no-op INVALID_SPAN so the instrumented
         # body's set_status/set_attribute calls are harmless no-ops and no span or
         # context-mapping entry is created.
@@ -294,7 +304,7 @@ class GraphRunnableTask(ConfiguredTask):
             yield trace.INVALID_SPAN
 
     @contextmanager
-    def _maybe_span(self, name: str) -> Iterator[Span]:
+    def _maybe_span(self, name: str) -> Generator[Span, None, None]:
         # A named span that becomes a no-op INVALID_SPAN when OTel is disabled.
         if _otel_enabled():
             with self.dbt_tracer.start_as_current_span(name) as span:
@@ -369,7 +379,7 @@ class GraphRunnableTask(ConfiguredTask):
                         node_span, "relative_path", getattr(node, "original_file_path", None)
                     )
                     _set_span_attr(
-                        node_span, "rows_affected", result.adapter_response.get("rows_affected")
+                        node_span, "rows_affected", _rows_affected(result.adapter_response)
                     )
                     _set_span_attr(node_span, "query_id", result.adapter_response.get("query_id"))
                     try:
@@ -734,7 +744,7 @@ class GraphRunnableTask(ConfiguredTask):
         # We set up a context manager here with "task_contextvars" because we
         # need the project_root in runtime_initialize.
         with task_contextvars(project_root=self.config.project_root), self._maybe_span(
-            "dbt invocation"
+            "dbt.invocation"
         ) as invocation_span:
             # Root span for the run. Node and hook spans nest under it because
             # _submit captures context.get_current() while this span is active.

--- a/core/hatch.toml
+++ b/core/hatch.toml
@@ -81,7 +81,7 @@ dependencies = [
     # Other
     "pip-tools",
     "protobuf>=6.0,<8.0",
-    "opentelemetry-sdk>=1.26,<3.0",
+    "opentelemetry-sdk>=1.26,<2.0",
 ]
 
 pre-install-commands = [
@@ -189,7 +189,7 @@ dependencies = [
     "flaky",
     "freezegun>=1.5.1",
     "hypothesis",
-    "opentelemetry-sdk>=1.26,<3.0",
+    "opentelemetry-sdk>=1.26,<2.0",
 ]
 
 pre-install-commands = [

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -74,7 +74,7 @@ dependencies = [
     "daff>=1.3.46",
     "python-dotenv>=1.2",
     "typing-extensions>=4.4",
-    "opentelemetry-api>=1.26,<3.0",
+    "opentelemetry-api>=1.26,<2.0",
 ]
 
 [project.urls]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,41 @@
 # Import the fuctional fixtures as a plugin
 # Note: fixtures with session scope need to be local
 
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
 pytest_plugins = [
     "dbt.tests.fixtures.project",
     "tests.functional.v2_parser_parity.plugin",
 ]
+
+
+@pytest.fixture(scope="session")
+def otel_tracer_provider():
+    """Install an in-memory OpenTelemetry exporter for the test session.
+
+    `trace.set_tracer_provider` only takes effect the first time it is called in a
+    process -- later calls log "Overriding of current TracerProvider is not allowed"
+    and are ignored. Installing per test therefore leaks a span processor onto the
+    first provider every time, and earlier tests' exporters keep collecting later
+    tests' spans. Install once here instead; `otel_spans` gives each test isolation
+    by clearing the exporter rather than by re-installing a provider.
+    """
+    provider = TracerProvider(resource=Resource.get_empty())
+    exporter = InMemorySpanExporter()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+    yield exporter
+    provider.shutdown()
+
+
+@pytest.fixture
+def otel_spans(otel_tracer_provider):
+    """The spans emitted by a single test, isolated from its neighbours."""
+    otel_tracer_provider.clear()
+    yield otel_tracer_provider
+    otel_tracer_provider.clear()

--- a/tests/functional/dbt_runner/test_dbt_runner.py
+++ b/tests/functional/dbt_runner/test_dbt_runner.py
@@ -2,6 +2,7 @@ import os
 from unittest import mock
 
 import pytest
+from opentelemetry.trace import StatusCode
 
 from dbt.adapters.factory import FACTORY, reset_adapters
 from dbt.cli.exceptions import DbtUsageException
@@ -208,9 +209,9 @@ class TestDbtRunnerHooks:
         # hooks on `models` run; only model2's pre-hook does, since it fails.
         assert span_names == [
             "dbt.invocation",
-            "hooks.inside_transaction",
-            "hooks.inside_transaction",
-            "hooks.inside_transaction",
+            "hooks.post_hook.inside_transaction",
+            "hooks.pre_hook.inside_transaction",
+            "hooks.pre_hook.inside_transaction",
             "metadata.setup",
             "model.test.model2",
             "model.test.models",
@@ -273,6 +274,21 @@ class TestDbtRunnerHooks:
         for hook_span in hook_spans:
             assert hook_span.attributes["inside_transaction"] is True
             assert hook_span.attributes["hook_count"] >= 1
+
+        # Both of `models`' hooks run, in separate phases, and both succeed.
+        models_hooks = [s for s in hook_spans if s.attributes["unique_id"] == "model.test.models"]
+        assert sorted(s.name for s in models_hooks) == [
+            "hooks.post_hook.inside_transaction",
+            "hooks.pre_hook.inside_transaction",
+        ]
+        assert all(s.status.status_code == StatusCode.OK for s in models_hooks)
+
+        # model2's pre-hook raises, so that span records the failure and the
+        # post-hook never runs.
+        model2_hooks = [s for s in hook_spans if s.attributes["unique_id"] == "model.test.model2"]
+        assert [s.name for s in model2_hooks] == ["hooks.pre_hook.inside_transaction"]
+        assert model2_hooks[0].attributes["hook_count"] == 2
+        assert model2_hooks[0].status.status_code == StatusCode.ERROR
 
         assert len(model2_span.links) == 1
         assert model2_span.links[0].attributes["upstream.name"] == "model.test.models"

--- a/tests/functional/dbt_runner/test_dbt_runner.py
+++ b/tests/functional/dbt_runner/test_dbt_runner.py
@@ -2,11 +2,6 @@ import os
 from unittest import mock
 
 import pytest
-from opentelemetry import trace
-from opentelemetry.sdk.resources import Resource
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import SimpleSpanProcessor
-from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 from dbt.adapters.factory import FACTORY, reset_adapters
 from dbt.cli.exceptions import DbtUsageException
@@ -199,27 +194,23 @@ class TestDbtRunnerHooks:
         dbt.invoke(["run", "--select", "models"])
         assert get_node_info() == {}
 
-    def test_dbt_runner_spans(self, project):
-        tracer_provider = TracerProvider(resource=Resource.get_empty())
-        span_exporter = InMemorySpanExporter()
-        trace.set_tracer_provider(tracer_provider)
-        trace.get_tracer_provider().add_span_processor(SimpleSpanProcessor(span_exporter))
+    def test_dbt_runner_spans(self, project, otel_spans):
         dbt = dbtRunner()
         dbt.invoke(["--snowflake-projects-otel", "run", "--select", "models", "model2"])
         assert get_node_info() == {}
-        exported_spans = span_exporter.get_finished_spans()
-        assert len(exported_spans) == 12
+        exported_spans = otel_spans.get_finished_spans()
         assert exported_spans[0].instrumentation_scope.name == "dbt.runner"
         span_names = [span.name for span in exported_spans]
         span_names.sort()
+        # `run_hooks` is called four times per model -- pre and post, each for the
+        # inside- and outside-transaction phase -- but filters by `transaction`
+        # internally, so only the calls that actually run a hook get a span. Both
+        # hooks on `models` run; only model2's pre-hook does, since it fails.
         assert span_names == [
-            "dbt invocation",
-            "hook_span",
-            "hook_span",
-            "hook_span",
-            "hook_span",
-            "hook_span",
-            "hook_span",
+            "dbt.invocation",
+            "hooks.inside_transaction",
+            "hooks.inside_transaction",
+            "hooks.inside_transaction",
             "metadata.setup",
             "model.test.model2",
             "model.test.models",
@@ -237,7 +228,7 @@ class TestDbtRunnerHooks:
                 models_span = span
             if span.name == "metadata.setup":
                 metadata_span = span
-            if span.name == "dbt invocation":
+            if span.name == "dbt.invocation":
                 invocation_span = span
 
         assert models_span is not None
@@ -273,20 +264,26 @@ class TestDbtRunnerHooks:
         assert "identifier" in models_span.attributes
         assert "relative_path" in models_span.attributes
 
+        # Hook spans carry enough context to attribute them to a node and phase.
+        hook_spans = [s for s in exported_spans if s.name.startswith("hooks.")]
+        assert {s.attributes["unique_id"] for s in hook_spans} == {
+            "model.test.models",
+            "model.test.model2",
+        }
+        for hook_span in hook_spans:
+            assert hook_span.attributes["inside_transaction"] is True
+            assert hook_span.attributes["hook_count"] >= 1
+
         assert len(model2_span.links) == 1
         assert model2_span.links[0].attributes["upstream.name"] == "model.test.models"
         assert model2_span.links[0].context.span_id == models_span.context.span_id
         assert model2_span.links[0].context.trace_id == models_span.context.trace_id
 
-    def test_dbt_runner_no_spans_when_flag_off(self, project):
+    def test_dbt_runner_no_spans_when_flag_off(self, project, otel_spans):
         # With the default (--no-snowflake-projects-otel), no spans are emitted.
-        tracer_provider = TracerProvider(resource=Resource.get_empty())
-        span_exporter = InMemorySpanExporter()
-        trace.set_tracer_provider(tracer_provider)
-        trace.get_tracer_provider().add_span_processor(SimpleSpanProcessor(span_exporter))
         dbt = dbtRunner()
         dbt.invoke(["run", "--select", "models", "model2"])
-        assert len(span_exporter.get_finished_spans()) == 0
+        assert len(otel_spans.get_finished_spans()) == 0
 
 
 class TestDbtRunnerUnitTestSpans:
@@ -313,18 +310,14 @@ unit_tests:
 """,
         }
 
-    def test_build_with_unit_tests_shares_one_trace(self, project):
-        tracer_provider = TracerProvider(resource=Resource.get_empty())
-        span_exporter = InMemorySpanExporter()
-        trace.set_tracer_provider(tracer_provider)
-        trace.get_tracer_provider().add_span_processor(SimpleSpanProcessor(span_exporter))
+    def test_build_with_unit_tests_shares_one_trace(self, project, otel_spans):
         dbt = dbtRunner()
         dbt.invoke(["--snowflake-projects-otel", "build"])
 
-        exported_spans = span_exporter.get_finished_spans()
+        exported_spans = otel_spans.get_finished_spans()
         by_name = {span.name: span for span in exported_spans}
 
-        invocation_span = by_name["dbt invocation"]
+        invocation_span = by_name["dbt.invocation"]
         model_span = by_name["model.test.my_model"]
         unit_test_span = by_name["unit_test.test.my_model.test_my_model"]
 

--- a/tests/unit/clients/test_jinja.py
+++ b/tests/unit/clients/test_jinja.py
@@ -3,7 +3,7 @@ from contextlib import contextmanager
 import pytest
 import yaml
 
-from dbt.clients.jinja import _hook_count, get_rendered, get_template
+from dbt.clients.jinja import _hook_count, _hook_span_name, get_rendered, get_template
 from dbt_common.exceptions import JinjaRenderingError
 
 
@@ -449,3 +449,33 @@ class TestHookCount:
         # run_hooks is reachable from user and adapter macros, so an unfamiliar
         # payload must disable instrumentation rather than raise.
         assert _hook_count(hooks, True) == 0
+
+
+class TestHookSpanName:
+    def test_names_each_of_the_four_materialization_calls(self):
+        # Every materialization hands `run_hooks` the context list itself, once per
+        # transaction phase, which is the only thing separating pre from post.
+        pre = [{"sql": "select 1", "transaction": True}]
+        post = [{"sql": "select 2", "transaction": True}]
+        context = {"pre_hooks": pre, "post_hooks": post}
+        assert _hook_span_name(pre, context, False) == "hooks.pre_hook.outside_transaction"
+        assert _hook_span_name(pre, context, True) == "hooks.pre_hook.inside_transaction"
+        assert _hook_span_name(post, context, True) == "hooks.post_hook.inside_transaction"
+        assert _hook_span_name(post, context, False) == "hooks.post_hook.outside_transaction"
+
+    def test_identical_hooks_are_still_told_apart(self):
+        # Equality cannot resolve the phase when both lists hold the same SQL.
+        hook = [{"sql": "select 1", "transaction": True}]
+        context = {"pre_hooks": hook, "post_hooks": list(hook)}
+        assert _hook_span_name(hook, context, True) == "hooks.pre_hook.inside_transaction"
+        assert (
+            _hook_span_name(context["post_hooks"], context, True)
+            == "hooks.post_hook.inside_transaction"
+        )
+
+    @pytest.mark.parametrize("context", [None, {}, {"pre_hooks": [], "post_hooks": []}])
+    def test_falls_back_to_the_transaction_phase_for_other_callers(self, context):
+        # A macro that builds its own hook list has no phase to report.
+        hooks = [{"sql": "select 1", "transaction": True}]
+        assert _hook_span_name(hooks, context, True) == "hooks.inside_transaction"
+        assert _hook_span_name(hooks, context, False) == "hooks.outside_transaction"

--- a/tests/unit/clients/test_jinja.py
+++ b/tests/unit/clients/test_jinja.py
@@ -3,7 +3,7 @@ from contextlib import contextmanager
 import pytest
 import yaml
 
-from dbt.clients.jinja import get_rendered, get_template
+from dbt.clients.jinja import _hook_count, get_rendered, get_template
 from dbt_common.exceptions import JinjaRenderingError
 
 
@@ -414,3 +414,38 @@ def test_native_render():
     s = "{{ 1991 | as_text }}"
     value = get_rendered(s, {}, native=True)
     assert value == "1991"
+
+
+class TestHookCount:
+    """A zero count means `run_hooks` was called for a phase it will run nothing in,
+    and so must not get a span."""
+
+    def test_counts_only_the_matching_transaction_phase(self):
+        hooks = [
+            {"sql": "select 1", "transaction": True},
+            {"sql": "select 2", "transaction": False},
+            {"sql": "select 3", "transaction": True},
+        ]
+        assert _hook_count(hooks, True) == 2
+        assert _hook_count(hooks, False) == 1
+
+    def test_zero_when_no_hook_runs_in_this_phase(self):
+        assert _hook_count([{"sql": "select 1", "transaction": True}], False) == 0
+
+    def test_zero_for_empty_hook_list(self):
+        assert _hook_count([], True) == 0
+
+    @pytest.mark.parametrize(
+        "hooks",
+        [
+            None,
+            "not a list",
+            [{"sql": "select 1"}],  # no 'transaction' key
+            ["a bare string"],
+            [None],
+        ],
+    )
+    def test_zero_for_unexpected_shapes(self, hooks):
+        # run_hooks is reachable from user and adapter macros, so an unfamiliar
+        # payload must disable instrumentation rather than raise.
+        assert _hook_count(hooks, True) == 0

--- a/tests/unit/task/test_run.py
+++ b/tests/unit/task/test_run.py
@@ -31,6 +31,7 @@ from dbt.events.types import LogModelResult
 from dbt.exceptions import DbtRuntimeError
 from dbt.flags import get_flags, set_from_args
 from dbt.task.run import MicrobatchModelRunner, ModelRunner, RunTask, _get_adapter_info
+from dbt.task.runnable import _rows_affected
 from dbt.tests.util import safe_set_invocation_context
 from dbt.version import __version__
 from dbt_common.events.base_types import EventLevel
@@ -1240,3 +1241,30 @@ class TestRunTask:
         assert captured["name"] == "dbt.invocation"
         assert captured["span_id"] == invocation_span.context.span_id
         assert captured["trace_id"] == invocation_span.context.trace_id
+
+
+class TestRowsAffected:
+    """Adapters do not agree on the type or the sentinel, and instrumentation must
+    never raise on either."""
+
+    @pytest.mark.parametrize("value", [0, 1, 42, "7"])
+    def test_keeps_real_counts(self, value):
+        assert _rows_affected({"rows_affected": value}) == int(value)
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            -1,
+            # materialized_view_execute_no_op stores the sentinel as a string.
+            "-1",
+        ],
+    )
+    def test_drops_the_no_row_count_sentinel(self, value):
+        assert _rows_affected({"rows_affected": value}) is None
+
+    @pytest.mark.parametrize("value", [None, "", "abc", object()])
+    def test_drops_values_that_are_not_numbers(self, value):
+        assert _rows_affected({"rows_affected": value}) is None
+
+    def test_drops_a_missing_key(self):
+        assert _rows_affected({}) is None

--- a/tests/unit/task/test_run.py
+++ b/tests/unit/task/test_run.py
@@ -8,10 +8,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from opentelemetry import trace
-from opentelemetry.sdk.resources import Resource
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import SimpleSpanProcessor
-from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.trace.status import StatusCode
 from psycopg2 import DatabaseError
 from pytest_mock import MockerFixture
@@ -766,15 +762,9 @@ class TestMicrobatchModelRunner:
 
 class TestRunTask:
 
-    def setup_class(self):
-        self.tracer_provider = TracerProvider(resource=Resource.get_empty())
-        self.span_exporter = InMemorySpanExporter()
-        trace.set_tracer_provider(self.tracer_provider)
-        trace.get_tracer_provider().add_span_processor(SimpleSpanProcessor(self.span_exporter))
-
     @pytest.fixture(autouse=True)
-    def before_each(self, monkeypatch):
-        self.span_exporter.clear()
+    def before_each(self, monkeypatch, otel_spans):
+        self.span_exporter = otel_spans
         # Instrumentation is gated behind --snowflake-projects-otel; enable it so
         # these span-emitting tests exercise the instrumented path.
         monkeypatch.setattr("dbt.task.runnable._otel_enabled", lambda: True)
@@ -810,7 +800,7 @@ class TestRunTask:
     @pytest.mark.parametrize(
         "error_to_raise,expected_result,expected_span_status",
         [
-            (None, RunStatus.Success, StatusCode.UNSET),
+            (None, RunStatus.Success, StatusCode.OK),
             (DbtRuntimeError, RunStatus.Error, StatusCode.ERROR),
             (DatabaseError, RunStatus.Error, StatusCode.ERROR),
             (KeyboardInterrupt, KeyboardInterrupt, StatusCode.UNSET),
@@ -1178,7 +1168,7 @@ class TestRunTask:
         run_task.run()
 
         exported_spans = self.span_exporter.get_finished_spans()
-        invocation_span = next(s for s in exported_spans if s.name == "dbt invocation")
+        invocation_span = next(s for s in exported_spans if s.name == "dbt.invocation")
 
         assert invocation_span.attributes["command"] == get_flags().WHICH
         assert invocation_span.attributes["invocation_id"] == get_invocation_id()
@@ -1245,8 +1235,8 @@ class TestRunTask:
         run_task.run()
 
         exported_spans = self.span_exporter.get_finished_spans()
-        invocation_span = next(s for s in exported_spans if s.name == "dbt invocation")
+        invocation_span = next(s for s in exported_spans if s.name == "dbt.invocation")
 
-        assert captured["name"] == "dbt invocation"
+        assert captured["name"] == "dbt.invocation"
         assert captured["span_id"] == invocation_span.context.span_id
         assert captured["trace_id"] == invocation_span.context.trace_id


### PR DESCRIPTION
Follow-up to #15551, improving in the merged implementation. No new instrumentation is added.

## What changed

**Hook spans**
- `run_hooks` was called with a `span_name` kwarg the macro does not accept, so it could never be supplied and every hook span was named the literal `hook_span`.
- Spans were opened for `run_hooks` calls that execute nothing. A materialization passes its whole hook list to all four calls and the macro filters by `transaction` internally, so half the spans wrapped no statements. `_hook_count` mirrors that filter.
- Hook spans had no attributes, so they couldn't be attributed to a node. They now record `inside_transaction`, `hook_count` and `unique_id`.
- Hook spans are named by pre/post as well as transaction phase. Nothing in the arguments separates the two — both are lists of the same shape — but every materialization passes the context's `pre_hooks`/`post_hooks` straight through, so identity against the context tells them apart. Equality would not: a node whose pre- and post-hook SQL match satisfies both.

**Span status**
- `on-run-start`/`on-run-end` and the `hooks.*` spans now set `OK` on success, matching their children. A hook that raises still leaves its span `ERROR` via `set_status_on_exception`.

**Span names**
- `"dbt invocation"` → `"dbt.invocation"`, consistent with the dotted names alongside it.
- `_maybe_span(hook_type)` → `hook_type.value`. `RunHookType` is a `StrEnum`, so the span name was rendering as `<RunHookType.Start: 'on-run-start'>`.

**Attributes**
- `rows_affected` is omitted rather than emitted as `-1`, which adapters report for statements with no row count (all DDL, and any DBAPI cursor with undefined `rowcount`). The value is coerced first: `materialized_view_execute_no_op` stores the sentinel as the string `"-1"`, so comparing it directly would raise `TypeError` on the materialized view no-op path.

**Other**
- Removed a redundant tracer in `RunTask.__init__`; `GraphRunnableTask.__init__` already sets it.
- Capped `opentelemetry-api`/`-sdk` below 2.0 rather than 3.0.
- Tests share one session-scoped `TracerProvider`. `trace.set_tracer_provider` only takes effect the first time it is called in a process, so the per-test calls were stacking span processors onto the first provider and earlier exporters kept collecting later tests' spans.

## Resulting trace

`dbt run` on a two-model project, each model with one pre- and one post-hook, plus project-level `on-run-start`/`on-run-end`:

```
- dbt.invocation                                     UNSET  {command, invocation_id, version}
  - metadata.setup                                   UNSET  {}
  - on-run-start                                     OK     {hook_type}
    - operation.<pkg>.<pkg>-on-run-start-0           OK     {hook_type, package_name, name,
                                                             hook_index, unique_id, hook_outcome}
  - model.<pkg>.model_a                              OK     {unique_id, node_outcome, materialization,
                                                             database, schema, name, node_type,
                                                             identifier, relative_path}
    - hooks.pre_hook.inside_transaction              OK     {inside_transaction, hook_count, unique_id}
    - hooks.post_hook.inside_transaction             OK     {inside_transaction, hook_count, unique_id}
  - model.<pkg>.model_b                              OK     {…}  links -> [model.<pkg>.model_a]
    - hooks.pre_hook.inside_transaction              OK     {inside_transaction, hook_count, unique_id}
    - hooks.post_hook.inside_transaction             OK     {inside_transaction, hook_count, unique_id}
  - on-run-end                                       OK     {hook_type}
    - operation.<pkg>.<pkg>-on-run-end-0             OK     {hook_type, package_name, name,
                                                             hook_index, unique_id, hook_outcome}
```

Hooks configured to run outside the transaction produce `hooks.pre_hook.outside_transaction` and `hooks.post_hook.outside_transaction`, so all four `run_hooks` calls a materialization makes are distinguishable by name alone.

## Before and after

Against the same run on `1.latest`, **16 spans → 12**:

| | before | after |
|---|---|---|
| root span name | `dbt invocation` | `dbt.invocation` |
| on-run-start/end name | `<RunHookType.Start: 'on-run-start'>` | `on-run-start` |
| on-run-start/end status | UNSET | OK |
| hook spans per model | 4 | 2 |
| hook span name | `hook_span` | `hooks.{pre,post}_hook.{inside,outside}_transaction` |
| hook span attributes | none | `inside_transaction`, `hook_count`, `unique_id` |
| hook span status | UNSET | OK, or ERROR if the hook raises |
| model `rows_affected` | `-1` | omitted |

Parenting, the single trace, and the `upstream.name` span link are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
