### PR TITLE
Bump dbt-core-experimental-parser lowerbound to 2.0.0b1

### DIFF
--- a/.changes/unreleased/Dependencies-20260811-120000.yaml
+++ b/.changes/unreleased/Dependencies-20260811-120000.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Bump dbt-core-experimental-parser to 2.0.0b1 lowerbound
+time: 2026-08-11T12:00:00.000000+05:30
+custom:
+    Author: tauhid621
+    Issue: ' '

--- a/.changes/unreleased/Dependencies-20260811-120000.yaml
+++ b/.changes/unreleased/Dependencies-20260811-120000.yaml
@@ -3,4 +3,4 @@ body: Bump dbt-core-experimental-parser to 2.0.0b1 lowerbound
 time: 2026-08-11T12:00:00.000000+05:30
 custom:
     Author: tauhid621
-    Issue: ' '
+    Issue: ""

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -58,7 +58,7 @@ dependencies = [
     "dbt-common>=1.37.5,<2.0",
     "dbt-adapters>=1.24.5,<2.0",
     "dbt-protos>=1.0.514,<2.0",
-    "dbt-core-experimental-parser>=2.0.0a4,<3",
+    "dbt-core-experimental-parser>=2.0.0b1,<3",
     # Bundled plugin: installed by default but opt-in. PluginManager skips loading
     # unless the user passes `--manage-state` on the CLI, sets
     # `DBT_ENGINE_MANAGE_STATE=true`, or sets `manage_state: true` in dbt_project.yml's


### PR DESCRIPTION
Bumps the `dbt-core-experimental-parser` lowerbound from `2.0.0a4` to `2.0.0b1`. Upper bound (`<3`) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)