### PR TITLE
Fix major.minor comparison in release.yml's hatch-detection check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,11 +97,16 @@ jobs:
       - name: "Check if using hatch"
         id: use_hatch
         run: |
-          # Extract major.minor from versions like 1.11.0a1 -> 1.11
-          INPUT_MAJ_MIN=$(echo "${{ inputs.version_number }}" | sed -E 's/^([0-9]+\.[0-9]+).*/\1/')
-          HATCH_MAJ_MIN=$(echo "${{ env.MIN_HATCH_VERSION }}" | sed -E 's/^([0-9]+\.[0-9]+).*/\1/')
+          # Extract major and minor separately (e.g. 1.11.0a1 -> 1, 11) and compare
+          # them as integers. Comparing "major.minor" as a single decimal via `bc`
+          # is wrong here: e.g. 1.9 > 1.11 as decimals, even though minor version 9
+          # is less than minor version 11.
+          INPUT_MAJOR=$(echo "${{ inputs.version_number }}" | sed -E 's/^([0-9]+)\.([0-9]+).*/\1/')
+          INPUT_MINOR=$(echo "${{ inputs.version_number }}" | sed -E 's/^([0-9]+)\.([0-9]+).*/\2/')
+          HATCH_MAJOR=$(echo "${{ env.MIN_HATCH_VERSION }}" | sed -E 's/^([0-9]+)\.([0-9]+).*/\1/')
+          HATCH_MINOR=$(echo "${{ env.MIN_HATCH_VERSION }}" | sed -E 's/^([0-9]+)\.([0-9]+).*/\2/')
 
-          if [ $(echo "$INPUT_MAJ_MIN >= $HATCH_MAJ_MIN" | bc) -eq 1 ]; then
+          if [ "$INPUT_MAJOR" -gt "$HATCH_MAJOR" ] || { [ "$INPUT_MAJOR" -eq "$HATCH_MAJOR" ] && [ "$INPUT_MINOR" -ge "$HATCH_MINOR" ]; }; then
             echo "use_hatch=true" >> $GITHUB_OUTPUT
           else
             echo "use_hatch=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
The use_hatch check compared "major.minor" as a single decimal via bc, so 1.9 (as a decimal) evaluated greater than 1.11, incorrectly routing any 1.x release with a single-digit minor (e.g. 1.9.11) through the hatch build path even though those branches still use setuptools. Compare major and minor as separate integers instead.

Resolves #

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `action:needs-docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
