### PR TITLE
add mechanism for version deprecation warning

### DIFF
--- a/.changes/unreleased/Features-20260812-015115.yaml
+++ b/.changes/unreleased/Features-20260812-015115.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Warn users if they are using a deprecated dbt version
+time: 2026-08-12T01:51:15.345868+05:30
+custom:
+    Author: ash2shukla
+    Issue: "15964"

--- a/core/dbt/cli/params.py
+++ b/core/dbt/cli/params.py
@@ -14,6 +14,7 @@ from dbt.cli.option_types import (
 )
 from dbt.cli.options import MultiOption
 from dbt.cli.resolvers import default_profiles_dir, default_project_dir
+from dbt.deprecated_version import check_deprecated_version
 from dbt.version import get_version_information
 from dbt_common.constants import ENGINE_ENV_PREFIX
 from dbt_common.exceptions import DbtInternalError
@@ -860,6 +861,7 @@ def _version_callback(ctx, _param, value):
     if not value or ctx.resilient_parsing:
         return
     click.echo(get_version_information())
+    check_deprecated_version(is_warn=True)
     ctx.exit()
 
 

--- a/core/dbt/cli/requires.py
+++ b/core/dbt/cli/requires.py
@@ -21,6 +21,7 @@ from dbt.config.catalogs import (
 from dbt.config.runtime import UnsetProfile, load_profile, load_project
 from dbt.context.providers import generate_runtime_macro_context
 from dbt.context.query_header import generate_query_header_context
+from dbt.deprecated_version import check_deprecated_version
 from dbt.deprecations import show_deprecations_summary
 from dbt.env_vars import KNOWN_ENGINE_ENV_VARS, validate_engine_env_vars
 from dbt.events.logging import setup_event_logger
@@ -132,6 +133,10 @@ def preflight(func):
         fire_event(MainReportVersion(version=str(installed_version), log_version=LOG_VERSION))
         flags_dict_str = cast_dict_to_dict_of_strings(get_flag_dict())
         fire_event(MainReportArgs(args=flags_dict_str))
+
+        # `init` already fires its own WARNING-level version of this notice
+        if flags.WHICH != "init":
+            check_deprecated_version()
 
         # Deprecation warnings
         flags.fire_deprecations(ctx)

--- a/core/dbt/deprecated_version.py
+++ b/core/dbt/deprecated_version.py
@@ -1,0 +1,47 @@
+from dbt.tracking import track_deprecated_version_invocation
+from dbt.version import get_installed_version
+from dbt_common.events.base_types import EventLevel
+from dbt_common.events.functions import fire_event
+from dbt_common.events.types import Note
+from dbt_common.ui import warning_tag
+
+# dbt Core 1.10 and older no longer receive patches. See
+# https://github.com/dbt-labs/dbt-core/issues/15694
+LAST_SUPPORTED_MINOR_VERSION = 10
+
+WARN_MSG = (
+    "This version of dbt is deprecated and no longer receives regular patches, including for "
+    "known bugs. Please upgrade to a newer supported version of dbt for new projects: "
+    "https://docs.getdbt.com/docs/dbt-versions?utm_source=dbt-cli"
+)
+INFO_MSG = (
+    "This version of dbt is deprecated and no longer receives regular patches, including for "
+    "known bugs. We recommend upgrading to a newer supported version of dbt: "
+    "https://docs.getdbt.com/docs/dbt-versions"
+)
+
+
+def is_deprecated_version() -> bool:
+    installed = get_installed_version()
+    if installed.major is None or installed.minor is None:
+        return False
+    return (int(installed.major), int(installed.minor)) <= (1, LAST_SUPPORTED_MINOR_VERSION)
+
+
+def check_deprecated_version(is_warn: bool = False) -> None:
+    """Notify and record telemetry if the installed dbt version is deprecated.
+
+    Callers that gate a user-facing entry point (first install, `dbt init`, `--version`)
+    should pass is_warn=True per the WARNING rows in
+    https://github.com/dbt-labs/dbt-core/issues/15694; everything else (regular
+    invocations) stays at INFO.
+    """
+    if not is_deprecated_version():
+        return
+
+    if is_warn:
+        fire_event(Note(msg=warning_tag(WARN_MSG)), level=EventLevel.WARN)
+    else:
+        fire_event(Note(msg=INFO_MSG))
+
+    track_deprecated_version_invocation()

--- a/core/dbt/deprecated_version.py
+++ b/core/dbt/deprecated_version.py
@@ -7,7 +7,7 @@ from dbt_common.ui import warning_tag
 
 # dbt Core 1.10 and older no longer receive patches. See
 # https://github.com/dbt-labs/dbt-core/issues/15694
-LAST_SUPPORTED_MINOR_VERSION = 10
+LAST_SUPPORTED_MINOR_VERSION = 11
 
 WARN_MSG = (
     "This version of dbt is deprecated and no longer receives regular patches, including for "
@@ -25,7 +25,7 @@ def is_deprecated_version() -> bool:
     installed = get_installed_version()
     if installed.major is None or installed.minor is None:
         return False
-    return (int(installed.major), int(installed.minor)) <= (1, LAST_SUPPORTED_MINOR_VERSION)
+    return (int(installed.major), int(installed.minor)) < (1, LAST_SUPPORTED_MINOR_VERSION)
 
 
 def check_deprecated_version(is_warn: bool = False) -> None:

--- a/core/dbt/task/init.py
+++ b/core/dbt/task/init.py
@@ -13,6 +13,7 @@ import dbt_common.clients.system
 from dbt.adapters.factory import get_include_paths, load_plugin
 from dbt.config.profile import read_profile
 from dbt.contracts.util import Identifier as ProjectName
+from dbt.deprecated_version import check_deprecated_version
 from dbt.events.types import (
     ConfigFolderDirectory,
     InvalidProfileTemplateYAML,
@@ -308,6 +309,8 @@ class InitTask(BaseTask):
 
     def run(self):
         """Entry point for the init task."""
+        check_deprecated_version(is_warn=True)
+
         profiles_dir = get_flags().PROFILES_DIR
         self.create_profiles_dir(profiles_dir)
 

--- a/core/dbt/tracking.py
+++ b/core/dbt/tracking.py
@@ -38,6 +38,7 @@ DBT_INVOCATION_ENV = "DBT_INVOCATION_ENV"
 
 ADAPTER_INFO_SPEC = "iglu:com.dbt/adapter_info/jsonschema/1-0-1"
 DEPRECATION_WARN_SPEC = "iglu:com.dbt/deprecation_warn/jsonschema/1-0-0"
+DEPRECATED_VERSION_INVOCATION_SPEC = "iglu:com.dbt/deprecated_version_invocation/jsonschema/1-0-0"
 BEHAVIOR_CHANGE_WARN_SPEC = "iglu:com.dbt/behavior_change_warn/jsonschema/1-0-0"
 EXPERIMENTAL_PARSER = "iglu:com.dbt/experimental_parser/jsonschema/1-0-0"
 INVOCATION_ENV_SPEC = "iglu:com.dbt/invocation_env/jsonschema/1-0-0"
@@ -570,3 +571,18 @@ def track_run(run_command=None):
         raise
     finally:
         flush()
+
+
+def track_deprecated_version_invocation() -> None:
+    if active_user is None:
+        return
+
+    context = [SelfDescribingJson(DEPRECATED_VERSION_INVOCATION_SPEC, {})]
+
+    track(
+        active_user,
+        category="dbt",
+        action="deprecated_version_invocation",
+        label=get_invocation_id(),
+        context=context,
+    )

--- a/tests/functional/cli/test_deprecated_version.py
+++ b/tests/functional/cli/test_deprecated_version.py
@@ -1,0 +1,95 @@
+from typing import List
+from unittest import mock
+
+import pytest
+
+import dbt_common.semver as semver
+from dbt.cli.main import dbtRunner
+from dbt_common.events.base_types import EventLevel, EventMsg
+
+DEPRECATED_VERSION = "1.9.5"
+
+
+def _deprecated_version() -> semver.VersionSpecifier:
+    return semver.VersionSpecifier.from_version_string(DEPRECATED_VERSION)
+
+
+def _split_deprecated_version_events(events: List[EventMsg]):
+    from dbt.deprecated_version import INFO_MSG, WARN_MSG
+
+    warn = [
+        e
+        for e in events
+        if e.info.name == "Note" and WARN_MSG in e.info.msg and e.info.level == "warn"
+    ]
+    info = [
+        e
+        for e in events
+        if e.info.name == "Note" and INFO_MSG in e.info.msg and e.info.level == "info"
+    ]
+    return warn, info
+
+
+class TestVersionFlagWarnsNotInfo:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {}
+
+    def test_version_flag_fires_warn_not_info(self, project):
+        # --version is an eager click option that runs before cli.invoke()/
+        # preflight() -- i.e. before dbtRunner's `callbacks` get registered
+        # with the event manager via setup_event_logger(). So this path can't
+        # be observed through callbacks like the other two tests; assert
+        # directly on fire_event instead.
+        with mock.patch(
+            "dbt.deprecated_version.get_installed_version", side_effect=_deprecated_version
+        ), mock.patch("dbt.deprecated_version.fire_event") as fire_event, mock.patch(
+            "dbt.cli.params.get_version_information", return_value=""
+        ):
+            res = dbtRunner().invoke(["--version"])
+
+        assert res.exception is None
+        fire_event.assert_called_once()
+        (fired_event,), kwargs = fire_event.call_args
+        assert type(fired_event).__name__ == "Note"
+        assert kwargs.get("level") == EventLevel.WARN
+
+
+class TestInitWarnsNotInfo:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {}
+
+    def test_init_fires_warn_not_info(self, project):
+        events: List[EventMsg] = []
+
+        with mock.patch(
+            "dbt.deprecated_version.get_installed_version", side_effect=_deprecated_version
+        ):
+            res = dbtRunner(callbacks=[events.append]).invoke(["init", "--skip-profile-setup"])
+
+        assert res.exception is None
+
+        warn, info = _split_deprecated_version_events(events)
+        assert len(warn) == 1
+        assert len(info) == 0
+
+
+class TestOtherCommandsInfoNotWarn:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {}
+
+    def test_other_command_fires_info_not_warn(self, project):
+        events: List[EventMsg] = []
+
+        with mock.patch(
+            "dbt.deprecated_version.get_installed_version", side_effect=_deprecated_version
+        ):
+            res = dbtRunner(callbacks=[events.append]).invoke(["run"])
+
+        assert res.exception is None
+
+        warn, info = _split_deprecated_version_events(events)
+        assert len(warn) == 0
+        assert len(info) == 1


### PR DESCRIPTION
Resolves #15694 

### Problem
Users are using older unsupported versions of dbt without being explicitly warned

### Solution
- Add warning mechanism
- Add corresponding telemetry

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
