### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/.changes/unreleased/Under the Hood-20260819-081238.yaml
+++ b/.changes/unreleased/Under the Hood-20260819-081238.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: sync JSON schemas from dbt-fusion
+time: 2026-08-19T08:12:38.609181265Z
+custom:
+    Author: fa-assistant
+    Issue: N/A

--- a/core/dbt/jsonschemas/project/latest.json
+++ b/core/dbt/jsonschemas/project/latest.json
@@ -4381,6 +4381,21 @@
             }
           ]
         },
+        "+unique_tmp_table_suffix": {
+          "anyOf": [
+            {
+              "default": null,
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^\\{.*\\}$"
+            }
+          ]
+        },
         "+unlogged": {
           "anyOf": [
             {
@@ -6422,6 +6437,21 @@
             }
           ]
         },
+        "+unique_tmp_table_suffix": {
+          "anyOf": [
+            {
+              "default": null,
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^\\{.*\\}$"
+            }
+          ]
+        },
         "+unlogged": {
           "anyOf": [
             {
@@ -7757,6 +7787,21 @@
           ]
         },
         "+transient": {
+          "anyOf": [
+            {
+              "default": null,
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^\\{.*\\}$"
+            }
+          ]
+        },
+        "+unique_tmp_table_suffix": {
           "anyOf": [
             {
               "default": null,

--- a/core/dbt/jsonschemas/resources/latest.json
+++ b/core/dbt/jsonschemas/resources/latest.json
@@ -2117,6 +2117,20 @@
             "null"
           ]
         },
+        "unique_tmp_table_suffix": {
+          "anyOf": [
+            {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^\\{.*\\}$"
+            }
+          ]
+        },
         "unlogged": {
           "anyOf": [
             {
@@ -4381,6 +4395,20 @@
             },
             {
               "type": "null"
+            }
+          ]
+        },
+        "unique_tmp_table_suffix": {
+          "anyOf": [
+            {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^\\{.*\\}$"
             }
           ]
         },
@@ -6931,6 +6959,20 @@
             }
           ]
         },
+        "unique_tmp_table_suffix": {
+          "anyOf": [
+            {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^\\{.*\\}$"
+            }
+          ]
+        },
         "unlogged": {
           "anyOf": [
             {
@@ -9136,6 +9178,20 @@
             "null"
           ]
         },
+        "unique_tmp_table_suffix": {
+          "anyOf": [
+            {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^\\{.*\\}$"
+            }
+          ]
+        },
         "unlogged": {
           "anyOf": [
             {
@@ -10570,6 +10626,20 @@
             }
           ]
         },
+        "unique_tmp_table_suffix": {
+          "anyOf": [
+            {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^\\{.*\\}$"
+            }
+          ]
+        },
         "unlogged": {
           "anyOf": [
             {
@@ -11852,6 +11922,20 @@
           "type": [
             "string",
             "null"
+          ]
+        },
+        "unique_tmp_table_suffix": {
+          "anyOf": [
+            {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^\\{.*\\}$"
+            }
           ]
         },
         "unlogged": {
@@ -13365,6 +13449,20 @@
           "type": [
             "string",
             "null"
+          ]
+        },
+        "unique_tmp_table_suffix": {
+          "anyOf": [
+            {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^\\{.*\\}$"
+            }
           ]
         },
         "unlogged": {


### PR DESCRIPTION
## Summary

This PR syncs the JSON schemas from the dbt-fusion repository.

### Files Updated
- `core/dbt/jsonschemas/project/latest.json`
- `core/dbt/jsonschemas/resources/latest.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Commit**: [`1d14a5446ce6ea7229972bdf385d86345b2c946f`](https://github.com/dbt-labs/fs/commit/1d14a5446ce6ea7229972bdf385d86345b2c946f)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/32229039697)