### PR TITLE
chore(deps): allow sqlparse 0.6.0 to pick up parser DoS fixes

### DIFF
--- a/.changes/unreleased/Dependencies-20260819-114500.yaml
+++ b/.changes/unreleased/Dependencies-20260819-114500.yaml
@@ -1,0 +1,9 @@
+kind: Dependencies
+body: Require `sqlparse>=0.6.0,<0.7.0`, raising the floor from `0.5.5` and the ceiling
+  from `<0.6.0`. `sqlparse` 0.6.0 is the fixed release for CVE-2026-54284, CVE-2026-59893,
+  CVE-2026-59894 and CVE-2026-71491 (parser denial-of-service); no `0.5.x` release carries
+  those fixes, so the floor is raised rather than only widening the ceiling.
+time: 2026-08-19T11:45:00.000000+05:30
+custom:
+    Author: ulixius9
+    Issue: "15988"

--- a/.changes/unreleased/Dependencies-20260819-114500.yaml
+++ b/.changes/unreleased/Dependencies-20260819-114500.yaml
@@ -1,6 +1,5 @@
 kind: Dependencies
-body: Require `sqlparse>=0.6.0,<0.7.0`, raising the floor from `0.5.5` and the ceiling
-  from `<0.6.0`. `sqlparse` 0.6.0 is the fixed release for CVE-2026-54284, CVE-2026-59893,
+body: Require `sqlparse>=0.5.5,<0.7.0`, `sqlparse` 0.6.0 is the fixed release for CVE-2026-54284, CVE-2026-59893,
   CVE-2026-59894 and CVE-2026-71491 (parser denial-of-service).
 time: 2026-08-19T11:45:00.000000+05:30
 custom:

--- a/.changes/unreleased/Dependencies-20260819-114500.yaml
+++ b/.changes/unreleased/Dependencies-20260819-114500.yaml
@@ -1,8 +1,7 @@
 kind: Dependencies
 body: Require `sqlparse>=0.6.0,<0.7.0`, raising the floor from `0.5.5` and the ceiling
   from `<0.6.0`. `sqlparse` 0.6.0 is the fixed release for CVE-2026-54284, CVE-2026-59893,
-  CVE-2026-59894 and CVE-2026-71491 (parser denial-of-service); no `0.5.x` release carries
-  those fixes, so the floor is raised rather than only widening the ceiling.
+  CVE-2026-59894 and CVE-2026-71491 (parser denial-of-service).
 time: 2026-08-19T11:45:00.000000+05:30
 custom:
     Author: ulixius9

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     # ----
     # These packages are major-version-0. Keep upper bounds on upcoming minor versions (which could have breaking changes)
     # and check compatibility / bump in each new minor version of dbt-core.
-    "sqlparse>=0.6.0,<0.7.0",
+    "sqlparse>=0.5.5,<0.7.0",
     # ----
     # These are major-version-0 packages also maintained by dbt-labs.
     # Accept patches but avoid automatically updating past a set minor version range.

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     # ----
     # These packages are major-version-0. Keep upper bounds on upcoming minor versions (which could have breaking changes)
     # and check compatibility / bump in each new minor version of dbt-core.
-    "sqlparse>=0.5.5,<0.6.0",
+    "sqlparse>=0.6.0,<0.7.0",
     # ----
     # These are major-version-0 packages also maintained by dbt-labs.
     # Accept patches but avoid automatically updating past a set minor version range.


### PR DESCRIPTION
Resolves #15988

### Problem

`core/pyproject.toml` pins `sqlparse>=0.5.5,<0.6.0`.

`sqlparse` 0.6.0 (released 2026-08-13) is the fixed release for four parser denial-of-service advisories:

| CVE | GHSA | Fixed in |
|---|---|---|
| CVE-2026-54284 | GHSA-pwgv-4x5q-6m9f | 0.6.0 |
| CVE-2026-59893 | GHSA-prg7-hcfm-mfcr | 0.6.0 |
| CVE-2026-59894 | GHSA-3496-9g83-7v6x | 0.6.0 |
| CVE-2026-71491 | GHSA-f2ff-p2ww-7p4p | 0.6.0 |

OSV reports `fixed: 0.6.0` for all four, so there is no patched `0.5.x` to resolve to — the current range can only ever produce a vulnerable `sqlparse`.

The ceiling also propagates. `dbt-core` is often a transitive dependency, and in our tree it is the *only* package that constrains `sqlparse` at all (`dbt-adapters`, `dbt-common`, `dbt-semantic-interfaces` and `dbt-postgres` declare none). Any environment holding `dbt-core` alongside a package that requires `sqlparse>=0.6.0` is unsatisfiable; pip backtracks `dbt-core` down through every release before failing, and the error it finally reports is unrelated to the actual conflict.

### Solution

Widen the ceiling to `<0.7.0` rather than removing it, keeping the guard against a future `0.7`.

I recognise this pin has history — 0.5.5 genuinely did break `dbt compile` (#12302, #12308), and it was only reinstated as `>=0.5.5,<0.6.0` once `--sqlparse` landed (#12558, #12694). 0.6.0 also rewrote statement splitting onto a stack-based architecture, so this is not a bump to wave through. Here is what I checked, against `1.latest` at 1.12.2, Python 3.10, real Postgres.

**1. The `sqlparse` API `dbt-core` depends on is unchanged in 0.6.0**

```
engine.grouping.MAX_GROUPING_DEPTH    present, default 100
engine.grouping.MAX_GROUPING_TOKENS   present, default 10000
lexer.Lexer.get_default_instance      present
sql.Token / tokens.Keyword            present
Statement.insert_before / insert_after / token_first   present
```

Those cover both `dbt/cli/option_types.py` (which `setattr`s the grouping limits) and `dbt/compilation.py`.

**2. Differential test of `inject_ctes_into_sql`**

This is the only place `dbt-core` mutates a `sqlparse` parse tree, so it is where a splitter rewrite would show up. 28 SQL shapes × with/without injected CTEs — recursive CTEs, leading line and block comments, comment-before-`WITH`, nested `CASE`/`END`, `MATERIALIZED`, dollar-quoted strings, 40-level nesting, multi-statement, quoted `"with"` identifiers, CTE column lists, `MERGE`, `CREATE TABLE AS`:

```
sqlparse 0.5.5 vs 0.6.0 — 56 cases, 56 byte-identical outputs, 0 differences
```

**3. `dbt-core`'s own suites under each version**

```
tests/unit                                    0.5.5: 2015 passed, 10 skipped
                                              0.6.0: 2015 passed, 10 skipped

tests/functional/compile
  + .../materializations/
      test_ephemeral_compilation.py           0.5.5: 35 passed
                                              0.6.0: 35 passed
```

That functional selection contains `test_sqlparse_grouping_token_limit` and `test_sqlparse_grouping_depth_limit` — the tests written for the 0.5.5 incident — and they pass unchanged.

**What I have not verified.** The full `tests/functional` suite under 0.6.0 is still running; I will post the result on this PR rather than imply it is green. And a passing suite is not proof for arbitrary user SQL — 0.6.0's splitter rewrite could surface cases only real projects hit. If you would rather gate this behind a release-candidate soak, that seems entirely reasonable; the security exposure is what makes it worth raising now.

One data point on the ceiling itself: `<0.6.0` has been present since at least the `setup.py` → `pyproject.toml` migration in November 2025 (#12129), nine months before 0.6.0 was released, so it looks like a precautionary bound rather than a response to a known incompatibility.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
