### PR TITLE
ci(copybara): only re-dispatch on the fork-approval label

### DIFF
--- a/.github/workflows/auto-public-pr-copybara.yml
+++ b/.github/workflows/auto-public-pr-copybara.yml
@@ -17,10 +17,12 @@ name: Copybara - Auto Public PR Migration
 # ready. PRs from public forks must carry the `ci:approve-public-fork-ci`
 # label before the secret-bearing dispatch runs; it's stripped on each push
 # so updates require re-approval.
+# `labeled` is filtered down to that one label so unrelated labels don't
+# re-dispatch.
 
 on:
   pull_request_target:
-    types: [opened, reopened, synchronize, labeled, unlabeled, ready_for_review]
+    types: [opened, reopened, synchronize, labeled, ready_for_review]
     branches:
       - main
     paths-ignore:
@@ -45,6 +47,11 @@ env:
 
 jobs:
   check_run_approval:
+    # Job-level `if` cannot read `env`, so CI_LABEL is spelled out here.
+    if: >-
+      github.event.action != 'labeled'
+      || (github.event.label.name == 'ci:approve-public-fork-ci'
+          && github.event.pull_request.head.repo.full_name != github.repository)
     permissions:
       pull-requests: write
       contents: read


### PR DESCRIPTION
**What:** Drop `unlabeled` from the trigger types and gate `check_run_approval` so `labeled` only proceeds for `ci:approve-public-fork-ci` on a fork PR.

**Why:** `labeled`/`unlabeled` existed only to serve the fork-approval gate, but nothing checked which label fired, so any label change re-ran the reverse sync. On #15868 a single commit produced three dispatches — `opened`, plus two `review-status: *` flips from internal automation. The last landed after the fs PR had merged, so copybara rebased onto an empty change and [exited 4](https://github.com/dbt-labs/fs/actions/runs/31410291877).

**How:** `dispatch` has `needs: check_run_approval`, so skipping the gate skips both jobs. Adding the approval label to a fork PR still triggers, and `synchronize` still strips the label and fails, so pushes under a stale approval stay blocked. `unlabeled` is gone because pulling the label cannot undo a dispatch that already fired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)