### PR TITLE
ci: pass release workflow_dispatch inputs through env

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,23 +99,31 @@ jobs:
           fi
 
       - name: "[DEBUG] Print Variables"
+        env:
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+          VERSION_NUMBER: ${{ inputs.version_number }}
+          TEST_RUN: ${{ inputs.test_run }}
+          NIGHTLY_RELEASE: ${{ inputs.nightly_release }}
+          ONLY_DOCKER: ${{ inputs.only_docker }}
         run: |
           echo Inputs
-          echo The branch to release from:         ${{ inputs.target_branch }}
-          echo The release version number:         ${{ inputs.version_number }}
-          echo Test run:                           ${{ inputs.test_run }}
-          echo Nightly release:                    ${{ inputs.nightly_release }}
-          echo Only Docker:                        ${{ inputs.only_docker }}
+          echo "The branch to release from:         $TARGET_BRANCH"
+          echo "The release version number:         $VERSION_NUMBER"
+          echo "Test run:                           $TEST_RUN"
+          echo "Nightly release:                    $NIGHTLY_RELEASE"
+          echo "Only Docker:                        $ONLY_DOCKER"
 
       # In version env.HATCH_VERSION we started to use hatch for build tooling.  Before that we used setuptools.
       # This needs to check if we're using hatch or setuptools based on the version being released.  We should
       # check if the version is greater than or equal to env.HATCH_VERSION.  If it is, we use hatch, otherwise we use setuptools.
       - name: "Check if using hatch"
         id: use_hatch
+        env:
+          VERSION_NUMBER: ${{ inputs.version_number }}
         run: |
           # Extract major.minor from versions like 1.11.0a1 -> 1.11
-          INPUT_MAJ_MIN=$(echo "${{ inputs.version_number }}" | sed -E 's/^([0-9]+\.[0-9]+).*/\1/')
-          HATCH_MAJ_MIN=$(echo "${{ env.MIN_HATCH_VERSION }}" | sed -E 's/^([0-9]+\.[0-9]+).*/\1/')
+          INPUT_MAJ_MIN=$(echo "$VERSION_NUMBER" | sed -E 's/^([0-9]+\.[0-9]+).*/\1/')
+          HATCH_MAJ_MIN=$(echo "$MIN_HATCH_VERSION" | sed -E 's/^([0-9]+\.[0-9]+).*/\1/')
 
           if [ $(echo "$INPUT_MAJ_MIN >= $HATCH_MAJ_MIN" | bc) -eq 1 ]; then
             echo "use_hatch=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### resolves #

### Problem

`release.yml` expands `workflow_dispatch` inputs directly into shell bodies in two steps.

**`[DEBUG] Print Variables`** — unquoted:

```yaml
echo The branch to release from:         ${{ inputs.target_branch }}
echo The release version number:         ${{ inputs.version_number }}
```

**`Check if using hatch`** — inside a command substitution:

```yaml
INPUT_MAJ_MIN=$(echo "${{ inputs.version_number }}" | sed -E 's/^([0-9]+\.[0-9]+).*/\1/')
```

A `${{ ... }}` expression is substituted as *text* before bash parses the line, so the input is not a value being read — it becomes part of the program. The `echo` step compounds it by being unquoted, so an input containing whitespace or a `;` does not merely print oddly.

Dispatching a release needs write access, so this is not reachable by an outside party. It matters because of where it sits: this is the workflow that publishes to **GitHub, PyPI and Docker**, and it runs after a human has clicked "Run workflow" and looked away.

### Solution

Both steps read the values from `env` and quote them.

The hatch check also now reads `MIN_HATCH_VERSION` directly rather than through `${{ env.MIN_HATCH_VERSION }}` — a workflow-level `env:` entry is already a real environment variable inside a `run` step, so re-expanding it added an expansion without adding anything.

Behaviour is unchanged for every well-formed input: the same strings reach the same `sed` pipeline and the same `echo` output.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.

### Verification

Workflow files carry no tests, so instead:

- **`zizmor --min-severity high`** on `release.yml`: `template-injection` findings **0**, down from **3**. No other finding in the file changed.
- **Parsed with PyYAML**: still 10 jobs, and both edited steps carry the expected `env` keys (`TARGET_BRANCH`, `VERSION_NUMBER`, `TEST_RUN`, `NIGHTLY_RELEASE`, `ONLY_DOCKER` on the debug step; `VERSION_NUMBER` on the hatch check).
- Confirmed the pushed file is byte-identical to the one those checks ran against.

I could not execute the workflow — it is `workflow_dispatch` and publishes releases, so triggering it is not something I can or should do from a fork.

### Not included

`zizmor` also flags four sites in `test-repeater.yml`, same class, also dispatch inputs. That is a debug/CI helper rather than the release path, and I kept this PR to one file. Happy to open it separately.

### Note

Prepared with assistance from Claude (Anthropic). The finding, the scope decision, and each verification step above I checked myself before opening this.
