### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/.changes/unreleased/Under the Hood-20260812-160034.yaml
+++ b/.changes/unreleased/Under the Hood-20260812-160034.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: sync JSON schemas from dbt-fusion
+time: 2026-08-12T16:00:34.409916009Z
+custom:
+    Author: fa-assistant
+    Issue: N/A

--- a/core/dbt/jsonschemas/project/latest.json
+++ b/core/dbt/jsonschemas/project/latest.json
@@ -4570,6 +4570,16 @@
             "null"
           ]
         },
+        "+alt_compute": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ComputePlatform"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "+as_columnstore": {
           "anyOf": [
             {

--- a/core/dbt/jsonschemas/resources/latest.json
+++ b/core/dbt/jsonschemas/resources/latest.json
@@ -7965,6 +7965,16 @@
             "null"
           ]
         },
+        "alt_compute": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ComputePlatform"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "as_columnstore": {
           "anyOf": [
             {


### PR DESCRIPTION
## Summary

This PR syncs the JSON schemas from the dbt-fusion repository.

### Files Updated
- `core/dbt/jsonschemas/project/latest.json`
- `core/dbt/jsonschemas/resources/latest.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Commit**: [`89ad19089bac25b076fb55cc945e10cdb784f23d`](https://github.com/dbt-labs/fs/commit/89ad19089bac25b076fb55cc945e10cdb784f23d)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/31612370983)