### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/.changes/unreleased/Under the Hood-20260822-042219.yaml
+++ b/.changes/unreleased/Under the Hood-20260822-042219.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: sync JSON schemas from dbt-fusion
+time: 2026-08-22T04:22:19.859254445Z
+custom:
+    Author: fa-assistant
+    Issue: N/A

--- a/core/dbt/jsonschemas/project/latest.json
+++ b/core/dbt/jsonschemas/project/latest.json
@@ -3135,6 +3135,7 @@
           ]
         },
         "+column_types": {
+          "default": null,
           "type": [
             "object",
             "null"
@@ -3365,6 +3366,7 @@
           ]
         },
         "+event_time": {
+          "default": null,
           "type": [
             "string",
             "null"
@@ -5797,6 +5799,7 @@
           ]
         },
         "+event_time": {
+          "default": null,
           "type": [
             "string",
             "null"
@@ -6670,6 +6673,7 @@
           ]
         },
         "+event_time": {
+          "default": null,
           "type": [
             "string",
             "null"

--- a/core/dbt/jsonschemas/resources/latest.json
+++ b/core/dbt/jsonschemas/resources/latest.json
@@ -5731,6 +5731,7 @@
           ]
         },
         "column_types": {
+          "default": null,
           "type": [
             "object",
             "null"
@@ -5955,6 +5956,7 @@
           ]
         },
         "event_time": {
+          "default": null,
           "type": [
             "string",
             "null"
@@ -8236,6 +8238,7 @@
           ]
         },
         "column_types": {
+          "default": null,
           "type": [
             "object",
             "null"
@@ -8408,6 +8411,7 @@
           ]
         },
         "event_time": {
+          "default": null,
           "type": [
             "string",
             "null"
@@ -9771,6 +9775,7 @@
           ]
         },
         "event_time": {
+          "default": null,
           "type": [
             "string",
             "null"
@@ -11196,6 +11201,7 @@
           ]
         },
         "event_time": {
+          "default": null,
           "type": [
             "string",
             "null"
@@ -13702,6 +13708,15 @@
       "description": "Column entry inside a model version block.\n\nUnlike `ColumnProperties`, `name` is optional here because version column lists can contain include/exclude directives (e.g. `include: all, exclude: [col]`) that have no name.",
       "type": "object",
       "properties": {
+        "classifiers": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
         "column_mask": {
           "anyOf": [
             {
@@ -13864,7 +13879,7 @@
           ]
         },
         "columns": {
-          "readOnly": true,
+          "description": "Columns for this version. Each entry is either a column definition or the single optional `include`/`exclude` directive controlling which model-level columns this version inherits. When no directive is given, every model-level column is inherited.",
           "type": [
             "array",
             "null"


### PR DESCRIPTION
## Summary

This PR syncs the JSON schemas from the dbt-fusion repository.

### Files Updated
- `core/dbt/jsonschemas/project/latest.json`
- `core/dbt/jsonschemas/resources/latest.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Commit**: [`1cd55e406d1341bb8f7673401f0222e7a23203b7`](https://github.com/dbt-labs/fs/commit/1cd55e406d1341bb8f7673401f0222e7a23203b7)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/32550155572)