### PR TITLE
Elide null macros key for unit test overrides

### DIFF
--- a/.changes/unreleased/Fixes-20260820-095251.yaml
+++ b/.changes/unreleased/Fixes-20260820-095251.yaml
@@ -1,0 +1,8 @@
+kind: Fixes
+body: Stop the v2 parser emitting a null `macros` key for unit tests that set `overrides`
+  without `macros`, which made dbt-core fail to deserialize the fusion-produced manifest
+time: 2026-08-20T09:52:51.000000Z
+custom:
+    author: CallumFriend-MP
+    issue: "16009"
+    project: dbt-core

--- a/crates/dbt-schemas/src/schemas/properties/unit_test_properties.rs
+++ b/crates/dbt-schemas/src/schemas/properties/unit_test_properties.rs
@@ -38,6 +38,13 @@ pub struct UnitTestOverrides {
     // rendering would round-trip a Jinja expression's return value through
     // `YmlValue` and lose non-scalar values (e.g. a datetime) before the
     // real render ever runs.
+    #[serde(skip_serializing_if = "verbatim_option_is_none")]
     pub macros: Verbatim<Option<BTreeMap<String, YmlValue>>>,
     pub vars: Option<BTreeMap<String, YmlValue>>,
+}
+
+// `skip_serializing_none` only rewrites fields whose declared outer type is
+// `Option`, so it cannot elide `macros` through the `Verbatim` wrapper.
+fn verbatim_option_is_none<T>(value: &Verbatim<Option<T>>) -> bool {
+    value.is_none()
 }


### PR DESCRIPTION
Fixes #16009.

`dbt parse --use-v2-parser` fails with `FusionParserSchemaError` on any project with a unit test that sets `overrides:` without `macros:`, because the parser emits `"macros": null` and Python's `UnitTestOverrides.macros` is a non-`Optional` `Dict`.

`UnitTestOverrides.macros` is `Verbatim<Option<T>>`, not a bare `Option<T>`. `#[skip_serializing_none]` matches on the declared outer type, so it does not apply through the wrapper, and `Verbatim`'s `Serialize` forwards to the inner value. Its siblings `env_vars` and `vars` are bare `Option<T>` and elide correctly. Introduced by 7c1726299, which wrapped the field and landed between the a5 and b1 parser releases; 1.12.1 and 1.12.2 raise the parser floor to `>=2.0.0b1`, so the current release pulls the failing pair by default.

This adds an explicit `skip_serializing_if` to that one field. `Verbatim` derefs to `T`, so the predicate is a one-liner and the wrapper 7c1726299 needs is untouched.

### Verification

I could not build the monorepo here, so I compiled the exact patched struct in isolation against `dbt-yaml` 0.9.6 with this repo's dependency versions, including the `DbtSchema` derive and `#[skip_serializing_none]`:

```
macros unset : {"vars":{"some_var":"'x'"}}
macros set   : {"macros":{"run_started_at":"2024-01-01"},"vars":{"some_var":"'x'"}}
round-trip   : macros.is_none()=true vars=true
```

Line 1 is the fix. Line 2 confirms a populated `macros` map still serialises, so the datetime behaviour 7c1726299 was added for is preserved. Line 3 confirms the elided form deserialises back to `None`. Before the change the same struct emits `{"macros":null,"vars":{"some_var":"'x'"}}`, reproducing the reported failure byte for byte. #16009 has a repro needing no warehouse connection.

I have not run dbt-core's own suite. Understood that fork CI needs `ci:approve-public-fork-ci` and that it clears on each push.

### Not included

A Python-side coercion of `None` to `{}` in `UnitTestOverrides` would also fix it, cover `vars` and `env_vars`, and unlike this change would help projects already pinned to a released b-series parser. It belongs on `1.latest` rather than here, so I have left it out and noted it on the issue.
