### PR TITLE
ci: use literal runner labels so CI runs on fork pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
   # ------------------------------------------------------------------
   fmt:
     name: Format
-    runs-on: ${{ vars.UBUNTU_LATEST }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
@@ -67,7 +67,7 @@ jobs:
 
   clippy:
     name: Clippy
-    runs-on: ${{ vars.UBUNTU_RUNNER_32 }}
+    runs-on: depot-ubuntu-24.04-32
     timeout-minutes: 45
     env:
       RUSTC_WRAPPER: sccache
@@ -96,7 +96,7 @@ jobs:
   # ------------------------------------------------------------------
   test:
     name: Test workspace
-    runs-on: ${{ vars.UBUNTU_RUNNER_32 }}
+    runs-on: depot-ubuntu-24.04-32
     timeout-minutes: 60
     env:
       RUSTC_WRAPPER: sccache


### PR DESCRIPTION
`vars.*` is not passed to workflows triggered by a pull request from a fork, so `runs-on` resolved to an empty string and every fork run ended as a startup failure with zero jobs — showing up on the PR as CI never running.

All 5 fork runs of `ci.yml` so far: `failure`, `jobs=0`. The one internal-branch run: `success`, `jobs=3`.

Values match the repo variables as currently set (`ubuntu-latest`, `depot-ubuntu-24.04-32`), so behavior on `main` and internal branches is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)