### PR TITLE
feat(snowflake): support catalog_sync config for Snowflake-managed Iceberg tables

### DIFF
--- a/.changes/unreleased/Features-20260812-164105.yaml
+++ b/.changes/unreleased/Features-20260812-164105.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Support catalog_sync config for Snowflake-managed Iceberg tables to sync with Snowflake Open Catalog
+time: 2026-08-12T16:41:05.803407+01:00
+custom:
+    author: zak-nuccio
+    issue: ""
+    project: dbt-core

--- a/.changes/unreleased/Features-20260812-164105.yaml
+++ b/.changes/unreleased/Features-20260812-164105.yaml
@@ -3,5 +3,5 @@ body: Support catalog_sync config for Snowflake-managed Iceberg tables to sync w
 time: 2026-08-12T16:41:05.803407+01:00
 custom:
     author: zak-nuccio
-    issue: ""
+    issue: "15919"
     project: dbt-core

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-snowflake/macros/relations/table/create.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-snowflake/macros/relations/table/create.sql
@@ -235,6 +235,7 @@ create or replace iceberg table {{ relation }}
     {{ optional('external_volume', catalog_relation.external_volume, "'") }}
     catalog = 'SNOWFLAKE'  -- required, and always SNOWFLAKE for built-in Iceberg tables
     {{ optional('base_location', catalog_relation.base_location, "'") }}
+    {{ optional('catalog_sync', config.get('catalog_sync'), "'") }}
     {% if partition_by_string -%} partition by ({{ partition_by_string }}) {%- endif %}
     {{ optional('storage_serialization_policy', catalog_relation.storage_serialization_policy, "'")}}
     {{ optional('max_data_extension_time_in_days', catalog_relation.max_data_extension_time_in_days)}}

--- a/crates/dbt-schemas/src/schemas/manifest/manifest_nodes.rs
+++ b/crates/dbt-schemas/src/schemas/manifest/manifest_nodes.rs
@@ -849,6 +849,8 @@ pub struct ManifestModelConfig {
     pub classifiers: Option<StringOrArrayOfStrings>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub catalog_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub catalog_sync: Option<String>,
     // Internal-only placement hint; never written to the manifest.
     #[serde(skip_serializing, default)]
     pub alt_compute: Option<ComputePlatform>,
@@ -1122,6 +1124,7 @@ impl From<ModelConfig> for ManifestModelConfig {
             tags: config.tags.into_inner(),
             classifiers: config.classifiers.into_inner(),
             catalog_name: config.catalog_name,
+            catalog_sync: config.catalog_sync,
             alt_compute: config.alt_compute,
             meta: config.meta,
             group: config.group,
@@ -1196,6 +1199,7 @@ impl From<ManifestModelConfig> for ModelConfig {
                 config.classifiers,
             ),
             catalog_name: config.catalog_name,
+            catalog_sync: config.catalog_sync,
             alt_compute: config.alt_compute,
             compute: config.compute,
             meta: config.meta,

--- a/crates/dbt-schemas/src/schemas/project/configs/model_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/model_config.rs
@@ -1343,6 +1343,7 @@ impl ModelConfig {
         // Compare all fields.
         let enabled_eq = self.enabled == other.enabled;
         let catalog_name_eq = self.catalog_name == other.catalog_name;
+        let catalog_sync_eq = self.catalog_sync == other.catalog_sync;
         let alt_compute_eq = self.alt_compute == other.alt_compute;
         let meta_eq_result = meta_eq(&self.meta, &other.meta); // Custom comparison for meta
         let materialized_eq_result = materialized_eq(&self.materialized, &other.materialized);
@@ -1403,6 +1404,7 @@ impl ModelConfig {
 
         let result = enabled_eq
             && catalog_name_eq
+            && catalog_sync_eq
             && alt_compute_eq
             && meta_eq_result
             && materialized_eq_result
@@ -1458,6 +1460,14 @@ impl ModelConfig {
                         Some((
                             format!("{:?}", &self.catalog_name),
                             format!("{:?}", &other.catalog_name),
+                        )),
+                    ),
+                    (
+                        "catalog_sync",
+                        catalog_sync_eq,
+                        Some((
+                            format!("{:?}", &self.catalog_sync),
+                            format!("{:?}", &other.catalog_sync),
                         )),
                     ),
                     (
@@ -1970,6 +1980,25 @@ __warehouse_specific_config__: {}
         child.default_to(&parent);
 
         assert_eq!(child.catalog_sync.as_deref(), Some("PARENT_CATALOG"));
+    }
+
+    #[test]
+    fn test_catalog_sync_detects_config_change() {
+        let a = ModelConfig {
+            catalog_sync: Some("CAT_A".to_string()),
+            ..Default::default()
+        };
+        let b = ModelConfig {
+            catalog_sync: Some("CAT_B".to_string()),
+            ..Default::default()
+        };
+        let c = ModelConfig {
+            catalog_sync: Some("CAT_A".to_string()),
+            ..Default::default()
+        };
+
+        assert!(!a.same_config(&b));
+        assert!(a.same_config(&c));
     }
 
     #[test]

--- a/crates/dbt-schemas/src/schemas/project/configs/model_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/model_config.rs
@@ -610,6 +610,7 @@ impl TypedRecursiveConfig for ProjectModelConfig {
             || self.buckets.is_some()
             || self.catalog.is_some()
             || self.catalog_name.is_some()
+            || self.catalog_sync.is_some()
             || self.alt_compute.is_some()
             || self.cluster_by.is_some()
             || self.clustered_by.is_some()
@@ -1999,6 +2000,22 @@ __warehouse_specific_config__: {}
 
         assert!(!a.same_config(&b));
         assert!(a.same_config(&c));
+    }
+
+    #[test]
+    fn test_catalog_sync_counts_as_set_field() {
+        use crate::schemas::project::dbt_project::TypedRecursiveConfig;
+
+        let config: ProjectModelConfig = dbt_yaml::from_str(
+            r#"
++catalog_sync: MY_CATALOG
+__additional_properties__: {}
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(config.catalog_sync.as_deref(), Some("MY_CATALOG"));
+        assert!(config.has_set_fields());
     }
 
     #[test]

--- a/crates/dbt-schemas/src/schemas/project/configs/model_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/model_config.rs
@@ -113,6 +113,8 @@ pub struct ProjectModelConfig {
     pub catalog: Option<String>,
     #[serde(rename = "+catalog_name")]
     pub catalog_name: Option<String>,
+    #[serde(rename = "+catalog_sync")]
+    pub catalog_sync: Option<String>,
     #[serde(rename = "+alt_compute")]
     pub alt_compute: Option<ComputePlatform>,
     #[serde(rename = "+cluster_by")]
@@ -760,6 +762,7 @@ pub struct ModelConfig {
     #[serde(default)]
     pub classifiers: Classifiers,
     pub catalog_name: Option<String>,
+    pub catalog_sync: Option<String>,
     // Internal placement hint; kept out of serialized config/telemetry output.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub alt_compute: Option<ComputePlatform>,
@@ -878,6 +881,7 @@ impl From<ProjectModelConfig> for ModelConfig {
             additional_libs: config.additional_libs.clone(),
             user_folder_for_python: config.user_folder_for_python,
             catalog_name: config.catalog_name.clone(),
+            catalog_sync: config.catalog_sync.clone(),
             alt_compute: config.alt_compute,
             column_types: config.column_types,
             compute: config.compute,
@@ -1064,6 +1068,7 @@ impl From<ModelConfig> for ProjectModelConfig {
             begin: config.begin,
             bind: config.__warehouse_specific_config__.bind,
             catalog_name: config.catalog_name,
+            catalog_sync: config.catalog_sync,
             alt_compute: config.alt_compute,
             column_types: config.column_types,
             compute: config.compute,
@@ -1933,6 +1938,38 @@ mod tests {
                 "pii".to_string(),
             ]))
         );
+    }
+
+    #[test]
+    fn test_catalog_sync_parses() {
+        let config: ModelConfig = dbt_yaml::from_str(
+            r#"
+catalog_sync: MY_CATALOG
+__warehouse_specific_config__: {}
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(config.catalog_sync.as_deref(), Some("MY_CATALOG"));
+    }
+
+    #[test]
+    fn test_catalog_sync_none_child_inherits_parent() {
+        use crate::schemas::project::dbt_project::ResolvableConfig;
+
+        let parent = ModelConfig {
+            catalog_sync: Some("PARENT_CATALOG".to_string()),
+            ..Default::default()
+        };
+
+        let mut child = ModelConfig {
+            catalog_sync: None,
+            ..Default::default()
+        };
+
+        child.default_to(&parent);
+
+        assert_eq!(child.catalog_sync.as_deref(), Some("PARENT_CATALOG"));
     }
 
     #[test]


### PR DESCRIPTION
Resolves #15919

### Problem

dbt-fusion cannot emit a CATALOG_SYNC clause when building a Snowflake-managed Iceberg table (catalog = 'SNOWFLAKE'), so the table is never registered with a Snowflake Open Catalog (Polaris) and external engines cannot read it.

### Solution

- Add a +catalog_sync model config. When set, the Iceberg create materialization (snowflake__create_table_built_in_sql) appends catalog_sync = '<integration>' to the CREATE ICEBERG TABLE DDL, registering the table with the Open Catalog at creation time instead of via an ALTER SCHEMA post-hook.
- Declare the key on ProjectModelConfig, ModelConfig and ManifestModelConfig and thread it through their From conversions. dbt-core's DefaultTo derive inherits it automatically, and because the manifest path round-trips through ManifestModelConfig, the manifest config serialisation stays consistent with the runtime DDL.
- No behaviour change when the config is unset: the emitted DDL is byte-for-byte identical.

Example:

```yaml
models:
  my_project:
    3_marts:
      +table_format: iceberg
      +external_volume: ICEBERG
      +catalog_sync: MY_CATALOG_INTEGRATION
```

### Checklist

- [x] I have read the contributing guide and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes type annotations for new and modified functions.