### PR TITLE
feat: execute generic incremental lifecycle in Python

### DIFF
--- a/.changes/unreleased/Under the Hood-20260823-192430.yaml
+++ b/.changes/unreleased/Under the Hood-20260823-192430.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Run the built-in generic SQL table materialization lifecycle in typed Python while preserving Jinja fallback for overrides.
+time: 2026-08-23T19:24:30.807875-04:00
+custom:
+    Author: dataders
+    Issue: ""

--- a/.changes/unreleased/Under the Hood-20260823-195206.yaml
+++ b/.changes/unreleased/Under the Hood-20260823-195206.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Move the built-in SQL incremental materialization lifecycle into a compatibility-gated Python executor.
+time: 2026-08-23T19:52:06.808335-04:00
+custom:
+    Author: dataders
+    Issue: ""

--- a/core/dbt/materializations/incremental/executor.py
+++ b/core/dbt/materializations/incremental/executor.py
@@ -1,0 +1,208 @@
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+from dbt.adapters.base.relation import BaseRelation
+from dbt.contracts.graph.nodes import ModelNode
+from dbt.exceptions import DbtInternalError
+from dbt.materializations.table import TableMaterializationExecutor
+
+
+@dataclass(frozen=True)
+class IncrementalMaterializationExecutionState:
+    """Late-bound relations and a resolved incremental mutation plan."""
+
+    existing_relation: Optional[BaseRelation]
+    target_relation: BaseRelation
+    intermediate_relation: BaseRelation
+    backup_relation: BaseRelation
+    temp_relation: BaseRelation
+    preexisting_intermediate_relation: Optional[BaseRelation]
+    preexisting_backup_relation: Optional[BaseRelation]
+    incremental_plan: Any
+    strategy_macro: Any
+    catalog_relation: Any
+    unique_key: Any
+    staging_is_temporary: bool
+    full_refresh_mode: bool
+    on_schema_change: str
+    grant_config: Mapping[str, Any]
+
+
+class IncrementalMaterializationExecutor(TableMaterializationExecutor):
+    """Execute the built-in SQL incremental lifecycle in Python."""
+
+    REQUIRED_ADAPTER_METHODS = (
+        "build_catalog_relation",
+        "get_incremental_plan_macro",
+        "plan_incremental_arguments",
+        "plan_incremental_mutation",
+    )
+
+    def __init__(self, adapter: Any, model: ModelNode, context: dict[str, Any]) -> None:
+        super().__init__(adapter, model, context)
+
+    def resolve_incremental_execution_state(self) -> IncrementalMaterializationExecutionState:
+        existing_relation = self._call_macro("load_cached_relation", self._context_value("this"))
+        target_relation = self._context_value("this").incorporate(type="table")
+        intermediate_relation = self._call_macro("make_intermediate_relation", target_relation)
+        backup_relation_type = "table" if existing_relation is None else existing_relation.type
+        backup_relation = self._call_macro(
+            "make_backup_relation", target_relation, backup_relation_type
+        )
+
+        config = self._context_value("config")
+        unique_key = config.get("unique_key")
+        catalog_relation = self.adapter.build_catalog_relation(self.model)
+        incremental_plan = self.adapter.plan_incremental_mutation(
+            config.get("incremental_strategy") or "default",
+            language=str(self.model.language),
+            unique_key=unique_key,
+            requested_temp_relation_type=config.get("tmp_relation_type"),
+            catalog_relation=catalog_relation,
+        )
+        strategy_macro = self.adapter.get_incremental_plan_macro(self.context, incremental_plan)
+        if not callable(strategy_macro):
+            raise DbtInternalError("Incremental mutation plan did not resolve to a callable")
+
+        temp_relation = self._call_macro("make_temp_relation", target_relation)
+        temp_relation_type = getattr(incremental_plan, "temp_relation_type", None)
+        if temp_relation_type is not None:
+            object_type = getattr(temp_relation_type, "value", temp_relation_type)
+            if object_type == "transient":
+                object_type = "table"
+            temp_relation = temp_relation.incorporate(type=object_type)
+
+        catalog_staging = getattr(incremental_plan, "catalog_staging", None)
+        catalog_staging_value = getattr(catalog_staging, "value", catalog_staging)
+        staging_is_temporary = catalog_staging_value != "permanent_table_only"
+        full_refresh_mode = bool(
+            self._call_macro("should_full_refresh")
+            or (existing_relation is not None and existing_relation.is_view)
+        )
+        on_schema_change = self._call_macro(
+            "incremental_validate_on_schema_change",
+            config.get("on_schema_change"),
+            default="ignore",
+        )
+        if not isinstance(on_schema_change, str):
+            raise DbtInternalError("Incremental schema-change planner must return a string")
+
+        grant_config = config.get("grants") or {}
+        if not isinstance(grant_config, Mapping):
+            raise DbtInternalError("Incremental materialization grants config must be a mapping")
+
+        return IncrementalMaterializationExecutionState(
+            existing_relation=existing_relation,
+            target_relation=target_relation,
+            intermediate_relation=intermediate_relation,
+            backup_relation=backup_relation,
+            temp_relation=temp_relation,
+            preexisting_intermediate_relation=self._call_macro(
+                "load_cached_relation", intermediate_relation
+            ),
+            preexisting_backup_relation=self._call_macro("load_cached_relation", backup_relation),
+            incremental_plan=incremental_plan,
+            strategy_macro=strategy_macro,
+            catalog_relation=catalog_relation,
+            unique_key=unique_key,
+            staging_is_temporary=staging_is_temporary,
+            full_refresh_mode=full_refresh_mode,
+            on_schema_change=on_schema_change,
+            grant_config=grant_config,
+        )
+
+    def _contract_enforced(self) -> bool:
+        contract = self._context_value("config").get("contract")
+        if isinstance(contract, Mapping):
+            return bool(contract.get("enforced"))
+        return bool(getattr(contract, "enforced", False))
+
+    def _incremental_mutation_sql(self, state: IncrementalMaterializationExecutionState) -> str:
+        staging_sql = self._build_sql(
+            state.temp_relation,
+            temporary=state.staging_is_temporary,
+        )
+        self.adapter.execute(staging_sql, auto_begin=True, fetch=False)
+
+        if not self._contract_enforced():
+            self.adapter.expand_target_column_types(
+                from_relation=state.temp_relation,
+                to_relation=state.target_relation,
+            )
+
+        dest_columns = self._call_macro(
+            "process_schema_changes",
+            state.on_schema_change,
+            state.temp_relation,
+            state.existing_relation,
+        )
+        if not dest_columns:
+            dest_columns = self.adapter.get_columns_in_relation(state.existing_relation)
+
+        config = self._context_value("config")
+        incremental_predicates = config.get("predicates") or config.get("incremental_predicates")
+        strategy_arguments = self.adapter.plan_incremental_arguments(
+            target_relation=state.target_relation,
+            temp_relation=state.temp_relation,
+            unique_key=state.unique_key,
+            dest_columns=dest_columns,
+            incremental_predicates=incremental_predicates,
+            adapter_arguments={
+                "catalog_relation": state.catalog_relation,
+                "incremental_plan": state.incremental_plan,
+            },
+        )
+        build_sql = state.strategy_macro(strategy_arguments.to_macro_dict())
+        if not isinstance(build_sql, str):
+            raise DbtInternalError("Incremental mutation renderer must return SQL text")
+        return build_sql
+
+    def execute(self) -> dict[str, Any]:
+        state = self.resolve_incremental_execution_state()
+
+        self._call_macro("drop_relation_if_exists", state.preexisting_intermediate_relation)
+        self._call_macro("drop_relation_if_exists", state.preexisting_backup_relation)
+        self._call_macro("run_hooks", self._context_value("pre_hooks"), inside_transaction=False)
+        self._call_macro("run_hooks", self._context_value("pre_hooks"), inside_transaction=True)
+
+        need_swap = False
+        if state.existing_relation is None:
+            build_sql = self._build_sql(state.target_relation)
+            relation_for_indexes = state.target_relation
+        elif state.full_refresh_mode:
+            build_sql = self._build_sql(state.intermediate_relation)
+            relation_for_indexes = state.intermediate_relation
+            need_swap = True
+        else:
+            build_sql = self._incremental_mutation_sql(state)
+            relation_for_indexes = state.temp_relation
+
+        self._execute_main(build_sql)
+
+        if state.existing_relation is None or state.full_refresh_mode:
+            self._call_macro("create_indexes", relation_for_indexes)
+
+        if need_swap:
+            self.adapter.rename_relation(state.target_relation, state.backup_relation)
+            self.adapter.rename_relation(state.intermediate_relation, state.target_relation)
+
+        should_revoke = self._call_macro(
+            "should_revoke",
+            state.existing_relation,
+            state.full_refresh_mode,
+        )
+        self._call_macro(
+            "apply_grants",
+            state.target_relation,
+            state.grant_config,
+            should_revoke=should_revoke,
+        )
+        self._call_macro("persist_docs", state.target_relation, self._context_value("model"))
+        self._call_macro("run_hooks", self._context_value("post_hooks"), inside_transaction=True)
+        self._commit()
+
+        if need_swap:
+            self.adapter.drop_relation(state.backup_relation)
+
+        self._call_macro("run_hooks", self._context_value("post_hooks"), inside_transaction=False)
+        return {"relations": [state.target_relation]}

--- a/core/dbt/materializations/table.py
+++ b/core/dbt/materializations/table.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from importlib import import_module
 from typing import Any, Dict, Mapping, Optional
 
 from dbt.adapters.base.relation import BaseRelation
@@ -7,8 +8,8 @@ from dbt.exceptions import DbtInternalError
 
 
 @dataclass(frozen=True)
-class TableMaterializationPlan:
-    """Resolved relations and configuration for one table replacement."""
+class TableMaterializationExecutionState:
+    """Late-bound relations and configuration for one table replacement."""
 
     existing_relation: Optional[BaseRelation]
     target_relation: BaseRelation
@@ -47,7 +48,7 @@ class TableMaterializationExecutor:
             )
         return macro(*args, **kwargs)
 
-    def plan(self) -> TableMaterializationPlan:
+    def resolve_execution_state(self) -> TableMaterializationExecutionState:
         existing_relation = self._call_macro("load_cached_relation", self._context_value("this"))
         target_relation = self._context_value("this").incorporate(type="table")
         intermediate_relation = self._call_macro("make_intermediate_relation", target_relation)
@@ -60,7 +61,7 @@ class TableMaterializationExecutor:
         if not isinstance(grant_config, Mapping):
             raise DbtInternalError("Table materialization grants config must be a mapping")
 
-        return TableMaterializationPlan(
+        return TableMaterializationExecutionState(
             existing_relation=existing_relation,
             target_relation=target_relation,
             intermediate_relation=intermediate_relation,
@@ -84,32 +85,128 @@ class TableMaterializationExecutor:
             raise DbtInternalError("Python materialization adapter boundary cannot commit")
         commit()
 
-    def execute(self) -> Dict[str, Any]:
-        plan = self.plan()
+    @staticmethod
+    def _macro_unique_id(macro: Any) -> Optional[str]:
+        unique_id = getattr(getattr(macro, "macro", None), "unique_id", None)
+        return unique_id if isinstance(unique_id, str) else None
 
-        self._call_macro("drop_relation_if_exists", plan.preexisting_intermediate_relation)
-        self._call_macro("drop_relation_if_exists", plan.preexisting_backup_relation)
+    def _legacy_renderer_override(self, plan: Any) -> Optional[str]:
+        context_macros = (
+            ("get_create_table_as_sql", "macro.dbt.get_create_table_as_sql"),
+            ("render_create_from_query_plan", "macro.dbt.render_create_from_query_plan"),
+        )
+        for macro_name, expected_unique_id in context_macros:
+            selected_unique_id = self._macro_unique_id(self.context.get(macro_name))
+            if selected_unique_id != expected_unique_id:
+                return selected_unique_id or f"unresolved {macro_name} macro"
+
+        adapter_wrapper = self.context.get("adapter")
+        dispatch = getattr(adapter_wrapper, "dispatch", None)
+        if not callable(dispatch):
+            return "unresolved legacy renderer dispatch"
+
+        dispatched_macros = (
+            ("get_create_table_as_sql", "macro.dbt.default__get_create_table_as_sql"),
+            ("render_create_from_query_plan", "macro.dbt.default__render_create_from_query_plan"),
+            ("create_table_as", "macro.dbt.default__create_table_as"),
+        )
+        for macro_name, expected_unique_id in dispatched_macros:
+            selected = dispatch(macro_name, "dbt")
+            selected_unique_id = self._macro_unique_id(selected)
+            if selected_unique_id != expected_unique_id:
+                return selected_unique_id or f"unresolved {macro_name} dispatch"
+
+        renderer_macro = getattr(plan, "renderer_macro", None)
+        if not isinstance(renderer_macro, str):
+            return "unresolved plan renderer"
+        selected_renderer = self.context.get(renderer_macro)
+        selected_renderer_unique_id = self._macro_unique_id(selected_renderer)
+        expected_renderer_unique_id = f"macro.dbt.{renderer_macro}"
+        if selected_renderer_unique_id != expected_renderer_unique_id:
+            return selected_renderer_unique_id or f"unresolved {renderer_macro} renderer"
+        return None
+
+    @staticmethod
+    def _render_arguments_type() -> Optional[Any]:
+        """Load new adapter contract without raising core's adapter minimum version."""
+
+        try:
+            planning = import_module("dbt.adapters.planning")
+        except ModuleNotFoundError as exc:
+            if exc.name != "dbt.adapters.planning":
+                raise
+            return None
+        return getattr(planning, "CreateFromQueryRenderArguments", None)
+
+    def _legacy_build_sql(self, relation: BaseRelation, sql: str) -> str:
+        build_sql = self._call_macro("get_create_table_as_sql", False, relation, sql)
+        if not isinstance(build_sql, str):
+            raise DbtInternalError("Table create-from-query renderer must return SQL text")
+        return build_sql
+
+    def _build_sql(self, relation: BaseRelation) -> str:
+        sql = self._context_value("sql")
+        render_arguments_type = self._render_arguments_type()
+        resolve_render = getattr(self.adapter, "resolve_create_from_query_render", None)
+        plan_create = getattr(self.adapter, "plan_create_from_query", None)
+        if (
+            render_arguments_type is None
+            or not callable(resolve_render)
+            or not callable(plan_create)
+        ):
+            return self._legacy_build_sql(relation, sql)
+
+        create_plan = plan_create(False, relation, self.model)
+        relation_sql = str(relation.include(database=True, schema=True))
+        config = self._context_value("config")
+        contract = config.get("contract")
+        contract_enforced = (
+            bool(contract.get("enforced"))
+            if isinstance(contract, Mapping)
+            else bool(getattr(contract, "enforced", False))
+        )
+        render_arguments = render_arguments_type(
+            relation_sql=relation_sql,
+            query=sql,
+            sql_header=config.get("sql_header"),
+            contract_enforced=contract_enforced,
+            legacy_renderer_override=self._legacy_renderer_override(create_plan),
+        )
+        render_result = resolve_render(create_plan, render_arguments)
+        render_kind = getattr(getattr(render_result, "kind", None), "value", None)
+        if render_kind == "sql":
+            rendered_sql = getattr(render_result, "sql", None)
+            if not isinstance(rendered_sql, str):
+                raise DbtInternalError("Typed create-from-query renderer returned invalid SQL")
+            return rendered_sql
+        if render_kind == "legacy_macro":
+            renderer_macro = getattr(render_result, "renderer_macro", None)
+            if renderer_macro != "get_create_table_as_sql":
+                raise DbtInternalError(
+                    "Typed create-from-query renderer selected an unknown compatibility macro"
+                )
+            return self._legacy_build_sql(relation, sql)
+        raise DbtInternalError("Typed create-from-query renderer returned an unknown result kind")
+
+    def execute(self) -> Dict[str, Any]:
+        state = self.resolve_execution_state()
+
+        self._call_macro("drop_relation_if_exists", state.preexisting_intermediate_relation)
+        self._call_macro("drop_relation_if_exists", state.preexisting_backup_relation)
         self._call_macro("run_hooks", self._context_value("pre_hooks"), inside_transaction=False)
         self._call_macro("run_hooks", self._context_value("pre_hooks"), inside_transaction=True)
 
-        build_sql = self._call_macro(
-            "get_create_table_as_sql",
-            False,
-            plan.intermediate_relation,
-            self._context_value("sql"),
-        )
-        if not isinstance(build_sql, str):
-            raise DbtInternalError("Table create-from-query renderer must return SQL text")
+        build_sql = self._build_sql(state.intermediate_relation)
         self._execute_main(build_sql)
-        self._call_macro("create_indexes", plan.intermediate_relation)
+        self._call_macro("create_indexes", state.intermediate_relation)
 
-        existing_relation = plan.existing_relation
+        existing_relation = state.existing_relation
         if existing_relation is not None:
             existing_relation = self._call_macro("load_cached_relation", existing_relation)
             if existing_relation is not None:
-                self.adapter.rename_relation(existing_relation, plan.backup_relation)
+                self.adapter.rename_relation(existing_relation, state.backup_relation)
 
-        self.adapter.rename_relation(plan.intermediate_relation, plan.target_relation)
+        self.adapter.rename_relation(state.intermediate_relation, state.target_relation)
         self._call_macro("run_hooks", self._context_value("post_hooks"), inside_transaction=True)
 
         should_revoke = self._call_macro(
@@ -117,13 +214,13 @@ class TableMaterializationExecutor:
         )
         self._call_macro(
             "apply_grants",
-            plan.target_relation,
-            plan.grant_config,
+            state.target_relation,
+            state.grant_config,
             should_revoke=should_revoke,
         )
-        self._call_macro("persist_docs", plan.target_relation, self._context_value("model"))
+        self._call_macro("persist_docs", state.target_relation, self._context_value("model"))
         self._commit()
-        self._call_macro("drop_relation_if_exists", plan.backup_relation)
+        self._call_macro("drop_relation_if_exists", state.backup_relation)
         self._call_macro("run_hooks", self._context_value("post_hooks"), inside_transaction=False)
 
-        return {"relations": [plan.target_relation]}
+        return {"relations": [state.target_relation]}

--- a/core/dbt/materializations/table.py
+++ b/core/dbt/materializations/table.py
@@ -138,13 +138,13 @@ class TableMaterializationExecutor:
             return None
         return getattr(planning, "CreateFromQueryRenderArguments", None)
 
-    def _legacy_build_sql(self, relation: BaseRelation, sql: str) -> str:
-        build_sql = self._call_macro("get_create_table_as_sql", False, relation, sql)
+    def _legacy_build_sql(self, relation: BaseRelation, sql: str, temporary: bool = False) -> str:
+        build_sql = self._call_macro("get_create_table_as_sql", temporary, relation, sql)
         if not isinstance(build_sql, str):
             raise DbtInternalError("Table create-from-query renderer must return SQL text")
         return build_sql
 
-    def _build_sql(self, relation: BaseRelation) -> str:
+    def _build_sql(self, relation: BaseRelation, temporary: bool = False) -> str:
         sql = self._context_value("sql")
         render_arguments_type = self._render_arguments_type()
         resolve_render = getattr(self.adapter, "resolve_create_from_query_render", None)
@@ -154,10 +154,10 @@ class TableMaterializationExecutor:
             or not callable(resolve_render)
             or not callable(plan_create)
         ):
-            return self._legacy_build_sql(relation, sql)
+            return self._legacy_build_sql(relation, sql, temporary)
 
-        create_plan = plan_create(False, relation, self.model)
-        relation_sql = str(relation.include(database=True, schema=True))
+        create_plan = plan_create(temporary, relation, self.model)
+        relation_sql = str(relation.include(database=not temporary, schema=not temporary))
         config = self._context_value("config")
         contract = config.get("contract")
         contract_enforced = (
@@ -185,7 +185,7 @@ class TableMaterializationExecutor:
                 raise DbtInternalError(
                     "Typed create-from-query renderer selected an unknown compatibility macro"
                 )
-            return self._legacy_build_sql(relation, sql)
+            return self._legacy_build_sql(relation, sql, temporary)
         raise DbtInternalError("Typed create-from-query renderer returned an unknown result kind")
 
     def execute(self) -> Dict[str, Any]:

--- a/core/dbt/materializations/table.py
+++ b/core/dbt/materializations/table.py
@@ -77,6 +77,13 @@ class TableMaterializationExecutor:
         response, table = self.adapter.execute(sql, auto_begin=True, fetch=False)
         self._call_macro("store_result", "main", response=response, agate_table=table)
 
+    def _commit(self) -> None:
+        runtime_adapter = self._context_value("adapter")
+        commit = getattr(runtime_adapter, "commit", None)
+        if not callable(commit):
+            raise DbtInternalError("Python materialization adapter boundary cannot commit")
+        commit()
+
     def execute(self) -> Dict[str, Any]:
         plan = self.plan()
 
@@ -115,7 +122,7 @@ class TableMaterializationExecutor:
             should_revoke=should_revoke,
         )
         self._call_macro("persist_docs", plan.target_relation, self._context_value("model"))
-        self.adapter.commit()
+        self._commit()
         self._call_macro("drop_relation_if_exists", plan.backup_relation)
         self._call_macro("run_hooks", self._context_value("post_hooks"), inside_transaction=False)
 

--- a/core/dbt/materializations/table.py
+++ b/core/dbt/materializations/table.py
@@ -1,0 +1,122 @@
+from dataclasses import dataclass
+from typing import Any, Dict, Mapping, Optional
+
+from dbt.adapters.base.relation import BaseRelation
+from dbt.contracts.graph.nodes import ModelNode
+from dbt.exceptions import DbtInternalError
+
+
+@dataclass(frozen=True)
+class TableMaterializationPlan:
+    """Resolved relations and configuration for one table replacement."""
+
+    existing_relation: Optional[BaseRelation]
+    target_relation: BaseRelation
+    intermediate_relation: BaseRelation
+    backup_relation: BaseRelation
+    preexisting_intermediate_relation: Optional[BaseRelation]
+    preexisting_backup_relation: Optional[BaseRelation]
+    grant_config: Mapping[str, Any]
+
+
+class TableMaterializationExecutor:
+    """Execute built-in table lifecycle in Python.
+
+    Project and adapter macros remain callable at explicit compatibility boundaries,
+    but control flow and database mutation ordering live here rather than in Jinja.
+    """
+
+    def __init__(self, adapter: Any, model: ModelNode, context: Dict[str, Any]) -> None:
+        self.adapter = adapter
+        self.model = model
+        self.context = context
+
+    def _context_value(self, name: str) -> Any:
+        try:
+            return self.context[name]
+        except KeyError:
+            raise DbtInternalError(
+                f"Python table materialization context is missing '{name}'"
+            ) from None
+
+    def _call_macro(self, name: str, *args: Any, **kwargs: Any) -> Any:
+        macro = self._context_value(name)
+        if not callable(macro):
+            raise DbtInternalError(
+                f"Python table materialization context value '{name}' is not callable"
+            )
+        return macro(*args, **kwargs)
+
+    def plan(self) -> TableMaterializationPlan:
+        existing_relation = self._call_macro("load_cached_relation", self._context_value("this"))
+        target_relation = self._context_value("this").incorporate(type="table")
+        intermediate_relation = self._call_macro("make_intermediate_relation", target_relation)
+        backup_relation_type = "table" if existing_relation is None else existing_relation.type
+        backup_relation = self._call_macro(
+            "make_backup_relation", target_relation, backup_relation_type
+        )
+
+        grant_config = self._context_value("config").get("grants") or {}
+        if not isinstance(grant_config, Mapping):
+            raise DbtInternalError("Table materialization grants config must be a mapping")
+
+        return TableMaterializationPlan(
+            existing_relation=existing_relation,
+            target_relation=target_relation,
+            intermediate_relation=intermediate_relation,
+            backup_relation=backup_relation,
+            preexisting_intermediate_relation=self._call_macro(
+                "load_cached_relation", intermediate_relation
+            ),
+            preexisting_backup_relation=self._call_macro("load_cached_relation", backup_relation),
+            grant_config=grant_config,
+        )
+
+    def _execute_main(self, sql: str) -> None:
+        self._call_macro("write", sql)
+        response, table = self.adapter.execute(sql, auto_begin=True, fetch=False)
+        self._call_macro("store_result", "main", response=response, agate_table=table)
+
+    def execute(self) -> Dict[str, Any]:
+        plan = self.plan()
+
+        self._call_macro("drop_relation_if_exists", plan.preexisting_intermediate_relation)
+        self._call_macro("drop_relation_if_exists", plan.preexisting_backup_relation)
+        self._call_macro("run_hooks", self._context_value("pre_hooks"), inside_transaction=False)
+        self._call_macro("run_hooks", self._context_value("pre_hooks"), inside_transaction=True)
+
+        build_sql = self._call_macro(
+            "get_create_table_as_sql",
+            False,
+            plan.intermediate_relation,
+            self._context_value("sql"),
+        )
+        if not isinstance(build_sql, str):
+            raise DbtInternalError("Table create-from-query renderer must return SQL text")
+        self._execute_main(build_sql)
+        self._call_macro("create_indexes", plan.intermediate_relation)
+
+        existing_relation = plan.existing_relation
+        if existing_relation is not None:
+            existing_relation = self._call_macro("load_cached_relation", existing_relation)
+            if existing_relation is not None:
+                self.adapter.rename_relation(existing_relation, plan.backup_relation)
+
+        self.adapter.rename_relation(plan.intermediate_relation, plan.target_relation)
+        self._call_macro("run_hooks", self._context_value("post_hooks"), inside_transaction=True)
+
+        should_revoke = self._call_macro(
+            "should_revoke", existing_relation, full_refresh_mode=True
+        )
+        self._call_macro(
+            "apply_grants",
+            plan.target_relation,
+            plan.grant_config,
+            should_revoke=should_revoke,
+        )
+        self._call_macro("persist_docs", plan.target_relation, self._context_value("model"))
+        self.adapter.commit()
+        self._call_macro("drop_relation_if_exists", plan.backup_relation)
+        self._call_macro("run_hooks", self._context_value("post_hooks"), inside_transaction=False)
+
+        return {"relations": [plan.target_relation]}

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -69,6 +69,7 @@ from dbt.graph import ResourceTypeSelector
 from dbt.graph.thread_pool import DbtThreadPool
 from dbt.hooks import get_hook_dict
 from dbt.materializations.incremental.microbatch import MicrobatchBuilder
+from dbt.materializations.table import TableMaterializationExecutor
 from dbt.node_types import NodeType, RunHookType
 from dbt.task import group_lookup
 from dbt.task.base import BaseRunner
@@ -234,6 +235,20 @@ def _validate_materialization_relations_dict(inp: Dict[Any, Any], model) -> List
 
 
 class ModelRunner(CompileRunner[ModelNode]):
+    _PYTHON_MATERIALIZATION_EXECUTORS = {
+        "macro.dbt.materialization_table_default": TableMaterializationExecutor,
+    }
+
+    def _get_python_materialization_executor(
+        self, model: ModelNode, materialization_macro: MacroProtocol
+    ) -> Optional[Type[TableMaterializationExecutor]]:
+        if str(model.language) != "sql":
+            return None
+        unique_id = getattr(materialization_macro, "unique_id", None)
+        if not isinstance(unique_id, str):
+            return None
+        return self._PYTHON_MATERIALIZATION_EXECUTORS.get(unique_id)
+
     def _relation_identifier(self, relation: BaseRelation) -> str:
         identifier = getattr(relation, "identifier", None)
         if identifier is not None:
@@ -437,9 +452,13 @@ class ModelRunner(CompileRunner[ModelNode]):
     ) -> RunResult:
         relations: List[BaseRelation] = []
         try:
-            result = MacroGenerator(
-                materialization_macro, context, stack=context["context_macro_stack"]
-            )()
+            executor_type = self._get_python_materialization_executor(model, materialization_macro)
+            if executor_type is None:
+                result = MacroGenerator(
+                    materialization_macro, context, stack=context["context_macro_stack"]
+                )()
+            else:
+                result = executor_type(self.adapter, model, context).execute()
             relations = self._materialization_relations(result, model)
             relations.extend(
                 self._materialize_latest_version_pointer(manifest, model, context, relations)

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -68,6 +68,7 @@ from dbt.flags import get_flags
 from dbt.graph import ResourceTypeSelector
 from dbt.graph.thread_pool import DbtThreadPool
 from dbt.hooks import get_hook_dict
+from dbt.materializations.incremental.executor import IncrementalMaterializationExecutor
 from dbt.materializations.incremental.microbatch import MicrobatchBuilder
 from dbt.materializations.table import TableMaterializationExecutor
 from dbt.node_types import NodeType, RunHookType
@@ -236,6 +237,7 @@ def _validate_materialization_relations_dict(inp: Dict[Any, Any], model) -> List
 
 class ModelRunner(CompileRunner[ModelNode]):
     _PYTHON_MATERIALIZATION_EXECUTORS = {
+        "macro.dbt.materialization_incremental_default": IncrementalMaterializationExecutor,
         "macro.dbt.materialization_table_default": TableMaterializationExecutor,
     }
 
@@ -247,7 +249,16 @@ class ModelRunner(CompileRunner[ModelNode]):
         unique_id = getattr(materialization_macro, "unique_id", None)
         if not isinstance(unique_id, str):
             return None
-        return self._PYTHON_MATERIALIZATION_EXECUTORS.get(unique_id)
+        executor_type = self._PYTHON_MATERIALIZATION_EXECUTORS.get(unique_id)
+        if executor_type is None:
+            return None
+        required_adapter_methods = getattr(executor_type, "REQUIRED_ADAPTER_METHODS", ())
+        if not all(
+            callable(getattr(self.adapter, method_name, None))
+            for method_name in required_adapter_methods
+        ):
+            return None
+        return executor_type
 
     def _relation_identifier(self, relation: BaseRelation) -> str:
         identifier = getattr(relation, "identifier", None)

--- a/tests/unit/materializations/test_incremental.py
+++ b/tests/unit/materializations/test_incremental.py
@@ -1,0 +1,251 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call
+
+from dbt.materializations.incremental.executor import (
+    IncrementalMaterializationExecutionState,
+    IncrementalMaterializationExecutor,
+)
+
+
+def _relation(name, relation_type="table", *, is_view=False):
+    relation = MagicMock(name=name)
+    relation.name = name
+    relation.type = relation_type
+    relation.is_view = is_view
+    relation.include.return_value = f'"analytics"."{name}"'
+    return relation
+
+
+def _context(existing_relation):
+    this = MagicMock(name="this")
+    target = _relation("target")
+    intermediate = _relation("intermediate")
+    backup = _relation("backup")
+    temp = _relation("temp")
+    this.incorporate.return_value = target
+    context = {
+        "adapter": MagicMock(),
+        "this": this,
+        "config": {
+            "unique_key": "id",
+            "incremental_strategy": "delete+insert",
+            "tmp_relation_type": "view",
+            "on_schema_change": "append_new_columns",
+            "grants": {"select": ["reporter"]},
+            "predicates": ["id > 0"],
+            "contract": {"enforced": False},
+        },
+        "model": {"unique_id": "model.test.orders"},
+        "sql": "select 1 as id",
+        "pre_hooks": ["pre"],
+        "post_hooks": ["post"],
+        "load_cached_relation": MagicMock(side_effect=[existing_relation, None, None]),
+        "make_intermediate_relation": MagicMock(return_value=intermediate),
+        "make_backup_relation": MagicMock(return_value=backup),
+        "make_temp_relation": MagicMock(return_value=temp),
+        "should_full_refresh": MagicMock(return_value=False),
+        "incremental_validate_on_schema_change": MagicMock(return_value="append_new_columns"),
+        "drop_relation_if_exists": MagicMock(),
+        "run_hooks": MagicMock(),
+        "process_schema_changes": MagicMock(return_value=["id"]),
+        "write": MagicMock(),
+        "store_result": MagicMock(),
+        "create_indexes": MagicMock(),
+        "should_revoke": MagicMock(return_value=False),
+        "apply_grants": MagicMock(),
+        "persist_docs": MagicMock(),
+    }
+    return context, target, intermediate, backup, temp
+
+
+def _model():
+    return SimpleNamespace(language="sql")
+
+
+def test_incremental_executor_plans_before_constructing_typed_staging_relation():
+    existing = _relation("existing")
+    context, target, intermediate, backup, temp = _context(existing)
+    typed_temp = _relation("typed_temp", "view")
+    temp.incorporate.return_value = typed_temp
+    incremental_plan = SimpleNamespace(
+        temp_relation_type=SimpleNamespace(value="view"),
+        catalog_staging=SimpleNamespace(value="permanent_table_only"),
+    )
+    strategy_macro = MagicMock()
+    catalog_relation = object()
+    adapter = MagicMock()
+    adapter.build_catalog_relation.return_value = catalog_relation
+    adapter.plan_incremental_mutation.return_value = incremental_plan
+    adapter.get_incremental_plan_macro.return_value = strategy_macro
+
+    state = IncrementalMaterializationExecutor(
+        adapter, _model(), context
+    ).resolve_incremental_execution_state()
+
+    adapter.plan_incremental_mutation.assert_called_once_with(
+        "delete+insert",
+        language="sql",
+        unique_key="id",
+        requested_temp_relation_type="view",
+        catalog_relation=catalog_relation,
+    )
+    temp.incorporate.assert_called_once_with(type="view")
+    assert state.temp_relation is typed_temp
+    assert state.staging_is_temporary is False
+    assert state.incremental_plan is incremental_plan
+    assert state.strategy_macro is strategy_macro
+    assert state.target_relation is target
+    assert state.intermediate_relation is intermediate
+    assert state.backup_relation is backup
+
+
+def test_incremental_executor_builds_staging_then_mutation_from_typed_arguments(
+    monkeypatch,
+):
+    existing = _relation("existing")
+    context, target, intermediate, backup, temp = _context(existing)
+    strategy_macro = MagicMock(return_value="delete from target; insert into target")
+    state = IncrementalMaterializationExecutionState(
+        existing_relation=existing,
+        target_relation=target,
+        intermediate_relation=intermediate,
+        backup_relation=backup,
+        temp_relation=temp,
+        preexisting_intermediate_relation=None,
+        preexisting_backup_relation=None,
+        incremental_plan=SimpleNamespace(),
+        strategy_macro=strategy_macro,
+        catalog_relation=object(),
+        unique_key="id",
+        staging_is_temporary=True,
+        full_refresh_mode=False,
+        on_schema_change="append_new_columns",
+        grant_config={},
+    )
+    strategy_arguments = MagicMock()
+    strategy_arguments.to_macro_dict.return_value = {"target_relation": target}
+    adapter = MagicMock()
+    adapter.plan_incremental_arguments.return_value = strategy_arguments
+    executor = IncrementalMaterializationExecutor(adapter, _model(), context)
+    monkeypatch.setattr(executor, "_build_sql", MagicMock(return_value="create temp view"))
+
+    build_sql = executor._incremental_mutation_sql(state)
+
+    assert build_sql == "delete from target; insert into target"
+    executor._build_sql.assert_called_once_with(temp, temporary=True)
+    adapter.execute.assert_called_once_with("create temp view", auto_begin=True, fetch=False)
+    adapter.expand_target_column_types.assert_called_once_with(
+        from_relation=temp,
+        to_relation=target,
+    )
+    adapter.plan_incremental_arguments.assert_called_once_with(
+        target_relation=target,
+        temp_relation=temp,
+        unique_key="id",
+        dest_columns=["id"],
+        incremental_predicates=["id > 0"],
+        adapter_arguments={
+            "catalog_relation": state.catalog_relation,
+            "incremental_plan": state.incremental_plan,
+        },
+    )
+    strategy_macro.assert_called_once_with({"target_relation": target})
+
+
+def test_incremental_executor_runs_python_lifecycle_and_mutation(monkeypatch):
+    existing = _relation("existing")
+    context, target, intermediate, backup, temp = _context(existing)
+    state = IncrementalMaterializationExecutionState(
+        existing_relation=existing,
+        target_relation=target,
+        intermediate_relation=intermediate,
+        backup_relation=backup,
+        temp_relation=temp,
+        preexisting_intermediate_relation=None,
+        preexisting_backup_relation=None,
+        incremental_plan=SimpleNamespace(),
+        strategy_macro=MagicMock(),
+        catalog_relation=None,
+        unique_key="id",
+        staging_is_temporary=True,
+        full_refresh_mode=False,
+        on_schema_change="ignore",
+        grant_config={"select": ["reporter"]},
+    )
+    adapter = MagicMock()
+    executor = IncrementalMaterializationExecutor(adapter, _model(), context)
+    monkeypatch.setattr(
+        executor,
+        "resolve_incremental_execution_state",
+        MagicMock(return_value=state),
+    )
+    monkeypatch.setattr(
+        executor,
+        "_incremental_mutation_sql",
+        MagicMock(return_value="merge into target"),
+    )
+    monkeypatch.setattr(executor, "_execute_main", MagicMock())
+
+    result = executor.execute()
+
+    assert result == {"relations": [target]}
+    executor._incremental_mutation_sql.assert_called_once_with(state)
+    executor._execute_main.assert_called_once_with("merge into target")
+    context["create_indexes"].assert_not_called()
+    context["run_hooks"].assert_has_calls(
+        [
+            call(context["pre_hooks"], inside_transaction=False),
+            call(context["pre_hooks"], inside_transaction=True),
+            call(context["post_hooks"], inside_transaction=True),
+            call(context["post_hooks"], inside_transaction=False),
+        ]
+    )
+    context["apply_grants"].assert_called_once_with(
+        target,
+        {"select": ["reporter"]},
+        should_revoke=False,
+    )
+    context["adapter"].commit.assert_called_once_with()
+    adapter.rename_relation.assert_not_called()
+    adapter.drop_relation.assert_not_called()
+
+
+def test_incremental_executor_full_refresh_swaps_and_drops_backup(monkeypatch):
+    existing = _relation("existing")
+    context, target, intermediate, backup, temp = _context(existing)
+    state = IncrementalMaterializationExecutionState(
+        existing_relation=existing,
+        target_relation=target,
+        intermediate_relation=intermediate,
+        backup_relation=backup,
+        temp_relation=temp,
+        preexisting_intermediate_relation=None,
+        preexisting_backup_relation=None,
+        incremental_plan=SimpleNamespace(),
+        strategy_macro=MagicMock(),
+        catalog_relation=None,
+        unique_key="id",
+        staging_is_temporary=True,
+        full_refresh_mode=True,
+        on_schema_change="ignore",
+        grant_config={},
+    )
+    adapter = MagicMock()
+    executor = IncrementalMaterializationExecutor(adapter, _model(), context)
+    monkeypatch.setattr(
+        executor,
+        "resolve_incremental_execution_state",
+        MagicMock(return_value=state),
+    )
+    monkeypatch.setattr(executor, "_build_sql", MagicMock(return_value="create intermediate"))
+    monkeypatch.setattr(executor, "_execute_main", MagicMock())
+
+    executor.execute()
+
+    executor._build_sql.assert_called_once_with(intermediate)
+    context["create_indexes"].assert_called_once_with(intermediate)
+    assert adapter.rename_relation.call_args_list == [
+        call(target, backup),
+        call(intermediate, target),
+    ]
+    adapter.drop_relation.assert_called_once_with(backup)

--- a/tests/unit/materializations/test_table.py
+++ b/tests/unit/materializations/test_table.py
@@ -1,0 +1,103 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from dbt.exceptions import DbtInternalError
+from dbt.materializations.table import TableMaterializationExecutor
+
+
+def _relation(name, relation_type="table"):
+    return SimpleNamespace(name=name, type=relation_type)
+
+
+def _executor_context(*, existing_relation=None, grant_config=None):
+    this = MagicMock(name="this")
+    target = _relation("target")
+    intermediate = _relation("intermediate")
+    backup = _relation("backup")
+    this.incorporate.return_value = target
+
+    load_cached_relation = MagicMock(
+        side_effect=[existing_relation, None, None, existing_relation]
+    )
+    context = {
+        "this": this,
+        "config": {"grants": grant_config},
+        "model": {"unique_id": "model.test.orders"},
+        "sql": "select 1 as id",
+        "pre_hooks": ["pre"],
+        "post_hooks": ["post"],
+        "load_cached_relation": load_cached_relation,
+        "make_intermediate_relation": MagicMock(return_value=intermediate),
+        "make_backup_relation": MagicMock(return_value=backup),
+        "drop_relation_if_exists": MagicMock(),
+        "run_hooks": MagicMock(),
+        "get_create_table_as_sql": MagicMock(return_value="create table intermediate as select 1"),
+        "write": MagicMock(),
+        "store_result": MagicMock(),
+        "create_indexes": MagicMock(),
+        "should_revoke": MagicMock(return_value=True),
+        "apply_grants": MagicMock(),
+        "persist_docs": MagicMock(),
+    }
+    return context, target, intermediate, backup
+
+
+def test_table_executor_runs_builtin_lifecycle_in_python():
+    existing = _relation("existing", "view")
+    context, target, intermediate, backup = _executor_context(
+        existing_relation=existing,
+        grant_config={"select": ["reporter"]},
+    )
+    response = object()
+    table = object()
+    adapter = MagicMock()
+    adapter.execute.return_value = (response, table)
+
+    result = TableMaterializationExecutor(adapter, MagicMock(), context).execute()
+
+    assert result == {"relations": [target]}
+    context["load_cached_relation"].assert_has_calls(
+        [call(context["this"]), call(intermediate), call(backup), call(existing)]
+    )
+    context["run_hooks"].assert_has_calls(
+        [
+            call(context["pre_hooks"], inside_transaction=False),
+            call(context["pre_hooks"], inside_transaction=True),
+            call(context["post_hooks"], inside_transaction=True),
+            call(context["post_hooks"], inside_transaction=False),
+        ]
+    )
+    adapter.execute.assert_called_once_with(
+        "create table intermediate as select 1", auto_begin=True, fetch=False
+    )
+    context["store_result"].assert_called_once_with("main", response=response, agate_table=table)
+    assert adapter.rename_relation.call_args_list == [
+        call(existing, backup),
+        call(intermediate, target),
+    ]
+    context["apply_grants"].assert_called_once_with(
+        target,
+        {"select": ["reporter"]},
+        should_revoke=True,
+    )
+    context["persist_docs"].assert_called_once_with(target, context["model"])
+    adapter.commit.assert_called_once_with()
+    assert context["drop_relation_if_exists"].call_args_list == [
+        call(None),
+        call(None),
+        call(backup),
+    ]
+
+
+def test_table_executor_rejects_missing_or_untyped_context_boundaries():
+    executor = TableMaterializationExecutor(MagicMock(), MagicMock(), {})
+
+    with pytest.raises(DbtInternalError, match="missing 'this'"):
+        executor.plan()
+
+    executor.context["this"] = object()
+    executor.context["load_cached_relation"] = "not callable"
+    with pytest.raises(DbtInternalError, match="not callable"):
+        executor.plan()

--- a/tests/unit/materializations/test_table.py
+++ b/tests/unit/materializations/test_table.py
@@ -137,7 +137,8 @@ def _typed_renderer_context():
     return context, intermediate
 
 
-def test_table_executor_uses_typed_python_renderer(monkeypatch):
+@pytest.mark.parametrize("temporary,include_schema", [(False, True), (True, False)])
+def test_table_executor_uses_typed_python_renderer(monkeypatch, temporary, include_schema):
     context, intermediate = _typed_renderer_context()
     create_plan = SimpleNamespace(renderer_macro="render_create_from_query_ctas")
     render_result = SimpleNamespace(
@@ -150,11 +151,15 @@ def test_table_executor_uses_typed_python_renderer(monkeypatch):
     executor = TableMaterializationExecutor(adapter, MagicMock(), context)
     monkeypatch.setattr(executor, "_render_arguments_type", lambda: _RenderArguments)
 
-    sql = executor._build_sql(intermediate)
+    sql = executor._build_sql(intermediate, temporary=temporary)
 
     assert sql == "create table typed as select 1"
     context["get_create_table_as_sql"].assert_not_called()
-    adapter.plan_create_from_query.assert_called_once_with(False, intermediate, executor.model)
+    adapter.plan_create_from_query.assert_called_once_with(temporary, intermediate, executor.model)
+    intermediate.include.assert_called_once_with(
+        database=include_schema,
+        schema=include_schema,
+    )
     arguments = adapter.resolve_create_from_query_render.call_args.args[1]
     assert arguments.relation_sql == '"analytics"."intermediate"'
     assert arguments.query == context["sql"]

--- a/tests/unit/materializations/test_table.py
+++ b/tests/unit/materializations/test_table.py
@@ -8,7 +8,11 @@ from dbt.materializations.table import TableMaterializationExecutor
 
 
 def _relation(name, relation_type="table"):
-    return SimpleNamespace(name=name, type=relation_type)
+    relation = MagicMock(name=name)
+    relation.name = name
+    relation.type = relation_type
+    relation.include.return_value = f'"analytics"."{name}"'
+    return relation
 
 
 def _executor_context(*, existing_relation=None, grant_config=None):
@@ -53,7 +57,7 @@ def test_table_executor_runs_builtin_lifecycle_in_python():
     )
     response = object()
     table = object()
-    adapter = MagicMock()
+    adapter = MagicMock(spec=["execute", "rename_relation"])
     adapter.execute.return_value = (response, table)
 
     result = TableMaterializationExecutor(adapter, MagicMock(), context).execute()
@@ -96,9 +100,116 @@ def test_table_executor_rejects_missing_or_untyped_context_boundaries():
     executor = TableMaterializationExecutor(MagicMock(), MagicMock(), {})
 
     with pytest.raises(DbtInternalError, match="missing 'this'"):
-        executor.plan()
+        executor.resolve_execution_state()
 
     executor.context["this"] = object()
     executor.context["load_cached_relation"] = "not callable"
     with pytest.raises(DbtInternalError, match="not callable"):
-        executor.plan()
+        executor.resolve_execution_state()
+
+
+class _RenderArguments:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+def _macro(unique_id):
+    return SimpleNamespace(macro=SimpleNamespace(unique_id=unique_id))
+
+
+def _typed_renderer_context():
+    context, _, intermediate, _ = _executor_context()
+    context["get_create_table_as_sql"].macro.unique_id = "macro.dbt.get_create_table_as_sql"
+    context["render_create_from_query_plan"] = _macro("macro.dbt.render_create_from_query_plan")
+    adapter_wrapper = MagicMock()
+    adapter_wrapper.dispatch.side_effect = (
+        _macro("macro.dbt.default__get_create_table_as_sql"),
+        _macro("macro.dbt.default__render_create_from_query_plan"),
+        _macro("macro.dbt.default__create_table_as"),
+    )
+    context["adapter"] = adapter_wrapper
+    context["render_create_from_query_ctas"] = _macro("macro.dbt.render_create_from_query_ctas")
+    context["config"] = {
+        "grants": None,
+        "contract": {"enforced": False},
+        "sql_header": "alter session set query_tag = 'dbt'",
+    }
+    return context, intermediate
+
+
+def test_table_executor_uses_typed_python_renderer(monkeypatch):
+    context, intermediate = _typed_renderer_context()
+    create_plan = SimpleNamespace(renderer_macro="render_create_from_query_ctas")
+    render_result = SimpleNamespace(
+        kind=SimpleNamespace(value="sql"),
+        sql="create table typed as select 1",
+    )
+    adapter = MagicMock()
+    adapter.plan_create_from_query.return_value = create_plan
+    adapter.resolve_create_from_query_render.return_value = render_result
+    executor = TableMaterializationExecutor(adapter, MagicMock(), context)
+    monkeypatch.setattr(executor, "_render_arguments_type", lambda: _RenderArguments)
+
+    sql = executor._build_sql(intermediate)
+
+    assert sql == "create table typed as select 1"
+    context["get_create_table_as_sql"].assert_not_called()
+    adapter.plan_create_from_query.assert_called_once_with(False, intermediate, executor.model)
+    arguments = adapter.resolve_create_from_query_render.call_args.args[1]
+    assert arguments.relation_sql == '"analytics"."intermediate"'
+    assert arguments.query == context["sql"]
+    assert arguments.sql_header == "alter session set query_tag = 'dbt'"
+    assert arguments.contract_enforced is False
+    assert arguments.legacy_renderer_override is None
+
+
+def test_table_executor_honors_typed_legacy_fallback(monkeypatch):
+    context, intermediate = _typed_renderer_context()
+    create_plan = SimpleNamespace(renderer_macro="render_create_from_query_ctas")
+    adapter = MagicMock()
+    adapter.plan_create_from_query.return_value = create_plan
+    adapter.resolve_create_from_query_render.return_value = SimpleNamespace(
+        kind=SimpleNamespace(value="legacy_macro"),
+        renderer_macro="get_create_table_as_sql",
+        reason="Enforced table contracts still require the compatibility renderer",
+    )
+    executor = TableMaterializationExecutor(adapter, MagicMock(), context)
+    monkeypatch.setattr(executor, "_render_arguments_type", lambda: _RenderArguments)
+
+    sql = executor._build_sql(intermediate)
+
+    assert sql == "create table intermediate as select 1"
+    context["get_create_table_as_sql"].assert_called_once_with(False, intermediate, context["sql"])
+
+
+def test_table_executor_reports_project_renderer_override(monkeypatch):
+    context, intermediate = _typed_renderer_context()
+    context["get_create_table_as_sql"].macro.unique_id = "macro.project.get_create_table_as_sql"
+    create_plan = SimpleNamespace(renderer_macro="render_create_from_query_ctas")
+    adapter = MagicMock()
+    adapter.plan_create_from_query.return_value = create_plan
+    adapter.resolve_create_from_query_render.return_value = SimpleNamespace(
+        kind=SimpleNamespace(value="legacy_macro"),
+        renderer_macro="get_create_table_as_sql",
+    )
+    executor = TableMaterializationExecutor(adapter, MagicMock(), context)
+    monkeypatch.setattr(executor, "_render_arguments_type", lambda: _RenderArguments)
+
+    executor._build_sql(intermediate)
+
+    arguments = adapter.resolve_create_from_query_render.call_args.args[1]
+    assert arguments.legacy_renderer_override == "macro.project.get_create_table_as_sql"
+
+
+def test_table_executor_reports_adapter_dispatch_override():
+    context, _ = _typed_renderer_context()
+    context["adapter"].dispatch.side_effect = (
+        _macro("macro.adapter.adapter__get_create_table_as_sql"),
+    )
+    executor = TableMaterializationExecutor(MagicMock(), MagicMock(), context)
+
+    override = executor._legacy_renderer_override(
+        SimpleNamespace(renderer_macro="render_create_from_query_ctas")
+    )
+
+    assert override == "macro.adapter.adapter__get_create_table_as_sql"

--- a/tests/unit/materializations/test_table.py
+++ b/tests/unit/materializations/test_table.py
@@ -22,6 +22,7 @@ def _executor_context(*, existing_relation=None, grant_config=None):
         side_effect=[existing_relation, None, None, existing_relation]
     )
     context = {
+        "adapter": MagicMock(),
         "this": this,
         "config": {"grants": grant_config},
         "model": {"unique_id": "model.test.orders"},
@@ -83,7 +84,7 @@ def test_table_executor_runs_builtin_lifecycle_in_python():
         should_revoke=True,
     )
     context["persist_docs"].assert_called_once_with(target, context["model"])
-    adapter.commit.assert_called_once_with()
+    context["adapter"].commit.assert_called_once_with()
     assert context["drop_relation_if_exists"].call_args_list == [
         call(None),
         call(None),

--- a/tests/unit/task/test_run.py
+++ b/tests/unit/task/test_run.py
@@ -136,6 +136,29 @@ class TestModelRunner:
         add_callback_to_manager(catcher.catch)
         return catcher
 
+    @pytest.mark.parametrize(
+        "unique_id,language,uses_python",
+        [
+            ("macro.dbt.materialization_table_default", "sql", True),
+            ("macro.project.materialization_table_default", "sql", False),
+            ("macro.dbt.materialization_table_postgres", "sql", False),
+            ("macro.dbt.materialization_table_default", "python", False),
+        ],
+    )
+    def test_python_materialization_executor_only_claims_exact_builtin_sql_table(
+        self,
+        model_runner: ModelRunner,
+        unique_id: str,
+        language: str,
+        uses_python: bool,
+    ) -> None:
+        model = mock.Mock(language=language)
+        materialization_macro = mock.Mock(unique_id=unique_id)
+
+        executor = model_runner._get_python_materialization_executor(model, materialization_macro)
+
+        assert (executor is not None) is uses_python
+
     def test_print_result_line(
         self,
         log_model_result_catcher: EventCatcher,

--- a/tests/unit/task/test_run.py
+++ b/tests/unit/task/test_run.py
@@ -30,6 +30,7 @@ from dbt.contracts.graph.nodes import Exposure, HookNode, ModelNode
 from dbt.events.types import LogModelResult
 from dbt.exceptions import DbtRuntimeError
 from dbt.flags import get_flags, set_from_args
+from dbt.materializations.incremental.executor import IncrementalMaterializationExecutor
 from dbt.task.run import MicrobatchModelRunner, ModelRunner, RunTask, _get_adapter_info
 from dbt.task.runnable import _rows_affected
 from dbt.tests.util import safe_set_invocation_context
@@ -158,6 +159,26 @@ class TestModelRunner:
         executor = model_runner._get_python_materialization_executor(model, materialization_macro)
 
         assert (executor is not None) is uses_python
+
+    def test_python_incremental_executor_requires_typed_adapter_contract(
+        self, model_runner: ModelRunner
+    ) -> None:
+        model = mock.Mock(language="sql")
+        materialization_macro = mock.Mock(
+            unique_id="macro.dbt.materialization_incremental_default"
+        )
+        model_runner.adapter = mock.Mock(spec=[])
+
+        assert (
+            model_runner._get_python_materialization_executor(model, materialization_macro) is None
+        )
+
+        model_runner.adapter = mock.Mock(
+            spec=list(IncrementalMaterializationExecutor.REQUIRED_ADAPTER_METHODS)
+        )
+        executor = model_runner._get_python_materialization_executor(model, materialization_macro)
+
+        assert executor is IncrementalMaterializationExecutor
 
     def test_print_result_line(
         self,


### PR DESCRIPTION
## Summary

Stacked on #16059, #16058, and dbt-labs/dbt-adapters#2137/#2138.

- adds a compatibility-gated Python executor for the exact built-in SQL incremental materialization
- resolves the typed mutation plan from real config, language, unique-key, catalog, and requested staging facts before constructing staging
- lets the resolved plan control staging relation type and permanence
- moves initial create, full-refresh swap, staging execution, schema-change orchestration, hooks, grants, docs, commit, and cleanup into Python
- retains the selected incremental strategy macro as the explicit mutation-SQL compatibility boundary
- falls back to the established Jinja materialization when the installed adapter lacks the typed planning contract or an adapter/project materialization override wins

## Validation

- dbt-core unit suite: 2,145 passed, 10 skipped
- focused incremental/table/registry tests: 15 passed
- focused tests with stacked dbt-adapters source: 11 passed
- Black, isort, Flake8, MyPy, YAML, artifact import guard, and CodeScene delta checks passed

## Follow-up

Replace portable built-in mutation strategy macros with typed render outcomes, using the same explicit compatibility fallback used for CTAS.