### PR TITLE
fix: preserve required tracing spans under filters

### DIFF
--- a/.changes/unreleased/Fixes-20260814-021401.yaml
+++ b/.changes/unreleased/Fixes-20260814-021401.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Prevent debug builds from panicking when RUST_LOG filters infrastructure tracing spans
+time: 2026-08-14T02:14:01+05:30
+custom:
+    author: ""
+    issue: ""
+    project: dbt-core

--- a/crates/dbt-common/src/tracing/dbt_init.rs
+++ b/crates/dbt-common/src/tracing/dbt_init.rs
@@ -27,6 +27,8 @@ const DBT_TRACING_FILTER_DIRECTIVES: &[&str] = &[
     "reqwest=off",
     "ureq=off",
     "opentelemetry=off",
+    // Keep structural spans alive for SpanManager; sink filters still control output.
+    "dbt_tracing::emit=debug",
 ];
 
 /// Maps dbt output verbosity to the base subscriber cap.

--- a/crates/dbt-common/src/tracing/tests/dbt_init_tests.rs
+++ b/crates/dbt-common/src/tracing/tests/dbt_init_tests.rs
@@ -1,0 +1,57 @@
+use dbt_tracing::{
+    TelemetryOutputFlags,
+    emit::create_debug_span,
+    layer::ConsumerLayer,
+    test_support::mocks::{MockDynSpanEvent, TestLayer, test_data_layer},
+};
+use std::process::Command;
+use tracing::level_filters::LevelFilter;
+
+use crate::tracing::dbt_init::create_tracing_subcriber_with_layer;
+
+const CHILD_PROCESS_MARKER: &str = "DBT_TEST_RUST_LOG_FILTER_CHILD";
+
+#[test]
+fn dbt_filter_directives_preserve_structural_spans_under_rust_log() {
+    if std::env::var_os(CHILD_PROCESS_MARKER).is_none() {
+        let status = Command::new(std::env::current_exe().expect("test executable must exist"))
+            .arg("--exact")
+            .arg("tracing::tests::dbt_init_tests::dbt_filter_directives_preserve_structural_spans_under_rust_log")
+            .arg("--nocapture")
+            .env(
+                "RUST_LOG",
+                "warn,dbt_tracing::emit=off,unrelated_target=off",
+            )
+            .env(CHILD_PROCESS_MARKER, "1")
+            .status()
+            .expect("child test process must start");
+
+        assert!(status.success());
+        return;
+    }
+
+    let trace_id = rand::random::<u128>();
+    let (test_layer, _, _, _) = TestLayer::new();
+    let subscriber = create_tracing_subcriber_with_layer(
+        LevelFilter::DEBUG,
+        test_data_layer(
+            trace_id,
+            None,
+            false,
+            std::iter::empty(),
+            std::iter::once(Box::new(test_layer) as ConsumerLayer),
+        ),
+    );
+
+    tracing::subscriber::with_default(subscriber, || {
+        let structural_span = create_debug_span(MockDynSpanEvent {
+            name: "structural".to_string(),
+            flags: TelemetryOutputFlags::ALL,
+            ..Default::default()
+        });
+        assert!(structural_span.id().is_some());
+
+        let unrelated_span = tracing::debug_span!(target: "unrelated_target", "unrelated");
+        assert!(unrelated_span.id().is_none());
+    });
+}

--- a/crates/dbt-common/src/tracing/tests/mod.rs
+++ b/crates/dbt-common/src/tracing/tests/mod.rs
@@ -1,4 +1,5 @@
 mod dbt_emit_tests;
+mod dbt_init_tests;
 mod dbt_middleware_tests;
 mod layers_file_log_tests;
 mod layers_json_compat_tests;

--- a/crates/dbt-tracing/src/init.rs
+++ b/crates/dbt-tracing/src/init.rs
@@ -31,6 +31,9 @@ use crate::{
 // tests - it may stay uninitialized
 static PROCESS_SPAN: OnceLock<span::Id> = OnceLock::new();
 
+// init_tracing requires this span's ID even when caller or RUST_LOG filters disable INFO.
+const PROCESS_SPAN_FILTER_DIRECTIVE: &str = concat!(module_path!(), "=info");
+
 /// The process span for the current process. Only available after
 /// tracing has been initialized and before tracing handle is dropped.
 ///
@@ -181,7 +184,22 @@ pub fn create_tracing_subcriber_with_layer<D: Layer<BaseSubscriber> + Send + Syn
     #[cfg(not(debug_assertions))]
     let base_telemetry_filter = EnvFilter::builder().parse_lossy(max_log_verbosity.to_string());
 
-    let base_telemetry_filter = parse_filter_directives(filter_directives)?
+    create_tracing_subscriber_with_base_filter(base_telemetry_filter, data_layer, filter_directives)
+}
+
+fn create_tracing_subscriber_with_base_filter<D: Layer<BaseSubscriber> + Send + Sync + 'static>(
+    base_telemetry_filter: EnvFilter,
+    data_layer: D,
+    filter_directives: &[&str],
+) -> TracingResult<impl Subscriber + Send + Sync + 'static> {
+    let mut filter_directives = parse_filter_directives(filter_directives)?;
+    filter_directives.push(
+        PROCESS_SPAN_FILTER_DIRECTIVE
+            .parse()
+            .expect("the process span filter directive must be valid"),
+    );
+
+    let base_telemetry_filter = filter_directives
         .into_iter()
         .fold(base_telemetry_filter, |filter, directive| {
             filter.add_directive(directive)
@@ -191,4 +209,20 @@ pub fn create_tracing_subcriber_with_layer<D: Layer<BaseSubscriber> + Send + Syn
     Ok(Registry::default()
         .with(base_telemetry_filter)
         .with(data_layer))
+}
+
+#[cfg(test)]
+pub(crate) fn create_tracing_subscriber_with_layer_and_rust_log<
+    D: Layer<BaseSubscriber> + Send + Sync + 'static,
+>(
+    max_log_verbosity: LevelFilter,
+    rust_log: &str,
+    data_layer: D,
+    filter_directives: &[&str],
+) -> TracingResult<impl Subscriber + Send + Sync + 'static> {
+    let base_telemetry_filter = EnvFilter::builder()
+        .with_default_directive(max_log_verbosity.into())
+        .parse_lossy(rust_log);
+
+    create_tracing_subscriber_with_base_filter(base_telemetry_filter, data_layer, filter_directives)
 }

--- a/crates/dbt-tracing/src/tests/init_tests.rs
+++ b/crates/dbt-tracing/src/tests/init_tests.rs
@@ -1,8 +1,10 @@
 use crate::{
     TelemetryOutputFlags,
-    emit::{create_root_info_span, emit_debug_event, emit_info_event},
+    emit::{create_debug_span, create_root_info_span, emit_debug_event, emit_info_event},
     error::TracingError,
-    init::create_tracing_subcriber_with_layer,
+    init::{
+        create_tracing_subcriber_with_layer, create_tracing_subscriber_with_layer_and_rust_log,
+    },
     layer::ConsumerLayer,
 };
 
@@ -102,4 +104,80 @@ fn generic_subscriber_rejects_invalid_directives() {
     };
 
     assert!(matches!(error, TracingError::InvalidFilterDirective(_)));
+}
+
+#[test]
+fn infrastructure_spans_remain_enabled_when_rust_log_filters_their_levels() {
+    for rust_log in ["warn", "info"] {
+        let trace_id = rand::random::<u128>();
+        let (test_layer, _, _, _) = TestLayer::new();
+        let subscriber = create_tracing_subscriber_with_layer_and_rust_log(
+            LevelFilter::DEBUG,
+            rust_log,
+            test_data_layer(
+                trace_id,
+                None,
+                false,
+                std::iter::empty(),
+                std::iter::once(Box::new(test_layer) as ConsumerLayer),
+            ),
+            &["dbt_tracing::emit=debug"],
+        )
+        .expect("test tracing filter directives must be valid");
+
+        tracing::subscriber::with_default(subscriber, || {
+            let process_span = tracing::info_span!(
+                target: "dbt_tracing::init",
+                "__tracing_process_span__"
+            );
+            assert!(process_span.id().is_some());
+
+            let structural_span = create_debug_span(MockDynSpanEvent {
+                name: "structural".to_string(),
+                flags: TelemetryOutputFlags::ALL,
+                ..Default::default()
+            });
+            assert!(structural_span.id().is_some());
+
+            let unrelated_span = tracing::debug_span!(target: "unrelated_target", "unrelated");
+            assert!(unrelated_span.id().is_none());
+        });
+    }
+}
+
+#[test]
+fn infrastructure_directives_override_explicit_rust_log_target_filters() {
+    let trace_id = rand::random::<u128>();
+    let (test_layer, _, _, _) = TestLayer::new();
+    let subscriber = create_tracing_subscriber_with_layer_and_rust_log(
+        LevelFilter::DEBUG,
+        "dbt_tracing::init=off,dbt_tracing::emit=off,unrelated_target=off",
+        test_data_layer(
+            trace_id,
+            None,
+            false,
+            std::iter::empty(),
+            std::iter::once(Box::new(test_layer) as ConsumerLayer),
+        ),
+        &["dbt_tracing::emit=debug"],
+    )
+    .expect("test tracing filter directives must be valid");
+
+    tracing::subscriber::with_default(subscriber, || {
+        let process_span = tracing::info_span!(
+            target: "dbt_tracing::init",
+            "__tracing_process_span__"
+        );
+        assert!(process_span.id().is_some());
+
+        let structural_span = create_debug_span(MockDynSpanEvent {
+            name: "structural".to_string(),
+            flags: TelemetryOutputFlags::ALL,
+            ..Default::default()
+        });
+        assert!(structural_span.id().is_some());
+
+        let unrelated_span = tracing::info_span!(target: "unrelated_target", "unrelated");
+        assert!(unrelated_span.id().is_none());
+    });
 }


### PR DESCRIPTION
## Summary

- preserve the process INFO span after environment and caller filter directives are applied
- preserve structural DEBUG spans required by `SpanManager` while retaining output-layer filtering
- add regression coverage for WARN/INFO filters, explicit target disabling, and unrelated targets

## Motivation

Our test environment inherited `RUST_LOG=warn`. In debug builds, dbt uses `RUST_LOG` when constructing the base tracing filter. That filter disabled the INFO process span and the DEBUG structural spans before tracing could assign IDs to them.

Tracing initialization and `SpanManager` require those IDs, so the test run panicked with `Process span must have an ID`. Running with `RUST_LOG=debug DBT_LOG_LEVEL=debug` avoided the panic, which masked the regression rather than fixing it.

This change restores only the exact internal targets whose spans must exist. Output sinks still honor `DBT_LOG_LEVEL`, and `RUST_LOG` continues to filter unrelated targets.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p dbt-tracing`
- `cargo test -p dbt-common tracing::tests`
- `cargo test -p dbt-tasks-core span_manager`
- clippy and `dbt-sa-cli` debug build
- full Databricks conformance suite
- WARN-level lifecycle reproduction