### PR TITLE
Fix Databricks catalog schema filtering for large schemas

### DIFF
--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-databricks/macros/adapters/catalog.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-databricks/macros/adapters/catalog.sql
@@ -66,8 +66,8 @@ ORDER BY column_index
 
 {% macro databricks__get_catalog_schemas_where_clause_sql(catalog, schemas) -%}
 WHERE table_catalog = '{{ catalog|lower }}' AND (
-  {%- for relation in schemas -%}
-  table_schema = '{{ relation[1]|lower }}'{%- if not loop.last %} OR {% endif -%}
+  {%- for schema in schemas -%}
+  table_schema = '{{ schema|lower }}'{%- if not loop.last %} OR {% endif -%}
   {%- endfor -%})
 {%- endmacro %}
 


### PR DESCRIPTION
Resolves #15795

When a Databricks schema contained more than 50 relations, catalog generation
used the second character of the schema name instead of the complete schema
name. This caused models to be missing from catalog.json.

The Databricks catalog macro now uses the complete schema name directly.