### PR TITLE
fix(dbt-jinja): handle empty substring in str.count

### DIFF
--- a/.changes/unreleased/Fixes-20260824-102251.yaml
+++ b/.changes/unreleased/Fixes-20260824-102251.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Fix Fusion Jinja str.count() hanging when called with an empty substring
+time: 2026-08-24T10:22:51+02:00
+custom:
+    author: fallintoplace
+    issue: "16062"
+    project: dbt-core

--- a/crates/dbt-jinja/minijinja-contrib/src/pycompat.rs
+++ b/crates/dbt-jinja/minijinja-contrib/src/pycompat.rs
@@ -294,6 +294,9 @@ fn string_methods(value: &Value, method: &str, args: &[Value]) -> Result<Value, 
         }
         "count" => {
             let (what,): (&str,) = from_args(args)?;
+            if what.is_empty() {
+                return Ok(Value::from(s.chars().count() + 1));
+            }
             let mut c = 0;
             let mut rest = s;
             while let Some(offset) = rest.find(what) {

--- a/crates/dbt-jinja/minijinja-contrib/tests/pycompat.rs
+++ b/crates/dbt-jinja/minijinja-contrib/tests/pycompat.rs
@@ -45,6 +45,8 @@ fn test_string_methods() {
         Some("Foo bar")
     );
     assert_eq!(eval_expr("'foo barooo'.count('oo')").as_usize(), Some(2));
+    assert_eq!(eval_expr("'abc'.count('')").as_usize(), Some(4));
+    assert_eq!(eval_expr("''.count('')").as_usize(), Some(1));
     assert_eq!(eval_expr("'foo barooo'.find('oo')").as_usize(), Some(1));
     assert_eq!(eval_expr("'foo barooo'.rfind('oo')").as_usize(), Some(8));
     assert!(eval_expr("'a b c'.split() == ['a', 'b', 'c']").is_true());


### PR DESCRIPTION
Resolves #16062

### Problem

`str.count()` loops forever when the substring is empty. `rest.find("")` returns 0, and `what.len()` is 0, so the loop never advances.

### Solution

- Return the number of Unicode characters plus 1 for an empty substring.
- Add regression coverage for `"abc".count("")` and `"".count("")`.
- Add a changelog entry.

### Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p minijinja-contrib --features pycompat --test pycompat test_string_methods -- --exact`
- [x] `cargo test -p minijinja-contrib --all-features`
- [x] `cargo clippy -p minijinja-contrib --all-targets --all-features -- -D warnings`

### Checklist

- [x] I have read the contributing guide and understand what is expected.
- [x] This PR includes tests.
- [x] This PR has no interface changes.