### PR TITLE
Execute generic table materializations in typed Python

### DIFF
--- a/.changes/unreleased/Under the Hood-20260823-192430.yaml
+++ b/.changes/unreleased/Under the Hood-20260823-192430.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Run the built-in generic SQL table materialization lifecycle in typed Python while preserving Jinja fallback for overrides.
+time: 2026-08-23T19:24:30.807875-04:00
+custom:
+    Author: dataders
+    Issue: ""

--- a/core/dbt/materializations/table.py
+++ b/core/dbt/materializations/table.py
@@ -77,6 +77,13 @@ class TableMaterializationExecutor:
         response, table = self.adapter.execute(sql, auto_begin=True, fetch=False)
         self._call_macro("store_result", "main", response=response, agate_table=table)
 
+    def _commit(self) -> None:
+        runtime_adapter = self._context_value("adapter")
+        commit = getattr(runtime_adapter, "commit", None)
+        if not callable(commit):
+            raise DbtInternalError("Python materialization adapter boundary cannot commit")
+        commit()
+
     def execute(self) -> Dict[str, Any]:
         plan = self.plan()
 
@@ -115,7 +122,7 @@ class TableMaterializationExecutor:
             should_revoke=should_revoke,
         )
         self._call_macro("persist_docs", plan.target_relation, self._context_value("model"))
-        self.adapter.commit()
+        self._commit()
         self._call_macro("drop_relation_if_exists", plan.backup_relation)
         self._call_macro("run_hooks", self._context_value("post_hooks"), inside_transaction=False)
 

--- a/core/dbt/materializations/table.py
+++ b/core/dbt/materializations/table.py
@@ -1,0 +1,122 @@
+from dataclasses import dataclass
+from typing import Any, Dict, Mapping, Optional
+
+from dbt.adapters.base.relation import BaseRelation
+from dbt.contracts.graph.nodes import ModelNode
+from dbt.exceptions import DbtInternalError
+
+
+@dataclass(frozen=True)
+class TableMaterializationPlan:
+    """Resolved relations and configuration for one table replacement."""
+
+    existing_relation: Optional[BaseRelation]
+    target_relation: BaseRelation
+    intermediate_relation: BaseRelation
+    backup_relation: BaseRelation
+    preexisting_intermediate_relation: Optional[BaseRelation]
+    preexisting_backup_relation: Optional[BaseRelation]
+    grant_config: Mapping[str, Any]
+
+
+class TableMaterializationExecutor:
+    """Execute built-in table lifecycle in Python.
+
+    Project and adapter macros remain callable at explicit compatibility boundaries,
+    but control flow and database mutation ordering live here rather than in Jinja.
+    """
+
+    def __init__(self, adapter: Any, model: ModelNode, context: Dict[str, Any]) -> None:
+        self.adapter = adapter
+        self.model = model
+        self.context = context
+
+    def _context_value(self, name: str) -> Any:
+        try:
+            return self.context[name]
+        except KeyError:
+            raise DbtInternalError(
+                f"Python table materialization context is missing '{name}'"
+            ) from None
+
+    def _call_macro(self, name: str, *args: Any, **kwargs: Any) -> Any:
+        macro = self._context_value(name)
+        if not callable(macro):
+            raise DbtInternalError(
+                f"Python table materialization context value '{name}' is not callable"
+            )
+        return macro(*args, **kwargs)
+
+    def plan(self) -> TableMaterializationPlan:
+        existing_relation = self._call_macro("load_cached_relation", self._context_value("this"))
+        target_relation = self._context_value("this").incorporate(type="table")
+        intermediate_relation = self._call_macro("make_intermediate_relation", target_relation)
+        backup_relation_type = "table" if existing_relation is None else existing_relation.type
+        backup_relation = self._call_macro(
+            "make_backup_relation", target_relation, backup_relation_type
+        )
+
+        grant_config = self._context_value("config").get("grants") or {}
+        if not isinstance(grant_config, Mapping):
+            raise DbtInternalError("Table materialization grants config must be a mapping")
+
+        return TableMaterializationPlan(
+            existing_relation=existing_relation,
+            target_relation=target_relation,
+            intermediate_relation=intermediate_relation,
+            backup_relation=backup_relation,
+            preexisting_intermediate_relation=self._call_macro(
+                "load_cached_relation", intermediate_relation
+            ),
+            preexisting_backup_relation=self._call_macro("load_cached_relation", backup_relation),
+            grant_config=grant_config,
+        )
+
+    def _execute_main(self, sql: str) -> None:
+        self._call_macro("write", sql)
+        response, table = self.adapter.execute(sql, auto_begin=True, fetch=False)
+        self._call_macro("store_result", "main", response=response, agate_table=table)
+
+    def execute(self) -> Dict[str, Any]:
+        plan = self.plan()
+
+        self._call_macro("drop_relation_if_exists", plan.preexisting_intermediate_relation)
+        self._call_macro("drop_relation_if_exists", plan.preexisting_backup_relation)
+        self._call_macro("run_hooks", self._context_value("pre_hooks"), inside_transaction=False)
+        self._call_macro("run_hooks", self._context_value("pre_hooks"), inside_transaction=True)
+
+        build_sql = self._call_macro(
+            "get_create_table_as_sql",
+            False,
+            plan.intermediate_relation,
+            self._context_value("sql"),
+        )
+        if not isinstance(build_sql, str):
+            raise DbtInternalError("Table create-from-query renderer must return SQL text")
+        self._execute_main(build_sql)
+        self._call_macro("create_indexes", plan.intermediate_relation)
+
+        existing_relation = plan.existing_relation
+        if existing_relation is not None:
+            existing_relation = self._call_macro("load_cached_relation", existing_relation)
+            if existing_relation is not None:
+                self.adapter.rename_relation(existing_relation, plan.backup_relation)
+
+        self.adapter.rename_relation(plan.intermediate_relation, plan.target_relation)
+        self._call_macro("run_hooks", self._context_value("post_hooks"), inside_transaction=True)
+
+        should_revoke = self._call_macro(
+            "should_revoke", existing_relation, full_refresh_mode=True
+        )
+        self._call_macro(
+            "apply_grants",
+            plan.target_relation,
+            plan.grant_config,
+            should_revoke=should_revoke,
+        )
+        self._call_macro("persist_docs", plan.target_relation, self._context_value("model"))
+        self.adapter.commit()
+        self._call_macro("drop_relation_if_exists", plan.backup_relation)
+        self._call_macro("run_hooks", self._context_value("post_hooks"), inside_transaction=False)
+
+        return {"relations": [plan.target_relation]}

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -69,6 +69,7 @@ from dbt.graph import ResourceTypeSelector
 from dbt.graph.thread_pool import DbtThreadPool
 from dbt.hooks import get_hook_dict
 from dbt.materializations.incremental.microbatch import MicrobatchBuilder
+from dbt.materializations.table import TableMaterializationExecutor
 from dbt.node_types import NodeType, RunHookType
 from dbt.task import group_lookup
 from dbt.task.base import BaseRunner
@@ -234,6 +235,20 @@ def _validate_materialization_relations_dict(inp: Dict[Any, Any], model) -> List
 
 
 class ModelRunner(CompileRunner[ModelNode]):
+    _PYTHON_MATERIALIZATION_EXECUTORS = {
+        "macro.dbt.materialization_table_default": TableMaterializationExecutor,
+    }
+
+    def _get_python_materialization_executor(
+        self, model: ModelNode, materialization_macro: MacroProtocol
+    ) -> Optional[Type[TableMaterializationExecutor]]:
+        if str(model.language) != "sql":
+            return None
+        unique_id = getattr(materialization_macro, "unique_id", None)
+        if not isinstance(unique_id, str):
+            return None
+        return self._PYTHON_MATERIALIZATION_EXECUTORS.get(unique_id)
+
     def _relation_identifier(self, relation: BaseRelation) -> str:
         identifier = getattr(relation, "identifier", None)
         if identifier is not None:
@@ -437,9 +452,13 @@ class ModelRunner(CompileRunner[ModelNode]):
     ) -> RunResult:
         relations: List[BaseRelation] = []
         try:
-            result = MacroGenerator(
-                materialization_macro, context, stack=context["context_macro_stack"]
-            )()
+            executor_type = self._get_python_materialization_executor(model, materialization_macro)
+            if executor_type is None:
+                result = MacroGenerator(
+                    materialization_macro, context, stack=context["context_macro_stack"]
+                )()
+            else:
+                result = executor_type(self.adapter, model, context).execute()
             relations = self._materialization_relations(result, model)
             relations.extend(
                 self._materialize_latest_version_pointer(manifest, model, context, relations)

--- a/tests/unit/materializations/test_table.py
+++ b/tests/unit/materializations/test_table.py
@@ -1,0 +1,103 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from dbt.exceptions import DbtInternalError
+from dbt.materializations.table import TableMaterializationExecutor
+
+
+def _relation(name, relation_type="table"):
+    return SimpleNamespace(name=name, type=relation_type)
+
+
+def _executor_context(*, existing_relation=None, grant_config=None):
+    this = MagicMock(name="this")
+    target = _relation("target")
+    intermediate = _relation("intermediate")
+    backup = _relation("backup")
+    this.incorporate.return_value = target
+
+    load_cached_relation = MagicMock(
+        side_effect=[existing_relation, None, None, existing_relation]
+    )
+    context = {
+        "this": this,
+        "config": {"grants": grant_config},
+        "model": {"unique_id": "model.test.orders"},
+        "sql": "select 1 as id",
+        "pre_hooks": ["pre"],
+        "post_hooks": ["post"],
+        "load_cached_relation": load_cached_relation,
+        "make_intermediate_relation": MagicMock(return_value=intermediate),
+        "make_backup_relation": MagicMock(return_value=backup),
+        "drop_relation_if_exists": MagicMock(),
+        "run_hooks": MagicMock(),
+        "get_create_table_as_sql": MagicMock(return_value="create table intermediate as select 1"),
+        "write": MagicMock(),
+        "store_result": MagicMock(),
+        "create_indexes": MagicMock(),
+        "should_revoke": MagicMock(return_value=True),
+        "apply_grants": MagicMock(),
+        "persist_docs": MagicMock(),
+    }
+    return context, target, intermediate, backup
+
+
+def test_table_executor_runs_builtin_lifecycle_in_python():
+    existing = _relation("existing", "view")
+    context, target, intermediate, backup = _executor_context(
+        existing_relation=existing,
+        grant_config={"select": ["reporter"]},
+    )
+    response = object()
+    table = object()
+    adapter = MagicMock()
+    adapter.execute.return_value = (response, table)
+
+    result = TableMaterializationExecutor(adapter, MagicMock(), context).execute()
+
+    assert result == {"relations": [target]}
+    context["load_cached_relation"].assert_has_calls(
+        [call(context["this"]), call(intermediate), call(backup), call(existing)]
+    )
+    context["run_hooks"].assert_has_calls(
+        [
+            call(context["pre_hooks"], inside_transaction=False),
+            call(context["pre_hooks"], inside_transaction=True),
+            call(context["post_hooks"], inside_transaction=True),
+            call(context["post_hooks"], inside_transaction=False),
+        ]
+    )
+    adapter.execute.assert_called_once_with(
+        "create table intermediate as select 1", auto_begin=True, fetch=False
+    )
+    context["store_result"].assert_called_once_with("main", response=response, agate_table=table)
+    assert adapter.rename_relation.call_args_list == [
+        call(existing, backup),
+        call(intermediate, target),
+    ]
+    context["apply_grants"].assert_called_once_with(
+        target,
+        {"select": ["reporter"]},
+        should_revoke=True,
+    )
+    context["persist_docs"].assert_called_once_with(target, context["model"])
+    adapter.commit.assert_called_once_with()
+    assert context["drop_relation_if_exists"].call_args_list == [
+        call(None),
+        call(None),
+        call(backup),
+    ]
+
+
+def test_table_executor_rejects_missing_or_untyped_context_boundaries():
+    executor = TableMaterializationExecutor(MagicMock(), MagicMock(), {})
+
+    with pytest.raises(DbtInternalError, match="missing 'this'"):
+        executor.plan()
+
+    executor.context["this"] = object()
+    executor.context["load_cached_relation"] = "not callable"
+    with pytest.raises(DbtInternalError, match="not callable"):
+        executor.plan()

--- a/tests/unit/materializations/test_table.py
+++ b/tests/unit/materializations/test_table.py
@@ -22,6 +22,7 @@ def _executor_context(*, existing_relation=None, grant_config=None):
         side_effect=[existing_relation, None, None, existing_relation]
     )
     context = {
+        "adapter": MagicMock(),
         "this": this,
         "config": {"grants": grant_config},
         "model": {"unique_id": "model.test.orders"},
@@ -83,7 +84,7 @@ def test_table_executor_runs_builtin_lifecycle_in_python():
         should_revoke=True,
     )
     context["persist_docs"].assert_called_once_with(target, context["model"])
-    adapter.commit.assert_called_once_with()
+    context["adapter"].commit.assert_called_once_with()
     assert context["drop_relation_if_exists"].call_args_list == [
         call(None),
         call(None),

--- a/tests/unit/task/test_run.py
+++ b/tests/unit/task/test_run.py
@@ -136,6 +136,29 @@ class TestModelRunner:
         add_callback_to_manager(catcher.catch)
         return catcher
 
+    @pytest.mark.parametrize(
+        "unique_id,language,uses_python",
+        [
+            ("macro.dbt.materialization_table_default", "sql", True),
+            ("macro.project.materialization_table_default", "sql", False),
+            ("macro.dbt.materialization_table_postgres", "sql", False),
+            ("macro.dbt.materialization_table_default", "python", False),
+        ],
+    )
+    def test_python_materialization_executor_only_claims_exact_builtin_sql_table(
+        self,
+        model_runner: ModelRunner,
+        unique_id: str,
+        language: str,
+        uses_python: bool,
+    ) -> None:
+        model = mock.Mock(language=language)
+        materialization_macro = mock.Mock(unique_id=unique_id)
+
+        executor = model_runner._get_python_materialization_executor(model, materialization_macro)
+
+        assert (executor is not None) is uses_python
+
     def test_print_result_line(
         self,
         log_model_result_catcher: EventCatcher,


### PR DESCRIPTION
## Summary

- add a typed Python executor for the built-in generic SQL table materialization lifecycle
- let `ModelRunner` select that executor only for the exact core `materialization_table_default` macro
- keep project, package, adapter-specific, and non-SQL materializations on the existing Jinja execution path
- preserve existing hook, renderer, index, grant, docs, transaction, relation-swap, cache, and result contracts

## Why this exists

Materialization control flow currently lives in Jinja even after DDL strategy selection moves into typed adapter plans. This slice moves relation preparation, hook ordering, statement execution, swap, grants/docs, commit, and cleanup into Python.

Jinja remains at explicit compatibility boundaries for now: DDL rendering and established hook/grant/docs macros. Follow-up work can replace those boundaries independently without keeping the materialization state machine in a template.

## Compatibility

- exact built-in generic SQL `table`: Python executor
- root-project or package override: existing Jinja materialization
- adapter-specific materialization: existing Jinja materialization
- Python-language model: existing Jinja materialization

This deliberately does not claim Snowflake, BigQuery, Redshift, Spark, Athena, or DuckDB adapter-specific table materializations yet.

## Validation

- focused executor and model-runner files: 81 passed, 1 pre-existing skip
- isort, Black, Flake8, MyPy, resource-import boundary, and Codescene delta hooks: passed
- generated Changie entry included

## Related

- typed adapter planner contracts: dbt-labs/dbt-adapters#2137
- follow-up: move generic create-from-query rendering into typed adapter code, then add adapter-specific Python executors
