### PR TITLE
[ClickHouse] seed's columns are always not nullable. Fix primary_key for list of values

### DIFF
--- a/.changes/unreleased/Features-20260812-173249.yaml
+++ b/.changes/unreleased/Features-20260812-173249.yaml
@@ -1,5 +1,5 @@
 kind: Features
-body: '[ClickHouse] Seed data types are now Nullable only if Null values exists. Fix wrong primary key declaration when list configured'
+body: '[ClickHouse] Seed data types are now Nullable only when NULL values exist. Fix incorrect primary key declaration when configured as a list'
 time: 2026-08-12T17:32:49.757029+02:00
 custom:
     author: koletzilla

--- a/.changes/unreleased/Features-20260812-173249.yaml
+++ b/.changes/unreleased/Features-20260812-173249.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: '[ClickHouse] Seed data types are now Nullable only if Null values exists. Fix wrong primary key declaration when list configured'
+time: 2026-08-12T17:32:49.757029+02:00
+custom:
+    author: koletzilla
+    issue: "14585"
+    project: dbt-core

--- a/.changes/unreleased/Features-20260812-173249.yaml
+++ b/.changes/unreleased/Features-20260812-173249.yaml
@@ -1,5 +1,5 @@
 kind: Features
-body: '[ClickHouse] Seed data types are now Nullable only when NULL values exist. Fix incorrect primary key declaration when configured as a list'
+body: Seed data types are not Nullable for ClickHouse. Fix incorrect primary key declaration when configured as a list'
 time: 2026-08-12T17:32:49.757029+02:00
 custom:
     author: koletzilla

--- a/crates/dbt-adapter/src/adapter/adapter_impl.rs
+++ b/crates/dbt-adapter/src/adapter/adapter_impl.rs
@@ -2727,6 +2727,13 @@ impl AdapterImpl {
             {
                 Ok("text".to_string())
             }
+            // ClickHouse: Only add Nullable(...) when the column's data actually contains NULLs
+            Impl(ClickHouse, _) => {
+                let has_nulls = batch.column(col_idx as usize).null_count() > 0;
+                let mut out = String::new();
+                crate::sql_types::clickhouse::try_format_type(data_type, has_nulls, &mut out)?;
+                Ok(out)
+            }
             Impl(_, engine) => {
                 let mut out = String::new();
                 engine

--- a/crates/dbt-adapter/src/adapter/adapter_impl.rs
+++ b/crates/dbt-adapter/src/adapter/adapter_impl.rs
@@ -2727,11 +2727,13 @@ impl AdapterImpl {
             {
                 Ok("text".to_string())
             }
-            // ClickHouse: Only add Nullable(...) when the column's data actually contains NULLs
+            // ClickHouse: never wrap seed columns in Nullable(...), matching the Python
+            // adapter's agate-based typing. Missing CSV values arrive as literal NULLs and
+            // are turned into column defaults ('' / 0) by the server's
+            // input_format_null_as_default setting, which is what Python produces too.
             Impl(ClickHouse, _) => {
-                let has_nulls = batch.column(col_idx as usize).null_count() > 0;
                 let mut out = String::new();
-                crate::sql_types::clickhouse::try_format_type(data_type, has_nulls, &mut out)?;
+                crate::sql_types::clickhouse::try_format_type(data_type, false, &mut out)?;
                 Ok(out)
             }
             Impl(_, engine) => {
@@ -6466,11 +6468,14 @@ mod tests {
     }
 
     #[test]
-    fn test_convert_type_clickhouse_nullable_only_for_columns_with_nulls() {
+    fn test_convert_type_clickhouse_never_nullable() {
         use arrow_array::Int64Array;
 
-        // Both fields are declared nullable — seed schemas always are — so the
-        // decision must come from the actual data (null_count), not the field flag.
+        // Seed columns must never render as Nullable(...), regardless of the field
+        // flag (seed schemas always declare nullable) or the actual data: this
+        // matches the Python adapter's agate-based typing. Missing values are
+        // inserted as literal NULLs and become column defaults server-side via
+        // input_format_null_as_default.
         let schema = Arc::new(Schema::new(vec![
             Field::new("with_nulls", DataType::Int64, true),
             Field::new("no_nulls", DataType::Int64, true),
@@ -6486,7 +6491,7 @@ mod tests {
 
         assert_eq!(
             adapter.convert_type(&state, Arc::clone(&table), 0).unwrap(),
-            "Nullable(Int64)"
+            "Int64"
         );
         assert_eq!(adapter.convert_type(&state, table, 1).unwrap(), "Int64");
     }

--- a/crates/dbt-adapter/src/adapter/adapter_impl.rs
+++ b/crates/dbt-adapter/src/adapter/adapter_impl.rs
@@ -6466,6 +6466,32 @@ mod tests {
     }
 
     #[test]
+    fn test_convert_type_clickhouse_nullable_only_for_columns_with_nulls() {
+        use arrow_array::Int64Array;
+
+        // Both fields are declared nullable — seed schemas always are — so the
+        // decision must come from the actual data (null_count), not the field flag.
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("with_nulls", DataType::Int64, true),
+            Field::new("no_nulls", DataType::Int64, true),
+        ]));
+        let with_nulls = Arc::new(Int64Array::from(vec![Some(1), None, Some(3)])) as ArrayRef;
+        let no_nulls = Arc::new(Int64Array::from(vec![Some(1), Some(2), Some(3)])) as ArrayRef;
+        let batch = RecordBatch::try_new(schema, vec![with_nulls, no_nulls]).unwrap();
+        let table = Arc::new(AgateTable::from_record_batch(Arc::new(batch)));
+
+        let adapter = clickhouse_adapter(Mapping::new());
+        let env = Environment::new();
+        let state = State::new_for_env(&env);
+
+        assert_eq!(
+            adapter.convert_type(&state, Arc::clone(&table), 0).unwrap(),
+            "Nullable(Int64)"
+        );
+        assert_eq!(adapter.convert_type(&state, table, 1).unwrap(), "Int64");
+    }
+
+    #[test]
     fn test_verify_database_redshift_cross_db_blocked_without_flags() {
         let config = Mapping::from_iter([("database".into(), "mydb".into())]);
         let adapter = AdapterImpl::new(build_engine(Redshift, config), None);

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-clickhouse/macros/materializations/table.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-clickhouse/macros/materializations/table.sql
@@ -92,9 +92,9 @@
   {%- set primary_key = config.get('primary_key', validator=validation.any[list, basestring]) -%}
   {#- An empty value ('' or []) would emit "PRIMARY KEY" with no columns,
       which is invalid DDL - treat it as unset instead. -#}
-  {%- if primary_key is not none and primary_key | length == 0 -%}
-    {%- set primary_key = none -%}
-  {%- endif -%}
+{%- if primary_key is not none and ((primary_key is string and primary_key | trim | length == 0) or (primary_key is not string and primary_key | length == 0)) -%}
+  {%- set primary_key = none -%}
+{%- endif -%}
   {#- v2 compatibility: v2's typed primary_key config arrives as a list
       (scalar inputs are listified). Render it as a single parenthesized
       expression, since bare "PRIMARY KEY a, b" is a ClickHouse syntax error.

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-clickhouse/macros/materializations/table.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-clickhouse/macros/materializations/table.sql
@@ -90,12 +90,17 @@
 
 {% macro primary_key_clause(label) %}
   {%- set primary_key = config.get('primary_key', validator=validation.any[list, basestring]) -%}
-  {#- Fusion compatibility: Fusion's typed primary_key config arrives as a list
-      (scalar inputs are listified), so join it back into the raw string this
-      clause renders. Guarded like the incremental macros' unique_key handling.
-      No-op in Python, where a plain string passes through untouched. -#}
+  {#- An empty value ('' or []) would emit "PRIMARY KEY" with no columns,
+      which is invalid DDL - treat it as unset instead. -#}
+  {%- if primary_key is not none and primary_key | length == 0 -%}
+    {%- set primary_key = none -%}
+  {%- endif -%}
+  {#- v2 compatibility: v2's typed primary_key config arrives as a list
+      (scalar inputs are listified). Render it as a single parenthesized
+      expression, since bare "PRIMARY KEY a, b" is a ClickHouse syntax error.
+      Guarded like the incremental macros' unique_key handling. -#}
   {%- if primary_key is not none and primary_key is iterable and (primary_key is not string and primary_key is not mapping) -%}
-    {%- set primary_key = primary_key | join(', ') -%}
+    {%- set primary_key = '(' ~ (primary_key | join(', ')) ~ ')' -%}
   {%- endif %}
 
   {%- if primary_key is not none %}


### PR DESCRIPTION
Related to https://github.com/dbt-labs/dbt-core/issues/14585

### Problem

- Seeds data types are always not `Nullable`. **This matches the behavior in v1**.
- primary_key wasn't correctly printed when there was a list of values:
  - Before `primary_key: [a, b]` rendered `PRIMARY KEY a, b` which causes a syntax error. It nows renders a correct `PRIMARY KEY (a, b)`.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
