### PR TITLE
ci: add workflow running fmt, clippy, and the test suite

### DIFF
--- a/.github/actions/setup-rust-linux/action.yml
+++ b/.github/actions/setup-rust-linux/action.yml
@@ -1,0 +1,62 @@
+name: "Set up Rust (Linux)"
+description: "Installs the Rust toolchain, sccache, protoc, and restores the cargo cache for a Linux CI job"
+
+inputs:
+  cache-key:
+    description: "Distinguishes this job's cargo/target cache from other jobs'. Jobs that build the same artifacts should share a key."
+    required: true
+  components:
+    description: "Space-separated extra rustup components to install (e.g. `clippy`)"
+    required: false
+    default: ""
+  protoc-version:
+    description: "Protocol Buffer Compiler version. Keep in sync with the release workflow so cached protoc installs are interchangeable."
+    required: false
+    default: "29.4"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # dtolnay/rust-toolchain@stable
+      with:
+        components: ${{ inputs.components }}
+
+    - name: Cache cargo registry and target
+      uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # Swatinem/rust-cache@v2.9.1
+      with:
+        key: ${{ inputs.cache-key }}
+
+    - name: Setup sccache
+      uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # mozilla-actions/sccache-action@v0.0.9
+      with:
+        version: "v0.12.0"
+
+    - name: Install Protocol Buffer Compiler
+      shell: bash
+      env:
+        PB_VERSION: ${{ inputs.protoc-version }}
+      run: |
+        if command -v protoc &> /dev/null; then
+          echo "protoc already installed: $(protoc --version)"
+          exit 0
+        fi
+        if [ -x "/tmp/protoc/bin/protoc" ]; then
+          echo "protoc found in /tmp/protoc/bin"
+          echo "/tmp/protoc/bin" >> $GITHUB_PATH
+          /tmp/protoc/bin/protoc --version
+          exit 0
+        fi
+        echo "Installing Protocol Buffer Compiler..."
+        case "$(uname -m)" in
+          x86_64) PB_ARCH="x86_64" ;;
+          aarch64|arm64) PB_ARCH="aarch_64" ;;
+          *) echo "::error::Unsupported arch: $(uname -m)"; exit 1 ;;
+        esac
+        PB_URL="https://github.com/protocolbuffers/protobuf/releases/download/v$PB_VERSION/protoc-$PB_VERSION-linux-$PB_ARCH.zip"
+        curl -LsSf $PB_URL -o /tmp/protoc.zip
+        rm -rf /tmp/protoc
+        unzip -o /tmp/protoc.zip -d /tmp/protoc
+        echo "/tmp/protoc/bin" >> $GITHUB_PATH
+        /tmp/protoc/bin/protoc --version
+        rm /tmp/protoc.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,127 @@
+# **what?**
+# Runs the Rust workspace CI gates for every change to `main`: formatting,
+# clippy, and the workspace test suite.
+
+# **why?**
+# `main` is the Rust branch, but until now the only place the workspace test
+# suite ran was the `test` gate in release-v2.yml, which fires at release time —
+# long after the offending change merged. This runs the same suite per-change so
+# a break is attributed to the pull request that caused it.
+
+# **when?**
+# On pull requests targeting `main` and on pushes to `main`, plus manual
+# dispatch. Legacy Python branches such as `1.latest` are deliberately excluded;
+# their CI runs through the reusable workflows in dbt-labs/actions.
+
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+# Superseded pull request runs tell us nothing, so cancel them. Each push to
+# `main` is a distinct commit we want a recorded result for, so those run to
+# completion.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+# Read-only: no secrets are needed, which keeps these gates working on pull
+# requests from public forks.
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  # ------------------------------------------------------------------
+  # Formatting is a pure text check — no protoc, sccache, or cargo cache
+  # needed, so it stays on the cheap runner and reports in under a minute.
+  # ------------------------------------------------------------------
+  fmt:
+    name: Format
+    runs-on: ${{ vars.UBUNTU_LATEST }}
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --all --check
+
+  clippy:
+    name: Clippy
+    runs-on: ${{ vars.UBUNTU_RUNNER_32 }}
+    timeout-minutes: 45
+    env:
+      RUSTC_WRAPPER: sccache
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
+
+      - uses: ./.github/actions/setup-rust-linux
+        with:
+          cache-key: clippy-x86_64-unknown-linux-gnu
+          components: clippy
+
+      # No `--locked`: the root Cargo.lock is not committed, so cargo has to
+      # resolve and write one on a fresh checkout.
+      - name: Run clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats || true
+
+  # ------------------------------------------------------------------
+  # The workspace test suite. Mirrors the release gate in release-v2.yml so a
+  # green pull request means a green release gate. Linux-only: the release
+  # workflow is where per-platform binaries get built, and tests that need live
+  # warehouse credentials are `#[ignore]`d, so this needs no secrets.
+  # ------------------------------------------------------------------
+  test:
+    name: Test workspace
+    runs-on: ${{ vars.UBUNTU_RUNNER_32 }}
+    timeout-minutes: 60
+    env:
+      RUSTC_WRAPPER: sccache
+      # Load-bearing, not a tuning knob: the parser/jinja recursion overflows
+      # the default thread stack, and tests like dbt-sa-cli's
+      # `parse::parse_hello_world` abort with SIGABRT without this. Matches the
+      # release gate. 8 MiB.
+      RUST_MIN_STACK: "8388608"
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
+
+      - uses: ./.github/actions/setup-rust-linux
+        with:
+          cache-key: test-x86_64-unknown-linux-gnu
+
+      # rust-cache caches ~/.cargo/bin, so this compiles from source on a cold
+      # cache only. The `--locked` here is cargo-nextest's own published
+      # lockfile, unrelated to this workspace.
+      - name: Install cargo-nextest
+        run: cargo install cargo-nextest --locked
+
+      # No `--locked`, matching the release gate: see the clippy job above.
+      - name: Run tests
+        run: cargo nextest run --workspace
+
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats || true


### PR DESCRIPTION
Adds a CI workflow for pull requests and pushes to `main`: `fmt`, `clippy`, and the workspace test suite. The test job mirrors the release gate in `release-v2.yml`, so a green PR means a green release gate. Linux-only, no secrets, so it works on fork PRs.

Verified locally: fmt, clippy (`-D warnings`), and `cargo nextest run --workspace` (5050 passed / 38 skipped) all pass, and `actionlint` is clean.

Verified CI in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)