### PR TITLE
feat(databricks): accept Python model environment_key on serverless submit

### DIFF
--- a/.changes/unreleased/Features-20260816-173807.yaml
+++ b/.changes/unreleased/Features-20260816-173807.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Fusion accepts Databricks Python environment_key and environment_dependencies and uses them on serverless job submit (https://github.com/databricks/dbt-databricks/issues/1636).
+time: 2026-08-16T17:38:07.085838+05:30
+custom:
+    author: sd-db
+    issue: "15966"
+    project: dbt-core

--- a/crates/dbt-adapter/src/python/databricks/api_client.rs
+++ b/crates/dbt-adapter/src/python/databricks/api_client.rs
@@ -96,16 +96,14 @@ impl DatabricksApiClient {
         run_name: &str,
         job_spec: &serde_json::Value,
         timeout_seconds: u64,
+        additional_job_config: &serde_json::Value,
     ) -> AdapterResult<String> {
-        let capped_timeout = timeout_seconds.min(i64::MAX as u64);
-        let payload = json!({
-            "run_name": run_name,
-            "timeout_seconds": capped_timeout as i64,
-            "tasks": [job_spec.clone()],
-            "queue": {
-                "enabled": true
-            }
-        });
+        let payload = super::build_job_run_payload(
+            run_name,
+            job_spec.clone(),
+            timeout_seconds,
+            additional_job_config.clone(),
+        );
 
         let response: SubmitRunResponse = self.post_json("/api/2.1/jobs/runs/submit", payload)?;
         Ok(response.run_id.to_string())

--- a/crates/dbt-adapter/src/python/databricks/mod.rs
+++ b/crates/dbt-adapter/src/python/databricks/mod.rs
@@ -390,6 +390,7 @@ fn submit_via_notebook(
         &notebook_path,
         task_settings,
         timeout,
+        &extract_python_environment_spec(config),
     )?;
 
     poll_job_completion(&api_client, &run_id, timeout)?;
@@ -518,6 +519,119 @@ fn extract_timeout(config: &Value) -> u64 {
     }
 }
 
+#[derive(Debug, Clone, Default)]
+struct PythonEnvironmentSpec {
+    environment_key: Option<String>,
+    environment_dependencies: Vec<String>,
+    user_environments: Option<serde_json::Value>,
+}
+
+fn extract_python_environment_spec(config: &Value) -> PythonEnvironmentSpec {
+    let environment_key = config
+        .get_attr("environment_key")
+        .ok()
+        .and_then(|v| v.as_str().map(String::from))
+        .filter(|s| !s.is_empty());
+
+    let environment_dependencies = config
+        .get_attr("environment_dependencies")
+        .ok()
+        .and_then(|v| v.try_iter().ok())
+        .map(|iter| {
+            iter.filter_map(|item| item.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let user_environments = config
+        .get_attr("python_job_config")
+        .ok()
+        .and_then(|pjc| pjc.get_attr("environments").ok())
+        .and_then(|envs| {
+            if envs.is_undefined() || envs.is_none() {
+                None
+            } else {
+                serde_json::to_value(&envs)
+                    .ok()
+                    .filter(|value| !value.is_null())
+            }
+        });
+
+    PythonEnvironmentSpec {
+        environment_key,
+        environment_dependencies,
+        user_environments,
+    }
+}
+
+fn additional_job_config_for_environment(spec: &PythonEnvironmentSpec) -> serde_json::Value {
+    if let Some(user_environments) = &spec.user_environments {
+        return json!({ "environments": user_environments });
+    }
+    if let Some(environment_key) = &spec.environment_key
+        && !spec.environment_dependencies.is_empty()
+    {
+        return json!({
+            "environments": [{
+                "environment_key": environment_key,
+                "spec": {
+                    "environment_version": "4",
+                    "dependencies": spec.environment_dependencies,
+                }
+            }]
+        });
+    }
+    json!({})
+}
+
+fn build_notebook_task(
+    notebook_path: &str,
+    task_settings: serde_json::Value,
+    environment_key: Option<&str>,
+) -> serde_json::Value {
+    let mut task = json!({
+        "task_key": "inner_notebook",
+        "notebook_task": {
+            "notebook_path": notebook_path,
+            "source": "WORKSPACE"
+        }
+    });
+    if let Some(environment_key) = environment_key {
+        task["environment_key"] = json!(environment_key);
+    }
+    if let serde_json::Value::Object(settings_map) = task_settings
+        && let serde_json::Value::Object(ref mut task_map) = task
+    {
+        task_map.extend(settings_map);
+    }
+    task
+}
+
+pub(crate) fn build_job_run_payload(
+    run_name: &str,
+    task: serde_json::Value,
+    timeout_seconds: u64,
+    additional_job_config: serde_json::Value,
+) -> serde_json::Value {
+    let capped_timeout = timeout_seconds.min(i64::MAX as u64);
+    let mut payload = json!({
+        "run_name": run_name,
+        "timeout_seconds": capped_timeout as i64,
+        "tasks": [task],
+        "queue": {
+            "enabled": true
+        }
+    });
+    if let serde_json::Value::Object(extra) = additional_job_config
+        && let serde_json::Value::Object(ref mut map) = payload
+    {
+        for (key, value) in extra {
+            map.insert(key, value);
+        }
+    }
+    payload
+}
+
 fn build_libraries(
     packages: &[String],
     index_url: Option<&str>,
@@ -553,22 +667,11 @@ fn submit_notebook_job(
     notebook_path: &str,
     task_settings: serde_json::Value,
     timeout_seconds: u64,
+    env: &PythonEnvironmentSpec,
 ) -> AdapterResult<String> {
-    let mut task = json!({
-        "task_key": "inner_notebook",
-        "notebook_task": {
-            "notebook_path": notebook_path,
-            "source": "WORKSPACE"
-        }
-    });
-
-    if let serde_json::Value::Object(settings_map) = task_settings
-        && let serde_json::Value::Object(ref mut task_map) = task
-    {
-        task_map.extend(settings_map);
-    }
-
-    api_client.submit_job_run(run_name, &task, timeout_seconds)
+    let task = build_notebook_task(notebook_path, task_settings, env.environment_key.as_deref());
+    let additional_job_config = additional_job_config_for_environment(env);
+    api_client.submit_job_run(run_name, &task, timeout_seconds, &additional_job_config)
 }
 
 fn poll_job_completion(
@@ -759,4 +862,77 @@ fn create_or_update_workflow(
     }
 
     api_client.create_workflow(workflow_spec)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn payload_for(spec: PythonEnvironmentSpec) -> serde_json::Value {
+        let task = build_notebook_task(
+            "/Workspace/model",
+            json!({}),
+            spec.environment_key.as_deref(),
+        );
+        let additional = additional_job_config_for_environment(&spec);
+        build_job_run_payload("run-name", task, 0, additional)
+    }
+
+    #[test]
+    fn environment_key_only_sets_task_key_without_environments() {
+        let payload = payload_for(PythonEnvironmentSpec {
+            environment_key: Some("test_key".to_string()),
+            ..Default::default()
+        });
+        assert_eq!(payload["tasks"][0]["environment_key"], json!("test_key"));
+        assert!(payload.get("environments").is_none());
+    }
+
+    #[test]
+    fn environment_key_and_deps_auto_build_environments() {
+        let payload = payload_for(PythonEnvironmentSpec {
+            environment_key: Some("test_key".to_string()),
+            environment_dependencies: vec!["requests".to_string()],
+            user_environments: None,
+        });
+        assert_eq!(payload["tasks"][0]["environment_key"], json!("test_key"));
+        assert_eq!(
+            payload["environments"],
+            json!([{
+                "environment_key": "test_key",
+                "spec": {
+                    "environment_version": "4",
+                    "dependencies": ["requests"]
+                }
+            }])
+        );
+    }
+
+    #[test]
+    fn user_python_job_config_environments_are_not_overwritten() {
+        let user_environments = json!([{
+            "environment_key": "custom_env",
+            "spec": {
+                "environment_version": "3",
+                "dependencies": ["pandas"]
+            }
+        }]);
+        let payload = payload_for(PythonEnvironmentSpec {
+            environment_key: Some("custom_env".to_string()),
+            environment_dependencies: vec!["requests".to_string()],
+            user_environments: Some(user_environments.clone()),
+        });
+        assert_eq!(payload["tasks"][0]["environment_key"], json!("custom_env"));
+        assert_eq!(payload["environments"], user_environments);
+    }
+
+    #[test]
+    fn missing_environment_key_leaves_payload_unchanged() {
+        let payload = payload_for(PythonEnvironmentSpec::default());
+        assert!(payload["tasks"][0].get("environment_key").is_none());
+        assert!(payload.get("environments").is_none());
+        assert_eq!(payload["run_name"], json!("run-name"));
+        assert_eq!(payload["queue"], json!({ "enabled": true }));
+    }
 }

--- a/crates/dbt-adapter/src/python/databricks/mod.rs
+++ b/crates/dbt-adapter/src/python/databricks/mod.rs
@@ -519,7 +519,7 @@ fn extract_timeout(config: &Value) -> u64 {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default)]
 struct PythonEnvironmentSpec {
     environment_key: Option<String>,
     environment_dependencies: Vec<String>,
@@ -547,15 +547,9 @@ fn extract_python_environment_spec(config: &Value) -> PythonEnvironmentSpec {
         .get_attr("python_job_config")
         .ok()
         .and_then(|pjc| pjc.get_attr("environments").ok())
-        .and_then(|envs| {
-            if envs.is_undefined() || envs.is_none() {
-                None
-            } else {
-                serde_json::to_value(&envs)
-                    .ok()
-                    .filter(|value| !value.is_null())
-            }
-        });
+        .filter(|envs| !envs.is_undefined() && !envs.is_none())
+        .and_then(|envs| serde_json::to_value(&envs).ok())
+        .filter(user_environments_are_set);
 
     PythonEnvironmentSpec {
         environment_key,
@@ -564,8 +558,24 @@ fn extract_python_environment_spec(config: &Value) -> PythonEnvironmentSpec {
     }
 }
 
+fn user_environments_are_set(value: &serde_json::Value) -> bool {
+    // v1 uses `not python_job_config.environments`, so [] is missing.
+    match value {
+        serde_json::Value::Null => false,
+        serde_json::Value::Array(items) => !items.is_empty(),
+        serde_json::Value::Object(map) => !map.is_empty(),
+        serde_json::Value::String(s) => !s.is_empty(),
+        serde_json::Value::Bool(flag) => *flag,
+        serde_json::Value::Number(number) => number.as_f64().is_some_and(|n| n != 0.0),
+    }
+}
+
 fn additional_job_config_for_environment(spec: &PythonEnvironmentSpec) -> serde_json::Value {
-    if let Some(user_environments) = &spec.user_environments {
+    if let Some(user_environments) = spec
+        .user_environments
+        .as_ref()
+        .filter(|value| user_environments_are_set(value))
+    {
         return json!({ "environments": user_environments });
     }
     if let Some(environment_key) = &spec.environment_key
@@ -625,9 +635,7 @@ pub(crate) fn build_job_run_payload(
     if let serde_json::Value::Object(extra) = additional_job_config
         && let serde_json::Value::Object(ref mut map) = payload
     {
-        for (key, value) in extra {
-            map.insert(key, value);
-        }
+        map.extend(extra);
     }
     payload
 }
@@ -667,10 +675,14 @@ fn submit_notebook_job(
     notebook_path: &str,
     task_settings: serde_json::Value,
     timeout_seconds: u64,
-    env: &PythonEnvironmentSpec,
+    environment: &PythonEnvironmentSpec,
 ) -> AdapterResult<String> {
-    let task = build_notebook_task(notebook_path, task_settings, env.environment_key.as_deref());
-    let additional_job_config = additional_job_config_for_environment(env);
+    let task = build_notebook_task(
+        notebook_path,
+        task_settings,
+        environment.environment_key.as_deref(),
+    );
+    let additional_job_config = additional_job_config_for_environment(environment);
     api_client.submit_job_run(run_name, &task, timeout_seconds, &additional_job_config)
 }
 
@@ -925,6 +937,26 @@ mod tests {
         });
         assert_eq!(payload["tasks"][0]["environment_key"], json!("custom_env"));
         assert_eq!(payload["environments"], user_environments);
+    }
+
+    #[test]
+    fn empty_user_environments_still_auto_build() {
+        let payload = payload_for(PythonEnvironmentSpec {
+            environment_key: Some("test_key".to_string()),
+            environment_dependencies: vec!["requests".to_string()],
+            user_environments: Some(json!([])),
+        });
+        assert_eq!(payload["tasks"][0]["environment_key"], json!("test_key"));
+        assert_eq!(
+            payload["environments"],
+            json!([{
+                "environment_key": "test_key",
+                "spec": {
+                    "environment_version": "4",
+                    "dependencies": ["requests"]
+                }
+            }])
+        );
     }
 
     #[test]

--- a/crates/dbt-adapter/src/python/databricks/mod.rs
+++ b/crates/dbt-adapter/src/python/databricks/mod.rs
@@ -108,7 +108,7 @@ fn submit_all_purpose_cluster(
 
     if create_notebook {
         // Extract library configuration (packages, index_url, additional_libs)
-        let packages = extract_packages(config);
+        let packages = extract_string_list(config, "packages");
         let index_url = config
             .get_attr("index_url")
             .ok()
@@ -254,7 +254,7 @@ fn submit_job_cluster(
 
     validate_job_cluster_config(&job_cluster_config)?;
 
-    let packages = extract_packages(config);
+    let packages = extract_string_list(config, "packages");
     let index_url = config
         .get_attr("index_url")
         .ok()
@@ -485,14 +485,14 @@ fn validate_job_cluster_config(config: &Value) -> AdapterResult<()> {
     Ok(())
 }
 
-fn extract_packages(config: &Value) -> Vec<String> {
+fn extract_string_list(config: &Value, attr: &str) -> Vec<String> {
     config
-        .get_attr("packages")
+        .get_attr(attr)
         .ok()
         .and_then(|v| v.try_iter().ok())
         .map(|iter| {
-            iter.filter_map(|v| v.as_str().map(String::from))
-                .collect::<Vec<_>>()
+            iter.filter_map(|item| item.as_str().map(String::from))
+                .collect()
         })
         .unwrap_or_default()
 }
@@ -533,23 +533,24 @@ fn extract_python_environment_spec(config: &Value) -> PythonEnvironmentSpec {
         .and_then(|v| v.as_str().map(String::from))
         .filter(|s| !s.is_empty());
 
-    let environment_dependencies = config
-        .get_attr("environment_dependencies")
-        .ok()
-        .and_then(|v| v.try_iter().ok())
-        .map(|iter| {
-            iter.filter_map(|item| item.as_str().map(String::from))
-                .collect()
-        })
-        .unwrap_or_default();
+    let environment_dependencies = extract_string_list(config, "environment_dependencies");
 
+    // Empty `python_job_config.environments` is unset (`not environments` in v1).
+    // https://github.com/databricks/dbt-databricks/blob/955743ab67543ef1fad3c4f7c13cc8b4a0ab8c06/dbt/adapters/databricks/python_models/python_submissions.py#L362
     let user_environments = config
         .get_attr("python_job_config")
         .ok()
         .and_then(|pjc| pjc.get_attr("environments").ok())
         .filter(|envs| !envs.is_undefined() && !envs.is_none())
         .and_then(|envs| serde_json::to_value(&envs).ok())
-        .filter(user_environments_are_set);
+        .and_then(|value| match &value {
+            serde_json::Value::Array(items) if !items.is_empty() => Some(value),
+            serde_json::Value::Object(map) if !map.is_empty() => Some(value),
+            serde_json::Value::String(s) if !s.is_empty() => Some(value),
+            serde_json::Value::Bool(true) => Some(value),
+            serde_json::Value::Number(n) if n.as_f64().is_some_and(|n| n != 0.0) => Some(value),
+            _ => None,
+        });
 
     PythonEnvironmentSpec {
         environment_key,
@@ -558,30 +559,14 @@ fn extract_python_environment_spec(config: &Value) -> PythonEnvironmentSpec {
     }
 }
 
-fn user_environments_are_set(value: &serde_json::Value) -> bool {
-    // v1 uses `not python_job_config.environments`, so [] is missing.
-    match value {
-        serde_json::Value::Null => false,
-        serde_json::Value::Array(items) => !items.is_empty(),
-        serde_json::Value::Object(map) => !map.is_empty(),
-        serde_json::Value::String(s) => !s.is_empty(),
-        serde_json::Value::Bool(flag) => *flag,
-        serde_json::Value::Number(number) => number.as_f64().is_some_and(|n| n != 0.0),
-    }
-}
-
 fn additional_job_config_for_environment(spec: &PythonEnvironmentSpec) -> serde_json::Value {
-    if let Some(user_environments) = spec
-        .user_environments
-        .as_ref()
-        .filter(|value| user_environments_are_set(value))
-    {
-        return json!({ "environments": user_environments });
-    }
-    if let Some(environment_key) = &spec.environment_key
-        && !spec.environment_dependencies.is_empty()
-    {
-        return json!({
+    let user_environments = match spec.user_environments.as_ref() {
+        Some(serde_json::Value::Array(items)) if items.is_empty() => None,
+        other => other,
+    };
+    match (user_environments, spec.environment_key.as_deref()) {
+        (Some(user_environments), _) => json!({ "environments": user_environments }),
+        (None, Some(environment_key)) if !spec.environment_dependencies.is_empty() => json!({
             "environments": [{
                 "environment_key": environment_key,
                 "spec": {
@@ -589,9 +574,9 @@ fn additional_job_config_for_environment(spec: &PythonEnvironmentSpec) -> serde_
                     "dependencies": spec.environment_dependencies,
                 }
             }]
-        });
+        }),
+        _ => json!({}),
     }
-    json!({})
 }
 
 fn build_notebook_task(
@@ -792,20 +777,8 @@ fn build_workflow_spec(
         })
         .unwrap_or_default();
 
-    let mut notebook_task = json!({
-        "task_key": "inner_notebook",
-        "notebook_task": {
-            "notebook_path": notebook_path,
-            "source": "WORKSPACE"
-        }
-    });
-
-    // notebook_task is always an Object since we just created it with json!({...})
+    let mut notebook_task = build_notebook_task(notebook_path, task_settings, None);
     let task_map = notebook_task.as_object_mut().unwrap();
-
-    if let serde_json::Value::Object(settings_map) = task_settings {
-        task_map.extend(settings_map);
-    }
 
     if let Ok(additional_settings) = python_job_config.get_attr("additional_task_settings") {
         let additional_json =

--- a/crates/dbt-parser/src/tests.rs
+++ b/crates/dbt-parser/src/tests.rs
@@ -1509,4 +1509,95 @@ mod tests {
             vec!["cloud_plan".to_string(), "database_source".to_string()]
         );
     }
+
+    #[test]
+    fn test_databricks_python_environment_config_keys_are_recognized() {
+        let yaml = r#"
+        +environment_key: test_key
+        +environment_dependencies:
+          - requests
+        +submission_method: serverless_cluster
+        "#;
+
+        let val: dbt_yaml::Value = dbt_yaml::from_str(yaml).unwrap();
+        let (env, _sql_resources, _init_cfg) = setup_test_env();
+        let ctx: BTreeMap<String, Value> = BTreeMap::new();
+        let listeners: Vec<Rc<dyn minijinja::listener::RenderingEventListener>> = Vec::new();
+
+        let cfg: ProjectModelConfig = dbt_jinja_utils::serde::into_typed_with_jinja(
+            val, false, &env, &ctx, &listeners, None, true,
+        )
+        .unwrap();
+
+        assert_eq!(cfg.environment_key.as_deref(), Some("test_key"));
+        assert_eq!(
+            cfg.environment_dependencies.as_deref(),
+            Some(["requests".to_string()].as_slice())
+        );
+        assert_eq!(cfg.submission_method.as_deref(), Some("serverless_cluster"));
+    }
+
+    #[test]
+    fn test_databricks_python_environment_config_keys_on_model_config() {
+        let yaml = r#"
+        environment_key: test_key
+        environment_dependencies:
+          - requests
+        submission_method: serverless_cluster
+        "#;
+
+        let val: dbt_yaml::Value = dbt_yaml::from_str(yaml).unwrap();
+        let (env, _sql_resources, _init_cfg) = setup_test_env();
+        let ctx: BTreeMap<String, Value> = BTreeMap::new();
+        let listeners: Vec<Rc<dyn minijinja::listener::RenderingEventListener>> = Vec::new();
+
+        let cfg: ModelConfig = dbt_jinja_utils::serde::into_typed_with_jinja(
+            val, false, &env, &ctx, &listeners, None, true,
+        )
+        .unwrap();
+
+        assert_eq!(cfg.environment_key.as_deref(), Some("test_key"));
+        assert_eq!(
+            cfg.environment_dependencies.as_deref(),
+            Some(["requests".to_string()].as_slice())
+        );
+        assert_eq!(cfg.submission_method.as_deref(), Some("serverless_cluster"));
+    }
+
+    #[test]
+    fn test_unknown_python_config_key_is_still_unused() {
+        // schema.yml config keys (no `+` prefix). ProjectModelConfig absorbs
+        // unknown `+` keys as nested folder configs via __additional_properties__.
+        let yaml = r#"
+        environment_key: test_key
+        not_a_real_python_config: true
+        "#;
+
+        let val: dbt_yaml::Value = dbt_yaml::from_str(yaml).unwrap();
+        let mut unused_keys = Vec::new();
+        let cfg: ModelConfig = val
+            .into_typed(
+                |path, key, _| {
+                    let key_repr =
+                        dbt_yaml::to_string(key).unwrap_or_else(|_| "<opaque>".to_string());
+                    unused_keys.push((path.to_string(), key_repr));
+                },
+                |_| Ok(None),
+            )
+            .unwrap();
+
+        assert_eq!(cfg.environment_key.as_deref(), Some("test_key"));
+        assert!(
+            unused_keys
+                .iter()
+                .any(|(_, key)| key.contains("not_a_real_python_config")),
+            "expected unused key warning, got {unused_keys:?}"
+        );
+        assert!(
+            unused_keys
+                .iter()
+                .all(|(_, key)| !key.contains("environment_key")),
+            "environment_key should not be reported unused, got {unused_keys:?}"
+        );
+    }
 }

--- a/crates/dbt-schemas/src/schemas/manifest/manifest_nodes.rs
+++ b/crates/dbt-schemas/src/schemas/manifest/manifest_nodes.rs
@@ -975,6 +975,10 @@ pub struct ManifestModelConfig {
     pub additional_libs: Option<Vec<YmlValue>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user_folder_for_python: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub environment_key: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub environment_dependencies: Option<Vec<String>>,
     /// Schema synchronization configuration
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sync: Option<SyncConfig>,
@@ -1186,6 +1190,8 @@ impl From<ModelConfig> for ManifestModelConfig {
             index_url: config.index_url.clone(),
             additional_libs: config.additional_libs.clone(),
             user_folder_for_python: config.user_folder_for_python,
+            environment_key: config.environment_key.clone(),
+            environment_dependencies: config.environment_dependencies.clone(),
             sync: config.sync,
             __warehouse_specific_config__: config.__warehouse_specific_config__,
         }
@@ -1265,6 +1271,8 @@ impl From<ManifestModelConfig> for ModelConfig {
             index_url: config.index_url.clone(),
             additional_libs: config.additional_libs.clone(),
             user_folder_for_python: config.user_folder_for_python,
+            environment_key: config.environment_key.clone(),
+            environment_dependencies: config.environment_dependencies.clone(),
             sync: config.sync,
             __warehouse_specific_config__: config.__warehouse_specific_config__,
             // config_keys_used and config_keys_defaults are not in ManifestModelConfig

--- a/crates/dbt-schemas/src/schemas/project/configs/model_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/model_config.rs
@@ -177,6 +177,10 @@ pub struct ProjectModelConfig {
         deserialize_with = "bool_or_string_bool"
     )]
     pub user_folder_for_python: Option<bool>,
+    #[serde(rename = "+environment_key")]
+    pub environment_key: Option<String>,
+    #[serde(rename = "+environment_dependencies")]
+    pub environment_dependencies: Option<Vec<String>>,
     #[serde(
         default,
         rename = "+incremental_apply_config_changes",
@@ -630,6 +634,8 @@ impl TypedRecursiveConfig for ProjectModelConfig {
             || self.index_url.is_some()
             || self.additional_libs.is_some()
             || self.user_folder_for_python.is_some()
+            || self.environment_key.is_some()
+            || self.environment_dependencies.is_some()
             || self.incremental_apply_config_changes.is_some()
             || self.use_safer_relation_operations.is_some()
             || self.view_update_via_alter.is_some()
@@ -839,6 +845,8 @@ pub struct ModelConfig {
     pub index_url: Option<String>,
     pub additional_libs: Option<Vec<YmlValue>>,
     pub user_folder_for_python: Option<bool>,
+    pub environment_key: Option<String>,
+    pub environment_dependencies: Option<Vec<String>>,
     /// Config keys accessed via dbt.config.get() in Python models
     /// Used to populate config_dict at runtime
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -877,6 +885,8 @@ impl From<ProjectModelConfig> for ModelConfig {
             index_url: config.index_url.clone(),
             additional_libs: config.additional_libs.clone(),
             user_folder_for_python: config.user_folder_for_python,
+            environment_key: config.environment_key.clone(),
+            environment_dependencies: config.environment_dependencies.clone(),
             catalog_name: config.catalog_name.clone(),
             alt_compute: config.alt_compute,
             column_types: config.column_types,
@@ -1098,6 +1108,8 @@ impl From<ModelConfig> for ProjectModelConfig {
             index_url: config.index_url.clone(),
             additional_libs: config.additional_libs.clone(),
             user_folder_for_python: config.user_folder_for_python,
+            environment_key: config.environment_key.clone(),
+            environment_dependencies: config.environment_dependencies.clone(),
             on_configuration_change: config.on_configuration_change,
             on_error: config.on_error,
             on_schema_change: config.on_schema_change,


### PR DESCRIPTION
Fixes #15781

Upstream: https://github.com/databricks/dbt-databricks/issues/1636

### Problem

Fusion parse rejects Databricks Python model YAML `config.environment_key` and `environment_dependencies` as unused (`UnusedConfigKey`, dbt1060). dbt-databricks already consumes those keys on serverless Jobs submit.

### Solution

- Recognize `environment_key` and `environment_dependencies` on Fusion model config (schema.yml and `dbt_project.yml`).
- On serverless notebook submit, set task `environment_key` and auto-build job-level `environments` when dependencies are set (`environment_version: "4"`), matching dbt-databricks.
- If the user sets `python_job_config.environments`, keep that value. Empty `[]` is treated as unset, same as v1.

### Testing

Ran a serverless Python model (`environment_key` + `environment_dependencies`) live on Databricks with both dbt-databricks and Fusion. Parse no longer raises `UnusedConfigKey`. Create and rerun both succeeded, the Python model table matched, and `jobs/runs/get?include_resolved_values=true` returned the same resolved spec on both engines (`environment_key`, `environment_version: "4"`, dependencies).

Unit tests cover YAML key recognition (including unused-key behavior) and the Jobs submit payload (auto-build, user `environments` override, empty `[]`).

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.