### PR TITLE
fix(databricks): respect full refresh with view_update_via_alter

### DIFF
--- a/.changes/unreleased/Fixes-20260819-211302.yaml
+++ b/.changes/unreleased/Fixes-20260819-211302.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Respect full refresh when view_update_via_alter is enabled for Databricks views.
+time: 2026-08-19T21:13:02.759619+05:30
+custom:
+    author: sd-db
+    issue: "14359"
+    project: dbt-core

--- a/crates/dbt-loader/src/dbt_macro_assets/README.md
+++ b/crates/dbt-loader/src/dbt_macro_assets/README.md
@@ -5,6 +5,9 @@ All adapter macros are currently maintained in:
 
 ## Changelog
 
+### [2026-08-19]
+  - dbt-databricks: view full-refresh precedence from commit 45351e11517d3f37c5ac7a736b5fcba453d3f368
+
 ### [2026-03-04]
   - dbt-databricks: v1.11.5 (commit 24325a3195171d36972804e545b2ccf967ab575d)
 

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-databricks/macros/materializations/view.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-databricks/macros/materializations/view.sql
@@ -86,6 +86,9 @@
 {% endmacro %}
 
 {% macro relation_should_be_altered(existing_relation) %}
+  {% if should_full_refresh() %}
+    {{ return(False) }}
+  {% endif %}
   {% set update_via_alter = config.get('view_update_via_alter', False) | as_bool %}
   {% if existing_relation.is_view and update_via_alter %}
     {% if existing_relation.is_hive_metastore() %}

--- a/crates/dbt-loader/src/loader.rs
+++ b/crates/dbt-loader/src/loader.rs
@@ -1531,13 +1531,52 @@ async fn prepare_inline_sql(
 mod tests {
     use super::*;
     use dbt_schemas::schemas::profiles::DbConfig;
+    use dbt_schemas::schemas::project::{ProjectModelConfig, WarehouseSpecificNodeConfig};
     use dbt_schemas::state::ProfileAdapter;
     use dbt_schemas::state::ResourcePathKind;
+    use serde::de::DeserializeOwned;
     use std::collections::HashMap;
     use std::fs::File;
     use std::io::Write;
     use std::path::PathBuf;
     use std::time::SystemTime;
+
+    fn render_typed_config<T: DeserializeOwned>(yaml: &str) -> T {
+        let raw = dbt_yaml::from_str(yaml).expect("valid config yaml");
+        let env = initialize_load_profile_jinja_environment();
+        let ctx = BTreeMap::from([(
+            "target".to_string(),
+            minijinja::Value::from_serialize(BTreeMap::from([(
+                "database".to_string(),
+                "main".to_string(),
+            )])),
+        )]);
+        into_typed_with_jinja(raw, true, &env, &ctx, &[], None, true)
+            .expect("config should render and deserialize")
+    }
+
+    #[test]
+    fn view_update_via_alter_renders_jinja_booleans_in_project_config() {
+        for (expression, expected) in [
+            ("'psbx' not in target.database", true),
+            ("'main' not in target.database", false),
+        ] {
+            let config: ProjectModelConfig = render_typed_config(&format!(
+                "+view_update_via_alter: \"{{{{ {expression} }}}}\"\n"
+            ));
+            assert_eq!(config.view_update_via_alter, Some(expected));
+        }
+    }
+
+    #[test]
+    fn view_update_via_alter_renders_jinja_booleans_in_model_config() {
+        for (expression, expected) in [("true", true), ("false", false)] {
+            let config: WarehouseSpecificNodeConfig = render_typed_config(&format!(
+                "view_update_via_alter: \"{{{{ {expression} }}}}\"\n"
+            ));
+            assert_eq!(config.view_update_via_alter, Some(expected));
+        }
+    }
 
     #[test]
     fn resolve_threads_sets_profile_threads_from_target() {

--- a/crates/dbt-loader/tests/materializations/view.rs
+++ b/crates/dbt-loader/tests/materializations/view.rs
@@ -76,6 +76,24 @@ fn full_refresh_mock_config() -> Arc<MockJinjaObject> {
     mock
 }
 
+fn v2_update_via_alter_config(full_refresh: bool) -> Arc<MockJinjaObject> {
+    let mock = default_mock_config();
+    mock.on("get", move |args| {
+        let key = args.first().and_then(|v| v.as_str());
+        let default = args.get(1).cloned().unwrap_or(Value::UNDEFINED);
+        match key {
+            Some("contract") => Ok(Value::from_serialize(BTreeMap::from([(
+                "enforced".to_string(),
+                Value::from(false),
+            )]))),
+            Some("full_refresh") => Ok(Value::from(full_refresh)),
+            Some("view_update_via_alter") => Ok(Value::from(true)),
+            _ => Ok(default),
+        }
+    });
+    mock
+}
+
 // Scenarios:
 // 1. Nothing already exists under the target namespace
 // 2. A view already exists under the target namespace
@@ -233,6 +251,71 @@ mod databricks {
             .observed_calls()
             .assert_not_called("drop_relation");
         assert_executed_contains(harness.mock(), "create");
+    }
+
+    #[test]
+    fn v2_full_refresh_replaces_view_when_update_via_alter_is_enabled() {
+        let mut harness = build_view_harness(ADAPTER);
+        harness
+            .env_mut()
+            .env
+            .add_function("store_raw_result", |_kwargs: minijinja::value::Kwargs| {
+                Ok(Value::UNDEFINED)
+            });
+        harness.set_behavior_flags([("use_materialization_v2", true)]);
+        let existing = harness.relation(
+            "TEST_DB",
+            "TEST_SCHEMA",
+            "my_view",
+            Some(RelationType::View),
+        );
+        harness.mock().on("get_relation", move |_| {
+            Ok(RelationObject::new(Arc::clone(&existing)).into_value())
+        });
+        harness
+            .mock()
+            .on("get_relation_config", |_| Ok(Value::UNDEFINED));
+        let model_config = Arc::new(MockJinjaObject::new());
+        model_config.on("get_changeset", |_| Ok(Value::UNDEFINED));
+        harness.mock().on("get_config_from_model", move |_| {
+            Ok(Value::from_dyn_object(Arc::clone(&model_config)))
+        });
+
+        let ctx = harness
+            .materialization_context("my_view", "SELECT id, name FROM source_table")
+            .config(Value::from_dyn_object(v2_update_via_alter_config(true)))
+            .build();
+        render_view(&harness, ADAPTER, ctx).expect("v2 full refresh should replace the view");
+
+        assert_executed_contains(harness.mock(), "create or replace");
+    }
+
+    #[test]
+    fn v2_update_via_alter_rejects_hive_metastore_views() {
+        let harness = build_view_harness(ADAPTER);
+        harness.set_behavior_flags([("use_materialization_v2", true)]);
+        let existing = harness.relation(
+            "hive_metastore",
+            "TEST_SCHEMA",
+            "my_view",
+            Some(RelationType::View),
+        );
+        harness.mock().on("get_relation", move |_| {
+            Ok(RelationObject::new(Arc::clone(&existing)).into_value())
+        });
+
+        let ctx = harness
+            .materialization_context("my_view", "SELECT id, name FROM source_table")
+            .config(Value::from_dyn_object(v2_update_via_alter_config(false)))
+            .build();
+        let error = render_view(&harness, ADAPTER, ctx)
+            .expect_err("Hive Metastore views must reject update-via-alter");
+
+        assert!(
+            error
+                .to_string()
+                .contains("Cannot update a view in the Hive metastore via ALTER VIEW")
+        );
     }
 }
 


### PR DESCRIPTION
Fixes #14359 (See more details on the issue, the issue is already fixed; this is just one-case that was differing from v1 today)

## Summary

- make full refresh take precedence over `view_update_via_alter` for materialization v2
- add focused typed-loader coverage for Jinja-rendered booleans at Databricks project and model configuration boundaries
- preserve the Hive Metastore rejection path

## Testing

- `cargo test -p dbt-loader`
- current dbt-databricks view functional suite: 16 passed, 7 profile-inapplicable skips
- focused dbt-databricks Hive Metastore functional test: 1 passed
- dual-live current-v1/Fusion lifecycle covering create, marker setup, ALTER or replacement, no-op, and full refresh; exact ordered SQL and server-observable state passed for all five steps
