### PR TITLE
[Backport 1.13.latest] chore(deps): allow sqlparse 0.6.0 to pick up parser DoS fixes

### DIFF
--- a/.changes/unreleased/Dependencies-20260819-114500.yaml
+++ b/.changes/unreleased/Dependencies-20260819-114500.yaml
@@ -1,0 +1,7 @@
+kind: Dependencies
+body: Require `sqlparse>=0.5.5,<0.7.0`, `sqlparse` 0.6.0 is the fixed release for CVE-2026-54284, CVE-2026-59893,
+  CVE-2026-59894 and CVE-2026-71491 (parser denial-of-service).
+time: 2026-08-19T11:45:00.000000+05:30
+custom:
+    Author: ulixius9
+    Issue: "15988"

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     # ----
     # These packages are major-version-0. Keep upper bounds on upcoming minor versions (which could have breaking changes)
     # and check compatibility / bump in each new minor version of dbt-core.
-    "sqlparse>=0.5.5,<0.6.0",
+    "sqlparse>=0.5.5,<0.7.0",
     # ----
     # These are major-version-0 packages also maintained by dbt-labs.
     # Accept patches but avoid automatically updating past a set minor version range.


### PR DESCRIPTION
Backport of #15989 (commit `defa080fb5f65f574d9b2a589eba55893d4bf958`) to `1.13.latest`.

### Description

`sqlparse` 0.6.0 is the fixed release for CVE-2026-54284, CVE-2026-59893, CVE-2026-59894 and CVE-2026-71491 (parser denial-of-service). This widens the upper bound from `<0.6.0` to `<0.7.0` so the fixed version can be installed. Floor stays at `0.5.5`.

### Checklist

- [x] Clean backport — applied identically to the original commit (dependency bound + changelog entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)