### PR TITLE
chore: drop Python type-annotation checkbox from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,4 +30,3 @@ Resolves #
 - [ ] I have run this code in development, and it appears to resolve the stated issue.
 - [ ] This PR includes tests, or tests are not required or relevant for this PR.
 - [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
-- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.


### PR DESCRIPTION
Resolves #15839

### Problem

`main` is the Rust v2 engine, but the PR checklist still requires [Python type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions. That item is leftover from the Python v1 template and is not relevant on this branch.

### Solution

Remove the type-annotation checkbox from `.github/pull_request_template.md`. The other four checklist items are unchanged.

This does not add a Rust-specific replacement (clippy/fmt). Those are already covered by CI (`cargo fmt`, `clippy`) and `CONTRIBUTING.md`.

No changelog entry: `changelog-existence.yml` has `paths-ignore: ['.changes/**', '.github/**', ...]`.

### How to test

Open `.github/pull_request_template.md` and confirm the Python `typing` bullet is gone. No `cargo` run is needed.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
