### PR TITLE
feat: add "End of Execution" delimiter to invocation summary output

### DIFF
--- a/.changes/unreleased/Features-20260818-223520.yaml
+++ b/.changes/unreleased/Features-20260818-223520.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Improve delineation of one invocation ending.
+time: 2026-08-18T22:35:20.558981+09:00
+custom:
+    author: shon0526
+    issue: "15108"
+    project: dbt-core

--- a/crates/dbt-common/src/tracing/formatters/invocation.rs
+++ b/crates/dbt-common/src/tracing/formatters/invocation.rs
@@ -242,6 +242,9 @@ pub fn format_invocation_summary(
         }
     }
 
+    let footer = format_delimiter(" End of Execution ", max_line_width, colorize);
+    lines.push(footer);
+
     let autofix_line = if summary.metrics.autofix > 0 {
         Some(format_autofix_line(colorize))
     } else {

--- a/crates/dbt-sa-cli/tests/golden/hello_world/parse_hello_world.stdout
+++ b/crates/dbt-sa-cli/tests/golden/hello_world/parse_hello_world.stdout
@@ -3,3 +3,4 @@ dbt-fusion
    Parsing models/hello_world.sql
 ==================== Execution Summary =====================
 Finished 'parse' successfully for target 'snowflake_local' [duration]
+===================== End of Execution =====================


### PR DESCRIPTION
Resolves [#15108](https://github.com/dbt-labs/dbt-core/issues/15108)

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `action:needs-docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->
There's a delimiter showing where the execution summary begins, but not where it ends.
### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->
Add an "End of Execution" delimiter that mirrors the existing "begin" delimiter, so the invocaiton summary output clearly marks both the start and the end of an execution.
### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.