### PR TITLE
fix(fusion): handle empty substring in str.count()

### DIFF
--- a/.changes/unreleased/Fixes-20260824-str-count-empty.yaml
+++ b/.changes/unreleased/Fixes-20260824-str-count-empty.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Fix infinite loop in str.count() when search substring is empty; now matches Python behavior (len(chars) + 1)
+time: 2026-08-24T16:35:00.000000-07:00
+custom:
+    author: mmustafasenoglu
+    issue: "16062"
+    project: dbt-core

--- a/crates/dbt-jinja/minijinja-contrib/src/pycompat.rs
+++ b/crates/dbt-jinja/minijinja-contrib/src/pycompat.rs
@@ -294,6 +294,11 @@ fn string_methods(value: &Value, method: &str, args: &[Value]) -> Result<Value, 
         }
         "count" => {
             let (what,): (&str,) = from_args(args)?;
+            if what.is_empty() {
+                // Python behavior: "abc".count("") == 4, "".count("") == 1
+                // Number of Unicode characters + 1
+                return Ok(Value::from(s.chars().count() + 1));
+            }
             let mut c = 0;
             let mut rest = s;
             while let Some(offset) = rest.find(what) {

--- a/crates/dbt-jinja/minijinja-contrib/tests/pycompat.rs
+++ b/crates/dbt-jinja/minijinja-contrib/tests/pycompat.rs
@@ -45,6 +45,10 @@ fn test_string_methods() {
         Some("Foo bar")
     );
     assert_eq!(eval_expr("'foo barooo'.count('oo')").as_usize(), Some(2));
+    // Python behavior: empty substring returns len(chars) + 1
+    assert_eq!(eval_expr("'abc'.count('')").as_usize(), Some(4));
+    assert_eq!(eval_expr("''.count('')").as_usize(), Some(1));
+    assert_eq!(eval_expr("'a'.count('')").as_usize(), Some(2));
     assert_eq!(eval_expr("'foo barooo'.find('oo')").as_usize(), Some(1));
     assert_eq!(eval_expr("'foo barooo'.rfind('oo')").as_usize(), Some(8));
     assert!(eval_expr("'a b c'.split() == ['a', 'b', 'c']").is_true());


### PR DESCRIPTION
Fixes #16062

## Summary
When the search substring is empty in str.count(), Python returns the number of Unicode characters + 1 (e.g., abc.count('') == 4, ''.count('') == 1).

## Changes
- Added check for empty substring before the search loop in crates/dbt-jinja/minijinja-contrib/src/pycompat.rs
- Added tests for empty substring cases in crates/dbt-jinja/minijinja-contrib/tests/pycompat.rs

## Testing
- New tests cover: abc.count('') == 4, ''.count('') == 1, 'a'.count('') == 2
- Existing tests still pass