### PR TITLE
Backport #15551 to 1.13.latest: add opentelemetry trace instrumentation for dbt executions

### DIFF
--- a/.changes/unreleased/Features-20260708-120000.yaml
+++ b/.changes/unreleased/Features-20260708-120000.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Add OpenTelemetry span instrumentation for node and hook execution, gated behind
+    the --snowflake-projects-otel flag (off by default)
+time: 2026-07-08T12:00:00.000000-07:00
+custom:
+    Author: sfc-gh-vguttha sfc-gh-ppruett
+    Issue: "11367"

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -141,6 +141,7 @@ def global_flags(func):
     @p.record_timing_info
     @p.send_anonymous_usage_stats
     @p.single_threaded
+    @p.snowflake_projects_otel
     @p.show_all_deprecations
     @p.state
     @p.static_parser

--- a/core/dbt/cli/params.py
+++ b/core/dbt/cli/params.py
@@ -700,6 +700,13 @@ single_threaded = _create_option_and_track_env_var(
     hidden=True,
 )
 
+snowflake_projects_otel = _create_option_and_track_env_var(
+    "--snowflake-projects-otel/--no-snowflake-projects-otel",
+    envvar="DBT_ENGINE_SNOWFLAKE_PROJECTS_OTEL",
+    help="Enable OpenTelemetry span instrumentation for node and hook execution.",
+    default=False,
+)
+
 show_all_deprecations = _create_option_and_track_env_var(
     "--show-all-deprecations/--no-show-all-deprecations",
     envvar=None,

--- a/core/dbt/cli/requires.py
+++ b/core/dbt/cli/requires.py
@@ -96,6 +96,9 @@ def preflight(func):
         flags = Flags(ctx)
         ctx.obj["flags"] = flags
         set_flags(flags)
+        get_invocation_context().enable_snowflake_projects_otel = getattr(
+            flags, "SNOWFLAKE_PROJECTS_OTEL", False
+        )
         get_event_manager().require_warn_or_error_handling = (
             flags.require_all_warnings_handled_by_warn_error
         )

--- a/core/dbt/clients/jinja.py
+++ b/core/dbt/clients/jinja.py
@@ -9,6 +9,7 @@ import jinja2.nativetypes  # type: ignore
 import jinja2.nodes
 import jinja2.parser
 import jinja2.sandbox
+from opentelemetry import trace
 
 from dbt.artifacts.resources.types import FunctionLanguage
 from dbt.contracts.graph.nodes import GenericTestNode
@@ -17,6 +18,7 @@ from dbt.exceptions import (
     MaterializtionMacroNotUsedError,
     NoSupportedLanguagesFoundError,
 )
+from dbt.flags import get_flags
 from dbt.node_types import ModelLanguage
 from dbt_common.clients.jinja import (
     CallableMacroGenerator,
@@ -27,6 +29,10 @@ from dbt_common.clients.jinja import (
 from dbt_common.utils import deep_map_render
 
 SUPPORTED_LANG_ARG = jinja2.nodes.Name("supported_languages", "param")
+
+# Module-level tracer. Inert (creates no spans) until the
+# --snowflake-projects-otel gate opens a span in __call__.
+_TRACER = trace.get_tracer("dbt.runner")
 
 
 class MacroStack(threading.local):
@@ -78,9 +84,15 @@ class MacroGenerator(CallableMacroGenerator):
                 self.stack.pop(unique_id)
 
     # this makes MacroGenerator objects callable like functions
-    def __call__(self, *args, **kwargs):
-        with self.track_call():
-            return self.call_macro(*args, **kwargs)
+    def __call__(self, *args, **kwargs) -> Any:
+        otel_enabled = getattr(get_flags(), "SNOWFLAKE_PROJECTS_OTEL", False)
+        if otel_enabled and self.get_name() == "run_hooks" and args and args[0]:
+            span_name = kwargs["span_name"] if "span_name" in kwargs else "hook_span"
+            with self.track_call(), _TRACER.start_as_current_span(span_name):
+                return self.call_macro(*args, **kwargs)
+        else:
+            with self.track_call():
+                return self.call_macro(*args, **kwargs)
 
 
 class UnitTestMacroGenerator(MacroGenerator):

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -358,6 +358,7 @@ class ProjectFlags(ExtensibleDbtClassMixin):
     populate_cache: Optional[bool] = None
     printer_width: Optional[int] = None
     send_anonymous_usage_stats: bool = DEFAULT_SEND_ANONYMOUS_USAGE_STATS
+    snowflake_projects_otel: Optional[bool] = None
     static_parser: Optional[bool] = None
     use_colors: Optional[bool] = None
     use_colors_file: Optional[bool] = None

--- a/core/dbt/task/build.py
+++ b/core/dbt/task/build.py
@@ -1,5 +1,8 @@
 from typing import AbstractSet, Dict, Iterable, List, Optional, Set, Type
 
+from opentelemetry import context
+from opentelemetry.context.context import Context
+
 from dbt.adapters.base import BaseAdapter, BaseRelation
 from dbt.artifacts.resources import Catalog
 from dbt.artifacts.schemas.results import NodeResult, NodeStatus, RunStatus
@@ -14,6 +17,7 @@ from dbt.runners import ExposureRunner as exposure_runner
 from dbt.runners import SavedQueryRunner as saved_query_runner
 from dbt.task.base import BaseRunner, resource_types_from_args
 from dbt.task.run import MicrobatchModelRunner
+from dbt.task.runnable import _otel_enabled
 
 from .function import FunctionRunner as function_runner
 from .run import ModelRunner as run_model_runner
@@ -156,12 +160,19 @@ class BuildTask(RunTask):
     def handle_model_with_unit_tests_node(self, node, pool, callback):
         self._raise_set_error()
         args = [node, pool]
+        # Mirrors _submit: capture the submitting thread's context so the node
+        # and its unit tests parent under the invocation span instead of
+        # starting new traces on the worker thread.
+        if _otel_enabled():
+            args.append(context.get_current())
         if self.config.args.single_threaded:
             callback(self.call_model_and_unit_tests_runner(*args))
         else:
             pool.apply_async(self.call_model_and_unit_tests_runner, args=args, callback=callback)
 
-    def call_model_and_unit_tests_runner(self, node, pool) -> NodeResult:
+    def call_model_and_unit_tests_runner(
+        self, node, pool, parent_context: Optional[Context] = None
+    ) -> NodeResult:
         assert self.manifest
         for unit_test_unique_id in self.model_to_unit_test_map[node.unique_id]:
             unit_test_node = self.manifest.unit_tests[unit_test_unique_id]
@@ -170,7 +181,7 @@ class BuildTask(RunTask):
             if node.unique_id in self._skipped_children:
                 # cause is only for ephemeral nodes
                 unit_test_runner.do_skip(cause=None)
-            result = self.call_runner(unit_test_runner)
+            result = self.call_runner(unit_test_runner, parent_context)
             self._handle_result(result)
             if result.status in self.MARK_DEPENDENT_ERRORS_STATUSES:
                 # The _skipped_children dictionary can contain a run_result for ephemeral nodes,
@@ -185,7 +196,7 @@ class BuildTask(RunTask):
             runner.set_parent_task(self)
             runner.set_pool(pool)
 
-        return self.call_runner(runner)
+        return self.call_runner(runner, parent_context)
 
     # handle non-model-plus-unit-tests nodes
     def handle_job_queue_node(self, node, pool, callback):

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -21,6 +21,9 @@ from typing import (
     cast,
 )
 
+from opentelemetry import trace
+from opentelemetry.trace import StatusCode
+
 from dbt import tracking, utils
 from dbt.adapters.base import BaseAdapter, BaseRelation
 from dbt.adapters.capability import Capability
@@ -1005,6 +1008,9 @@ class RunTask(CompileTask):
         self.batch_map = batch_map
         self.overload_map: Optional[Dict[str, OverloadResults]] = None
         self.original_invocation_started_at: Optional[datetime] = None
+        # Tracer handle is created unconditionally; it is inert (creates no spans)
+        # until the --snowflake-projects-otel gate opens a span via _maybe_span.
+        self.dbt_tracer = trace.get_tracer("dbt.runner")
 
     def raise_on_first_error(self) -> bool:
         return False
@@ -1169,80 +1175,96 @@ class RunTask(CompileTask):
         failed = False
         num_hooks = len(ordered_hooks)
 
-        for idx, hook in enumerate(ordered_hooks, 1):
-            with log_contextvars(node_info=hook.node_info):
-                hook.index = idx
-                hook_name = f"{hook.package_name}.{hook_type}.{hook.index - 1}"
-                execution_time = 0.0
-                timing: List[TimingInfo] = []
-                failures = 1
+        with self._maybe_span(hook_type) as hook_span:
+            hook_span.set_attribute("hook_type", hook_type.value)
+            for idx, hook in enumerate(ordered_hooks, 1):
+                with log_contextvars(node_info=hook.node_info), self._maybe_span(
+                    hook.unique_id
+                ) as hook_node_span:
+                    hook.index = idx
+                    hook_name = f"{hook.package_name}.{hook_type}.{hook.index - 1}"
+                    execution_time = 0.0
+                    timing: List[TimingInfo] = []
+                    failures = 1
 
-                if not failed:
-                    with collect_timing_info("compile", timing.append):
-                        sql = self.get_hook_sql(
-                            adapter, hook, hook.index, num_hooks, extra_context
+                    if not failed:
+                        with collect_timing_info("compile", timing.append):
+                            sql = self.get_hook_sql(
+                                adapter, hook, hook.index, num_hooks, extra_context
+                            )
+
+                        started_at = timing[0].started_at or datetime.now(timezone.utc).replace(
+                            tzinfo=None
+                        )
+                        hook.update_event_status(
+                            started_at=started_at.isoformat(), node_status=RunningStatus.Started
                         )
 
-                    started_at = timing[0].started_at or datetime.now(timezone.utc).replace(
-                        tzinfo=None
+                        fire_event(
+                            LogHookStartLine(
+                                statement=hook_name,
+                                index=hook.index,
+                                total=num_hooks,
+                                node_info=hook.node_info,
+                            )
+                        )
+
+                        with collect_timing_info("execute", timing.append):
+                            status, message = get_execution_status(sql, adapter)
+
+                        finished_at = timing[1].completed_at or datetime.now(timezone.utc).replace(
+                            tzinfo=None
+                        )
+                        hook.update_event_status(finished_at=finished_at.isoformat())
+                        execution_time = (finished_at - started_at).total_seconds()
+                        failures = 0 if status == RunStatus.Success else 1
+
+                        if status == RunStatus.Success:
+                            message = f"{hook_name} passed"
+                        else:
+                            message = f"{hook_name} failed, error:\n {message}"
+                            failed = True
+                            hook_span.set_status(StatusCode.ERROR)
+                    else:
+                        status = RunStatus.Skipped
+                        message = f"{hook_name} skipped"
+
+                    hook.update_event_status(node_status=status)
+                    hook_node_span.set_attribute("hook_type", hook_type.value)
+                    hook_node_span.set_attribute("package_name", hook.package_name)
+                    hook_node_span.set_attribute("name", hook.name)
+                    hook_node_span.set_attribute("hook_index", hook.index)
+                    hook_node_span.set_attribute("unique_id", hook.unique_id)
+                    hook_node_span.set_attribute("hook_outcome", status.value)
+                    hook_node_span.set_status(
+                        StatusCode.ERROR
+                        if status not in (RunStatus.Success, RunStatus.Skipped)
+                        else StatusCode.OK
                     )
-                    hook.update_event_status(
-                        started_at=started_at.isoformat(), node_status=RunningStatus.Started
+
+                    self.node_results.append(
+                        RunResult(
+                            status=status,
+                            thread_id="main",
+                            timing=timing,
+                            message=message,
+                            adapter_response={},
+                            execution_time=execution_time,
+                            failures=failures,
+                            node=hook,
+                        )
                     )
 
                     fire_event(
-                        LogHookStartLine(
+                        LogHookEndLine(
                             statement=hook_name,
+                            status=status,
                             index=hook.index,
                             total=num_hooks,
+                            execution_time=execution_time,
                             node_info=hook.node_info,
                         )
                     )
-
-                    with collect_timing_info("execute", timing.append):
-                        status, message = get_execution_status(sql, adapter)
-
-                    finished_at = timing[1].completed_at or datetime.now(timezone.utc).replace(
-                        tzinfo=None
-                    )
-                    hook.update_event_status(finished_at=finished_at.isoformat())
-                    execution_time = (finished_at - started_at).total_seconds()
-                    failures = 0 if status == RunStatus.Success else 1
-
-                    if status == RunStatus.Success:
-                        message = f"{hook_name} passed"
-                    else:
-                        message = f"{hook_name} failed, error:\n {message}"
-                        failed = True
-                else:
-                    status = RunStatus.Skipped
-                    message = f"{hook_name} skipped"
-
-                hook.update_event_status(node_status=status)
-
-                self.node_results.append(
-                    RunResult(
-                        status=status,
-                        thread_id="main",
-                        timing=timing,
-                        message=message,
-                        adapter_response={},
-                        execution_time=execution_time,
-                        failures=failures,
-                        node=hook,
-                    )
-                )
-
-                fire_event(
-                    LogHookEndLine(
-                        statement=hook_name,
-                        status=status,
-                        index=hook.index,
-                        total=num_hooks,
-                        execution_time=execution_time,
-                        node_info=hook.node_info,
-                    )
-                )
 
         if hook_type == RunHookType.Start and ordered_hooks:
             fire_event(Formatting(""))
@@ -1286,8 +1308,9 @@ class RunTask(CompileTask):
         with adapter.connection_named("master"):
             self.defer_to_manifest()
             required_schemas = self.get_model_schemas(adapter, selected_uids)
-            self.create_schemas(adapter, required_schemas)
-            self.populate_adapter_cache(adapter, required_schemas)
+            with self._maybe_span("metadata.setup"):
+                self.create_schemas(adapter, required_schemas)
+                self.populate_adapter_cache(adapter, required_schemas)
             self.populate_microbatch_batches(selected_uids)
             self.populate_function_overloads(selected_uids)
             group_lookup.init(self.manifest, selected_uids)

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -2,6 +2,7 @@ import os
 import time
 from abc import abstractmethod
 from concurrent.futures import as_completed
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import (
@@ -10,6 +11,7 @@ from typing import (
     Callable,
     Dict,
     Iterable,
+    Iterator,
     List,
     Optional,
     Set,
@@ -17,6 +19,10 @@ from typing import (
     Type,
     Union,
 )
+
+from opentelemetry import context, trace
+from opentelemetry.context.context import Context
+from opentelemetry.trace import Link, Span, SpanContext, StatusCode
 
 import dbt.exceptions
 import dbt.tracking
@@ -69,12 +75,23 @@ from dbt.task import group_lookup
 from dbt.task.base import BaseRunner, ConfiguredTask
 from dbt.task.printer import print_run_end_messages, print_run_result_error
 from dbt.utils.artifact_upload import add_artifact_produced
+from dbt.version import __version__
 from dbt_common.context import _INVOCATION_CONTEXT_VAR, get_invocation_context
 from dbt_common.dataclass_schema import StrEnum
 from dbt_common.events.contextvars import log_contextvars, task_contextvars
 from dbt_common.events.functions import fire_event
 from dbt_common.events.types import Formatting
 from dbt_common.exceptions import NotImplementedError
+from dbt_common.invocation import get_invocation_id
+
+
+def _otel_enabled() -> bool:
+    return getattr(get_flags(), "SNOWFLAKE_PROJECTS_OTEL", False)
+
+
+def _set_span_attr(span: Span, key: str, value: Any) -> None:
+    if value is not None:
+        span.set_attribute(key, value)
 
 
 class GraphRunnableMode(StrEnum):
@@ -112,6 +129,10 @@ class GraphRunnableTask(ConfiguredTask):
         self.previous_defer_state: Optional[PreviousState] = None
         self.run_count: int = 0
         self.started_at: float = 0
+        self._node_span_context_mapping: Dict[str, SpanContext] = {}
+        # Tracer handle is created unconditionally; it is inert (creates no spans)
+        # until the --snowflake-projects-otel gate opens a span via _node_span/_maybe_span.
+        self.dbt_tracer = trace.get_tracer("dbt.runner")
 
         if self.args.state:
             self.previous_state = PreviousState(
@@ -254,8 +275,55 @@ class GraphRunnableTask(ConfiguredTask):
         runner.compiler.selected_node_ids = self.compiler.selected_node_ids
         return runner
 
-    def call_runner(self, runner: BaseRunner) -> NodeResult:
-        with log_contextvars(node_info=runner.node.node_info):
+    @contextmanager
+    def _node_span(
+        self, node_info: Dict[str, Any], parent_context: Optional[Context], links: List[Link]
+    ) -> Iterator[Span]:
+        # When OTel is disabled, yield the no-op INVALID_SPAN so the instrumented
+        # body's set_status/set_attribute calls are harmless no-ops and no span or
+        # context-mapping entry is created.
+        if _otel_enabled():
+            with self.dbt_tracer.start_as_current_span(
+                node_info["unique_id"], context=parent_context, links=links
+            ) as node_span:
+                self._node_span_context_mapping[node_info["unique_id"]] = (
+                    node_span.get_span_context()
+                )
+                yield node_span
+        else:
+            yield trace.INVALID_SPAN
+
+    @contextmanager
+    def _maybe_span(self, name: str) -> Iterator[Span]:
+        # A named span that becomes a no-op INVALID_SPAN when OTel is disabled.
+        if _otel_enabled():
+            with self.dbt_tracer.start_as_current_span(name) as span:
+                yield span
+        else:
+            yield trace.INVALID_SPAN
+
+    def call_runner(
+        self, runner: BaseRunner, parent_context: Optional[Context] = None
+    ) -> NodeResult:
+        node_info = runner.node.node_info
+        links = []
+        if (
+            _otel_enabled()
+            and hasattr(runner.node, "depends_on")
+            and hasattr(runner.node.depends_on, "nodes")
+        ):
+            for parent_node in runner.node.depends_on.nodes:
+                if parent_node in self._node_span_context_mapping:
+                    links.append(
+                        Link(
+                            self._node_span_context_mapping[parent_node],
+                            {"upstream.name": parent_node},
+                        ),
+                    )
+
+        with log_contextvars(node_info=runner.node.node_info), self._node_span(
+            node_info, parent_context, links
+        ) as node_span:
             runner.node.update_event_status(
                 started_at=datetime.now(timezone.utc).replace(tzinfo=None).isoformat(),
                 node_status=RunningStatus.Started,
@@ -279,6 +347,31 @@ class GraphRunnableTask(ConfiguredTask):
                 thread_exception = e
             finally:
                 if result is not None:
+                    if result.status in (
+                        NodeStatus.Error,
+                        NodeStatus.Fail,
+                        NodeStatus.PartialSuccess,
+                    ):
+                        node_span.set_status(StatusCode.ERROR)
+                    else:
+                        node_span.set_status(StatusCode.OK)
+                    node = runner.node
+                    node_relation = node_info["node_relation"]
+                    _set_span_attr(node_span, "unique_id", node_info["unique_id"])
+                    _set_span_attr(node_span, "node_outcome", result.status.value)
+                    _set_span_attr(node_span, "materialization", node_info["materialized"])
+                    _set_span_attr(node_span, "database", node_relation["database"])
+                    _set_span_attr(node_span, "schema", node_relation["schema"])
+                    _set_span_attr(node_span, "name", node_info["node_name"])
+                    _set_span_attr(node_span, "node_type", node_info["resource_type"])
+                    _set_span_attr(node_span, "identifier", node_relation["alias"])
+                    _set_span_attr(
+                        node_span, "relative_path", getattr(node, "original_file_path", None)
+                    )
+                    _set_span_attr(
+                        node_span, "rows_affected", result.adapter_response.get("rows_affected")
+                    )
+                    _set_span_attr(node_span, "query_id", result.adapter_response.get("query_id"))
                     try:
                         fire_event(
                             NodeFinished(
@@ -289,6 +382,11 @@ class GraphRunnableTask(ConfiguredTask):
                     except Exception as e:
                         result = self._handle_thread_exception(runner, e)
                 else:
+                    # No result means run_with_hooks raised; record the exception
+                    # on the node span and mark it errored before handling it.
+                    if thread_exception is not None:
+                        node_span.set_status(StatusCode.ERROR)
+                        node_span.record_exception(thread_exception)
                     result = self._handle_thread_exception(runner, thread_exception)
 
             # `_event_status` dict is only used for logging.  Make sure
@@ -323,6 +421,8 @@ class GraphRunnableTask(ConfiguredTask):
 
         This does still go through the callback path for result collection.
         """
+        if _otel_enabled():
+            args.append(context.get_current())
         if self.config.args.single_threaded:
             callback(self.call_runner(*args))
         else:
@@ -558,7 +658,8 @@ class GraphRunnableTask(ConfiguredTask):
     def before_run(self, adapter: BaseAdapter, selected_uids: AbstractSet[str]) -> RunStatus:
         with adapter.connection_named("master"):
             self.defer_to_manifest()
-            self.populate_adapter_cache(adapter)
+            with self._maybe_span("metadata.setup"):
+                self.populate_adapter_cache(adapter)
             return RunStatus.Success
 
     def after_run(self, adapter, results) -> None:
@@ -632,7 +733,14 @@ class GraphRunnableTask(ConfiguredTask):
         """
         # We set up a context manager here with "task_contextvars" because we
         # need the project_root in runtime_initialize.
-        with task_contextvars(project_root=self.config.project_root):
+        with task_contextvars(project_root=self.config.project_root), self._maybe_span(
+            "dbt invocation"
+        ) as invocation_span:
+            # Root span for the run. Node and hook spans nest under it because
+            # _submit captures context.get_current() while this span is active.
+            _set_span_attr(invocation_span, "command", getattr(get_flags(), "WHICH", None))
+            _set_span_attr(invocation_span, "invocation_id", get_invocation_id())
+            _set_span_attr(invocation_span, "version", __version__)
             self._runtime_initialize()
 
             if self._flattened_nodes is None:

--- a/core/hatch.toml
+++ b/core/hatch.toml
@@ -81,6 +81,7 @@ dependencies = [
     # Other
     "pip-tools",
     "protobuf>=6.0,<8.0",
+    "opentelemetry-sdk>=1.26,<3.0",
 ]
 
 pre-install-commands = [
@@ -188,6 +189,7 @@ dependencies = [
     "flaky",
     "freezegun>=1.5.1",
     "hypothesis",
+    "opentelemetry-sdk>=1.26,<3.0",
 ]
 
 pre-install-commands = [

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -74,6 +74,7 @@ dependencies = [
     "daff>=1.3.46",
     "python-dotenv>=1.2",
     "typing-extensions>=4.4",
+    "opentelemetry-api>=1.26,<3.0",
 ]
 
 [project.urls]

--- a/tests/functional/cli/test_requires.py
+++ b/tests/functional/cli/test_requires.py
@@ -107,6 +107,7 @@ class TestKnownEngineEnvVarsExplicit:
             "DBT_ENGINE_VERSION_CHECK",
             "DBT_ENGINE_QUIET",
             "DBT_ENGINE_SINGLE_THREADED",
+            "DBT_ENGINE_SNOWFLAKE_PROJECTS_OTEL",
             "DBT_ENGINE_SQLPARSE",
             "DBT_ENGINE_ARTIFACT_STATE_PATH",
             "DBT_ENGINE_FULL_REFRESH",

--- a/tests/functional/dbt_runner/test_dbt_runner.py
+++ b/tests/functional/dbt_runner/test_dbt_runner.py
@@ -2,6 +2,11 @@ import os
 from unittest import mock
 
 import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 from dbt.adapters.factory import FACTORY, reset_adapters
 from dbt.cli.exceptions import DbtUsageException
@@ -10,6 +15,7 @@ from dbt.exceptions import DbtProjectError
 from dbt.tests.util import read_file, write_file
 from dbt.version import __version__ as dbt_version
 from dbt_common.events.contextvars import get_node_info
+from dbt_common.invocation import get_invocation_id
 
 
 class TestDbtRunner:
@@ -168,7 +174,20 @@ class TestDbtRunnerHooks:
     @pytest.fixture(scope="class")
     def models(self):
         return {
-            "models.sql": "select 1 as id",
+            "models.sql": """
+                            {{ config(
+                                pre_hook=["select 1"],
+                                post_hook="select 2",
+                            ) }}
+                            select 1 as id
+                        """,
+            "model2.sql": """
+                            {{ config(
+                                pre_hook=["select 1", "select 1/0"],
+                                post_hook="select 2/0",
+                            ) }}
+                            select * from {{ ref('models') }}
+                        """,
         }
 
     @pytest.fixture(scope="class")
@@ -179,3 +198,141 @@ class TestDbtRunnerHooks:
         dbt = dbtRunner()
         dbt.invoke(["run", "--select", "models"])
         assert get_node_info() == {}
+
+    def test_dbt_runner_spans(self, project):
+        tracer_provider = TracerProvider(resource=Resource.get_empty())
+        span_exporter = InMemorySpanExporter()
+        trace.set_tracer_provider(tracer_provider)
+        trace.get_tracer_provider().add_span_processor(SimpleSpanProcessor(span_exporter))
+        dbt = dbtRunner()
+        dbt.invoke(["--snowflake-projects-otel", "run", "--select", "models", "model2"])
+        assert get_node_info() == {}
+        exported_spans = span_exporter.get_finished_spans()
+        assert len(exported_spans) == 12
+        assert exported_spans[0].instrumentation_scope.name == "dbt.runner"
+        span_names = [span.name for span in exported_spans]
+        span_names.sort()
+        assert span_names == [
+            "dbt invocation",
+            "hook_span",
+            "hook_span",
+            "hook_span",
+            "hook_span",
+            "hook_span",
+            "hook_span",
+            "metadata.setup",
+            "model.test.model2",
+            "model.test.models",
+            "on-run-end",
+            "operation.test.test-on-run-end-0",
+        ]
+        model2_span = None
+        models_span = None
+        metadata_span = None
+        invocation_span = None
+        for span in exported_spans:
+            if span.name == "model.test.model2":
+                model2_span = span
+            if span.name == "model.test.models":
+                models_span = span
+            if span.name == "metadata.setup":
+                metadata_span = span
+            if span.name == "dbt invocation":
+                invocation_span = span
+
+        assert models_span is not None
+        assert model2_span is not None
+        assert metadata_span is not None
+        assert invocation_span is not None
+
+        # The invocation span is the root of the run: it has no parent, and every
+        # other span shares its trace and descends from it.
+        assert invocation_span.parent is None
+        assert invocation_span.attributes["command"] == "run"
+        assert invocation_span.attributes["invocation_id"] == get_invocation_id()
+        assert invocation_span.attributes["version"] == dbt_version
+
+        for span in exported_spans:
+            assert span.context.trace_id == invocation_span.context.trace_id
+
+        # Node and hook spans parent under the invocation span.
+        assert models_span.parent.span_id == invocation_span.context.span_id
+        assert model2_span.parent.span_id == invocation_span.context.span_id
+        assert metadata_span.parent.span_id == invocation_span.context.span_id
+
+        assert "node_outcome" in models_span.attributes
+        assert "materialization" in models_span.attributes
+        assert "database" in models_span.attributes
+        assert "schema" in models_span.attributes
+        assert models_span.attributes["node_outcome"] in ("success", "error", "warn", "skipped")
+        assert models_span.attributes["materialization"] is not None
+        assert models_span.attributes["node_type"] == "model"
+        assert "unique_id" in models_span.attributes
+        assert "name" in models_span.attributes
+        assert "node_type" in models_span.attributes
+        assert "identifier" in models_span.attributes
+        assert "relative_path" in models_span.attributes
+
+        assert len(model2_span.links) == 1
+        assert model2_span.links[0].attributes["upstream.name"] == "model.test.models"
+        assert model2_span.links[0].context.span_id == models_span.context.span_id
+        assert model2_span.links[0].context.trace_id == models_span.context.trace_id
+
+    def test_dbt_runner_no_spans_when_flag_off(self, project):
+        # With the default (--no-snowflake-projects-otel), no spans are emitted.
+        tracer_provider = TracerProvider(resource=Resource.get_empty())
+        span_exporter = InMemorySpanExporter()
+        trace.set_tracer_provider(tracer_provider)
+        trace.get_tracer_provider().add_span_processor(SimpleSpanProcessor(span_exporter))
+        dbt = dbtRunner()
+        dbt.invoke(["run", "--select", "models", "model2"])
+        assert len(span_exporter.get_finished_spans()) == 0
+
+
+class TestDbtRunnerUnitTestSpans:
+    """A model with unit tests is submitted by BuildTask via
+    handle_model_with_unit_tests_node rather than _submit, so it needs its own
+    coverage that the invocation context still reaches the node spans."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "model_a.sql": "select 1 as id",
+            "my_model.sql": "select id from {{ ref('model_a') }}",
+            "schema.yml": """
+unit_tests:
+  - name: test_my_model
+    model: my_model
+    given:
+      - input: ref('model_a')
+        rows:
+          - {id: 1}
+    expect:
+      rows:
+        - {id: 1}
+""",
+        }
+
+    def test_build_with_unit_tests_shares_one_trace(self, project):
+        tracer_provider = TracerProvider(resource=Resource.get_empty())
+        span_exporter = InMemorySpanExporter()
+        trace.set_tracer_provider(tracer_provider)
+        trace.get_tracer_provider().add_span_processor(SimpleSpanProcessor(span_exporter))
+        dbt = dbtRunner()
+        dbt.invoke(["--snowflake-projects-otel", "build"])
+
+        exported_spans = span_exporter.get_finished_spans()
+        by_name = {span.name: span for span in exported_spans}
+
+        invocation_span = by_name["dbt invocation"]
+        model_span = by_name["model.test.my_model"]
+        unit_test_span = by_name["unit_test.test.my_model.test_my_model"]
+
+        # Every span belongs to the invocation's trace: no node may start a new one.
+        assert {span.context.trace_id for span in exported_spans} == {
+            invocation_span.context.trace_id
+        }
+
+        # The model and its unit test parent under the invocation span.
+        assert model_span.parent.span_id == invocation_span.context.span_id
+        assert unit_test_span.parent.span_id == invocation_span.context.span_id

--- a/tests/unit/cli/test_flags.py
+++ b/tests/unit/cli/test_flags.py
@@ -619,3 +619,38 @@ class TestFusionParserFlags:
         ctx = self.make_dbt_context("run", ["--no-use-v2-parser", "run"])
         flags = Flags(ctx, project_flags)
         assert flags.USE_V2_PARSER is False
+
+
+class TestSnowflakeProjectsOtelFlag:
+    def make_dbt_context(
+        self, context_name: str, args: List[str], parent: Optional[click.Context] = None
+    ) -> click.Context:
+        return cli.make_context(context_name, args.copy(), parent)
+
+    def test_default_off(self):
+        ctx = self.make_dbt_context("run", ["run"])
+        flags = Flags(ctx)
+        assert flags.SNOWFLAKE_PROJECTS_OTEL is False
+
+    def test_cli_arg_enables(self):
+        ctx = self.make_dbt_context("run", ["--snowflake-projects-otel", "run"])
+        flags = Flags(ctx)
+        assert flags.SNOWFLAKE_PROJECTS_OTEL is True
+
+    def test_env_var_enables(self, monkeypatch):
+        monkeypatch.setenv("DBT_ENGINE_SNOWFLAKE_PROJECTS_OTEL", "True")
+        ctx = self.make_dbt_context("run", ["run"])
+        flags = Flags(ctx)
+        assert flags.SNOWFLAKE_PROJECTS_OTEL is True
+
+    def test_project_flags_enables(self):
+        project_flags = ProjectFlags(snowflake_projects_otel=True)
+        ctx = self.make_dbt_context("run", ["run"])
+        flags = Flags(ctx, project_flags)
+        assert flags.SNOWFLAKE_PROJECTS_OTEL is True
+
+    def test_cli_overrides_project_flags(self):
+        project_flags = ProjectFlags(snowflake_projects_otel=True)
+        ctx = self.make_dbt_context("run", ["--no-snowflake-projects-otel", "run"])
+        flags = Flags(ctx, project_flags)
+        assert flags.SNOWFLAKE_PROJECTS_OTEL is False

--- a/tests/unit/task/test_run.py
+++ b/tests/unit/task/test_run.py
@@ -7,6 +7,12 @@ from unittest import mock
 from unittest.mock import MagicMock, patch
 
 import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace.status import StatusCode
 from psycopg2 import DatabaseError
 from pytest_mock import MockerFixture
 
@@ -17,20 +23,24 @@ from dbt.artifacts.resources.base import FileHash
 from dbt.artifacts.resources.types import NodeType, RunHookType
 from dbt.artifacts.resources.v1.components import DependsOn
 from dbt.artifacts.resources.v1.config import Hook, NodeConfig
+from dbt.artifacts.resources.v1.exposure import ExposureType
 from dbt.artifacts.resources.v1.model import LatestVersionPointer, ModelConfig
+from dbt.artifacts.resources.v1.owner import Owner
 from dbt.artifacts.schemas.results import RunStatus
 from dbt.artifacts.schemas.run import RunResult
 from dbt.config.runtime import RuntimeConfig
 from dbt.contracts.graph.manifest import Manifest
-from dbt.contracts.graph.nodes import HookNode, ModelNode
+from dbt.contracts.graph.nodes import Exposure, HookNode, ModelNode
 from dbt.events.types import LogModelResult
 from dbt.exceptions import DbtRuntimeError
 from dbt.flags import get_flags, set_from_args
 from dbt.task.run import MicrobatchModelRunner, ModelRunner, RunTask, _get_adapter_info
 from dbt.tests.util import safe_set_invocation_context
+from dbt.version import __version__
 from dbt_common.events.base_types import EventLevel
 from dbt_common.events.event_catcher import EventCatcher
 from dbt_common.events.event_manager_client import add_callback_to_manager
+from dbt_common.invocation import get_invocation_id
 
 
 @pytest.mark.parametrize(
@@ -92,41 +102,42 @@ def test_adapter_info_tracking():
     }
 
 
+@pytest.fixture
+def model_runner(
+    postgres_adapter: PostgresAdapter,
+    table_model: ModelNode,
+    runtime_config: RuntimeConfig,
+) -> ModelRunner:
+    return ModelRunner(
+        config=runtime_config,
+        adapter=postgres_adapter,
+        node=table_model,
+        node_index=1,
+        num_nodes=1,
+    )
+
+
+@pytest.fixture
+def run_result(table_model: ModelNode) -> RunResult:
+    return RunResult(
+        status=RunStatus.Success,
+        timing=[],
+        thread_id="an_id",
+        execution_time=0,
+        adapter_response={},
+        message="It did it",
+        failures=None,
+        batch_results=None,
+        node=table_model,
+    )
+
+
 class TestModelRunner:
     @pytest.fixture
     def log_model_result_catcher(self) -> EventCatcher:
         catcher = EventCatcher(event_to_catch=LogModelResult)
         add_callback_to_manager(catcher.catch)
         return catcher
-
-    @pytest.fixture
-    def model_runner(
-        self,
-        postgres_adapter: PostgresAdapter,
-        table_model: ModelNode,
-        runtime_config: RuntimeConfig,
-    ) -> ModelRunner:
-        return ModelRunner(
-            config=runtime_config,
-            adapter=postgres_adapter,
-            node=table_model,
-            node_index=1,
-            num_nodes=1,
-        )
-
-    @pytest.fixture
-    def run_result(self, table_model: ModelNode) -> RunResult:
-        return RunResult(
-            status=RunStatus.Success,
-            timing=[],
-            thread_id="an_id",
-            execution_time=0,
-            adapter_response={},
-            message="It did it",
-            failures=None,
-            batch_results=None,
-            node=table_model,
-        )
 
     def test_print_result_line(
         self,
@@ -754,6 +765,21 @@ class TestMicrobatchModelRunner:
 
 
 class TestRunTask:
+
+    def setup_class(self):
+        self.tracer_provider = TracerProvider(resource=Resource.get_empty())
+        self.span_exporter = InMemorySpanExporter()
+        trace.set_tracer_provider(self.tracer_provider)
+        trace.get_tracer_provider().add_span_processor(SimpleSpanProcessor(self.span_exporter))
+
+    @pytest.fixture(autouse=True)
+    def before_each(self, monkeypatch):
+        self.span_exporter.clear()
+        # Instrumentation is gated behind --snowflake-projects-otel; enable it so
+        # these span-emitting tests exercise the instrumented path.
+        monkeypatch.setattr("dbt.task.runnable._otel_enabled", lambda: True)
+        yield
+
     @pytest.fixture
     def hook_node(self) -> HookNode:
         return HookNode(
@@ -782,12 +808,12 @@ class TestRunTask:
         )
 
     @pytest.mark.parametrize(
-        "error_to_raise,expected_result",
+        "error_to_raise,expected_result,expected_span_status",
         [
-            (None, RunStatus.Success),
-            (DbtRuntimeError, RunStatus.Error),
-            (DatabaseError, RunStatus.Error),
-            (KeyboardInterrupt, KeyboardInterrupt),
+            (None, RunStatus.Success, StatusCode.UNSET),
+            (DbtRuntimeError, RunStatus.Error, StatusCode.ERROR),
+            (DatabaseError, RunStatus.Error, StatusCode.ERROR),
+            (KeyboardInterrupt, KeyboardInterrupt, StatusCode.UNSET),
         ],
     )
     def test_safe_run_hooks(
@@ -798,6 +824,7 @@ class TestRunTask:
         hook_node: HookNode,
         error_to_raise: Optional[Type[Exception]],
         expected_result: Union[RunStatus, Type[Exception]],
+        expected_span_status: StatusCode,
     ):
         mocker.patch("dbt.task.run.RunTask.get_hooks_by_type").return_value = [hook_node]
         mocker.patch("dbt.task.run.RunTask.get_hook_sql").return_value = hook_node.raw_code
@@ -829,7 +856,397 @@ class TestRunTask:
             )
             assert isinstance(expected_result, RunStatus)
             assert result == expected_result
+            exported_spans = self.span_exporter.get_finished_spans()
         except BaseException as e:
             assert not isinstance(expected_result, RunStatus)
             assert issubclass(expected_result, BaseException)
             assert type(e) == expected_result
+            exported_spans = self.span_exporter.get_finished_spans()
+
+        # each hook emits a child span + an outer type span.
+        assert len(exported_spans) == 2
+        outer_span = next(s for s in exported_spans if s.name == "on-run-end")
+        child_span = next(s for s in exported_spans if s.name == hook_node.unique_id)
+
+        assert expected_span_status == outer_span.status.status_code
+        assert outer_span.attributes.get("hook_type") == "on-run-end"
+        assert "hook_outcome" not in outer_span.attributes
+        assert "node.status" not in outer_span.attributes
+
+        # Per-hook child span attributes
+        if error_to_raise is not KeyboardInterrupt:
+            assert child_span.attributes.get("hook_type") == "on-run-end"
+            assert child_span.attributes.get("package_name") == hook_node.package_name
+            assert child_span.attributes.get("name") == hook_node.name
+            assert child_span.attributes.get("hook_index") == 1
+            assert child_span.attributes.get("unique_id") == hook_node.unique_id
+            expected_child_outcome = "error" if error_to_raise is not None else "success"
+            assert child_span.attributes.get("hook_outcome") == expected_child_outcome
+            expected_child_status = (
+                StatusCode.ERROR if error_to_raise is not None else StatusCode.OK
+            )
+            assert child_span.status.status_code == expected_child_status
+        else:
+            assert "hook_outcome" not in child_span.attributes
+            assert child_span.status.status_code == StatusCode.UNSET
+
+    def test_no_run_hooks(
+        self,
+        mocker: MockerFixture,
+        runtime_config: RuntimeConfig,
+        manifest: Manifest,
+    ):
+        mocker.patch("dbt.task.run.RunTask.get_hooks_by_type").return_value = []
+
+        flags = mock.Mock()
+        flags.state = None
+        flags.defer_state = None
+
+        run_task = RunTask(
+            args=flags,
+            config=runtime_config,
+            manifest=manifest,
+        )
+
+        adapter = mock.Mock()
+        adapter_execute = mock.Mock()
+        adapter_execute.return_value = (AdapterResponse(_message="Success"), None)
+        adapter.execute = adapter_execute
+
+        run_task.safe_run_hooks(
+            adapter=adapter,
+            hook_type=RunHookType.End,
+            extra_context={},
+        )
+        exported_spans = self.span_exporter.get_finished_spans()
+        assert len(exported_spans) == 0
+
+    def test_safe_run_hooks_no_spans_when_otel_disabled(
+        self,
+        monkeypatch,
+        mocker: MockerFixture,
+        runtime_config: RuntimeConfig,
+        manifest: Manifest,
+        hook_node: HookNode,
+    ):
+        # With the gate off, safe_run_hooks must emit no spans even when hooks run.
+        monkeypatch.setattr("dbt.task.runnable._otel_enabled", lambda: False)
+        mocker.patch("dbt.task.run.RunTask.get_hooks_by_type").return_value = [hook_node]
+        mocker.patch("dbt.task.run.RunTask.get_hook_sql").return_value = hook_node.raw_code
+
+        flags = mock.Mock()
+        flags.state = None
+        flags.defer_state = None
+
+        run_task = RunTask(args=flags, config=runtime_config, manifest=manifest)
+
+        adapter = mock.Mock()
+        adapter.execute = mock.Mock(return_value=(AdapterResponse(_message="Success"), None))
+
+        result = run_task.safe_run_hooks(
+            adapter=adapter,
+            hook_type=RunHookType.End,
+            extra_context={},
+        )
+        assert result == RunStatus.Success
+        assert len(self.span_exporter.get_finished_spans()) == 0
+
+    def test_call_runner(
+        self,
+        mocker: MockerFixture,
+        runtime_config: RuntimeConfig,
+        manifest: Manifest,
+        model_runner: ModelRunner,
+        run_result: RunResult,
+    ):
+        mocker.patch("dbt.task.run.ModelRunner.run_with_hooks").return_value = run_result
+        flags = mock.Mock()
+        flags.state = None
+        flags.defer_state = None
+
+        run_task = RunTask(
+            args=flags,
+            config=runtime_config,
+            manifest=manifest,
+        )
+
+        run_task.call_runner(runner=model_runner)
+        exported_spans = self.span_exporter.get_finished_spans()
+        assert len(exported_spans) == 1
+        assert exported_spans[0].status.status_code == StatusCode.OK
+
+    def test_call_runner_error_sets_span_error(
+        self,
+        mocker: MockerFixture,
+        runtime_config: RuntimeConfig,
+        manifest: Manifest,
+        model_runner: ModelRunner,
+        run_result: RunResult,
+    ):
+        """error node result must set StatusCode.ERROR on the span."""
+        from dbt.artifacts.schemas.results import RunStatus as RS
+
+        run_result_error = RunResult(
+            status=RS.Error,
+            timing=[],
+            thread_id="an_id",
+            execution_time=0,
+            adapter_response={},
+            message="It failed",
+            failures=1,
+            batch_results=None,
+            node=run_result.node,
+        )
+        mocker.patch("dbt.task.run.ModelRunner.run_with_hooks").return_value = run_result_error
+
+        flags = mock.Mock()
+        flags.state = None
+        flags.defer_state = None
+        run_task = RunTask(args=flags, config=runtime_config, manifest=manifest)
+
+        run_task.call_runner(runner=model_runner)
+        exported_spans = self.span_exporter.get_finished_spans()
+        assert len(exported_spans) == 1
+        assert exported_spans[0].status.status_code == StatusCode.ERROR
+
+    def test_call_runner_exception_records_on_span(
+        self,
+        mocker: MockerFixture,
+        runtime_config: RuntimeConfig,
+        manifest: Manifest,
+        model_runner: ModelRunner,
+    ):
+        """when run_with_hooks raises, the exception must be recorded on the node
+        span and the span marked StatusCode.ERROR."""
+        boom = ValueError("boom")
+        mocker.patch("dbt.task.run.ModelRunner.run_with_hooks").side_effect = boom
+
+        flags = mock.Mock()
+        flags.state = None
+        flags.defer_state = None
+        run_task = RunTask(args=flags, config=runtime_config, manifest=manifest)
+
+        run_task.call_runner(runner=model_runner)
+        exported_spans = self.span_exporter.get_finished_spans()
+        assert len(exported_spans) == 1
+        span = exported_spans[0]
+        assert span.status.status_code == StatusCode.ERROR
+        assert len(span.events) == 1
+        event = span.events[0]
+        assert event.name == "exception"
+        assert event.attributes["exception.type"] == "ValueError"
+        assert event.attributes["exception.message"] == "boom"
+
+    def test_call_runner_none_guard(
+        self,
+        mocker: MockerFixture,
+        runtime_config: RuntimeConfig,
+        manifest: Manifest,
+        run_result: RunResult,
+    ):
+        """non-relational nodes (e.g. Exposure) must not emit database/schema/
+        identifier/materialization span attrs when those values are None; the guard
+        in _set_span_attr must silently drop them so the OTel SDK never sees None."""
+        exposure = Exposure(
+            name="my_exposure",
+            resource_type=NodeType.Exposure,
+            type=ExposureType.Notebook,
+            owner=Owner(email="test@example.com"),
+            fqn=["pkg", "exposures", "my_exposure"],
+            unique_id="exposure.pkg.my_exposure",
+            package_name="pkg",
+            path="schema.yml",
+            original_file_path="models/schema.yml",
+        )
+
+        mock_runner = mock.Mock()
+        mock_runner.node = exposure
+        mock_runner.run_with_hooks.return_value = run_result
+
+        flags = mock.Mock()
+        flags.state = None
+        flags.defer_state = None
+        run_task = RunTask(args=flags, config=runtime_config, manifest=manifest)
+
+        run_task.call_runner(runner=mock_runner)
+        exported_spans = self.span_exporter.get_finished_spans()
+        assert len(exported_spans) == 1
+        span = exported_spans[0]
+
+        # None-valued attrs must be absent — the guard must have dropped them
+        assert "database" not in span.attributes
+        assert "schema" not in span.attributes
+        assert "identifier" not in span.attributes
+        assert "materialization" not in span.attributes
+
+        # no attribute value should be None
+        assert all(v is not None for v in span.attributes.values())
+
+        # Core attrs that ARE set for all nodes must still be present
+        assert "node_outcome" in span.attributes
+        assert "unique_id" in span.attributes
+        assert "name" in span.attributes
+        assert "node_type" in span.attributes
+        assert "relative_path" in span.attributes
+
+        assert span.status.status_code == StatusCode.OK
+
+    def test_safe_run_hooks_masking_bug_fixed(
+        self,
+        mocker: MockerFixture,
+        runtime_config: RuntimeConfig,
+        manifest: Manifest,
+        hook_node: HookNode,
+    ):
+        """when on-run-start hook[0] fails and hook[1] is consequently
+        skipped, per-hook child spans capture the correct per-hook outcome at full
+        granularity — no aggregate to mask anything.  hook[0] child → hook_outcome
+        'error', StatusCode.ERROR; hook[1] child → hook_outcome 'skipped',
+        StatusCode.OK (skipped is not an error).  Outer span → StatusCode.ERROR,
+        no hook_outcome."""
+        import copy
+
+        hook_node2 = copy.deepcopy(hook_node)
+        hook_node2.unique_id = "model.test.foo2"
+        hook_node2.name = "foo2"
+
+        mocker.patch("dbt.task.run.RunTask.get_hooks_by_type").return_value = [
+            hook_node,
+            hook_node2,
+        ]
+        mocker.patch("dbt.task.run.RunTask.get_hook_sql").return_value = hook_node.raw_code
+
+        flags = mock.Mock()
+        flags.state = None
+        flags.defer_state = None
+        run_task = RunTask(args=flags, config=runtime_config, manifest=manifest)
+
+        adapter = mock.Mock()
+        adapter_execute = mock.Mock()
+        adapter_execute.side_effect = DbtRuntimeError("hook failed!")
+        adapter.execute = adapter_execute
+
+        # hook[0] errors → hook[1] is skipped
+        run_task.safe_run_hooks(
+            adapter=adapter,
+            hook_type=RunHookType.Start,
+            extra_context={},
+        )
+
+        exported_spans = self.span_exporter.get_finished_spans()
+        # 1 outer span + 2 per-hook child spans
+        assert len(exported_spans) == 3
+
+        outer_span = next(s for s in exported_spans if s.name == "on-run-start")
+        child_span_0 = next(s for s in exported_spans if s.name == hook_node.unique_id)
+        child_span_1 = next(s for s in exported_spans if s.name == hook_node2.unique_id)
+
+        assert outer_span.attributes.get("hook_type") == "on-run-start"
+        assert "hook_outcome" not in outer_span.attributes
+        assert "node.status" not in outer_span.attributes
+        assert outer_span.status.status_code == StatusCode.ERROR
+
+        # hook[0] failed
+        assert child_span_0.attributes.get("hook_outcome") == "error"
+        assert child_span_0.status.status_code == StatusCode.ERROR
+
+        # hook[1] was skipped
+        assert child_span_1.attributes.get("hook_outcome") == "skipped"
+        assert child_span_1.status.status_code == StatusCode.OK
+
+    def test_run_emits_invocation_span(
+        self,
+        mocker: MockerFixture,
+        runtime_config: RuntimeConfig,
+        manifest: Manifest,
+    ):
+        """run() must emit a root 'dbt invocation' span carrying command,
+        invocation_id and version."""
+        safe_set_invocation_context()
+
+        flags = mock.Mock()
+        flags.state = None
+        flags.defer_state = None
+        flags.write_json = False
+        run_task = RunTask(args=flags, config=runtime_config, manifest=manifest)
+
+        # Take the "nothing to do" branch so run() needs no adapter/database.
+        mocker.patch.object(RunTask, "_runtime_initialize")
+        run_task._flattened_nodes = []
+        mocker.patch.object(RunTask, "task_end_messages")
+
+        run_task.run()
+
+        exported_spans = self.span_exporter.get_finished_spans()
+        invocation_span = next(s for s in exported_spans if s.name == "dbt invocation")
+
+        assert invocation_span.attributes["command"] == get_flags().WHICH
+        assert invocation_span.attributes["invocation_id"] == get_invocation_id()
+        assert invocation_span.attributes["version"] == __version__
+
+    def test_run_no_invocation_span_when_otel_disabled(
+        self,
+        mocker: MockerFixture,
+        monkeypatch,
+        runtime_config: RuntimeConfig,
+        manifest: Manifest,
+    ):
+        """with the gate off, run() must emit no spans at all."""
+        monkeypatch.setattr("dbt.task.runnable._otel_enabled", lambda: False)
+        safe_set_invocation_context()
+
+        flags = mock.Mock()
+        flags.state = None
+        flags.defer_state = None
+        flags.write_json = False
+        run_task = RunTask(args=flags, config=runtime_config, manifest=manifest)
+
+        mocker.patch.object(RunTask, "_runtime_initialize")
+        run_task._flattened_nodes = []
+        mocker.patch.object(RunTask, "task_end_messages")
+
+        run_task.run()
+
+        assert len(self.span_exporter.get_finished_spans()) == 0
+
+    def test_run_invocation_span_is_current_during_execution(
+        self,
+        mocker: MockerFixture,
+        runtime_config: RuntimeConfig,
+        manifest: Manifest,
+        model_runner: ModelRunner,
+    ):
+        """the invocation span must be the current span while execute_with_hooks
+        runs — that is what makes _submit's context.get_current() capture parent
+        node and hook spans under it."""
+        safe_set_invocation_context()
+
+        flags = mock.Mock()
+        flags.state = None
+        flags.defer_state = None
+        flags.write_json = False
+        run_task = RunTask(args=flags, config=runtime_config, manifest=manifest)
+
+        mocker.patch.object(RunTask, "_runtime_initialize")
+        run_task._flattened_nodes = [model_runner.node]
+        mocker.patch.object(RunTask, "task_end_messages")
+
+        captured = {}
+
+        def fake_execute_with_hooks(selected_uids):
+            current = trace.get_current_span()
+            captured["span_id"] = current.get_span_context().span_id
+            captured["trace_id"] = current.get_span_context().trace_id
+            captured["name"] = getattr(current, "name", None)
+            return mock.Mock(results=[])
+
+        mocker.patch.object(RunTask, "execute_with_hooks", side_effect=fake_execute_with_hooks)
+
+        run_task.run()
+
+        exported_spans = self.span_exporter.get_finished_spans()
+        invocation_span = next(s for s in exported_spans if s.name == "dbt invocation")
+
+        assert captured["name"] == "dbt invocation"
+        assert captured["span_id"] == invocation_span.context.span_id
+        assert captured["trace_id"] == invocation_span.context.trace_id


### PR DESCRIPTION
Manual backport of #15551 to `1.13.latest`.

The automated backport did not run: #15551 came from a fork (`Snowflake-Labs/dbt-core`), and `pull_request`-triggered runs from forks do not receive the `vars` context, so `runs-on: ${{ vars.UBUNTU_LATEST }}` in `.github/workflows/backport.yml` evaluated to `''` and the run failed at startup before any job was created:

```
Error when evaluating 'runs-on' for job 'backport'.
.github/workflows/backport.yml (Line: 32, Col: 14): Unexpected value ''
```

Cherry-picked `a472432f0a863d8cc454ca304d0d1e6e52effcc9` with no conflicts; the added/removed lines are identical to the original commit.

Scope is #15551 only. The follow-up work in #15826 is still open and is not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
