### PR TITLE
feat: consume typed table render outcomes

### DIFF
--- a/.changes/unreleased/Under the Hood-20260823-192430.yaml
+++ b/.changes/unreleased/Under the Hood-20260823-192430.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Run the built-in generic SQL table materialization lifecycle in typed Python while preserving Jinja fallback for overrides.
+time: 2026-08-23T19:24:30.807875-04:00
+custom:
+    Author: dataders
+    Issue: ""

--- a/core/dbt/materializations/table.py
+++ b/core/dbt/materializations/table.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from importlib import import_module
 from typing import Any, Dict, Mapping, Optional
 
 from dbt.adapters.base.relation import BaseRelation
@@ -7,8 +8,8 @@ from dbt.exceptions import DbtInternalError
 
 
 @dataclass(frozen=True)
-class TableMaterializationPlan:
-    """Resolved relations and configuration for one table replacement."""
+class TableMaterializationExecutionState:
+    """Late-bound relations and configuration for one table replacement."""
 
     existing_relation: Optional[BaseRelation]
     target_relation: BaseRelation
@@ -47,7 +48,7 @@ class TableMaterializationExecutor:
             )
         return macro(*args, **kwargs)
 
-    def plan(self) -> TableMaterializationPlan:
+    def resolve_execution_state(self) -> TableMaterializationExecutionState:
         existing_relation = self._call_macro("load_cached_relation", self._context_value("this"))
         target_relation = self._context_value("this").incorporate(type="table")
         intermediate_relation = self._call_macro("make_intermediate_relation", target_relation)
@@ -60,7 +61,7 @@ class TableMaterializationExecutor:
         if not isinstance(grant_config, Mapping):
             raise DbtInternalError("Table materialization grants config must be a mapping")
 
-        return TableMaterializationPlan(
+        return TableMaterializationExecutionState(
             existing_relation=existing_relation,
             target_relation=target_relation,
             intermediate_relation=intermediate_relation,
@@ -84,32 +85,128 @@ class TableMaterializationExecutor:
             raise DbtInternalError("Python materialization adapter boundary cannot commit")
         commit()
 
-    def execute(self) -> Dict[str, Any]:
-        plan = self.plan()
+    @staticmethod
+    def _macro_unique_id(macro: Any) -> Optional[str]:
+        unique_id = getattr(getattr(macro, "macro", None), "unique_id", None)
+        return unique_id if isinstance(unique_id, str) else None
 
-        self._call_macro("drop_relation_if_exists", plan.preexisting_intermediate_relation)
-        self._call_macro("drop_relation_if_exists", plan.preexisting_backup_relation)
+    def _legacy_renderer_override(self, plan: Any) -> Optional[str]:
+        context_macros = (
+            ("get_create_table_as_sql", "macro.dbt.get_create_table_as_sql"),
+            ("render_create_from_query_plan", "macro.dbt.render_create_from_query_plan"),
+        )
+        for macro_name, expected_unique_id in context_macros:
+            selected_unique_id = self._macro_unique_id(self.context.get(macro_name))
+            if selected_unique_id != expected_unique_id:
+                return selected_unique_id or f"unresolved {macro_name} macro"
+
+        adapter_wrapper = self.context.get("adapter")
+        dispatch = getattr(adapter_wrapper, "dispatch", None)
+        if not callable(dispatch):
+            return "unresolved legacy renderer dispatch"
+
+        dispatched_macros = (
+            ("get_create_table_as_sql", "macro.dbt.default__get_create_table_as_sql"),
+            ("render_create_from_query_plan", "macro.dbt.default__render_create_from_query_plan"),
+            ("create_table_as", "macro.dbt.default__create_table_as"),
+        )
+        for macro_name, expected_unique_id in dispatched_macros:
+            selected = dispatch(macro_name, "dbt")
+            selected_unique_id = self._macro_unique_id(selected)
+            if selected_unique_id != expected_unique_id:
+                return selected_unique_id or f"unresolved {macro_name} dispatch"
+
+        renderer_macro = getattr(plan, "renderer_macro", None)
+        if not isinstance(renderer_macro, str):
+            return "unresolved plan renderer"
+        selected_renderer = self.context.get(renderer_macro)
+        selected_renderer_unique_id = self._macro_unique_id(selected_renderer)
+        expected_renderer_unique_id = f"macro.dbt.{renderer_macro}"
+        if selected_renderer_unique_id != expected_renderer_unique_id:
+            return selected_renderer_unique_id or f"unresolved {renderer_macro} renderer"
+        return None
+
+    @staticmethod
+    def _render_arguments_type() -> Optional[Any]:
+        """Load new adapter contract without raising core's adapter minimum version."""
+
+        try:
+            planning = import_module("dbt.adapters.planning")
+        except ModuleNotFoundError as exc:
+            if exc.name != "dbt.adapters.planning":
+                raise
+            return None
+        return getattr(planning, "CreateFromQueryRenderArguments", None)
+
+    def _legacy_build_sql(self, relation: BaseRelation, sql: str) -> str:
+        build_sql = self._call_macro("get_create_table_as_sql", False, relation, sql)
+        if not isinstance(build_sql, str):
+            raise DbtInternalError("Table create-from-query renderer must return SQL text")
+        return build_sql
+
+    def _build_sql(self, relation: BaseRelation) -> str:
+        sql = self._context_value("sql")
+        render_arguments_type = self._render_arguments_type()
+        resolve_render = getattr(self.adapter, "resolve_create_from_query_render", None)
+        plan_create = getattr(self.adapter, "plan_create_from_query", None)
+        if (
+            render_arguments_type is None
+            or not callable(resolve_render)
+            or not callable(plan_create)
+        ):
+            return self._legacy_build_sql(relation, sql)
+
+        create_plan = plan_create(False, relation, self.model)
+        relation_sql = str(relation.include(database=True, schema=True))
+        config = self._context_value("config")
+        contract = config.get("contract")
+        contract_enforced = (
+            bool(contract.get("enforced"))
+            if isinstance(contract, Mapping)
+            else bool(getattr(contract, "enforced", False))
+        )
+        render_arguments = render_arguments_type(
+            relation_sql=relation_sql,
+            query=sql,
+            sql_header=config.get("sql_header"),
+            contract_enforced=contract_enforced,
+            legacy_renderer_override=self._legacy_renderer_override(create_plan),
+        )
+        render_result = resolve_render(create_plan, render_arguments)
+        render_kind = getattr(getattr(render_result, "kind", None), "value", None)
+        if render_kind == "sql":
+            rendered_sql = getattr(render_result, "sql", None)
+            if not isinstance(rendered_sql, str):
+                raise DbtInternalError("Typed create-from-query renderer returned invalid SQL")
+            return rendered_sql
+        if render_kind == "legacy_macro":
+            renderer_macro = getattr(render_result, "renderer_macro", None)
+            if renderer_macro != "get_create_table_as_sql":
+                raise DbtInternalError(
+                    "Typed create-from-query renderer selected an unknown compatibility macro"
+                )
+            return self._legacy_build_sql(relation, sql)
+        raise DbtInternalError("Typed create-from-query renderer returned an unknown result kind")
+
+    def execute(self) -> Dict[str, Any]:
+        state = self.resolve_execution_state()
+
+        self._call_macro("drop_relation_if_exists", state.preexisting_intermediate_relation)
+        self._call_macro("drop_relation_if_exists", state.preexisting_backup_relation)
         self._call_macro("run_hooks", self._context_value("pre_hooks"), inside_transaction=False)
         self._call_macro("run_hooks", self._context_value("pre_hooks"), inside_transaction=True)
 
-        build_sql = self._call_macro(
-            "get_create_table_as_sql",
-            False,
-            plan.intermediate_relation,
-            self._context_value("sql"),
-        )
-        if not isinstance(build_sql, str):
-            raise DbtInternalError("Table create-from-query renderer must return SQL text")
+        build_sql = self._build_sql(state.intermediate_relation)
         self._execute_main(build_sql)
-        self._call_macro("create_indexes", plan.intermediate_relation)
+        self._call_macro("create_indexes", state.intermediate_relation)
 
-        existing_relation = plan.existing_relation
+        existing_relation = state.existing_relation
         if existing_relation is not None:
             existing_relation = self._call_macro("load_cached_relation", existing_relation)
             if existing_relation is not None:
-                self.adapter.rename_relation(existing_relation, plan.backup_relation)
+                self.adapter.rename_relation(existing_relation, state.backup_relation)
 
-        self.adapter.rename_relation(plan.intermediate_relation, plan.target_relation)
+        self.adapter.rename_relation(state.intermediate_relation, state.target_relation)
         self._call_macro("run_hooks", self._context_value("post_hooks"), inside_transaction=True)
 
         should_revoke = self._call_macro(
@@ -117,13 +214,13 @@ class TableMaterializationExecutor:
         )
         self._call_macro(
             "apply_grants",
-            plan.target_relation,
-            plan.grant_config,
+            state.target_relation,
+            state.grant_config,
             should_revoke=should_revoke,
         )
-        self._call_macro("persist_docs", plan.target_relation, self._context_value("model"))
+        self._call_macro("persist_docs", state.target_relation, self._context_value("model"))
         self._commit()
-        self._call_macro("drop_relation_if_exists", plan.backup_relation)
+        self._call_macro("drop_relation_if_exists", state.backup_relation)
         self._call_macro("run_hooks", self._context_value("post_hooks"), inside_transaction=False)
 
-        return {"relations": [plan.target_relation]}
+        return {"relations": [state.target_relation]}

--- a/core/dbt/materializations/table.py
+++ b/core/dbt/materializations/table.py
@@ -77,6 +77,13 @@ class TableMaterializationExecutor:
         response, table = self.adapter.execute(sql, auto_begin=True, fetch=False)
         self._call_macro("store_result", "main", response=response, agate_table=table)
 
+    def _commit(self) -> None:
+        runtime_adapter = self._context_value("adapter")
+        commit = getattr(runtime_adapter, "commit", None)
+        if not callable(commit):
+            raise DbtInternalError("Python materialization adapter boundary cannot commit")
+        commit()
+
     def execute(self) -> Dict[str, Any]:
         plan = self.plan()
 
@@ -115,7 +122,7 @@ class TableMaterializationExecutor:
             should_revoke=should_revoke,
         )
         self._call_macro("persist_docs", plan.target_relation, self._context_value("model"))
-        self.adapter.commit()
+        self._commit()
         self._call_macro("drop_relation_if_exists", plan.backup_relation)
         self._call_macro("run_hooks", self._context_value("post_hooks"), inside_transaction=False)
 

--- a/core/dbt/materializations/table.py
+++ b/core/dbt/materializations/table.py
@@ -1,0 +1,122 @@
+from dataclasses import dataclass
+from typing import Any, Dict, Mapping, Optional
+
+from dbt.adapters.base.relation import BaseRelation
+from dbt.contracts.graph.nodes import ModelNode
+from dbt.exceptions import DbtInternalError
+
+
+@dataclass(frozen=True)
+class TableMaterializationPlan:
+    """Resolved relations and configuration for one table replacement."""
+
+    existing_relation: Optional[BaseRelation]
+    target_relation: BaseRelation
+    intermediate_relation: BaseRelation
+    backup_relation: BaseRelation
+    preexisting_intermediate_relation: Optional[BaseRelation]
+    preexisting_backup_relation: Optional[BaseRelation]
+    grant_config: Mapping[str, Any]
+
+
+class TableMaterializationExecutor:
+    """Execute built-in table lifecycle in Python.
+
+    Project and adapter macros remain callable at explicit compatibility boundaries,
+    but control flow and database mutation ordering live here rather than in Jinja.
+    """
+
+    def __init__(self, adapter: Any, model: ModelNode, context: Dict[str, Any]) -> None:
+        self.adapter = adapter
+        self.model = model
+        self.context = context
+
+    def _context_value(self, name: str) -> Any:
+        try:
+            return self.context[name]
+        except KeyError:
+            raise DbtInternalError(
+                f"Python table materialization context is missing '{name}'"
+            ) from None
+
+    def _call_macro(self, name: str, *args: Any, **kwargs: Any) -> Any:
+        macro = self._context_value(name)
+        if not callable(macro):
+            raise DbtInternalError(
+                f"Python table materialization context value '{name}' is not callable"
+            )
+        return macro(*args, **kwargs)
+
+    def plan(self) -> TableMaterializationPlan:
+        existing_relation = self._call_macro("load_cached_relation", self._context_value("this"))
+        target_relation = self._context_value("this").incorporate(type="table")
+        intermediate_relation = self._call_macro("make_intermediate_relation", target_relation)
+        backup_relation_type = "table" if existing_relation is None else existing_relation.type
+        backup_relation = self._call_macro(
+            "make_backup_relation", target_relation, backup_relation_type
+        )
+
+        grant_config = self._context_value("config").get("grants") or {}
+        if not isinstance(grant_config, Mapping):
+            raise DbtInternalError("Table materialization grants config must be a mapping")
+
+        return TableMaterializationPlan(
+            existing_relation=existing_relation,
+            target_relation=target_relation,
+            intermediate_relation=intermediate_relation,
+            backup_relation=backup_relation,
+            preexisting_intermediate_relation=self._call_macro(
+                "load_cached_relation", intermediate_relation
+            ),
+            preexisting_backup_relation=self._call_macro("load_cached_relation", backup_relation),
+            grant_config=grant_config,
+        )
+
+    def _execute_main(self, sql: str) -> None:
+        self._call_macro("write", sql)
+        response, table = self.adapter.execute(sql, auto_begin=True, fetch=False)
+        self._call_macro("store_result", "main", response=response, agate_table=table)
+
+    def execute(self) -> Dict[str, Any]:
+        plan = self.plan()
+
+        self._call_macro("drop_relation_if_exists", plan.preexisting_intermediate_relation)
+        self._call_macro("drop_relation_if_exists", plan.preexisting_backup_relation)
+        self._call_macro("run_hooks", self._context_value("pre_hooks"), inside_transaction=False)
+        self._call_macro("run_hooks", self._context_value("pre_hooks"), inside_transaction=True)
+
+        build_sql = self._call_macro(
+            "get_create_table_as_sql",
+            False,
+            plan.intermediate_relation,
+            self._context_value("sql"),
+        )
+        if not isinstance(build_sql, str):
+            raise DbtInternalError("Table create-from-query renderer must return SQL text")
+        self._execute_main(build_sql)
+        self._call_macro("create_indexes", plan.intermediate_relation)
+
+        existing_relation = plan.existing_relation
+        if existing_relation is not None:
+            existing_relation = self._call_macro("load_cached_relation", existing_relation)
+            if existing_relation is not None:
+                self.adapter.rename_relation(existing_relation, plan.backup_relation)
+
+        self.adapter.rename_relation(plan.intermediate_relation, plan.target_relation)
+        self._call_macro("run_hooks", self._context_value("post_hooks"), inside_transaction=True)
+
+        should_revoke = self._call_macro(
+            "should_revoke", existing_relation, full_refresh_mode=True
+        )
+        self._call_macro(
+            "apply_grants",
+            plan.target_relation,
+            plan.grant_config,
+            should_revoke=should_revoke,
+        )
+        self._call_macro("persist_docs", plan.target_relation, self._context_value("model"))
+        self.adapter.commit()
+        self._call_macro("drop_relation_if_exists", plan.backup_relation)
+        self._call_macro("run_hooks", self._context_value("post_hooks"), inside_transaction=False)
+
+        return {"relations": [plan.target_relation]}

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -69,6 +69,7 @@ from dbt.graph import ResourceTypeSelector
 from dbt.graph.thread_pool import DbtThreadPool
 from dbt.hooks import get_hook_dict
 from dbt.materializations.incremental.microbatch import MicrobatchBuilder
+from dbt.materializations.table import TableMaterializationExecutor
 from dbt.node_types import NodeType, RunHookType
 from dbt.task import group_lookup
 from dbt.task.base import BaseRunner
@@ -234,6 +235,20 @@ def _validate_materialization_relations_dict(inp: Dict[Any, Any], model) -> List
 
 
 class ModelRunner(CompileRunner[ModelNode]):
+    _PYTHON_MATERIALIZATION_EXECUTORS = {
+        "macro.dbt.materialization_table_default": TableMaterializationExecutor,
+    }
+
+    def _get_python_materialization_executor(
+        self, model: ModelNode, materialization_macro: MacroProtocol
+    ) -> Optional[Type[TableMaterializationExecutor]]:
+        if str(model.language) != "sql":
+            return None
+        unique_id = getattr(materialization_macro, "unique_id", None)
+        if not isinstance(unique_id, str):
+            return None
+        return self._PYTHON_MATERIALIZATION_EXECUTORS.get(unique_id)
+
     def _relation_identifier(self, relation: BaseRelation) -> str:
         identifier = getattr(relation, "identifier", None)
         if identifier is not None:
@@ -437,9 +452,13 @@ class ModelRunner(CompileRunner[ModelNode]):
     ) -> RunResult:
         relations: List[BaseRelation] = []
         try:
-            result = MacroGenerator(
-                materialization_macro, context, stack=context["context_macro_stack"]
-            )()
+            executor_type = self._get_python_materialization_executor(model, materialization_macro)
+            if executor_type is None:
+                result = MacroGenerator(
+                    materialization_macro, context, stack=context["context_macro_stack"]
+                )()
+            else:
+                result = executor_type(self.adapter, model, context).execute()
             relations = self._materialization_relations(result, model)
             relations.extend(
                 self._materialize_latest_version_pointer(manifest, model, context, relations)

--- a/tests/unit/materializations/test_table.py
+++ b/tests/unit/materializations/test_table.py
@@ -1,0 +1,103 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from dbt.exceptions import DbtInternalError
+from dbt.materializations.table import TableMaterializationExecutor
+
+
+def _relation(name, relation_type="table"):
+    return SimpleNamespace(name=name, type=relation_type)
+
+
+def _executor_context(*, existing_relation=None, grant_config=None):
+    this = MagicMock(name="this")
+    target = _relation("target")
+    intermediate = _relation("intermediate")
+    backup = _relation("backup")
+    this.incorporate.return_value = target
+
+    load_cached_relation = MagicMock(
+        side_effect=[existing_relation, None, None, existing_relation]
+    )
+    context = {
+        "this": this,
+        "config": {"grants": grant_config},
+        "model": {"unique_id": "model.test.orders"},
+        "sql": "select 1 as id",
+        "pre_hooks": ["pre"],
+        "post_hooks": ["post"],
+        "load_cached_relation": load_cached_relation,
+        "make_intermediate_relation": MagicMock(return_value=intermediate),
+        "make_backup_relation": MagicMock(return_value=backup),
+        "drop_relation_if_exists": MagicMock(),
+        "run_hooks": MagicMock(),
+        "get_create_table_as_sql": MagicMock(return_value="create table intermediate as select 1"),
+        "write": MagicMock(),
+        "store_result": MagicMock(),
+        "create_indexes": MagicMock(),
+        "should_revoke": MagicMock(return_value=True),
+        "apply_grants": MagicMock(),
+        "persist_docs": MagicMock(),
+    }
+    return context, target, intermediate, backup
+
+
+def test_table_executor_runs_builtin_lifecycle_in_python():
+    existing = _relation("existing", "view")
+    context, target, intermediate, backup = _executor_context(
+        existing_relation=existing,
+        grant_config={"select": ["reporter"]},
+    )
+    response = object()
+    table = object()
+    adapter = MagicMock()
+    adapter.execute.return_value = (response, table)
+
+    result = TableMaterializationExecutor(adapter, MagicMock(), context).execute()
+
+    assert result == {"relations": [target]}
+    context["load_cached_relation"].assert_has_calls(
+        [call(context["this"]), call(intermediate), call(backup), call(existing)]
+    )
+    context["run_hooks"].assert_has_calls(
+        [
+            call(context["pre_hooks"], inside_transaction=False),
+            call(context["pre_hooks"], inside_transaction=True),
+            call(context["post_hooks"], inside_transaction=True),
+            call(context["post_hooks"], inside_transaction=False),
+        ]
+    )
+    adapter.execute.assert_called_once_with(
+        "create table intermediate as select 1", auto_begin=True, fetch=False
+    )
+    context["store_result"].assert_called_once_with("main", response=response, agate_table=table)
+    assert adapter.rename_relation.call_args_list == [
+        call(existing, backup),
+        call(intermediate, target),
+    ]
+    context["apply_grants"].assert_called_once_with(
+        target,
+        {"select": ["reporter"]},
+        should_revoke=True,
+    )
+    context["persist_docs"].assert_called_once_with(target, context["model"])
+    adapter.commit.assert_called_once_with()
+    assert context["drop_relation_if_exists"].call_args_list == [
+        call(None),
+        call(None),
+        call(backup),
+    ]
+
+
+def test_table_executor_rejects_missing_or_untyped_context_boundaries():
+    executor = TableMaterializationExecutor(MagicMock(), MagicMock(), {})
+
+    with pytest.raises(DbtInternalError, match="missing 'this'"):
+        executor.plan()
+
+    executor.context["this"] = object()
+    executor.context["load_cached_relation"] = "not callable"
+    with pytest.raises(DbtInternalError, match="not callable"):
+        executor.plan()

--- a/tests/unit/materializations/test_table.py
+++ b/tests/unit/materializations/test_table.py
@@ -8,7 +8,11 @@ from dbt.materializations.table import TableMaterializationExecutor
 
 
 def _relation(name, relation_type="table"):
-    return SimpleNamespace(name=name, type=relation_type)
+    relation = MagicMock(name=name)
+    relation.name = name
+    relation.type = relation_type
+    relation.include.return_value = f'"analytics"."{name}"'
+    return relation
 
 
 def _executor_context(*, existing_relation=None, grant_config=None):
@@ -53,7 +57,7 @@ def test_table_executor_runs_builtin_lifecycle_in_python():
     )
     response = object()
     table = object()
-    adapter = MagicMock()
+    adapter = MagicMock(spec=["execute", "rename_relation"])
     adapter.execute.return_value = (response, table)
 
     result = TableMaterializationExecutor(adapter, MagicMock(), context).execute()
@@ -96,9 +100,116 @@ def test_table_executor_rejects_missing_or_untyped_context_boundaries():
     executor = TableMaterializationExecutor(MagicMock(), MagicMock(), {})
 
     with pytest.raises(DbtInternalError, match="missing 'this'"):
-        executor.plan()
+        executor.resolve_execution_state()
 
     executor.context["this"] = object()
     executor.context["load_cached_relation"] = "not callable"
     with pytest.raises(DbtInternalError, match="not callable"):
-        executor.plan()
+        executor.resolve_execution_state()
+
+
+class _RenderArguments:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+def _macro(unique_id):
+    return SimpleNamespace(macro=SimpleNamespace(unique_id=unique_id))
+
+
+def _typed_renderer_context():
+    context, _, intermediate, _ = _executor_context()
+    context["get_create_table_as_sql"].macro.unique_id = "macro.dbt.get_create_table_as_sql"
+    context["render_create_from_query_plan"] = _macro("macro.dbt.render_create_from_query_plan")
+    adapter_wrapper = MagicMock()
+    adapter_wrapper.dispatch.side_effect = (
+        _macro("macro.dbt.default__get_create_table_as_sql"),
+        _macro("macro.dbt.default__render_create_from_query_plan"),
+        _macro("macro.dbt.default__create_table_as"),
+    )
+    context["adapter"] = adapter_wrapper
+    context["render_create_from_query_ctas"] = _macro("macro.dbt.render_create_from_query_ctas")
+    context["config"] = {
+        "grants": None,
+        "contract": {"enforced": False},
+        "sql_header": "alter session set query_tag = 'dbt'",
+    }
+    return context, intermediate
+
+
+def test_table_executor_uses_typed_python_renderer(monkeypatch):
+    context, intermediate = _typed_renderer_context()
+    create_plan = SimpleNamespace(renderer_macro="render_create_from_query_ctas")
+    render_result = SimpleNamespace(
+        kind=SimpleNamespace(value="sql"),
+        sql="create table typed as select 1",
+    )
+    adapter = MagicMock()
+    adapter.plan_create_from_query.return_value = create_plan
+    adapter.resolve_create_from_query_render.return_value = render_result
+    executor = TableMaterializationExecutor(adapter, MagicMock(), context)
+    monkeypatch.setattr(executor, "_render_arguments_type", lambda: _RenderArguments)
+
+    sql = executor._build_sql(intermediate)
+
+    assert sql == "create table typed as select 1"
+    context["get_create_table_as_sql"].assert_not_called()
+    adapter.plan_create_from_query.assert_called_once_with(False, intermediate, executor.model)
+    arguments = adapter.resolve_create_from_query_render.call_args.args[1]
+    assert arguments.relation_sql == '"analytics"."intermediate"'
+    assert arguments.query == context["sql"]
+    assert arguments.sql_header == "alter session set query_tag = 'dbt'"
+    assert arguments.contract_enforced is False
+    assert arguments.legacy_renderer_override is None
+
+
+def test_table_executor_honors_typed_legacy_fallback(monkeypatch):
+    context, intermediate = _typed_renderer_context()
+    create_plan = SimpleNamespace(renderer_macro="render_create_from_query_ctas")
+    adapter = MagicMock()
+    adapter.plan_create_from_query.return_value = create_plan
+    adapter.resolve_create_from_query_render.return_value = SimpleNamespace(
+        kind=SimpleNamespace(value="legacy_macro"),
+        renderer_macro="get_create_table_as_sql",
+        reason="Enforced table contracts still require the compatibility renderer",
+    )
+    executor = TableMaterializationExecutor(adapter, MagicMock(), context)
+    monkeypatch.setattr(executor, "_render_arguments_type", lambda: _RenderArguments)
+
+    sql = executor._build_sql(intermediate)
+
+    assert sql == "create table intermediate as select 1"
+    context["get_create_table_as_sql"].assert_called_once_with(False, intermediate, context["sql"])
+
+
+def test_table_executor_reports_project_renderer_override(monkeypatch):
+    context, intermediate = _typed_renderer_context()
+    context["get_create_table_as_sql"].macro.unique_id = "macro.project.get_create_table_as_sql"
+    create_plan = SimpleNamespace(renderer_macro="render_create_from_query_ctas")
+    adapter = MagicMock()
+    adapter.plan_create_from_query.return_value = create_plan
+    adapter.resolve_create_from_query_render.return_value = SimpleNamespace(
+        kind=SimpleNamespace(value="legacy_macro"),
+        renderer_macro="get_create_table_as_sql",
+    )
+    executor = TableMaterializationExecutor(adapter, MagicMock(), context)
+    monkeypatch.setattr(executor, "_render_arguments_type", lambda: _RenderArguments)
+
+    executor._build_sql(intermediate)
+
+    arguments = adapter.resolve_create_from_query_render.call_args.args[1]
+    assert arguments.legacy_renderer_override == "macro.project.get_create_table_as_sql"
+
+
+def test_table_executor_reports_adapter_dispatch_override():
+    context, _ = _typed_renderer_context()
+    context["adapter"].dispatch.side_effect = (
+        _macro("macro.adapter.adapter__get_create_table_as_sql"),
+    )
+    executor = TableMaterializationExecutor(MagicMock(), MagicMock(), context)
+
+    override = executor._legacy_renderer_override(
+        SimpleNamespace(renderer_macro="render_create_from_query_ctas")
+    )
+
+    assert override == "macro.adapter.adapter__get_create_table_as_sql"

--- a/tests/unit/materializations/test_table.py
+++ b/tests/unit/materializations/test_table.py
@@ -22,6 +22,7 @@ def _executor_context(*, existing_relation=None, grant_config=None):
         side_effect=[existing_relation, None, None, existing_relation]
     )
     context = {
+        "adapter": MagicMock(),
         "this": this,
         "config": {"grants": grant_config},
         "model": {"unique_id": "model.test.orders"},
@@ -83,7 +84,7 @@ def test_table_executor_runs_builtin_lifecycle_in_python():
         should_revoke=True,
     )
     context["persist_docs"].assert_called_once_with(target, context["model"])
-    adapter.commit.assert_called_once_with()
+    context["adapter"].commit.assert_called_once_with()
     assert context["drop_relation_if_exists"].call_args_list == [
         call(None),
         call(None),

--- a/tests/unit/task/test_run.py
+++ b/tests/unit/task/test_run.py
@@ -136,6 +136,29 @@ class TestModelRunner:
         add_callback_to_manager(catcher.catch)
         return catcher
 
+    @pytest.mark.parametrize(
+        "unique_id,language,uses_python",
+        [
+            ("macro.dbt.materialization_table_default", "sql", True),
+            ("macro.project.materialization_table_default", "sql", False),
+            ("macro.dbt.materialization_table_postgres", "sql", False),
+            ("macro.dbt.materialization_table_default", "python", False),
+        ],
+    )
+    def test_python_materialization_executor_only_claims_exact_builtin_sql_table(
+        self,
+        model_runner: ModelRunner,
+        unique_id: str,
+        language: str,
+        uses_python: bool,
+    ) -> None:
+        model = mock.Mock(language=language)
+        materialization_macro = mock.Mock(unique_id=unique_id)
+
+        executor = model_runner._get_python_materialization_executor(model, materialization_macro)
+
+        assert (executor is not None) is uses_python
+
     def test_print_result_line(
         self,
         log_model_result_catcher: EventCatcher,


### PR DESCRIPTION
## Summary

Stacked on #16058 and dbt-labs/dbt-adapters#2138.

- asks the adapter planner for a typed create-from-query render outcome
- executes validated portable CTAS SQL directly from Python
- detects project, adapter-dispatch, and plan-renderer macro overrides by resolved macro identity
- re-enters get_create_table_as_sql for explicit compatibility fallbacks
- retains compatibility with older dbt-adapters packages through feature detection
- renames the late-bound relation bundle from Plan to ExecutionState so it is not confused with the serializable adapter plan

## Compatibility boundary

Jinja remains only for older adapter packages, table contracts, non-portable strategies, and user or adapter macro overrides. Default portable CTAS rendering no longer requires Jinja.

## Validation

- dbt-core unit suite: 2,139 passed, 10 skipped
- focused executor tests: 6 passed
- cross-repo test with stacked dbt-adapters source: 6 passed
- Black, isort, Flake8, MyPy, artifact import guard, and CodeScene delta hooks passed