### PR TITLE
fix: implement AgateTable __eq__/__ne__ for Jinja ==

### DIFF
--- a/.changes/unreleased/Fixes-20260816-152919.yaml
+++ b/.changes/unreleased/Fixes-20260816-152919.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Stop panicking on Jinja AgateTable equality comparisons
+time: 2026-08-16T15:29:19.021143+04:00
+custom:
+    author: daviddallakyan2005
+    issue: "15920"
+    project: dbt-core

--- a/crates/dbt-agate/src/lib.rs
+++ b/crates/dbt-agate/src/lib.rs
@@ -24,6 +24,7 @@ mod print_table;
 mod row;
 mod rows;
 mod table;
+mod table_eq;
 mod table_set;
 /// Fixtures for testing within this crate and by users of it.
 pub mod test_fixtures;

--- a/crates/dbt-agate/src/table.rs
+++ b/crates/dbt-agate/src/table.rs
@@ -1392,8 +1392,7 @@ impl Object for AgateTable {
                 })?;
                 Ok(Value::from_object(result))
             }
-            "__eq__" | "__ne__" => self.call_eq_ne(name, args),
-            other => unimplemented!("AgateTable::{}", other),
+            _ => self.call_unknown_method(name, args),
         }
     }
 }

--- a/crates/dbt-agate/src/table.rs
+++ b/crates/dbt-agate/src/table.rs
@@ -412,41 +412,6 @@ impl TableRepr {
             },
         )
     }
-
-    /// Cell-wise comparison: names, agate types, and converter-backed values.
-    ///
-    /// Physical Arrow identity is intentionally ignored (Utf8 vs Utf8View).
-    /// After a successful table downcast, [`Object::custom_cmp`] must return
-    /// `Some` so MiniJinja does not fall through to default Map equality.
-    fn semantic_cmp(&self, other: &Self) -> Ordering {
-        if std::ptr::eq(self, other) {
-            return Ordering::Equal;
-        }
-        self.num_rows()
-            .cmp(&other.num_rows())
-            .then_with(|| self.num_columns().cmp(&other.num_columns()))
-            .then_with(|| self.column_names().cmp(other.column_names()))
-            .then_with(|| {
-                self.column_types()
-                    .iter()
-                    .map(|t| t.type_name())
-                    .cmp(other.column_types().iter().map(|t| t.type_name()))
-            })
-            .then_with(|| {
-                for row_idx in 0..self.num_rows() {
-                    for col_idx in 0..self.num_columns() {
-                        match self
-                            .cell(row_idx as isize, col_idx as isize)
-                            .cmp(&other.cell(row_idx as isize, col_idx as isize))
-                        {
-                            Ordering::Equal => {}
-                            other => return other,
-                        }
-                    }
-                }
-                Ordering::Equal
-            })
-    }
 }
 
 /// The AgateTable object.
@@ -548,24 +513,6 @@ impl AgateTable {
     /// Get the internal representation of the table.
     pub fn cell(&self, row_idx: isize, col_idx: isize) -> Option<Value> {
         self.repr.cell(row_idx, col_idx)
-    }
-
-    fn semantic_cmp(&self, other: &Self) -> Ordering {
-        if Arc::ptr_eq(&self.repr, &other.repr) {
-            Ordering::Equal
-        } else {
-            self.repr.semantic_cmp(&other.repr)
-        }
-    }
-
-    fn semantic_eq(&self, other: &Self) -> bool {
-        self.semantic_cmp(other) == Ordering::Equal
-    }
-
-    fn eq_value(&self, other: &Value) -> bool {
-        other
-            .downcast_object_ref::<AgateTable>()
-            .is_some_and(|other| self.semantic_eq(other))
     }
 
     // Columns ----------------------------------------------------------------
@@ -1086,9 +1033,7 @@ impl Object for AgateTable {
     }
 
     fn custom_cmp(self: &Arc<Self>, other: &DynObject) -> Option<Ordering> {
-        other
-            .downcast_ref::<AgateTable>()
-            .map(|other| self.semantic_cmp(other))
+        self.custom_cmp_object(other)
     }
 
     fn call_method(
@@ -1447,18 +1392,7 @@ impl Object for AgateTable {
                 })?;
                 Ok(Value::from_object(result))
             }
-            "__eq__" => {
-                let iter = ArgsIter::for_unnamed_pos_args("Table.__eq__", 1, args);
-                let other = iter.next_arg::<&Value>()?;
-                iter.finish()?;
-                Ok(Value::from(self.eq_value(other)))
-            }
-            "__ne__" => {
-                let iter = ArgsIter::for_unnamed_pos_args("Table.__ne__", 1, args);
-                let other = iter.next_arg::<&Value>()?;
-                iter.finish()?;
-                Ok(Value::from(!self.eq_value(other)))
-            }
+            "__eq__" | "__ne__" => self.call_eq_ne(name, args),
             other => unimplemented!("AgateTable::{}", other),
         }
     }
@@ -1477,14 +1411,13 @@ mod tests {
     use arrow::csv::reader::ReaderBuilder;
     use arrow::datatypes::{DataType, Field, Int32Type, Schema};
     use arrow::record_batch::RecordBatch;
-    use arrow_array::{Array, ListArray, RecordBatchOptions, StringViewArray, UInt64Array};
+    use arrow_array::{Array, ListArray, RecordBatchOptions, UInt64Array};
     use arrow_schema::Fields;
     use minijinja::Environment;
     use minijinja::value::Kwargs;
     use minijinja::value::ValueMap;
     use minijinja::value::mutable_map::MutableMap;
     use minijinja_contrib::testing::jinja_assert;
-    use std::collections::HashMap;
     use std::io;
     use std::sync::Arc;
 
@@ -2896,176 +2829,5 @@ mod tests {
                 .contains("Table.join: right_table must be a Table"),
             "{err}"
         );
-    }
-
-    fn render_globals(globals: Vec<(&str, Value)>, template: &str) -> String {
-        let mut env = Environment::new();
-        for (name, value) in globals {
-            env.add_global(name, value);
-        }
-        env.render_str(template, HashMap::<String, String>::new(), &[])
-            .expect("render should succeed without panic")
-    }
-
-    fn table_from_ids_and_countries(
-        ids: Vec<Option<i32>>,
-        countries: Vec<Option<&str>>,
-    ) -> AgateTable {
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("id", DataType::Int32, true),
-            Field::new("country", DataType::Utf8, true),
-        ]));
-        let batch = RecordBatch::try_new(
-            schema,
-            vec![
-                Arc::new(Int32Array::from(ids)) as ArrayRef,
-                Arc::new(StringArray::from(countries)) as ArrayRef,
-            ],
-        )
-        .unwrap();
-        AgateTable::from_record_batch(Arc::new(batch))
-    }
-
-    #[test]
-    fn table_eq_same_object_is_true() {
-        let table = AgateTable::from_record_batch(simple_record_batch());
-        let out = render_globals(vec![("a", table.into_value())], "{{ a == a }}");
-        assert_eq!(out, "True");
-    }
-
-    #[test]
-    fn table_eq_is_cell_wise_not_arrow_identity() {
-        let utf8 =
-            table_from_ids_and_countries(vec![Some(1), None], vec![Some("Brazil"), Some("USA")]);
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("id", DataType::Int32, true),
-            Field::new("country", DataType::Utf8View, true),
-        ]));
-        let utf8_view = AgateTable::from_record_batch(Arc::new(
-            RecordBatch::try_new(
-                schema,
-                vec![
-                    Arc::new(Int32Array::from(vec![Some(1), None])) as ArrayRef,
-                    Arc::new(StringViewArray::from(vec![Some("Brazil"), Some("USA")])) as ArrayRef,
-                ],
-            )
-            .unwrap(),
-        ));
-
-        let out = render_globals(
-            vec![("a", utf8.into_value()), ("b", utf8_view.into_value())],
-            "{{ a == b }} {{ a != b }}",
-        );
-        assert_eq!(out, "True False");
-    }
-
-    #[test]
-    fn table_eq_false_when_values_names_or_types_differ() {
-        let left = table_from_ids_and_countries(vec![Some(1)], vec![Some("Brazil")]);
-        let different_values = table_from_ids_and_countries(vec![Some(2)], vec![Some("Brazil")]);
-        let different_names_schema = Arc::new(Schema::new(vec![
-            Field::new("id", DataType::Int32, true),
-            Field::new("nation", DataType::Utf8, true),
-        ]));
-        let different_names = AgateTable::from_record_batch(Arc::new(
-            RecordBatch::try_new(
-                different_names_schema,
-                vec![
-                    Arc::new(Int32Array::from(vec![Some(1)])) as ArrayRef,
-                    Arc::new(StringArray::from(vec![Some("Brazil")])) as ArrayRef,
-                ],
-            )
-            .unwrap(),
-        ));
-        let different_types_schema = Arc::new(Schema::new(vec![
-            Field::new("id", DataType::Int32, true),
-            Field::new("country", DataType::Int32, true),
-        ]));
-        let different_types = AgateTable::from_record_batch(Arc::new(
-            RecordBatch::try_new(
-                different_types_schema,
-                vec![
-                    Arc::new(Int32Array::from(vec![Some(1)])) as ArrayRef,
-                    Arc::new(Int32Array::from(vec![Some(0)])) as ArrayRef,
-                ],
-            )
-            .unwrap(),
-        ));
-
-        let out = render_globals(
-            vec![
-                ("a", left.into_value()),
-                ("values", different_values.into_value()),
-                ("names", different_names.into_value()),
-                ("types", different_types.into_value()),
-            ],
-            "{{ a == values }} {{ a == names }} {{ a == types }}",
-        );
-        assert_eq!(out, "False False False");
-    }
-
-    #[test]
-    fn table_eq_non_table_rhs_is_false() {
-        let table = AgateTable::from_record_batch(simple_record_batch());
-        let out = render_globals(vec![("a", table.into_value())], "{{ a == 1 }} {{ a != 1 }}");
-        assert_eq!(out, "False True");
-    }
-
-    #[test]
-    fn table_eq_empty_tables_with_same_schema_are_equal() {
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("id", DataType::Int32, true),
-            Field::new("country", DataType::Utf8, true),
-        ]));
-        let empty = || {
-            AgateTable::from_record_batch(Arc::new(
-                RecordBatch::try_new(
-                    Arc::clone(&schema),
-                    vec![
-                        Arc::new(Int32Array::from(Vec::<Option<i32>>::new())) as ArrayRef,
-                        Arc::new(StringArray::from(Vec::<Option<&str>>::new())) as ArrayRef,
-                    ],
-                )
-                .unwrap(),
-            ))
-        };
-        let nonempty = table_from_ids_and_countries(vec![Some(1)], vec![Some("Brazil")]);
-        let out = render_globals(
-            vec![
-                ("a", empty().into_value()),
-                ("b", empty().into_value()),
-                ("c", nonempty.into_value()),
-            ],
-            "{{ a == b }} {{ a == c }}",
-        );
-        assert_eq!(out, "True False");
-    }
-
-    fn empty_id_text_table(text_column: &str) -> AgateTable {
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("id", DataType::Int32, true),
-            Field::new(text_column, DataType::Utf8, true),
-        ]));
-        AgateTable::from_record_batch(Arc::new(
-            RecordBatch::try_new(
-                schema,
-                vec![
-                    Arc::new(Int32Array::from(Vec::<Option<i32>>::new())) as ArrayRef,
-                    Arc::new(StringArray::from(Vec::<Option<&str>>::new())) as ArrayRef,
-                ],
-            )
-            .unwrap(),
-        ))
-    }
-
-    #[test]
-    fn table_eq_nested_empty_tables_with_different_names_are_unequal() {
-        let a = empty_id_text_table("country");
-        let b = empty_id_text_table("nation");
-        let out = render_globals(
-            vec![("a", a.into_value()), ("b", b.into_value())],
-            "{{ [a] == [b] }} {{ a in [b] }}",
-        );
-        assert_eq!(out, "False False");
     }
 }

--- a/crates/dbt-agate/src/table.rs
+++ b/crates/dbt-agate/src/table.rs
@@ -18,7 +18,7 @@ use arrow_array::{Array, StringViewArray, UInt64Array};
 use arrow_schema::{ArrowError, Schema};
 use minijinja::arg_utils::ArgsIter;
 use minijinja::listener::RenderingEventListener;
-use minijinja::value::{Enumerator, Kwargs, Object, ValueMap, mutable_map::MutableMap};
+use minijinja::value::{DynObject, Enumerator, Kwargs, Object, ValueMap, mutable_map::MutableMap};
 use minijinja::{Error, ErrorKind, State, Value};
 use std::cmp::Ordering;
 use std::collections::HashSet;
@@ -412,6 +412,41 @@ impl TableRepr {
             },
         )
     }
+
+    /// Cell-wise comparison: names, agate types, and converter-backed values.
+    ///
+    /// Physical Arrow identity is intentionally ignored (Utf8 vs Utf8View).
+    /// After a successful table downcast, [`Object::custom_cmp`] must return
+    /// `Some` so MiniJinja does not fall through to default Map equality.
+    fn semantic_cmp(&self, other: &Self) -> Ordering {
+        if std::ptr::eq(self, other) {
+            return Ordering::Equal;
+        }
+        self.num_rows()
+            .cmp(&other.num_rows())
+            .then_with(|| self.num_columns().cmp(&other.num_columns()))
+            .then_with(|| self.column_names().cmp(other.column_names()))
+            .then_with(|| {
+                self.column_types()
+                    .iter()
+                    .map(|t| t.type_name())
+                    .cmp(other.column_types().iter().map(|t| t.type_name()))
+            })
+            .then_with(|| {
+                for row_idx in 0..self.num_rows() {
+                    for col_idx in 0..self.num_columns() {
+                        match self
+                            .cell(row_idx as isize, col_idx as isize)
+                            .cmp(&other.cell(row_idx as isize, col_idx as isize))
+                        {
+                            Ordering::Equal => {}
+                            other => return other,
+                        }
+                    }
+                }
+                Ordering::Equal
+            })
+    }
 }
 
 /// The AgateTable object.
@@ -513,6 +548,24 @@ impl AgateTable {
     /// Get the internal representation of the table.
     pub fn cell(&self, row_idx: isize, col_idx: isize) -> Option<Value> {
         self.repr.cell(row_idx, col_idx)
+    }
+
+    fn semantic_cmp(&self, other: &Self) -> Ordering {
+        if Arc::ptr_eq(&self.repr, &other.repr) {
+            Ordering::Equal
+        } else {
+            self.repr.semantic_cmp(&other.repr)
+        }
+    }
+
+    fn semantic_eq(&self, other: &Self) -> bool {
+        self.semantic_cmp(other) == Ordering::Equal
+    }
+
+    fn eq_value(&self, other: &Value) -> bool {
+        other
+            .downcast_object_ref::<AgateTable>()
+            .is_some_and(|other| self.semantic_eq(other))
     }
 
     // Columns ----------------------------------------------------------------
@@ -1032,6 +1085,12 @@ impl Object for AgateTable {
         Enumerator::Seq(self.num_rows())
     }
 
+    fn custom_cmp(self: &Arc<Self>, other: &DynObject) -> Option<Ordering> {
+        other
+            .downcast_ref::<AgateTable>()
+            .map(|other| self.semantic_cmp(other))
+    }
+
     fn call_method(
         self: &Arc<Self>,
         _state: &State,
@@ -1388,6 +1447,18 @@ impl Object for AgateTable {
                 })?;
                 Ok(Value::from_object(result))
             }
+            "__eq__" => {
+                let iter = ArgsIter::for_unnamed_pos_args("Table.__eq__", 1, args);
+                let other = iter.next_arg::<&Value>()?;
+                iter.finish()?;
+                Ok(Value::from(self.eq_value(other)))
+            }
+            "__ne__" => {
+                let iter = ArgsIter::for_unnamed_pos_args("Table.__ne__", 1, args);
+                let other = iter.next_arg::<&Value>()?;
+                iter.finish()?;
+                Ok(Value::from(!self.eq_value(other)))
+            }
             other => unimplemented!("AgateTable::{}", other),
         }
     }
@@ -1406,13 +1477,14 @@ mod tests {
     use arrow::csv::reader::ReaderBuilder;
     use arrow::datatypes::{DataType, Field, Int32Type, Schema};
     use arrow::record_batch::RecordBatch;
-    use arrow_array::{Array, ListArray, RecordBatchOptions, UInt64Array};
+    use arrow_array::{Array, ListArray, RecordBatchOptions, StringViewArray, UInt64Array};
     use arrow_schema::Fields;
     use minijinja::Environment;
     use minijinja::value::Kwargs;
     use minijinja::value::ValueMap;
     use minijinja::value::mutable_map::MutableMap;
     use minijinja_contrib::testing::jinja_assert;
+    use std::collections::HashMap;
     use std::io;
     use std::sync::Arc;
 
@@ -2824,5 +2896,176 @@ mod tests {
                 .contains("Table.join: right_table must be a Table"),
             "{err}"
         );
+    }
+
+    fn render_globals(globals: Vec<(&str, Value)>, template: &str) -> String {
+        let mut env = Environment::new();
+        for (name, value) in globals {
+            env.add_global(name, value);
+        }
+        env.render_str(template, HashMap::<String, String>::new(), &[])
+            .expect("render should succeed without panic")
+    }
+
+    fn table_from_ids_and_countries(
+        ids: Vec<Option<i32>>,
+        countries: Vec<Option<&str>>,
+    ) -> AgateTable {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, true),
+            Field::new("country", DataType::Utf8, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(ids)) as ArrayRef,
+                Arc::new(StringArray::from(countries)) as ArrayRef,
+            ],
+        )
+        .unwrap();
+        AgateTable::from_record_batch(Arc::new(batch))
+    }
+
+    #[test]
+    fn table_eq_same_object_is_true() {
+        let table = AgateTable::from_record_batch(simple_record_batch());
+        let out = render_globals(vec![("a", table.into_value())], "{{ a == a }}");
+        assert_eq!(out, "True");
+    }
+
+    #[test]
+    fn table_eq_is_cell_wise_not_arrow_identity() {
+        let utf8 =
+            table_from_ids_and_countries(vec![Some(1), None], vec![Some("Brazil"), Some("USA")]);
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, true),
+            Field::new("country", DataType::Utf8View, true),
+        ]));
+        let utf8_view = AgateTable::from_record_batch(Arc::new(
+            RecordBatch::try_new(
+                schema,
+                vec![
+                    Arc::new(Int32Array::from(vec![Some(1), None])) as ArrayRef,
+                    Arc::new(StringViewArray::from(vec![Some("Brazil"), Some("USA")])) as ArrayRef,
+                ],
+            )
+            .unwrap(),
+        ));
+
+        let out = render_globals(
+            vec![("a", utf8.into_value()), ("b", utf8_view.into_value())],
+            "{{ a == b }} {{ a != b }}",
+        );
+        assert_eq!(out, "True False");
+    }
+
+    #[test]
+    fn table_eq_false_when_values_names_or_types_differ() {
+        let left = table_from_ids_and_countries(vec![Some(1)], vec![Some("Brazil")]);
+        let different_values = table_from_ids_and_countries(vec![Some(2)], vec![Some("Brazil")]);
+        let different_names_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, true),
+            Field::new("nation", DataType::Utf8, true),
+        ]));
+        let different_names = AgateTable::from_record_batch(Arc::new(
+            RecordBatch::try_new(
+                different_names_schema,
+                vec![
+                    Arc::new(Int32Array::from(vec![Some(1)])) as ArrayRef,
+                    Arc::new(StringArray::from(vec![Some("Brazil")])) as ArrayRef,
+                ],
+            )
+            .unwrap(),
+        ));
+        let different_types_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, true),
+            Field::new("country", DataType::Int32, true),
+        ]));
+        let different_types = AgateTable::from_record_batch(Arc::new(
+            RecordBatch::try_new(
+                different_types_schema,
+                vec![
+                    Arc::new(Int32Array::from(vec![Some(1)])) as ArrayRef,
+                    Arc::new(Int32Array::from(vec![Some(0)])) as ArrayRef,
+                ],
+            )
+            .unwrap(),
+        ));
+
+        let out = render_globals(
+            vec![
+                ("a", left.into_value()),
+                ("values", different_values.into_value()),
+                ("names", different_names.into_value()),
+                ("types", different_types.into_value()),
+            ],
+            "{{ a == values }} {{ a == names }} {{ a == types }}",
+        );
+        assert_eq!(out, "False False False");
+    }
+
+    #[test]
+    fn table_eq_non_table_rhs_is_false() {
+        let table = AgateTable::from_record_batch(simple_record_batch());
+        let out = render_globals(vec![("a", table.into_value())], "{{ a == 1 }} {{ a != 1 }}");
+        assert_eq!(out, "False True");
+    }
+
+    #[test]
+    fn table_eq_empty_tables_with_same_schema_are_equal() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, true),
+            Field::new("country", DataType::Utf8, true),
+        ]));
+        let empty = || {
+            AgateTable::from_record_batch(Arc::new(
+                RecordBatch::try_new(
+                    Arc::clone(&schema),
+                    vec![
+                        Arc::new(Int32Array::from(Vec::<Option<i32>>::new())) as ArrayRef,
+                        Arc::new(StringArray::from(Vec::<Option<&str>>::new())) as ArrayRef,
+                    ],
+                )
+                .unwrap(),
+            ))
+        };
+        let nonempty = table_from_ids_and_countries(vec![Some(1)], vec![Some("Brazil")]);
+        let out = render_globals(
+            vec![
+                ("a", empty().into_value()),
+                ("b", empty().into_value()),
+                ("c", nonempty.into_value()),
+            ],
+            "{{ a == b }} {{ a == c }}",
+        );
+        assert_eq!(out, "True False");
+    }
+
+    fn empty_id_text_table(text_column: &str) -> AgateTable {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, true),
+            Field::new(text_column, DataType::Utf8, true),
+        ]));
+        AgateTable::from_record_batch(Arc::new(
+            RecordBatch::try_new(
+                schema,
+                vec![
+                    Arc::new(Int32Array::from(Vec::<Option<i32>>::new())) as ArrayRef,
+                    Arc::new(StringArray::from(Vec::<Option<&str>>::new())) as ArrayRef,
+                ],
+            )
+            .unwrap(),
+        ))
+    }
+
+    #[test]
+    fn table_eq_nested_empty_tables_with_different_names_are_unequal() {
+        let a = empty_id_text_table("country");
+        let b = empty_id_text_table("nation");
+        let out = render_globals(
+            vec![("a", a.into_value()), ("b", b.into_value())],
+            "{{ [a] == [b] }} {{ a in [b] }}",
+        );
+        assert_eq!(out, "False False");
     }
 }

--- a/crates/dbt-agate/src/table_eq.rs
+++ b/crates/dbt-agate/src/table_eq.rs
@@ -2,7 +2,7 @@ use std::cmp::Ordering;
 
 use minijinja::arg_utils::ArgsIter;
 use minijinja::value::{DynObject, Value};
-use minijinja::{Error, ErrorKind};
+use minijinja::Error;
 
 use crate::AgateTable;
 
@@ -16,30 +16,45 @@ impl AgateTable {
         if std::ptr::eq(self, other) {
             return Ordering::Equal;
         }
+        self.cmp_shape(other)
+            .then_with(|| self.cmp_cells(other))
+    }
+
+    fn cmp_shape(&self, other: &Self) -> Ordering {
         self.num_rows()
             .cmp(&other.num_rows())
             .then_with(|| self.num_columns().cmp(&other.num_columns()))
             .then_with(|| self.column_names_iter().cmp(other.column_names_iter()))
-            .then_with(|| {
-                self.column_types()
-                    .iter()
-                    .map(|t| t.type_name())
-                    .cmp(other.column_types().iter().map(|t| t.type_name()))
-            })
-            .then_with(|| {
-                for row_idx in 0..self.num_rows() {
-                    for col_idx in 0..self.num_columns() {
-                        match self
-                            .cell(row_idx as isize, col_idx as isize)
-                            .cmp(&other.cell(row_idx as isize, col_idx as isize))
-                        {
-                            Ordering::Equal => {}
-                            other => return other,
-                        }
-                    }
-                }
-                Ordering::Equal
-            })
+            .then_with(|| self.cmp_column_types(other))
+    }
+
+    fn cmp_column_types(&self, other: &Self) -> Ordering {
+        self.column_types()
+            .iter()
+            .map(|t| t.type_name())
+            .cmp(other.column_types().iter().map(|t| t.type_name()))
+    }
+
+    fn cmp_cells(&self, other: &Self) -> Ordering {
+        for row_idx in 0..self.num_rows() {
+            let row_ord = self.cmp_row(other, row_idx);
+            if row_ord != Ordering::Equal {
+                return row_ord;
+            }
+        }
+        Ordering::Equal
+    }
+
+    fn cmp_row(&self, other: &Self, row_idx: usize) -> Ordering {
+        for col_idx in 0..self.num_columns() {
+            let cell_ord = self
+                .cell(row_idx as isize, col_idx as isize)
+                .cmp(&other.cell(row_idx as isize, col_idx as isize));
+            if cell_ord != Ordering::Equal {
+                return cell_ord;
+            }
+        }
+        Ordering::Equal
     }
 
     pub(crate) fn custom_cmp_object(&self, other: &DynObject) -> Option<Ordering> {
@@ -54,25 +69,21 @@ impl AgateTable {
             .is_some_and(|other| self.semantic_cmp(other) == Ordering::Equal)
     }
 
-    pub(crate) fn call_eq_ne(&self, name: &str, args: &[Value]) -> Result<Value, Error> {
-        let fn_name = match name {
-            "__eq__" => "Table.__eq__",
-            "__ne__" => "Table.__ne__",
-            other => {
-                return Err(Error::new(
-                    ErrorKind::UnknownMethod,
-                    format!("AgateTable::{other}"),
-                ));
-            }
-        };
+    pub(crate) fn call_unknown_method(&self, name: &str, args: &[Value]) -> Result<Value, Error> {
+        match name {
+            "__eq__" | "__ne__" => self.call_eq_ne(name, args),
+            other => unimplemented!("AgateTable::{other}"),
+        }
+    }
+
+    fn call_eq_ne(&self, name: &str, args: &[Value]) -> Result<Value, Error> {
+        let eq = name == "__eq__";
+        let fn_name = if eq { "Table.__eq__" } else { "Table.__ne__" };
         let iter = ArgsIter::for_unnamed_pos_args(fn_name, 1, args);
         let other = iter.next_arg::<&Value>()?;
         iter.finish()?;
-        Ok(Value::from(if name == "__eq__" {
-            self.eq_value(other)
-        } else {
-            !self.eq_value(other)
-        }))
+        let equal = self.eq_value(other);
+        Ok(Value::from(if eq { equal } else { !equal }))
     }
 }
 

--- a/crates/dbt-agate/src/table_eq.rs
+++ b/crates/dbt-agate/src/table_eq.rs
@@ -1,0 +1,263 @@
+use std::cmp::Ordering;
+
+use minijinja::arg_utils::ArgsIter;
+use minijinja::value::{DynObject, Value};
+use minijinja::{Error, ErrorKind};
+
+use crate::AgateTable;
+
+impl AgateTable {
+    /// Cell-wise comparison: names, agate types, and converter-backed values.
+    ///
+    /// Physical Arrow identity is intentionally ignored (Utf8 vs Utf8View).
+    /// After a successful table downcast, [`minijinja::value::Object::custom_cmp`]
+    /// must return `Some` so MiniJinja does not fall through to default Map equality.
+    pub(crate) fn semantic_cmp(&self, other: &Self) -> Ordering {
+        if std::ptr::eq(self, other) {
+            return Ordering::Equal;
+        }
+        self.num_rows()
+            .cmp(&other.num_rows())
+            .then_with(|| self.num_columns().cmp(&other.num_columns()))
+            .then_with(|| self.column_names_iter().cmp(other.column_names_iter()))
+            .then_with(|| {
+                self.column_types()
+                    .iter()
+                    .map(|t| t.type_name())
+                    .cmp(other.column_types().iter().map(|t| t.type_name()))
+            })
+            .then_with(|| {
+                for row_idx in 0..self.num_rows() {
+                    for col_idx in 0..self.num_columns() {
+                        match self
+                            .cell(row_idx as isize, col_idx as isize)
+                            .cmp(&other.cell(row_idx as isize, col_idx as isize))
+                        {
+                            Ordering::Equal => {}
+                            other => return other,
+                        }
+                    }
+                }
+                Ordering::Equal
+            })
+    }
+
+    pub(crate) fn custom_cmp_object(&self, other: &DynObject) -> Option<Ordering> {
+        other
+            .downcast_ref::<AgateTable>()
+            .map(|other| self.semantic_cmp(other))
+    }
+
+    fn eq_value(&self, other: &Value) -> bool {
+        other
+            .downcast_object_ref::<AgateTable>()
+            .is_some_and(|other| self.semantic_cmp(other) == Ordering::Equal)
+    }
+
+    pub(crate) fn call_eq_ne(&self, name: &str, args: &[Value]) -> Result<Value, Error> {
+        let fn_name = match name {
+            "__eq__" => "Table.__eq__",
+            "__ne__" => "Table.__ne__",
+            other => {
+                return Err(Error::new(
+                    ErrorKind::UnknownMethod,
+                    format!("AgateTable::{other}"),
+                ));
+            }
+        };
+        let iter = ArgsIter::for_unnamed_pos_args(fn_name, 1, args);
+        let other = iter.next_arg::<&Value>()?;
+        iter.finish()?;
+        Ok(Value::from(if name == "__eq__" {
+            self.eq_value(other)
+        } else {
+            !self.eq_value(other)
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{ArrayRef, Int32Array, StringArray};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::record_batch::RecordBatch;
+    use arrow_array::StringViewArray;
+    use minijinja::Environment;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn render_globals(globals: Vec<(&str, Value)>, template: &str) -> String {
+        let mut env = Environment::new();
+        for (name, value) in globals {
+            env.add_global(name, value);
+        }
+        env.render_str(template, HashMap::<String, String>::new(), &[])
+            .expect("render should succeed without panic")
+    }
+
+    fn table_from_ids_and_countries(
+        ids: Vec<Option<i32>>,
+        countries: Vec<Option<&str>>,
+    ) -> AgateTable {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, true),
+            Field::new("country", DataType::Utf8, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(ids)) as ArrayRef,
+                Arc::new(StringArray::from(countries)) as ArrayRef,
+            ],
+        )
+        .unwrap();
+        AgateTable::from_record_batch(Arc::new(batch))
+    }
+
+    #[test]
+    fn table_eq_same_object_is_true() {
+        let table = table_from_ids_and_countries(
+            vec![Some(42), Some(43), Some(44)],
+            vec![Some("Brazil"), Some("USA"), Some("Canada")],
+        );
+        let out = render_globals(vec![("a", table.into_value())], "{{ a == a }}");
+        assert_eq!(out, "True");
+    }
+
+    #[test]
+    fn table_eq_is_cell_wise_not_arrow_identity() {
+        let utf8 =
+            table_from_ids_and_countries(vec![Some(1), None], vec![Some("Brazil"), Some("USA")]);
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, true),
+            Field::new("country", DataType::Utf8View, true),
+        ]));
+        let utf8_view = AgateTable::from_record_batch(Arc::new(
+            RecordBatch::try_new(
+                schema,
+                vec![
+                    Arc::new(Int32Array::from(vec![Some(1), None])) as ArrayRef,
+                    Arc::new(StringViewArray::from(vec![Some("Brazil"), Some("USA")])) as ArrayRef,
+                ],
+            )
+            .unwrap(),
+        ));
+
+        let out = render_globals(
+            vec![("a", utf8.into_value()), ("b", utf8_view.into_value())],
+            "{{ a == b }} {{ a != b }}",
+        );
+        assert_eq!(out, "True False");
+    }
+
+    #[test]
+    fn table_eq_false_when_values_names_or_types_differ() {
+        let left = table_from_ids_and_countries(vec![Some(1)], vec![Some("Brazil")]);
+        let different_values = table_from_ids_and_countries(vec![Some(2)], vec![Some("Brazil")]);
+        let different_names_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, true),
+            Field::new("nation", DataType::Utf8, true),
+        ]));
+        let different_names = AgateTable::from_record_batch(Arc::new(
+            RecordBatch::try_new(
+                different_names_schema,
+                vec![
+                    Arc::new(Int32Array::from(vec![Some(1)])) as ArrayRef,
+                    Arc::new(StringArray::from(vec![Some("Brazil")])) as ArrayRef,
+                ],
+            )
+            .unwrap(),
+        ));
+        let different_types_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, true),
+            Field::new("country", DataType::Int32, true),
+        ]));
+        let different_types = AgateTable::from_record_batch(Arc::new(
+            RecordBatch::try_new(
+                different_types_schema,
+                vec![
+                    Arc::new(Int32Array::from(vec![Some(1)])) as ArrayRef,
+                    Arc::new(Int32Array::from(vec![Some(0)])) as ArrayRef,
+                ],
+            )
+            .unwrap(),
+        ));
+
+        let out = render_globals(
+            vec![
+                ("a", left.into_value()),
+                ("values", different_values.into_value()),
+                ("names", different_names.into_value()),
+                ("types", different_types.into_value()),
+            ],
+            "{{ a == values }} {{ a == names }} {{ a == types }}",
+        );
+        assert_eq!(out, "False False False");
+    }
+
+    #[test]
+    fn table_eq_non_table_rhs_is_false() {
+        let table = table_from_ids_and_countries(vec![Some(1)], vec![Some("Brazil")]);
+        let out = render_globals(vec![("a", table.into_value())], "{{ a == 1 }} {{ a != 1 }}");
+        assert_eq!(out, "False True");
+    }
+
+    #[test]
+    fn table_eq_empty_tables_with_same_schema_are_equal() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, true),
+            Field::new("country", DataType::Utf8, true),
+        ]));
+        let empty = || {
+            AgateTable::from_record_batch(Arc::new(
+                RecordBatch::try_new(
+                    Arc::clone(&schema),
+                    vec![
+                        Arc::new(Int32Array::from(Vec::<Option<i32>>::new())) as ArrayRef,
+                        Arc::new(StringArray::from(Vec::<Option<&str>>::new())) as ArrayRef,
+                    ],
+                )
+                .unwrap(),
+            ))
+        };
+        let nonempty = table_from_ids_and_countries(vec![Some(1)], vec![Some("Brazil")]);
+        let out = render_globals(
+            vec![
+                ("a", empty().into_value()),
+                ("b", empty().into_value()),
+                ("c", nonempty.into_value()),
+            ],
+            "{{ a == b }} {{ a == c }}",
+        );
+        assert_eq!(out, "True False");
+    }
+
+    fn empty_id_text_table(text_column: &str) -> AgateTable {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, true),
+            Field::new(text_column, DataType::Utf8, true),
+        ]));
+        AgateTable::from_record_batch(Arc::new(
+            RecordBatch::try_new(
+                schema,
+                vec![
+                    Arc::new(Int32Array::from(Vec::<Option<i32>>::new())) as ArrayRef,
+                    Arc::new(StringArray::from(Vec::<Option<&str>>::new())) as ArrayRef,
+                ],
+            )
+            .unwrap(),
+        ))
+    }
+
+    #[test]
+    fn table_eq_nested_empty_tables_with_different_names_are_unequal() {
+        let a = empty_id_text_table("country");
+        let b = empty_id_text_table("nation");
+        let out = render_globals(
+            vec![("a", a.into_value()), ("b", b.into_value())],
+            "{{ [a] == [b] }} {{ a in [b] }}",
+        );
+        assert_eq!(out, "False False");
+    }
+}


### PR DESCRIPTION
Resolves #15920

### Problem

Jinja `run_query(a) == run_query(b)` process-aborts. MiniJinja always looks up `__eq__` on the left operand; `AgateTable::call_method` had no arm and hit `unimplemented!("AgateTable::__eq__")`.

On dbt 1.x the same snippet compiles to `select False as same_or_not` because `agate.Table` uses identity. The reporter's expected behavior is "no panic."

### Solution

Implement cell-wise `__eq__` / `__ne__` and `Object::custom_cmp`: column names, agate types, and converter-backed cell Values — not Arrow `RecordBatch` identity (Utf8 vs Utf8View). Two `run_query` results with the same data now compare `True`, which diverges from 1.x identity-`False` but matches the semantic-comparison TODO in `dbt-tasks-sa`. Non-table RHS is `False`. `custom_cmp` returns a total order after a successful table downcast so nested `[a] == [b]` does not fall through to empty-map equality.

The unimplemented catch-all is unchanged. `print_table` is untouched (#15598).

AgateTable `==` is a cell-wise converter walk (`cell()` → `Value`), O(rows×cols) with per-cell MiniJinja allocations rather than Arrow RecordBatch identity; MiniJinja evaluates Value PartialEq (`custom_cmp`) before `__eq__`, so a true comparison of two distinct tables does that walk twice.

### Checklist

- [x] I have read the contributing guide and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.

## How to test

```
cargo nextest run -p dbt-agate --features minijinja-contrib/testing
```

Isolated `-p dbt-agate` needs `minijinja-contrib/testing` so `jinja_assert` compiles; workspace nextest gets that feature via `dbt-adapter`'s dev-dep.
