### PR TITLE
fix: scope compile/show/docs generate relation-cache population to selected schemas

### DIFF
--- a/.changes/unreleased/Fixes-20260812-114732.yaml
+++ b/.changes/unreleased/Fixes-20260812-114732.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Scope relation-cache population in `compile`/`show`/`docs generate` to the selected nodes' schemas so `--cache-selected-only` is honored (previously only `run` respected the flag)
+time: 2026-08-12T11:47:32.848547-04:00
+custom:
+    Author: dataders claude
+    Issue: "12944"

--- a/core/dbt/task/compile.py
+++ b/core/dbt/task/compile.py
@@ -1,6 +1,7 @@
 import threading
-from typing import Optional, Type, TypeVar
+from typing import AbstractSet, Optional, Type, TypeVar
 
+from dbt.adapters.base import BaseAdapter
 from dbt.artifacts.schemas.run import RunResult, RunStatus
 from dbt.contracts.graph.manifest import Manifest
 from dbt.contracts.graph.nodes import ManifestSQLNode
@@ -63,6 +64,21 @@ class CompileTask(GraphRunnableTask):
 
     def raise_on_first_error(self) -> bool:
         return True
+
+    def before_run(self, adapter: BaseAdapter, selected_uids: AbstractSet[str]) -> RunStatus:
+        # Scope relation-cache population to the schemas of the selected nodes,
+        # mirroring RunTask.before_run. The base GraphRunnableTask.before_run
+        # calls populate_adapter_cache with no required_schemas, so with
+        # cache_selected_only enabled the cache would still be built over every
+        # schema in the project. Passing required_schemas here makes
+        # --cache-selected-only effective for compile (and show / docs
+        # generate), which inherit this task.
+        with adapter.connection_named("master"):
+            self.defer_to_manifest()
+            required_schemas = self.get_model_schemas(adapter, selected_uids)
+            with self._maybe_span("metadata.setup"):
+                self.populate_adapter_cache(adapter, required_schemas)
+            return RunStatus.Success
 
     def get_node_selector(self) -> ResourceTypeSelector:
         if getattr(self.args, "inline", None):

--- a/tests/functional/compile/test_compile_cache_selected_only.py
+++ b/tests/functional/compile/test_compile_cache_selected_only.py
@@ -1,0 +1,57 @@
+from unittest import mock
+
+import pytest
+
+from dbt.adapters.sql.impl import SQLAdapter
+from dbt.tests.util import run_dbt
+
+model_in_default_schema_sql = """
+select 1 as fun
+"""
+
+model_in_other_schema_sql = """
+{{ config(schema='cache_selected_only_other') }}
+select 1 as fun
+"""
+
+
+class TestCompileCacheSelectedOnly:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "model_in_default_schema.sql": model_in_default_schema_sql,
+            "model_in_other_schema.sql": model_in_other_schema_sql,
+        }
+
+    def test_cache_selected_only_scopes_compile_to_selected_schema(self, project):
+        # Build both models once so both schemas exist in the database.
+        run_dbt(["run"])
+
+        # dbt's default `generate_schema_name` suffixes the custom schema onto
+        # the profile's target schema, rather than replacing it outright.
+        other_schema = f"{project.test_schema}_cache_selected_only_other"
+
+        original_list_relations = SQLAdapter.list_relations_without_caching
+
+        def query_schemas(args):
+            with mock.patch.object(
+                SQLAdapter,
+                "list_relations_without_caching",
+                autospec=True,
+                side_effect=original_list_relations,
+            ) as listed_schemas:
+                run_dbt(args)
+            return {call.args[1].schema for call in listed_schemas.call_args_list}
+
+        # With the flag, cache population is scoped to the selected model's schema only.
+        queried_schemas = query_schemas(
+            ["compile", "--select", "model_in_default_schema", "--cache-selected-only"]
+        )
+        assert queried_schemas == {project.test_schema}
+        assert other_schema not in queried_schemas
+
+        # Without the flag, every schema in the project is still scanned.
+        queried_schemas = query_schemas(
+            ["compile", "--select", "model_in_default_schema", "--no-cache-selected-only"]
+        )
+        assert other_schema in queried_schemas


### PR DESCRIPTION
resolves #12944

### Problem

`--cache-selected-only` scopes relation-cache population to the schemas of the selected nodes for `dbt run`, but not for `compile`, `show`, or `docs generate` (all of which extend `CompileTask`).

`RunTask.before_run` passes `required_schemas` into `populate_adapter_cache`. `CompileTask` doesn't override `before_run`, so it inherits `GraphRunnableTask.before_run`, which calls `populate_adapter_cache(adapter)` with no schemas — the flag is only consulted when `required_schemas` are passed, so compile introspects every schema in the project regardless of the setting.

On adapters where per-schema introspection is expensive (e.g. Glue-backed Spark), this made `compile --select <one model>` scan every schema in the project instead of just the one containing the selection.

### Fix

Override `CompileTask.before_run` to scope cache population to the selected nodes' schemas via `get_model_schemas`, mirroring `RunTask.before_run`. Unlike `RunTask`, this doesn't call `create_schemas` or run start/end hooks, since compile doesn't need either.

### Scope

This covers `compile`/`show`/`docs generate`. It does not address the second gap flagged in the [issue's maintainer comment](https://github.com/dbt-labs/dbt-core/issues/12944#issuecomment-5222202417) — `dbt test` treating an empty `cache_schemas` set the same as `None` in `dbt-adapters/base/impl.py` — since that lives in the separate `dbt-labs/dbt-adapters` repo and was flagged as a behavior change needing a maintainer call. That gap is tracked separately in dbt-labs/dbt-adapters#2126, fixed by dbt-labs/dbt-adapters#2127.

### Testing

- Added a changelog entry
- Full `tests/unit/task/` + `tests/unit/cli/test_flags.py` suite: 278 passed, 1 skipped
- `black --check` on the changed file: clean
- Targeted mock test confirming `before_run` calls `get_model_schemas(adapter, selected_uids)` and passes the result into `populate_adapter_cache`
