### PR TITLE
ci(release-v2): stop caching CARGO_HOME/bin on the build matrix

### DIFF
--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -230,6 +230,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # Swatinem/rust-cache@v2.9.1
         with:
           key: ${{ matrix.target }}
+          cache-bin: "false"
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # mozilla-actions/sccache-action@v0.0.9


### PR DESCRIPTION
## What

Sets `cache-bin: "false"` on the `build` job's `Swatinem/rust-cache` step, so `$CARGO_HOME/bin` is neither restored nor saved.

## Why

Every macOS job in `Release dbt Core V2` started failing at `Build release binary` today, with `cargo` resolving to `rustup-init`:

```
error: error: unexpected argument 'build' found
Usage: rustup-init[EXE] [OPTIONS]
```

`rust-cache` defaults to caching `~/.cargo/bin`, whose entries on macOS are symlinks into the Homebrew rustup install. Depot rolled a new `depot-macos-latest` image today carrying Homebrew rustup 1.29.0, which split `rustup` and `rustup-init` into separate binaries — previously `rustup-init` *was* the multi-mode binary the shims pointed at. A cache saved Aug 7 against the old image, restored onto the new one, brings back a `cargo` symlink to a now setup-only `rustup-init`. `Install Rust` still passes because it calls `/opt/homebrew/bin/rustup` directly.

Upstream: [Homebrew/homebrew-core#283801](https://github.com/Homebrew/homebrew-core/issues/283801).

## Scope

No job in this matrix uses `cargo install`, so that cache path bought us nothing; registry, git, and target caches are untouched. This also sidesteps the already-poisoned entries without purging them. `build` is the repo's only macOS `rust-cache` consumer — the other four usages are Linux and keep `cache-bin` on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)