### PR TITLE
[Backport 1.12.latest] Bump dbt-core-experimental-parser lowerbound to 2.0.0b1

### DIFF
--- a/.changes/unreleased/Dependencies-20260811-120000.yaml
+++ b/.changes/unreleased/Dependencies-20260811-120000.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Bump dbt-core-experimental-parser to 2.0.0b1 lowerbound
+time: 2026-08-11T12:00:00.000000+05:30
+custom:
+    Author: tauhid621
+    Issue: ""

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -58,7 +58,7 @@ dependencies = [
     "dbt-common>=1.37.5,<2.0",
     "dbt-adapters>=1.24.5,<2.0",
     "dbt-protos>=1.0.514,<2.0",
-    "dbt-core-experimental-parser>=2.0.0a4,<3",
+    "dbt-core-experimental-parser>=2.0.0b1,<3",
     "pydantic<3",
     # ----
     # Expect compatibility with all new versions of these packages, so lower bounds only.


### PR DESCRIPTION
Manual backport of #15875 to `1.12.latest` (the automated backport failed on a context conflict).

Resolution: took only the pin bump. The adjacent `dbt-state` block in the source diff is 1.latest-only and was not carried over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)