### PR TITLE
fix: error when both tests and data_tests are set

### DIFF
--- a/.changes/unreleased/Fixes-20260816-150315.yaml
+++ b/.changes/unreleased/Fixes-20260816-150315.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: 'Error instead of panicking when both tests: and data_tests: are set in dbt_project.yml'
+time: 2026-08-16T15:03:15.756054+04:00
+custom:
+    author: daviddallakyan2005
+    issue: "15958"
+    project: dbt-core

--- a/crates/dbt-parser/src/dbt_project_config.rs
+++ b/crates/dbt-parser/src/dbt_project_config.rs
@@ -5,7 +5,7 @@
 use std::path::{Path, PathBuf};
 
 use dbt_common::warn_error_options::project_flags_get_value;
-use dbt_common::{ErrorCode, FsError};
+use dbt_common::{ErrorCode, FsError, err};
 use indexmap::IndexMap;
 
 use dbt_common::{
@@ -510,20 +510,33 @@ pub(crate) fn disallow_plus_prefix_from_flags(flags: Option<&dbt_yaml::Value>) -
         .unwrap_or(false)
 }
 
+/// Select `tests:` or `data_tests:` from a `dbt_project.yml`.
+///
+/// dbt 1.x rejects both keys on the same project. There is no merge.
+pub(crate) fn coalesce_project_tests_config<T>(
+    tests: Option<T>,
+    data_tests: Option<T>,
+) -> FsResult<Option<T>> {
+    match (tests, data_tests) {
+        (Some(_), Some(_)) => {
+            err!(
+                ErrorCode::InvalidConfig,
+                "Invalid project config: cannot have both 'tests' and 'data_tests' defined"
+            )
+        }
+        (Some(tests), None) => Ok(Some(tests)),
+        (None, Some(data_tests)) => Ok(Some(data_tests)),
+        (None, None) => Ok(None),
+    }
+}
+
 /// Build the [RootProjectConfigs] from a [DbtProject]
 pub fn build_root_project_configs(
     root_project: &DbtProject,
     root_project_quoting: DbtQuoting,
 ) -> FsResult<RootProjectConfigs> {
     let maybe_root_project_config =
-        match (root_project.tests.clone(), root_project.data_tests.clone()) {
-            (Some(_), Some(_)) => {
-                unimplemented!("Merge logic for tests and data tests is unimplemented")
-            }
-            (Some(tests), None) => Some(tests),
-            (None, Some(data_tests)) => Some(data_tests),
-            (None, None) => None,
-        };
+        coalesce_project_tests_config(root_project.tests.clone(), root_project.data_tests.clone())?;
     let disallow_plus_prefix = disallow_plus_prefix_from_flags(root_project.flags.as_ref());
 
     Ok(RootProjectConfigs {
@@ -1182,6 +1195,42 @@ mod tests {
             result.materialized,
             Some(dbt_schemas::schemas::common::DbtMaterialization::Incremental)
         );
+    }
+
+    fn dummy_data_test_config() -> dbt_schemas::schemas::project::ProjectDataTestConfig {
+        dbt_jinja_utils::serde::from_yaml_raw("+enabled: true", None, false, None)
+            .expect("dummy data test config")
+    }
+
+    #[test]
+    fn test_build_root_project_configs_rejects_both_tests_and_data_tests() {
+        let project = DbtProject {
+            tests: Some(dummy_data_test_config()),
+            data_tests: Some(dummy_data_test_config()),
+            ..Default::default()
+        };
+
+        let err = build_root_project_configs(&project, DbtQuoting::default()).unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidConfig);
+        assert!(
+            err.context
+                .contains("cannot have both 'tests' and 'data_tests' defined")
+        );
+    }
+
+    #[test]
+    fn test_build_root_project_configs_accepts_tests_or_data_tests_alone() {
+        let tests_only = DbtProject {
+            tests: Some(dummy_data_test_config()),
+            ..Default::default()
+        };
+        assert!(build_root_project_configs(&tests_only, DbtQuoting::default()).is_ok());
+
+        let data_tests_only = DbtProject {
+            data_tests: Some(dummy_data_test_config()),
+            ..Default::default()
+        };
+        assert!(build_root_project_configs(&data_tests_only, DbtQuoting::default()).is_ok());
     }
 }
 

--- a/crates/dbt-parser/src/resolve/resolve_tests/resolve_data_tests.rs
+++ b/crates/dbt-parser/src/resolve/resolve_tests/resolve_data_tests.rs
@@ -1,6 +1,7 @@
 use crate::args::ResolveArgs;
 use crate::dbt_project_config::ProjectConfigResolver;
 use crate::dbt_project_config::RootProjectConfigs;
+use crate::dbt_project_config::coalesce_project_tests_config;
 use crate::dbt_project_config::disallow_plus_prefix_from_flags;
 use crate::dbt_project_config::init_project_config;
 use crate::renderer::RenderCtx;
@@ -395,17 +396,10 @@ pub async fn resolve_data_tests(
 
     let config_resolver =
         ProjectConfigResolver::build(root_project_configs.tests.clone(), is_dependency, || {
-            let tests_config = match (
+            let tests_config = coalesce_project_tests_config(
                 package.dbt_project.tests.clone(),
                 package.dbt_project.data_tests.clone(),
-            ) {
-                (Some(_), Some(_)) => {
-                    unimplemented!("Merge logic for tests and data tests is unimplemented")
-                }
-                (Some(tests), None) => Some(tests),
-                (None, Some(data_tests)) => Some(data_tests),
-                (None, None) => None,
-            };
+            )?;
             let disallow_plus_prefix =
                 disallow_plus_prefix_from_flags(root_package.dbt_project.flags.as_ref());
             init_project_config(


### PR DESCRIPTION
Resolves #15958

### Problem

When a `dbt_project.yml` defines both `tests:` and `data_tests:`, dbt v2 panics:

```
not implemented: Merge logic for tests and data tests is unimplemented
```

dbt 1.x already rejects this combination with a config error. There is no merge to implement.

### Solution

Return `ErrorCode::InvalidConfig` with the 1.x message at both call sites (`build_root_project_configs` and `resolve_data_tests`):

```
Invalid project config: cannot have both 'tests' and 'data_tests' defined
```

`tests:` or `data_tests:` alone still works as an alias. A dependency may still use `tests:` while the root uses `data_tests:` (same as 1.x). Schema YAML dual-key errors are unchanged.

### How to test

```
cargo nextest run -p dbt-parser
```

New tests: `test_build_root_project_configs_rejects_both_tests_and_data_tests` and `test_build_root_project_configs_accepts_tests_or_data_tests_alone`.

Local run: 300 passed, 1 skipped. `cargo fmt -p dbt-parser -- --check` and `cargo clippy -p dbt-parser --all-targets -- -D warnings` clean.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
