### PR TITLE
[Backport 1.5.latest] add mechanism for version deprecation warning

### DIFF
--- a/.changes/unreleased/Features-20260812-015115.yaml
+++ b/.changes/unreleased/Features-20260812-015115.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Warn users if they are using a deprecated dbt version
+time: 2026-08-12T01:51:15.345868+05:30
+custom:
+    Author: ash2shukla
+    Issue: "15964"

--- a/core/dbt/cli/params.py
+++ b/core/dbt/cli/params.py
@@ -4,6 +4,7 @@ import click
 from dbt.cli.options import MultiOption
 from dbt.cli.option_types import YAML, ChoiceTuple, WarnErrorOptionsType
 from dbt.cli.resolvers import default_project_dir, default_profiles_dir
+from dbt.deprecated_version import check_deprecated_version
 from dbt.version import get_version_information
 
 args = click.option(
@@ -509,6 +510,7 @@ def _version_callback(ctx, _param, value):
     if not value or ctx.resilient_parsing:
         return
     click.echo(get_version_information())
+    check_deprecated_version(is_warn=True)
     ctx.exit()
 
 

--- a/core/dbt/cli/requires.py
+++ b/core/dbt/cli/requires.py
@@ -9,6 +9,7 @@ from dbt.cli.exceptions import (
 from dbt.cli.flags import Flags
 from dbt.config import RuntimeConfig
 from dbt.config.runtime import load_project, load_profile, UnsetProfile
+from dbt.deprecated_version import check_deprecated_version
 from dbt.events.functions import fire_event, LOG_VERSION, set_invocation_id, setup_event_logger
 from dbt.events.types import (
     CommandCompleted,
@@ -54,6 +55,10 @@ def preflight(func):
         fire_event(MainReportVersion(version=str(installed_version), log_version=LOG_VERSION))
         flags_dict_str = cast_dict_to_dict_of_strings(get_flag_dict())
         fire_event(MainReportArgs(args=flags_dict_str))
+
+        # `init` already fires its own WARNING-level version of this notice
+        if flags.WHICH != "init":
+            check_deprecated_version()
 
         # Deprecation warnings
         flags.fire_deprecations()

--- a/core/dbt/deprecated_version.py
+++ b/core/dbt/deprecated_version.py
@@ -1,0 +1,47 @@
+from dbt.events.base_types import EventLevel
+from dbt.events.functions import fire_event
+from dbt.events.types import Note
+from dbt.tracking import track_deprecated_version_invocation
+from dbt.ui import warning_tag
+from dbt.version import get_installed_version
+
+# dbt Core 1.10 and older no longer receive patches. See
+# https://github.com/dbt-labs/dbt-core/issues/15694
+LAST_SUPPORTED_MINOR_VERSION = 11
+
+WARN_MSG = (
+    "This version of dbt is deprecated and no longer receives regular patches, including for "
+    "known bugs. Please upgrade to a newer supported version of dbt for new projects: "
+    "https://docs.getdbt.com/docs/dbt-versions?utm_source=dbt-cli"
+)
+INFO_MSG = (
+    "This version of dbt is deprecated and no longer receives regular patches, including for "
+    "known bugs. We recommend upgrading to a newer supported version of dbt: "
+    "https://docs.getdbt.com/docs/dbt-versions"
+)
+
+
+def is_deprecated_version() -> bool:
+    installed = get_installed_version()
+    if installed.major is None or installed.minor is None:
+        return False
+    return (int(installed.major), int(installed.minor)) < (1, LAST_SUPPORTED_MINOR_VERSION)
+
+
+def check_deprecated_version(is_warn: bool = False) -> None:
+    """Notify and record telemetry if the installed dbt version is deprecated.
+
+    Callers that gate a user-facing entry point (first install, `dbt init`, `--version`)
+    should pass is_warn=True per the WARNING rows in
+    https://github.com/dbt-labs/dbt-core/issues/15694; everything else (regular
+    invocations) stays at INFO.
+    """
+    if not is_deprecated_version():
+        return
+
+    if is_warn:
+        fire_event(Note(msg=warning_tag(WARN_MSG)), level=EventLevel.WARN)
+    else:
+        fire_event(Note(msg=INFO_MSG))
+
+    track_deprecated_version_invocation()

--- a/core/dbt/task/init.py
+++ b/core/dbt/task/init.py
@@ -17,6 +17,7 @@ from dbt.adapters.factory import load_plugin, get_include_paths
 
 from dbt.contracts.util import Identifier as ProjectName
 
+from dbt.deprecated_version import check_deprecated_version
 from dbt.events.functions import fire_event
 from dbt.events.types import (
     StarterProjectPath,
@@ -246,6 +247,8 @@ class InitTask(BaseTask):
 
     def run(self):
         """Entry point for the init task."""
+        check_deprecated_version(is_warn=True)
+
         profiles_dir = get_flags().PROFILES_DIR
         self.create_profiles_dir(profiles_dir)
 

--- a/core/dbt/tracking.py
+++ b/core/dbt/tracking.py
@@ -34,6 +34,7 @@ DBT_INVOCATION_ENV = "DBT_INVOCATION_ENV"
 
 ADAPTER_INFO_SPEC = "iglu:com.dbt/adapter_info/jsonschema/1-0-1"
 DEPRECATION_WARN_SPEC = "iglu:com.dbt/deprecation_warn/jsonschema/1-0-0"
+DEPRECATED_VERSION_INVOCATION_SPEC = "iglu:com.dbt/deprecated_version_invocation/jsonschema/1-0-0"
 EXPERIMENTAL_PARSER = "iglu:com.dbt/experimental_parser/jsonschema/1-0-0"
 INVOCATION_ENV_SPEC = "iglu:com.dbt/invocation_env/jsonschema/1-0-0"
 INVOCATION_SPEC = "iglu:com.dbt/invocation/jsonschema/1-0-2"
@@ -487,3 +488,18 @@ def track_run(run_command=None):
         raise
     finally:
         flush()
+
+
+def track_deprecated_version_invocation() -> None:
+    if active_user is None:
+        return
+
+    context = [SelfDescribingJson(DEPRECATED_VERSION_INVOCATION_SPEC, {})]
+
+    track(
+        active_user,
+        category="dbt",
+        action="deprecated_version_invocation",
+        label=get_invocation_id(),
+        context=context,
+    )

--- a/tests/functional/cli/test_deprecated_version.py
+++ b/tests/functional/cli/test_deprecated_version.py
@@ -1,0 +1,104 @@
+from typing import List
+from unittest import mock
+
+import pytest
+
+import dbt.semver as semver
+from dbt.cli.main import dbtRunner
+from dbt.events.base_types import EventLevel, EventMsg
+
+DEPRECATED_VERSION = "1.9.5"
+
+
+def _deprecated_version() -> semver.VersionSpecifier:
+    return semver.VersionSpecifier.from_version_string(DEPRECATED_VERSION)
+
+
+def _split_deprecated_version_events(events: List[EventMsg]):
+    from dbt.deprecated_version import INFO_MSG, WARN_MSG
+
+    warn = [
+        e
+        for e in events
+        if e.info.name == "Note" and WARN_MSG in e.info.msg and e.info.level == "warn"
+    ]
+    info = [
+        e
+        for e in events
+        if e.info.name == "Note" and INFO_MSG in e.info.msg and e.info.level == "info"
+    ]
+    return warn, info
+
+
+class TestVersionFlagWarnsNotInfo:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {}
+
+    def test_version_flag_fires_warn_not_info(self, project):
+        # --version is an eager click option that runs before cli.invoke()/
+        # preflight() -- i.e. before dbtRunner's `callbacks` get registered
+        # with the event manager via setup_event_logger(). So this path can't
+        # be observed through callbacks like the other two tests; assert
+        # directly on fire_event instead.
+        with mock.patch(
+            "dbt.deprecated_version.get_installed_version", side_effect=_deprecated_version
+        ), mock.patch("dbt.deprecated_version.fire_event") as fire_event, mock.patch(
+            "dbt.cli.params.get_version_information", return_value=""
+        ):
+            res = dbtRunner().invoke(["--version"])
+
+        assert res.exception is None
+        fire_event.assert_called_once()
+        (fired_event,), kwargs = fire_event.call_args
+        assert type(fired_event).__name__ == "Note"
+        assert kwargs.get("level") == EventLevel.WARN
+
+
+class TestInitWarnsNotInfo:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {}
+
+    def test_init_fires_warn_not_info(self, project, tmp_path):
+        # --skip-profile-setup doesn't suppress profile setup for an existing
+        # project on this branch (that check was added in a later release), so
+        # the "in project" branch of InitTask.run() always tries to interactively
+        # set up a profile. check_deprecated_version() is the first line of
+        # run(), so stop right after it (before create_profiles_dir) rather than
+        # chasing every interactive prompt down the line.
+        events: List[EventMsg] = []
+
+        class _StopInit(Exception):
+            pass
+
+        with mock.patch(
+            "dbt.deprecated_version.get_installed_version", side_effect=_deprecated_version
+        ), mock.patch("dbt.task.init.InitTask.create_profiles_dir", side_effect=_StopInit):
+            res = dbtRunner(callbacks=[events.append]).invoke(["init"])
+
+        assert isinstance(res.exception, _StopInit)
+
+        warn, info = _split_deprecated_version_events(events)
+        assert len(warn) == 1
+        assert len(info) == 0
+
+
+class TestOtherCommandsInfoNotWarn:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {}
+
+    def test_other_command_fires_info_not_warn(self, project):
+        events: List[EventMsg] = []
+
+        with mock.patch(
+            "dbt.deprecated_version.get_installed_version", side_effect=_deprecated_version
+        ):
+            res = dbtRunner(callbacks=[events.append]).invoke(["run"])
+
+        assert res.exception is None
+
+        warn, info = _split_deprecated_version_events(events)
+        assert len(warn) == 0
+        assert len(info) == 1

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,17 @@
 skipsdist = True
 envlist = unit,integration
 
+[testenv]
+# Newer pip/setuptools default to an editable-install mode whose meta path
+# finder doesn't merge the dbt.tests implicit namespace package across
+# `-e ./core` and `-e ./tests/adapter`, breaking the `dbt.tests.fixtures`
+# import used by tests/conftest.py. `compat` mode uses plain .pth files,
+# which merge correctly. Note: --config-settings only applies to packages
+# passed directly on the pip command line, not ones pulled in via `-r`, so
+# the `-e` entries below are listed inline rather than via
+# editable-requirements.txt.
+install_command = python -m pip install --config-settings editable_mode=compat {opts} {packages}
+
 [testenv:{unit,py37,py38,py39,py310,py311,py}]
 description = unit testing
 download = true
@@ -14,7 +25,9 @@ commands =
   {envpython} -m pytest --cov=core {posargs} tests/unit
 deps =
   -rdev-requirements.txt
-  -reditable-requirements.txt
+  -e ./core
+  -e ./plugins/postgres
+  -e ./tests/adapter
 
 [testenv:{integration,py37-integration,py38-integration,py39-integration,py310-integration,py311-integration,py-integration}]
 description = functional testing
@@ -35,4 +48,6 @@ commands =
 
 deps =
   -rdev-requirements.txt
-  -reditable-requirements.txt
+  -e ./core
+  -e ./plugins/postgres
+  -e ./tests/adapter


### PR DESCRIPTION
Backport https://github.com/dbt-labs/dbt-core/commit/ee7613665102c3f440b5643b51f7fbee64c592e5 from https://github.com/dbt-labs/dbt-core/pull/15897.

Note: `TestInitWarnsNotInfo` needed a small adjustment on this branch — `--skip-profile-setup` doesn't suppress profile setup for an existing project here (that check was added in a later release), so `dbt init` always tries to interactively set up a profile. The test now stops execution right after `check_deprecated_version()` (the first line of `InitTask.run()`) instead of relying on that flag.