### PR TITLE
Fix Docker release build: bump pinned ca-certificates version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
   # Install version-pinned packages for reproducible builds
   && apt-get install -y --no-install-recommends \
     build-essential=12.9 \
-    ca-certificates=20230311+deb12u1~deb11u1 \
+    ca-certificates=20250419~deb12u1~deb11u1 \
     libpq-dev=13.23-0+deb11u4 \
     make=4.3-4.1 \
     openssh-client=1:8.4p1-5+deb11u7 \


### PR DESCRIPTION
## Summary
The `Release 1.12.1 to GitHub, PyPI & Docker` workflow is failing at the Docker build step ([run 31575471488](https://github.com/dbt-labs/dbt-core/actions/runs/31575471488/job/94089350805)):

```
E: Version '20230311+deb12u1~deb11u1' for 'ca-certificates' was not found
```

The pinned `ca-certificates` version has aged out of the Debian bullseye apt mirror. This bumps the pin to the currently available version (`20250419~deb12u1~deb11u1`, verified via `apt-cache madison ca-certificates` against `python:3.11.2-slim-bullseye`).

## Test plan
- [ ] Confirm `docker build --target base -f docker/Dockerfile docker/` succeeds with the new pin
- [ ] Re-run the `Release 1.12.1 to GitHub, PyPI & Docker` workflow
