### PR TITLE
ci: restore the reverse-sync dispatch for changelog backport PRs

### DIFF
--- a/.github/workflows/auto-public-pr-copybara.yml
+++ b/.github/workflows/auto-public-pr-copybara.yml
@@ -35,13 +35,9 @@ on:
       - 'crates/dbt-loader/src/loader.rs'
       - 'crates/dbt-loader/src/mod.rs'
 
-# only run this once per PR at a time
-#
-# Cancelling is scoped to `synchronize`: a new push supersedes the run for the
-# previous head, so dropping it is right. No other action may cancel, because
-# the `labeled` run that cla-bot's `cla:yes` triggers seconds after a PR opens
-# lands in this same group, skips at `check_run_approval`, and would otherwise
-# take the `opened` run's dispatch down with it.
+# Only run this once per PR at a time. Only a new push supersedes an earlier
+# run, so the `labeled` run cla-bot's `cla:yes` triggers can't cancel — and
+# then skip — the `opened` run's dispatch.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number }}
   cancel-in-progress: ${{ github.event.action == 'synchronize' }}

--- a/.github/workflows/auto-public-pr-copybara.yml
+++ b/.github/workflows/auto-public-pr-copybara.yml
@@ -36,9 +36,15 @@ on:
       - 'crates/dbt-loader/src/mod.rs'
 
 # only run this once per PR at a time
+#
+# Cancelling is scoped to `synchronize`: a new push supersedes the run for the
+# previous head, so dropping it is right. No other action may cancel, because
+# the `labeled` run that cla-bot's `cla:yes` triggers seconds after a PR opens
+# lands in this same group, skips at `check_run_approval`, and would otherwise
+# take the `opened` run's dispatch down with it.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event.action == 'synchronize' }}
 
 permissions: {}
 

--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -1024,7 +1024,12 @@ jobs:
       - name: Open or update pull request
         if: steps.backport.outputs.skip != 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Not GITHUB_TOKEN: a pull request opened with it delivers no
+          # `opened` event, so the reverse-sync dispatcher in
+          # auto-public-pr-copybara.yml never fires and the backported
+          # changelog is stranded in the public repo. Opening as the service
+          # account gets the event delivered.
+          GH_TOKEN: ${{ secrets.FS_SERVICE_PAT }}
           VERSION: ${{ needs.prepare-release.outputs.version }}
           PR_BRANCH: ${{ steps.backport.outputs.pr_branch }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -1024,11 +1024,9 @@ jobs:
       - name: Open or update pull request
         if: steps.backport.outputs.skip != 'true'
         env:
-          # Not GITHUB_TOKEN: a pull request opened with it delivers no
-          # `opened` event, so the reverse-sync dispatcher in
-          # auto-public-pr-copybara.yml never fires and the backported
-          # changelog is stranded in the public repo. Opening as the service
-          # account gets the event delivered.
+          # Not GITHUB_TOKEN: Actions won't trigger workflows from the
+          # events it creates, so the reverse sync in
+          # auto-public-pr-copybara.yml would never run for this PR.
           GH_TOKEN: ${{ secrets.FS_SERVICE_PAT }}
           VERSION: ${{ needs.prepare-release.outputs.version }}
           PR_BRANCH: ${{ steps.backport.outputs.pr_branch }}


### PR DESCRIPTION
## What

Make the dbt-core → fs reverse sync fire for changelog backport PRs.

## Why

#15984 never dispatched. Two causes:

1. `release-v2.yml` opens the PR with `GITHUB_TOKEN`, whose events don't start workflow runs — no `opened` event is ever delivered. Until #15869 the `cla:yes` label alone was enough to dispatch; that path is now closed, leaving no trigger at all.
2. `cancel-in-progress: true` on a per-PR concurrency group lets cla-bot's `labeled` run cancel the in-flight `opened` run and then skip itself. Seen five times since #15869 — all forks so far, but cla-bot labels same-repo PRs too.

## How

- `auto-public-pr-copybara.yml`: scope `cancel-in-progress` to `synchronize`.
- `release-v2.yml`: open the backport PR with `FS_SERVICE_PAT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)