### PR TITLE
fix: state:modified.body incorrectly flags unchanged snapshots as modified

### DIFF
--- a/crates/dbt-schemas/src/schemas/common.rs
+++ b/crates/dbt-schemas/src/schemas/common.rs
@@ -2219,17 +2219,15 @@ exclude: 3
     fn test_conform_normalized_snapshot_keeps_body_with_inner_whitespace_control() {
         let on_disk = "{% snapshot snap %}\n{{ config(unique_key='id', strategy='check', check_cols='all') }}\n{%- set x = 1 -%}\nselect 1 as id, 'alice' as first_name\n{% endsnapshot %}";
         let mantle_raw_code = "\n{{ config(unique_key='id', strategy='check', check_cols='all') }}\n{%- set x = 1 -%}\nselect 1 as id, 'alice' as first_name\n";
+        let expected = "{{ config(unique_key='id', strategy='check', check_cols='all') }} {%- set x = 1 -%} select 1 as id, 'alice' as first_name";
 
         let from_disk =
             conform_normalized_snapshot_raw_code_to_mantle_format(&normalize_sql(on_disk));
         let from_manifest =
             conform_normalized_snapshot_raw_code_to_mantle_format(&normalize_sql(mantle_raw_code));
 
-        assert_eq!(from_disk, from_manifest);
-        assert!(from_disk.contains("config("), "got: {from_disk:?}");
-        assert!(from_disk.contains("{%- set x = 1 -%}"), "got: {from_disk:?}");
-        assert!(!from_disk.contains("snapshot snap"), "got: {from_disk:?}");
-        assert!(!from_disk.contains("endsnapshot"), "got: {from_disk:?}");
+        assert_eq!(from_disk, expected);
+        assert_eq!(from_manifest, expected);
     }
 
     #[test]

--- a/crates/dbt-schemas/src/schemas/common.rs
+++ b/crates/dbt-schemas/src/schemas/common.rs
@@ -1747,18 +1747,9 @@ pub fn conform_normalized_snapshot_raw_code_to_mantle_format(normalized_full: &s
     // Remove everything before and including the opening snapshot tag.
     let sql_without_opening = find_opening(normalized_full)
         .and_then(|start_pos| {
-            let after_tag_start = &normalized_full[start_pos..];
-            after_tag_start
-                .find("-%}")
-                .or_else(|| after_tag_start.find("%}"))
-                .map(|end_offset| {
-                    let tag_end = if after_tag_start[end_offset..].starts_with("-%}") {
-                        end_offset + 3
-                    } else {
-                        end_offset + 2
-                    };
-                    &normalized_full[start_pos + tag_end..]
-                })
+            normalized_full[start_pos..]
+                .find("%}")
+                .map(|end_offset| &normalized_full[start_pos + end_offset + "%}".len()..])
         })
         .unwrap_or(normalized_full);
 
@@ -2222,6 +2213,23 @@ exclude: 3
             from_disk, from_manifest,
             "Conform pipeline must produce byte-equal output for on-disk and Mantle-stored raw_code"
         );
+    }
+
+    #[test]
+    fn test_conform_normalized_snapshot_keeps_body_with_inner_whitespace_control() {
+        let on_disk = "{% snapshot snap %}\n{{ config(unique_key='id', strategy='check', check_cols='all') }}\n{%- set x = 1 -%}\nselect 1 as id, 'alice' as first_name\n{% endsnapshot %}";
+        let mantle_raw_code = "\n{{ config(unique_key='id', strategy='check', check_cols='all') }}\n{%- set x = 1 -%}\nselect 1 as id, 'alice' as first_name\n";
+
+        let from_disk =
+            conform_normalized_snapshot_raw_code_to_mantle_format(&normalize_sql(on_disk));
+        let from_manifest =
+            conform_normalized_snapshot_raw_code_to_mantle_format(&normalize_sql(mantle_raw_code));
+
+        assert_eq!(from_disk, from_manifest);
+        assert!(from_disk.contains("config("), "got: {from_disk:?}");
+        assert!(from_disk.contains("{%- set x = 1 -%}"), "got: {from_disk:?}");
+        assert!(!from_disk.contains("snapshot snap"), "got: {from_disk:?}");
+        assert!(!from_disk.contains("endsnapshot"), "got: {from_disk:?}");
     }
 
     #[test]


### PR DESCRIPTION
Fixes #15956

## Root cause

Opening `{% snapshot %}` tag end search is unscoped, matching an inner tag's `-%}`

## Changes

- In `conform_normalized_snapshot_raw_code_to_mantle_format`, end the opening snapshot tag at the first `%}` after the tag start (which also covers the `-%}` whitespace-control form, since its `%}` ends at the same offset) instead of preferring the first `-%}` anywhere in the remaining text. Added a regression test asserting on-disk and Mantle-stored raw_code conform to byte-identical bodies for the reported repro.