### PR TITLE
fix: propagate config.group to test group when attached_node is null

### DIFF
--- a/crates/dbt-parser/src/resolve/resolve_tests/resolve_data_tests.rs
+++ b/crates/dbt-parser/src/resolve/resolve_tests/resolve_data_tests.rs
@@ -724,10 +724,18 @@ pub async fn resolve_data_tests(
                         ))
                     }
                 });
-                let group = attached_node
-                    .as_deref()
-                    .and_then(|id| models.get(id))
-                    .and_then(|m| m.__model_attr__.group.clone());
+                let group = if attached_node.is_some() {
+                    // Generic tests on models/seeds/snapshots inherit the parent's group
+                    // (which may be None even if an explicit config.group is set).
+                    attached_node
+                        .as_deref()
+                        .and_then(|id| models.get(id))
+                        .and_then(|m| m.__model_attr__.group.clone())
+                } else {
+                    // Source tests and singular tests have no attached node; fall back to
+                    // the explicit config.group, matching dbt-core 1.x behavior.
+                    test_config.group.clone()
+                };
                 DbtTestAttr {
                     column_name: test_asset.and_then(|ta| ta.test_metadata_column_name.clone()),
                     attached_node,


### PR DESCRIPTION
## Fix: config.group propagation for unattached test nodes

When a data test has no `attached_node` (source tests and singular tests), dbt-core 1.x copies the explicit `config.group` into the test's `group` property, but the Fusion engine leaves it `null`. This causes `--select group:xxx` and `state:modified` to give different results between the two engines.

### Root cause

In `resolve_data_tests.rs`, the `group` field on `DbtTestAttr` was set *only* from the parent model's group:

```rust
let group = attached_node
    .as_deref()
    .and_then(|id| models.get(id))
    .and_then(|m| m.__model_attr__.group.clone());
```

When `attached_node` is `None` (source tests, singular tests), this always produced `None`, even when the test had an explicit `config.group`.

### Fix

When `attached_node` is `None`, fall back to `test_config.group` (the explicit config value). Generic tests on models/seeds/snapshots continue to inherit the parent node's group.

Fixes: #15930
