### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/.changes/unreleased/Under the Hood-20260811-002517.yaml
+++ b/.changes/unreleased/Under the Hood-20260811-002517.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: sync JSON schemas from dbt-fusion
+time: 2026-08-11T00:25:17.408969953Z
+custom:
+    Author: fa-assistant
+    Issue: N/A

--- a/core/dbt/jsonschemas/project/latest.json
+++ b/core/dbt/jsonschemas/project/latest.json
@@ -452,6 +452,23 @@
       },
       "additionalProperties": false
     },
+    "ClickHouseIndex": {
+      "description": "A ClickHouse data-skipping index: `{name, definition}` items consumed by the ClickHouse macros (`ADD INDEX {{ index.get('name') }} {{ index.get('definition') }}`). Both fields are required, so no `skip_serializing_none` is needed.",
+      "type": "object",
+      "required": [
+        "definition",
+        "name"
+      ],
+      "properties": {
+        "definition": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
     "ClusterConfig": {
       "description": "Configuration for cluster by columns.\n\ndbt-core allows either of the variants for the `cluster_by` to allow cluster on a single column or on multiple columns",
       "anyOf": [
@@ -1072,6 +1089,31 @@
         }
       ]
     },
+    "IndexItem": {
+      "description": "One element of the shared `indexes` config. Adapter shapes are kept as distinct typed variants (like `PartitionConfig` does for BigQuery); the required fields are disjoint (`columns` vs `name`+`definition`), so untagged deserialization is unambiguous, and each variant serializes its own shape back to Jinja.",
+      "anyOf": [
+        {
+          "description": "Postgres: `{columns, unique, type}`",
+          "allOf": [
+            {
+              "$ref": "#/definitions/PostgresIndex"
+            }
+          ]
+        },
+        {
+          "description": "ClickHouse: `{name, definition}`",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ClickHouseIndex"
+            }
+          ]
+        },
+        {
+          "type": "string",
+          "pattern": "^\\{.*\\}$"
+        }
+      ]
+    },
     "IndexesConfig": {
       "description": "A wrapper type for the `indexes` config field that handles flexible deserialization.\n\ndbt-core accepts both list and dictionary formats for indexes. This type accepts either format on input but always serializes as a list.\n\n# Example\n\n```ignore // Input (list): [{columns: [\"id\"], unique: true}] // Serializes as: [{columns: [\"id\"], unique: true}]\n\n// Input (dict): {\"my_index\": {columns: [\"id\"], unique: true}} // Serializes as: [{columns: [\"id\"], unique: true}]  (keys are discarded) ```",
       "type": [
@@ -1079,7 +1121,7 @@
         "null"
       ],
       "items": {
-        "$ref": "#/definitions/PostgresIndex"
+        "$ref": "#/definitions/IndexItem"
       }
     },
     "LatestVersionPointer": {
@@ -3087,6 +3129,15 @@
             }
           ]
         },
+        "+connection_overrides": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/definitions/AnyValue"
+          }
+        },
         "+constraints": {
           "type": [
             "array",
@@ -3291,7 +3342,22 @@
             "null"
           ]
         },
+        "+fields": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/AnyValue"
+          }
+        },
         "+file_format": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "+format": {
           "type": [
             "string",
             "null"
@@ -3531,6 +3597,22 @@
           "anyOf": [
             {
               "$ref": "#/definitions/LatestVersionPointer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "+layout": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "+lifetime": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AnyValue"
             },
             {
               "type": "null"
@@ -3870,6 +3952,16 @@
             }
           ]
         },
+        "+range": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AnyValue"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "+refresh_interval_minutes": {
           "anyOf": [
             {
@@ -4054,6 +4146,12 @@
             "null"
           ]
         },
+        "+source_type": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "+sql_header": {
           "type": [
             "string",
@@ -4107,6 +4205,12 @@
             {
               "type": "null"
             }
+          ]
+        },
+        "+table": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "+table_format": {
@@ -4224,6 +4328,28 @@
               "type": "string",
               "pattern": "^\\{.*\\}$"
             }
+          ]
+        },
+        "+update_field": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "+update_lag": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AnyValue"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "+url": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "+use_anonymous_sproc": {

--- a/core/dbt/jsonschemas/resources/latest.json
+++ b/core/dbt/jsonschemas/resources/latest.json
@@ -344,6 +344,23 @@
       },
       "additionalProperties": false
     },
+    "ClickHouseIndex": {
+      "description": "A ClickHouse data-skipping index: `{name, definition}` items consumed by the ClickHouse macros (`ADD INDEX {{ index.get('name') }} {{ index.get('definition') }}`). Both fields are required, so no `skip_serializing_none` is needed.",
+      "type": "object",
+      "required": [
+        "definition",
+        "name"
+      ],
+      "properties": {
+        "definition": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
     "ClusterConfig": {
       "description": "Configuration for cluster by columns.\n\ndbt-core allows either of the variants for the `cluster_by` to allow cluster on a single column or on multiple columns",
       "anyOf": [
@@ -1144,6 +1161,15 @@
             }
           ]
         },
+        "connection_overrides": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/definitions/AnyValue"
+          }
+        },
         "copy_grants": {
           "anyOf": [
             {
@@ -1294,7 +1320,22 @@
             "null"
           ]
         },
+        "fields": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/AnyValue"
+          }
+        },
         "file_format": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "format": {
           "type": [
             "string",
             "null"
@@ -1458,6 +1499,22 @@
             {
               "type": "string",
               "pattern": "^\\{.*\\}$"
+            }
+          ]
+        },
+        "layout": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "lifetime": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AnyValue"
+            },
+            {
+              "type": "null"
             }
           ]
         },
@@ -1670,6 +1727,16 @@
             }
           ]
         },
+        "range": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AnyValue"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "refresh_interval_minutes": {
           "anyOf": [
             {
@@ -1849,6 +1916,12 @@
             "null"
           ]
         },
+        "source_type": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "sql_header": {
           "type": [
             "string",
@@ -1910,6 +1983,12 @@
             {
               "type": "null"
             }
+          ]
+        },
+        "table": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "table_tag": {
@@ -2016,6 +2095,28 @@
               "type": "string",
               "pattern": "^\\{.*\\}$"
             }
+          ]
+        },
+        "update_field": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "update_lag": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AnyValue"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "use_safer_relation_operations": {
@@ -3304,6 +3405,15 @@
             "null"
           ]
         },
+        "connection_overrides": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/definitions/AnyValue"
+          }
+        },
         "copy_grants": {
           "anyOf": [
             {
@@ -3457,7 +3567,22 @@
             "null"
           ]
         },
+        "fields": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/AnyValue"
+          }
+        },
         "file_format": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "format": {
           "type": [
             "string",
             "null"
@@ -3609,6 +3734,22 @@
             {
               "type": "string",
               "pattern": "^\\{.*\\}$"
+            }
+          ]
+        },
+        "layout": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "lifetime": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AnyValue"
+            },
+            {
+              "type": "null"
             }
           ]
         },
@@ -3812,6 +3953,16 @@
             }
           ]
         },
+        "range": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AnyValue"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "refresh_interval_minutes": {
           "anyOf": [
             {
@@ -3997,6 +4148,12 @@
             "null"
           ]
         },
+        "source_type": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "static_analysis": {
           "anyOf": [
             {
@@ -4014,6 +4171,12 @@
           ]
         },
         "storage_uri": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "table": {
           "type": [
             "string",
             "null"
@@ -4134,6 +4297,28 @@
               "type": "string",
               "pattern": "^\\{.*\\}$"
             }
+          ]
+        },
+        "update_field": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "update_lag": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AnyValue"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "use_safer_relation_operations": {
@@ -4565,6 +4750,31 @@
         }
       ]
     },
+    "IndexItem": {
+      "description": "One element of the shared `indexes` config. Adapter shapes are kept as distinct typed variants (like `PartitionConfig` does for BigQuery); the required fields are disjoint (`columns` vs `name`+`definition`), so untagged deserialization is unambiguous, and each variant serializes its own shape back to Jinja.",
+      "anyOf": [
+        {
+          "description": "Postgres: `{columns, unique, type}`",
+          "allOf": [
+            {
+              "$ref": "#/definitions/PostgresIndex"
+            }
+          ]
+        },
+        {
+          "description": "ClickHouse: `{name, definition}`",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ClickHouseIndex"
+            }
+          ]
+        },
+        {
+          "type": "string",
+          "pattern": "^\\{.*\\}$"
+        }
+      ]
+    },
     "IndexesConfig": {
       "description": "A wrapper type for the `indexes` config field that handles flexible deserialization.\n\ndbt-core accepts both list and dictionary formats for indexes. This type accepts either format on input but always serializes as a list.\n\n# Example\n\n```ignore // Input (list): [{columns: [\"id\"], unique: true}] // Serializes as: [{columns: [\"id\"], unique: true}]\n\n// Input (dict): {\"my_index\": {columns: [\"id\"], unique: true}} // Serializes as: [{columns: [\"id\"], unique: true}]  (keys are discarded) ```",
       "type": [
@@ -4572,7 +4782,7 @@
         "null"
       ],
       "items": {
-        "$ref": "#/definitions/PostgresIndex"
+        "$ref": "#/definitions/IndexItem"
       }
     },
     "LatestVersionPointer": {
@@ -5409,6 +5619,15 @@
             }
           ]
         },
+        "connection_overrides": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/definitions/AnyValue"
+          }
+        },
         "constraints": {
           "type": [
             "array",
@@ -5606,7 +5825,22 @@
             "null"
           ]
         },
+        "fields": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/AnyValue"
+          }
+        },
         "file_format": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "format": {
           "type": [
             "string",
             "null"
@@ -5840,6 +6074,22 @@
           "anyOf": [
             {
               "$ref": "#/definitions/LatestVersionPointer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "layout": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "lifetime": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AnyValue"
             },
             {
               "type": "null"
@@ -6176,6 +6426,16 @@
             }
           ]
         },
+        "range": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AnyValue"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "refresh_interval_minutes": {
           "anyOf": [
             {
@@ -6354,6 +6614,12 @@
             "null"
           ]
         },
+        "source_type": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "sql_header": {
           "type": [
             "string",
@@ -6407,6 +6673,12 @@
             {
               "type": "null"
             }
+          ]
+        },
+        "table": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "table_format": {
@@ -6529,6 +6801,28 @@
               "type": "string",
               "pattern": "^\\{.*\\}$"
             }
+          ]
+        },
+        "update_field": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "update_lag": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AnyValue"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "use_anonymous_sproc": {
@@ -7729,6 +8023,15 @@
             "null"
           ]
         },
+        "connection_overrides": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/definitions/AnyValue"
+          }
+        },
         "copy_grants": {
           "anyOf": [
             {
@@ -7889,7 +8192,22 @@
             "null"
           ]
         },
+        "fields": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/AnyValue"
+          }
+        },
         "file_format": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "format": {
           "type": [
             "string",
             "null"
@@ -8060,6 +8378,22 @@
             {
               "type": "string",
               "pattern": "^\\{.*\\}$"
+            }
+          ]
+        },
+        "layout": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "lifetime": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AnyValue"
+            },
+            {
+              "type": "null"
             }
           ]
         },
@@ -8302,6 +8636,16 @@
             }
           ]
         },
+        "range": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AnyValue"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "refresh_interval_minutes": {
           "anyOf": [
             {
@@ -8471,6 +8815,12 @@
             "null"
           ]
         },
+        "source_type": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "static_analysis": {
           "anyOf": [
             {
@@ -8488,6 +8838,12 @@
           ]
         },
         "storage_uri": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "table": {
           "type": [
             "string",
             "null"
@@ -8597,6 +8953,28 @@
               "type": "string",
               "pattern": "^\\{.*\\}$"
             }
+          ]
+        },
+        "update_field": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "update_lag": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AnyValue"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "use_safer_relation_operations": {
@@ -8951,6 +9329,15 @@
             }
           ]
         },
+        "connection_overrides": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/definitions/AnyValue"
+          }
+        },
         "copy_grants": {
           "anyOf": [
             {
@@ -9111,7 +9498,22 @@
             "null"
           ]
         },
+        "fields": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/AnyValue"
+          }
+        },
         "file_format": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "format": {
           "type": [
             "string",
             "null"
@@ -9308,6 +9710,22 @@
             {
               "type": "string",
               "pattern": "^\\{.*\\}$"
+            }
+          ]
+        },
+        "layout": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "lifetime": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AnyValue"
+            },
+            {
+              "type": "null"
             }
           ]
         },
@@ -9550,6 +9968,16 @@
             }
           ]
         },
+        "range": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AnyValue"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "refresh_interval_minutes": {
           "anyOf": [
             {
@@ -9729,6 +10157,12 @@
             "null"
           ]
         },
+        "source_type": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "state": {
           "anyOf": [
             {
@@ -9776,6 +10210,12 @@
             {
               "type": "null"
             }
+          ]
+        },
+        "table": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "table_tag": {
@@ -9906,7 +10346,29 @@
             }
           ]
         },
+        "update_field": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "update_lag": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AnyValue"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "updated_at": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "url": {
           "type": [
             "string",
             "null"
@@ -10257,6 +10719,15 @@
             "null"
           ]
         },
+        "connection_overrides": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/definitions/AnyValue"
+          }
+        },
         "copy_grants": {
           "anyOf": [
             {
@@ -10401,7 +10872,22 @@
             "null"
           ]
         },
+        "fields": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/AnyValue"
+          }
+        },
         "file_format": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "format": {
           "type": [
             "string",
             "null"
@@ -10561,6 +11047,22 @@
             {
               "type": "string",
               "pattern": "^\\{.*\\}$"
+            }
+          ]
+        },
+        "layout": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "lifetime": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AnyValue"
+            },
+            {
+              "type": "null"
             }
           ]
         },
@@ -10750,6 +11252,16 @@
             }
           ]
         },
+        "range": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AnyValue"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "refresh_interval_minutes": {
           "anyOf": [
             {
@@ -10924,6 +11436,12 @@
             "null"
           ]
         },
+        "source_type": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "static_analysis": {
           "anyOf": [
             {
@@ -10955,6 +11473,12 @@
             {
               "type": "null"
             }
+          ]
+        },
+        "table": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "table_tag": {
@@ -11061,6 +11585,28 @@
               "type": "string",
               "pattern": "^\\{.*\\}$"
             }
+          ]
+        },
+        "update_field": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "update_lag": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AnyValue"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "use_safer_relation_operations": {
@@ -11707,6 +12253,15 @@
             }
           ]
         },
+        "connection_overrides": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/definitions/AnyValue"
+          }
+        },
         "copy_grants": {
           "anyOf": [
             {
@@ -11838,7 +12393,22 @@
             "null"
           ]
         },
+        "fields": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/AnyValue"
+          }
+        },
         "file_format": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "format": {
           "type": [
             "string",
             "null"
@@ -11981,6 +12551,22 @@
             {
               "type": "string",
               "pattern": "^\\{.*\\}$"
+            }
+          ]
+        },
+        "layout": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "lifetime": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AnyValue"
+            },
+            {
+              "type": "null"
             }
           ]
         },
@@ -12158,6 +12744,16 @@
             }
           ]
         },
+        "range": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AnyValue"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "refresh_interval_minutes": {
           "anyOf": [
             {
@@ -12321,6 +12917,12 @@
             "null"
           ]
         },
+        "source_type": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "static_analysis": {
           "anyOf": [
             {
@@ -12338,6 +12940,12 @@
           ]
         },
         "storage_uri": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "table": {
           "type": [
             "string",
             "null"
@@ -12447,6 +13055,28 @@
               "type": "string",
               "pattern": "^\\{.*\\}$"
             }
+          ]
+        },
+        "update_field": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "update_lag": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AnyValue"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "use_safer_relation_operations": {


### PR DESCRIPTION
## Summary

This PR syncs the JSON schemas from the dbt-fusion repository.

### Files Updated
- `core/dbt/jsonschemas/project/latest.json`
- `core/dbt/jsonschemas/resources/latest.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Commit**: [`0711e4d1710aae8a44ef466658b317e57052dfe7`](https://github.com/dbt-labs/fs/commit/0711e4d1710aae8a44ef466658b317e57052dfe7)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/31444098283)