### PR TITLE
add databricks adapter macro for array_construct

### DIFF
--- a/.changes/unreleased/Fixes-20260811-101832.yaml
+++ b/.changes/unreleased/Fixes-20260811-101832.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Fixes array_construct bug for Databricks with new adapter-specific macro.
+time: 2026-08-11T10:18:32.886483-07:00
+custom:
+    author: ""
+    issue: "15893"
+    project: dbt-core

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-databricks/macros/utils/array_construct.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-databricks/macros/utils/array_construct.sql
@@ -1,7 +1,7 @@
 {% macro databricks__array_construct(inputs, data_type) -%}
-    {% if inputs | length > 0 %}
-    array({{ inputs | join(', ') }})
+    {% if inputs|length > 0 %}
+    array( {{ inputs|join(' , ') }} )
     {% else %}
-    cast(array() as array<{{ data_type }}>)
+    cast(array() as array<{{data_type}}>)
     {% endif %}
 {%- endmacro %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-databricks/macros/utils/array_construct.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-databricks/macros/utils/array_construct.sql
@@ -1,0 +1,7 @@
+{% macro databricks__array_construct(inputs, data_type) -%}
+    {% if inputs | length > 0 %}
+    array({{ inputs | join(', ') }})
+    {% else %}
+    cast(array() as array<{{ data_type }}>)
+    {% endif %}
+{%- endmacro %}


### PR DESCRIPTION
Resolves #15893

### Problem
- in Databricks, using the dbt macro `{{ dbt.array_construct() }}` with an empty array, even with a defined data type, throws an error during model creation:
```
  [DELTA_COMPLEX_TYPE_COLUMN_CONTAINS_NULL_TYPE] Found nested VOID field in column rbe_managed_program_type which is of ArrayType. Delta doesn't support writing VOID in complex types.
```

Because in Databricks, `{{ dbt.array_construct() }}` compiles to:
```
create or replace table `dev`.`dbt_tony_test`.`test`
using delta
as
  select
    array(  ) as array_column,
    typeof(array(  )) as array_column_type
```

### Solution
- This PR creates a Databricks-specific adapter macro that will properly construct Databricks arrays, which use parentheses to construct them.

### Testing

```
-- test.sql
select
  {{ dbt.array_construct([]) }} as empty_array,
  typeof({{ dbt.array_construct([], 'string') }}) as array_type,
  {{ dbt.array_construct([]) }} as default_empty_array,
  typeof({{ dbt.array_construct([]) }}) as default_array_type

$ dbt run --select test
17:27:45  1 of 1 START sql table model dbt_tony_test.test ........................... [RUN]
17:27:56  1 of 1 OK created sql table model dbt_tony_test.test ...................... [OK in 10.99s]

> Databricks
select * from dev.dbt_tony_test.test;
```

|empty_array|array_type|default_empty_array|default_array_type|
|---|---|---|---|
|[]|array\<string\>|[]|array\<int\>|

```
$ dbt compile --select test
select

        cast(array() as array<integer>)
     as empty_array,
  typeof(
        cast(array() as array<string>)
    ) as array_type,
 
        cast(array() as array<integer>)
     as default_empty_array,
  typeof(
        cast(array() as array<integer>)
    ) as default_array_type


-- inspect information_schema for data types 
select
  column_name,
  full_data_type
from dev.information_schema.columns
where
  table_schema = 'dbt_tony_test'
  and table_name = 'test
```

|column_name|full_data_type|
|---|---|
|empty_array|array\<int\>|
|default_empty_array|array\<int\>|



### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required or relevant for this PR. -- N/A
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
	- ? Not sure, this adds a macro functionality for Databricks.
- N/A -- This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions. 
