### PR TITLE
[ClickHouse] add get catalog macros to unblock `compile --write-catalog`

### DIFF
--- a/.changes/unreleased/Features-20260811-202858.yaml
+++ b/.changes/unreleased/Features-20260811-202858.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Add relation-scoped catalog macro (get_catalog_relations) for ClickHouse, fixing catalog fetch failures with --write-catalog
+time: 2026-08-11T20:28:58.346067+02:00
+custom:
+    author: koletzilla
+    issue: "14585"
+    project: dbt-core

--- a/crates/dbt-adapter/src/metadata/clickhouse/mod.rs
+++ b/crates/dbt-adapter/src/metadata/clickhouse/mod.rs
@@ -61,6 +61,8 @@ impl MetadataAdapter for ClickHouseMetadataAdapter {
         self.adapter.adapter_type()
     }
 
+    /// Parse the record batch produced by the `clickhouse__get_catalog*` macros
+    /// into per-relation table metadata.
     fn build_schemas_from_stats_sql(
         &self,
         stats_sql_result: Arc<RecordBatch>,
@@ -125,6 +127,8 @@ impl MetadataAdapter for ClickHouseMetadataAdapter {
         Ok(result)
     }
 
+    /// Parse the record batch produced by the `clickhouse__get_catalog*` macros
+    /// into per-relation column metadata.
     fn build_columns_from_get_columns(
         &self,
         stats_sql_result: Arc<RecordBatch>,
@@ -427,6 +431,155 @@ fn build_schema_from_clickhouse_describe(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::sql_types::DefaultTypeOps;
+    use crate::stmt_splitter::DefaultStmtSplitter;
+    use arrow_schema::{DataType, Field};
+    use dbt_schemas::schemas::relations::DEFAULT_RESOLVED_QUOTING;
+
+    /// A ClickHouse metadata adapter backed by a mock engine (no live
+    /// connection); the catalog batch parsers never touch the engine.
+    fn make_metadata_adapter() -> ClickHouseMetadataAdapter {
+        ClickHouseMetadataAdapter {
+            adapter: AdapterImpl::new_mock(
+                AdapterType::ClickHouse,
+                BTreeMap::new(),
+                DEFAULT_RESOLVED_QUOTING,
+                Arc::new(DefaultTypeOps::new(AdapterType::ClickHouse)),
+                Arc::new(DefaultStmtSplitter),
+            ),
+        }
+    }
+
+    /// Build a catalog record batch with the same Arrow types the ClickHouse
+    /// ADBC driver produces for the `clickhouse__get_catalog*` macro SQL:
+    /// strings everywhere except `column_index`, which is a `UInt64`
+    /// (`system.columns.position`). Using other types here (e.g. Decimal128
+    /// for `column_index`) must fail, so these tests pin the wire format.
+    fn catalog_batch(rows: &[(&str, &str, &str, &str, &str, u64, &str, &str)]) -> Arc<RecordBatch> {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("table_database", DataType::Utf8, false),
+            Field::new("table_schema", DataType::Utf8, false),
+            Field::new("table_name", DataType::Utf8, false),
+            Field::new("table_type", DataType::Utf8, false),
+            Field::new("table_comment", DataType::Utf8, true),
+            Field::new("column_name", DataType::Utf8, false),
+            Field::new("column_index", DataType::UInt64, false),
+            Field::new("column_type", DataType::Utf8, false),
+            Field::new("column_comment", DataType::Utf8, true),
+            Field::new("table_owner", DataType::Utf8, true),
+        ]));
+        Arc::new(
+            RecordBatch::try_new(
+                schema,
+                vec![
+                    // table_database is always '' for ClickHouse (2-part naming)
+                    Arc::new(StringArray::from(vec![""; rows.len()])),
+                    Arc::new(StringArray::from_iter_values(rows.iter().map(|r| r.0))),
+                    Arc::new(StringArray::from_iter_values(rows.iter().map(|r| r.1))),
+                    Arc::new(StringArray::from_iter_values(rows.iter().map(|r| r.2))),
+                    Arc::new(StringArray::from_iter_values(rows.iter().map(|r| r.3))),
+                    Arc::new(StringArray::from_iter_values(rows.iter().map(|r| r.4))),
+                    Arc::new(UInt64Array::from_iter_values(rows.iter().map(|r| r.5))),
+                    Arc::new(StringArray::from_iter_values(rows.iter().map(|r| r.6))),
+                    Arc::new(StringArray::from_iter_values(rows.iter().map(|r| r.7))),
+                    // table_owner is `cast(null as Nullable(String))` in the macro
+                    Arc::new(StringArray::from(vec![None::<&str>; rows.len()])),
+                ],
+            )
+            .expect("catalog_batch test fixture should build a valid RecordBatch"),
+        )
+    }
+
+    fn sample_batch() -> Arc<RecordBatch> {
+        catalog_batch(&[
+            (
+                "db1",
+                "orders",
+                "table",
+                "fact table",
+                "id",
+                1,
+                "UInt64",
+                "",
+            ),
+            (
+                "db1",
+                "orders",
+                "table",
+                "fact table",
+                "amount",
+                2,
+                "Decimal(18, 2)",
+                "in cents",
+            ),
+            ("db1", "orders_v", "view", "", "id", 1, "UInt64", ""),
+        ])
+    }
+
+    #[test]
+    fn build_schemas_from_stats_sql_groups_rows_per_relation() {
+        let adapter = make_metadata_adapter();
+        let result = adapter
+            .build_schemas_from_stats_sql(sample_batch())
+            .unwrap();
+
+        assert_eq!(
+            result.keys().collect::<Vec<_>>(),
+            vec![".db1.orders", ".db1.orders_v"]
+        );
+
+        let orders = &result[".db1.orders"].metadata;
+        assert_eq!(orders.materialization_type, "table");
+        assert_eq!(orders.schema, "db1");
+        assert_eq!(orders.name, "orders");
+        assert_eq!(orders.database, Some("".to_string()));
+        assert_eq!(orders.comment, Some("fact table".to_string()));
+        // null table_owner reads back as an empty string
+        assert_eq!(orders.owner, Some("".to_string()));
+
+        let view = &result[".db1.orders_v"].metadata;
+        assert_eq!(view.materialization_type, "view");
+        assert_eq!(view.comment, None);
+    }
+
+    #[test]
+    fn build_columns_from_get_columns_reads_uint64_positions() {
+        let adapter = make_metadata_adapter();
+        let result = adapter
+            .build_columns_from_get_columns(sample_batch())
+            .unwrap();
+
+        let orders = &result[".db1.orders"];
+        assert_eq!(orders.len(), 2);
+        assert_eq!(orders["id"].index, 1);
+        assert_eq!(orders["id"].data_type, "UInt64");
+        assert_eq!(orders["id"].comment, None);
+        assert_eq!(orders["amount"].index, 2);
+        assert_eq!(orders["amount"].data_type, "Decimal(18, 2)");
+        assert_eq!(orders["amount"].comment, Some("in cents".to_string()));
+
+        let view = &result[".db1.orders_v"];
+        assert_eq!(view.len(), 1);
+        assert_eq!(view["id"].index, 1);
+    }
+
+    #[test]
+    fn catalog_batch_parsers_accept_empty_batches() {
+        let adapter = make_metadata_adapter();
+        let batch = catalog_batch(&[]);
+        assert!(
+            adapter
+                .build_schemas_from_stats_sql(batch.clone())
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            adapter
+                .build_columns_from_get_columns(batch)
+                .unwrap()
+                .is_empty()
+        );
+    }
 
     /// ClickHouse's `system.tables` is case-sensitive on `database` and `name`
     #[test]

--- a/crates/dbt-adapter/src/metadata/clickhouse/mod.rs
+++ b/crates/dbt-adapter/src/metadata/clickhouse/mod.rs
@@ -7,7 +7,7 @@ use crate::sql_types::{TypeOps, make_arrow_field_v2};
 use crate::{AdapterResult, errors::AsyncAdapterResult, metadata::*};
 use arrow_schema::Schema;
 
-use arrow_array::{Array, Decimal128Array, RecordBatch, StringArray};
+use arrow_array::{Array, RecordBatch, StringArray, UInt64Array};
 
 use dbt_adapter_core::ExecutionPhase;
 use dbt_adbc::{Connection, MapReduce, QueryCtx};
@@ -138,7 +138,7 @@ impl MetadataAdapter for ClickHouseMetadataAdapter {
         let table_names = stats_sql_result.column_values::<StringArray>("table_name")?;
 
         let column_names = stats_sql_result.column_values::<StringArray>("column_name")?;
-        let column_indices = stats_sql_result.column_values::<Decimal128Array>("column_index")?;
+        let column_indices = stats_sql_result.column_values::<UInt64Array>("column_index")?;
         let column_types = stats_sql_result.column_values::<StringArray>("column_type")?;
         let column_comments = stats_sql_result.column_values::<StringArray>("column_comment")?;
 
@@ -158,7 +158,7 @@ impl MetadataAdapter for ClickHouseMetadataAdapter {
 
             let column = ColumnMetadata {
                 name: column_name.to_string(),
-                index: column_index,
+                index: column_index as i128,
                 data_type: column_type.to_string(),
                 comment: match column_comment {
                     "" => None,

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-clickhouse/macros/catalog.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-clickhouse/macros/catalog.sql
@@ -1,5 +1,18 @@
 {% macro clickhouse__get_catalog(information_schema, schemas) -%}
   {%- call statement('catalog', fetch_result=True) -%}
+    {{ clickhouse__get_catalog_results_sql(clickhouse__get_catalog_schemas_where_clause_sql(schemas)) }}
+  {%- endcall -%}
+  {{ return(load_result('catalog').table) }}
+{%- endmacro %}
+
+{% macro clickhouse__get_catalog_relations(information_schema, relations) -%}
+  {%- call statement('catalog', fetch_result=True) -%}
+    {{ clickhouse__get_catalog_results_sql(clickhouse__get_catalog_relations_where_clause_sql(relations)) }}
+  {%- endcall -%}
+  {{ return(load_result('catalog').table) }}
+{%- endmacro %}
+
+{% macro clickhouse__get_catalog_results_sql(where_clause) -%}
     select
       '' as table_database,
       columns.database as table_schema,
@@ -10,17 +23,48 @@
       columns.position as column_index,
       columns.type as column_type,
       nullIf(columns.comment, '') as column_comment,
-      null as table_owner
+      cast(null as Nullable(String)) as table_owner
     from system.columns as columns
     join system.tables as tables on tables.database = columns.database and tables.name = columns.table
-    where database != 'system' and
-    (
-    {%- for schema in schemas -%}
-      columns.database = '{{ schema }}'
-      {%- if not loop.last %} or {% endif -%}
-    {%- endfor -%}
-    )
+    {{ where_clause }}
     order by columns.database, columns.table, columns.position
-  {%- endcall -%}
-  {{ return(load_result('catalog').table) }}
+{%- endmacro %}
+
+{% macro clickhouse__get_catalog_schemas_where_clause_sql(schemas) -%}
+  {% if schemas | length == 0 %}
+    where 1 = 0
+  {% else %}
+    where columns.database != 'system'
+      and (
+      {%- for schema in schemas -%}
+        columns.database = '{{ schema }}'
+        {%- if not loop.last %} or {% endif -%}
+      {%- endfor -%}
+      )
+  {% endif %}
+{%- endmacro %}
+
+{% macro clickhouse__get_catalog_relations_where_clause_sql(relations) -%}
+  {% if relations | length == 0 %}
+    where 1 = 0
+  {% else %}
+    where columns.database != 'system'
+      and (
+      {%- for relation in relations -%}
+        {% if not relation.schema %}
+          {% do exceptions.raise_compiler_error(
+            '`get_catalog_relations` requires a list of relations, each with a schema'
+          ) %}
+        {% endif %}
+
+        (
+          columns.database = '{{ relation.schema }}'
+          {%- if relation.identifier %}
+          and columns.table = '{{ relation.identifier }}'
+          {%- endif %}
+        )
+        {%- if not loop.last %} or {% endif -%}
+      {%- endfor -%}
+      )
+  {% endif %}
 {%- endmacro %}


### PR DESCRIPTION
Related to https://github.com/dbt-labs/dbt-core/issues/14585

### Problem

In ClickHouse, `dbt compile --write-catalog` now fails with:
```
[Non-critical] Issue fetching catalog for schema '.default': Failed to run macro get_catalog_relations invalid operation: Compilation Error: get_catalog_relations not implemented for clickhouse
```

### Solution

We already fixed this in `dbt-clickhouse` in this PR by @dataders : https://github.com/ClickHouse/dbt-clickhouse/pull/657. 
Now this PR:
- Copies the macro from `dbt-clickhouse`
- Fixes a couple of datatype issues that arise when dealing with Arrow/ADBC

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
