### PR TITLE
docs: fix two typos in dbt-adbc README

### DIFF
--- a/crates/dbt-adbc/README.md
+++ b/crates/dbt-adbc/README.md
@@ -74,7 +74,7 @@ data warehouse backend.
 
 ### Changing driver code
 
-When you need to extend the funcionality of an ADBC diver, you can do so by
+When you need to extend the functionality of an ADBC driver, you can do so by
 cloning our fork of `apache/arrow-adbc` and modifying the Go code of the driver
 you want to work on.
 


### PR DESCRIPTION
One line in `crates/dbt-adbc/README.md` has two typos: "extend the funcionality of an ADBC diver" -> "extend the functionality of an ADBC driver".

Targeting `main` because `crates/dbt-adbc` does not exist on `1.latest`. Docs only.