### PR TITLE
fix: preserve declaration order for Databricks tblproperties

### DIFF
--- a/.changes/unreleased/Fixes-20260824-234801.yaml
+++ b/.changes/unreleased/Fixes-20260824-234801.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Preserve declaration order when rendering Databricks table properties
+time: 2026-08-24T23:48:01.091558+05:30
+custom:
+    author: sd-db
+    issue: "16036"
+    project: dbt-core

--- a/crates/dbt-adapter/src/adapter/adapter_impl.rs
+++ b/crates/dbt-adapter/src/adapter/adapter_impl.rs
@@ -4659,7 +4659,7 @@ impl AdapterImpl {
         conn: &mut dyn Connection,
         config: ModelConfig,
         node: &InternalDbtNodeWrapper,
-        tblproperties: &mut BTreeMap<String, Value>,
+        tblproperties: &mut IndexMap<String, Value>,
         token: CancellationToken,
     ) -> AdapterResult<()> {
         match self.adapter_type() {

--- a/crates/dbt-adapter/src/adapter/mod.rs
+++ b/crates/dbt-adapter/src/adapter/mod.rs
@@ -2889,7 +2889,7 @@ impl Adapter {
 
                 let mut tblproperties = match tblproperties_val {
                     Some(v) if !v.is_none() => minijinja_value_to_typed_struct::<
-                        BTreeMap<String, Value>,
+                        IndexMap<String, Value>,
                     >(v)
                     .map_err(|e| {
                         minijinja::Error::new(
@@ -2902,6 +2902,7 @@ impl Adapter {
                         .tblproperties
                         .clone()
                         .unwrap_or_default()
+                        .0
                         .into_iter()
                         .map(|(k, v)| (k, yml_value_to_minijinja(v)))
                         .collect(),

--- a/crates/dbt-adapter/src/relation/databricks/config/components/tbl_properties.rs
+++ b/crates/dbt-adapter/src/relation/databricks/config/components/tbl_properties.rs
@@ -142,7 +142,7 @@ fn from_local_config(
     if let Some(databricks_attr) = &model.__adapter_attr__.databricks_attr
         && let Some(props_map) = &databricks_attr.tblproperties
     {
-        for (key, value) in props_map {
+        for (key, value) in &props_map.0 {
             if let YmlValue::String(value_str, _) = value {
                 tblproperties.insert(key.clone(), value_str.clone());
             }

--- a/crates/dbt-adapter/src/relation/databricks/config/relation_types/incremental_table.rs
+++ b/crates/dbt-adapter/src/relation/databricks/config/relation_types/incremental_table.rs
@@ -275,15 +275,15 @@ mod tests {
 </tags>
 <tblproperties>
     <tblproperties>
+        <delta.enableRowTracking>
+            true
+        </delta.enableRowTracking>
         <customKey>
             new
         </customKey>
         <customKey2>
             value
         </customKey2>
-        <delta.enableRowTracking>
-            true
-        </delta.enableRowTracking>
     </tblproperties>
     <pipeline_id>
         my_new_pipeline

--- a/crates/dbt-adapter/src/relation/databricks/config/relation_types/materialized_view.rs
+++ b/crates/dbt-adapter/src/relation/databricks/config/relation_types/materialized_view.rs
@@ -110,12 +110,12 @@ mod tests {
 </partitioned_by>
 <tblproperties>
     <tblproperties>
-        <custom.key>
-            new
-        </custom.key>
         <delta.enableRowTracking>
             true
         </delta.enableRowTracking>
+        <custom.key>
+            new
+        </custom.key>
     </tblproperties>
     <pipeline_id>
         my_old_pipeline

--- a/crates/dbt-adapter/src/relation/databricks/config/relation_types/streaming_table.rs
+++ b/crates/dbt-adapter/src/relation/databricks/config/relation_types/streaming_table.rs
@@ -147,15 +147,15 @@ mod tests {
 </comment>
 <tblproperties>
     <tblproperties>
+        <delta.enableRowTracking>
+            true
+        </delta.enableRowTracking>
         <customKey>
             new
         </customKey>
         <customKey2>
             value
         </customKey2>
-        <delta.enableRowTracking>
-            true
-        </delta.enableRowTracking>
     </tblproperties>
     <pipeline_id>
         my_new_pipeline

--- a/crates/dbt-adapter/src/relation/databricks/config/relation_types/view.rs
+++ b/crates/dbt-adapter/src/relation/databricks/config/relation_types/view.rs
@@ -179,15 +179,15 @@ mod tests {
 </tags>
 <tblproperties>
     <tblproperties>
+        <delta.enableRowTracking>
+            true
+        </delta.enableRowTracking>
         <customKey>
             new
         </customKey>
         <customKey2>
             value
         </customKey2>
-        <delta.enableRowTracking>
-            true
-        </delta.enableRowTracking>
     </tblproperties>
     <pipeline_id>
         my_new_pipeline

--- a/crates/dbt-adapter/src/relation/databricks/config/test_helpers.rs
+++ b/crates/dbt-adapter/src/relation/databricks/config/test_helpers.rs
@@ -95,12 +95,12 @@ pub(crate) fn create_mock_dbt_model(cfg: TestModelConfig) -> DbtModel {
     };
 
     let wh_config = WarehouseSpecificNodeConfig {
-        tblproperties: Some(
+        tblproperties: Some(TblProperties(
             cfg.tbl_properties
                 .into_iter()
                 .map(|(k, v)| (k, dbt_yaml::Value::from(v)))
                 .collect(),
-        ),
+        )),
         partition_by: Some(PartitionConfig::List(cfg.partition_by)),
         schedule: Some(Schedule::ScheduleConfig(ScheduleConfig {
             cron: cfg.cron,

--- a/crates/dbt-loader/tests/macros/relations.rs
+++ b/crates/dbt-loader/tests/macros/relations.rs
@@ -4,7 +4,9 @@ use dbt_adapter::catalog_relation::CatalogRelation;
 use dbt_adapter_core::AdapterType;
 use dbt_schemas::dbt_types::RelationType;
 use dbt_schemas::schemas::dbt_catalogs_v2::CatalogType;
+use dbt_schemas::schemas::project::{ModelConfig, ProjectModelConfig};
 use dbt_schemas::schemas::relations::base::TableFormat;
+use indexmap::IndexMap;
 use minijinja::Value;
 
 use crate::macro_test_harness::MacroTestHarness;
@@ -32,6 +34,60 @@ mod databricks {
             )
             .build()
             .expect("harness should build")
+    }
+
+    #[test]
+    fn tblproperties_clause_preserves_project_declaration_order() {
+        let databricks_tblproperties_sql = include_str!(
+            "../../src/dbt_macro_assets/dbt-databricks/macros/relations/tblproperties.sql"
+        );
+        let harness = MacroTestHarness::for_adapter(AdapterType::Databricks)
+            .with_macro_at_path(
+                "dbt_databricks",
+                "databricks__tblproperties_clause",
+                databricks_tblproperties_sql,
+                "dbt-databricks/macros/relations/tblproperties.sql",
+            )
+            .build()
+            .expect("tblproperties harness should build");
+        harness.mock().on("is_uniform", |_| Ok(Value::from(false)));
+
+        let project_config: ProjectModelConfig = dbt_yaml::from_str(
+            r#"
++tblproperties:
+  zeta: last
+  alpha: first
+  middle: center
+__additional_properties__: {}
+"#,
+        )
+        .expect("project config should parse");
+        let model_config: ModelConfig = project_config.into();
+        let tblproperties = model_config
+            .__warehouse_specific_config__
+            .tblproperties
+            .expect("tblproperties should be present");
+        let config = IndexMap::from([(
+            "tblproperties".to_string(),
+            Value::from_serialize(tblproperties),
+        )]);
+
+        let rendered = harness
+            .render(
+                "{{ databricks__tblproperties_clause() }}",
+                BTreeMap::from([("config".to_string(), Value::from_serialize(config))]),
+            )
+            .expect("tblproperties clause should render");
+
+        let zeta = rendered.find("'zeta' = 'last'").expect("zeta property");
+        let alpha = rendered.find("'alpha' = 'first'").expect("alpha property");
+        let middle = rendered
+            .find("'middle' = 'center'")
+            .expect("middle property");
+        assert!(
+            zeta < alpha && alpha < middle,
+            "rendered clause: {rendered}"
+        );
     }
 
     // `databricks__create_table_as` calls these clause helpers (defined in other asset files)

--- a/crates/dbt-schemas/src/lib.rs
+++ b/crates/dbt-schemas/src/lib.rs
@@ -154,7 +154,7 @@ pub mod schemas {
         };
         pub use configs::common::{WarehouseSpecificNodeConfig, same_warehouse_config};
         pub use configs::config_keys::ConfigKeys;
-        pub use configs::config_merge::{DefaultTo, Packages, Tags};
+        pub use configs::config_merge::{DefaultTo, Packages, Tags, TblProperties};
         pub use configs::data_test_config::{
             DEFAULT_DATA_TEST_ERROR_IF, DEFAULT_DATA_TEST_FAIL_CALC, DEFAULT_DATA_TEST_SEVERITY,
             DEFAULT_DATA_TEST_WARN_IF, DataTestConfig, ProjectDataTestConfig,

--- a/crates/dbt-schemas/src/schemas/nodes.rs
+++ b/crates/dbt-schemas/src/schemas/nodes.rs
@@ -20,7 +20,7 @@ use crate::schemas::dbt_column::{DbtColumnRef, deserialize_dbt_columns, serializ
 use crate::schemas::manifest::GrantAccessToTarget;
 use crate::schemas::project::configs::common::log_state_mod_diff;
 use crate::schemas::project::configs::common::{grants_equal, tags_eq_vec};
-use crate::schemas::project::{WarehouseSpecificNodeConfig, same_warehouse_config};
+use crate::schemas::project::{TblProperties, WarehouseSpecificNodeConfig, same_warehouse_config};
 use crate::schemas::relations::default_dbt_quoting_for;
 use crate::schemas::serde::{PartitionsConfig, QueryTag, StringOrArrayOfStrings};
 use crate::schemas::{
@@ -5907,7 +5907,7 @@ pub struct DatabricksAttr {
     pub file_format: Option<String>,
     pub location_root: Option<String>,
     pub use_uniform: Option<bool>,
-    pub tblproperties: Option<BTreeMap<String, YmlValue>>,
+    pub tblproperties: Option<TblProperties>,
     pub include_full_name_in_path: Option<bool>,
     pub liquid_clustered_by: Option<StringOrArrayOfStrings>,
     pub auto_liquid_cluster: Option<bool>,

--- a/crates/dbt-schemas/src/schemas/project/configs/README_OMISSIBLE.md
+++ b/crates/dbt-schemas/src/schemas/project/configs/README_OMISSIBLE.md
@@ -35,6 +35,7 @@ Each field type implements `inherit_from` with its own merge semantics:
 | `Option<DbtQuoting>` | Deep-merge: each sub-field inherits from parent when unset |
 | `Option<DocsConfig>` | Deep-merge: `node_color` falls back to parent |
 | `Option<IndexMap<String, YmlValue>>` | Union-merge: child keys win, missing keys fall back to parent |
+| `Option<TblProperties>` | Replace-if-none while preserving mapping insertion order |
 | `Option<BTreeMap<Spanned<String>, String>>` | Union-merge: parent keys fill missing child keys |
 | `OmissibleGrantConfig` | DictKeyAppend: `+key` extends, plain key clobbers |
 | `Verbatim<Option<Hooks>>` | Append: parent hooks prepended to child hooks |

--- a/crates/dbt-schemas/src/schemas/project/configs/common.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/common.rs
@@ -13,6 +13,7 @@ use dbt_telemetry::StateModifiedDiff;
 use crate::schemas::common::PartitionConfig;
 use crate::schemas::common::{ClusterConfig, DocsConfig, Schedule};
 use crate::schemas::manifest::GrantAccessToTarget;
+use crate::schemas::project::configs::config_merge::TblProperties;
 use crate::schemas::project::configs::model_config::DataLakeObjectCategory;
 use crate::schemas::project::dbt_project::{ResolvableConfig, ResolvedConfig};
 use crate::schemas::serde::PartitionsConfig;
@@ -144,7 +145,7 @@ pub struct WarehouseSpecificNodeConfig {
     pub location_root: Option<String>,
     #[serde(default, deserialize_with = "bool_or_string_bool")]
     pub use_uniform: Option<bool>,
-    pub tblproperties: Option<BTreeMap<String, YmlValue>>,
+    pub tblproperties: Option<TblProperties>,
     // this config is introduced here https://github.com/databricks/dbt-databricks/pull/823
     #[serde(default, deserialize_with = "bool_or_string_bool")]
     pub include_full_name_in_path: Option<bool>,

--- a/crates/dbt-schemas/src/schemas/project/configs/config_merge.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/config_merge.rs
@@ -12,6 +12,7 @@ use dbt_proc_macros::StringOrArrayNewtype;
 use dbt_yaml::{Spanned, Verbatim};
 use indexmap::IndexMap;
 use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
 use crate::schemas::common::{DbtQuoting, DocsConfig, Hooks, merge_meta, merge_tags, merge_vec};
 use crate::schemas::serde::{
@@ -121,6 +122,14 @@ impl DefaultTo for Option<IndexMap<String, YmlValue>> {
         *self = merge_meta(parent.clone(), self.take());
     }
 }
+
+/// Insertion-ordered `tblproperties` map.
+///
+/// Newtype over `IndexMap` so this field can implement `ReplaceIfNone`. A bare
+/// `Option<IndexMap<String, YmlValue>>` already uses union-merge (`meta`).
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(transparent)]
+pub struct TblProperties(pub IndexMap<String, YmlValue>);
 
 // `#[derive(StringOrArrayNewtype)]` (defined in `dbt-proc-macros`) generates the
 // `AsStringOrArrayOfStrings` impl and shared accessors for newtypes wrapping
@@ -293,9 +302,11 @@ impl<T: Clone> ReplaceIfNone for Spanned<T> {}
 impl ReplaceIfNone for YmlValue {}
 
 // std collections used as replace-if-none fields.
-// BTreeMap<String, YmlValue> (replace-if-none) is distinct from
-// BTreeMap<Spanned<String>, String> (column_types, handled by special DefaultTo impl).
+// BTreeMap<String, YmlValue> is distinct from BTreeMap<Spanned<String>, String>
+// (column_types, handled by a special DefaultTo impl).
 impl ReplaceIfNone for BTreeMap<String, YmlValue> {}
+// See TblProperties: cannot use IndexMap<String, YmlValue> here (that type is meta).
+impl ReplaceIfNone for TblProperties {}
 impl<T: Clone> ReplaceIfNone for Vec<T> {}
 // IndexMap<String, String> for labels/resource_tags (replace-if-none).
 // IndexMap<String, YmlValue> for meta uses a custom merge — do NOT add ReplaceIfNone for it.

--- a/crates/dbt-schemas/src/schemas/project/configs/data_test_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/data_test_config.rs
@@ -18,7 +18,7 @@ use crate::schemas::common::{
 };
 use crate::schemas::manifest::GrantAccessToTarget;
 use crate::schemas::project::configs::common::WarehouseSpecificNodeConfig;
-use crate::schemas::project::configs::config_merge::Tags;
+use crate::schemas::project::configs::config_merge::{Tags, TblProperties};
 use crate::schemas::properties::DataTestState;
 use dbt_proc_macros::DefaultTo;
 use dbt_proc_macros::Resolvable;
@@ -218,7 +218,7 @@ pub struct ProjectDataTestConfig {
     #[serde(rename = "+location_root")]
     pub location_root: Option<String>,
     #[serde(rename = "+tblproperties")]
-    pub tblproperties: Option<BTreeMap<String, YmlValue>>,
+    pub tblproperties: Option<TblProperties>,
     #[serde(
         default,
         rename = "+include_full_name_in_path",

--- a/crates/dbt-schemas/src/schemas/project/configs/model_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/model_config.rs
@@ -34,7 +34,7 @@ use crate::schemas::project::configs::common::{
     WarehouseSpecificNodeConfig, access_eq, docs_eq, grants_equal, meta_eq, omissible_option_eq,
     same_warehouse_config,
 };
-use crate::schemas::project::configs::config_merge::{Classifiers, Packages, Tags};
+use crate::schemas::project::configs::config_merge::{Classifiers, Packages, Tags, TblProperties};
 use crate::schemas::project::dbt_project::ResolvableConfig;
 use crate::schemas::project::dbt_project::TypedRecursiveConfig;
 use crate::schemas::properties::model_properties::ModelConstraint;
@@ -487,7 +487,7 @@ pub struct ProjectModelConfig {
     #[serde(rename = "+target_file_size")]
     pub target_file_size: Option<String>,
     #[serde(rename = "+tblproperties")]
-    pub tblproperties: Option<BTreeMap<String, YmlValue>>,
+    pub tblproperties: Option<TblProperties>,
     #[serde(rename = "+tmp_relation_type")]
     pub tmp_relation_type: Option<String>,
     #[serde(
@@ -1938,6 +1938,104 @@ __additional_properties__: {}
                 "region".to_string(),
             ]))
         );
+    }
+
+    #[test]
+    fn test_tblproperties_order_survives_project_to_model_config() {
+        let project_config: ProjectModelConfig = dbt_yaml::from_str(
+            r#"
++tblproperties:
+  zeta: last
+  alpha: first
+  middle: center
+__additional_properties__: {}
+"#,
+        )
+        .unwrap();
+
+        let model_config: ModelConfig = project_config.into();
+        let keys = model_config
+            .__warehouse_specific_config__
+            .tblproperties
+            .as_ref()
+            .expect("tblproperties should parse")
+            .0
+            .keys()
+            .map(String::as_str)
+            .collect::<Vec<_>>();
+
+        assert_eq!(keys, ["zeta", "alpha", "middle"]);
+    }
+
+    #[test]
+    fn test_tblproperties_default_to_clobbers_or_inherits_without_reordering() {
+        use crate::schemas::project::dbt_project::ResolvableConfig;
+
+        let parent: ModelConfig = dbt_yaml::from_str(
+            r#"
+__warehouse_specific_config__:
+  tblproperties:
+    parent_zeta: last
+    parent_alpha: first
+"#,
+        )
+        .unwrap();
+        let mut configured_child: ModelConfig = dbt_yaml::from_str(
+            r#"
+__warehouse_specific_config__:
+  tblproperties:
+    child_zeta: last
+    child_alpha: first
+"#,
+        )
+        .unwrap();
+
+        configured_child.default_to(&parent);
+        let configured_keys = configured_child
+            .__warehouse_specific_config__
+            .tblproperties
+            .as_ref()
+            .expect("configured child should retain tblproperties")
+            .0
+            .keys()
+            .map(String::as_str)
+            .collect::<Vec<_>>();
+        assert_eq!(configured_keys, ["child_zeta", "child_alpha"]);
+
+        let mut empty_child: ModelConfig = dbt_yaml::from_str(
+            r#"
+__warehouse_specific_config__:
+  tblproperties: {}
+"#,
+        )
+        .unwrap();
+        empty_child.default_to(&parent);
+        let empty_keys = empty_child
+            .__warehouse_specific_config__
+            .tblproperties
+            .as_ref()
+            .expect("empty tblproperties should remain Some, not inherit")
+            .0
+            .keys()
+            .map(String::as_str)
+            .collect::<Vec<_>>();
+        assert!(
+            empty_keys.is_empty(),
+            "empty tblproperties should clobber parent, got {empty_keys:?}"
+        );
+
+        let mut unset_child = ModelConfig::default();
+        unset_child.default_to(&parent);
+        let inherited_keys = unset_child
+            .__warehouse_specific_config__
+            .tblproperties
+            .as_ref()
+            .expect("unset child should inherit tblproperties")
+            .0
+            .keys()
+            .map(String::as_str)
+            .collect::<Vec<_>>();
+        assert_eq!(inherited_keys, ["parent_zeta", "parent_alpha"]);
     }
 
     #[test]

--- a/crates/dbt-schemas/src/schemas/project/configs/seed_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/seed_config.rs
@@ -29,7 +29,7 @@ use crate::schemas::manifest::GrantAccessToTarget;
 use crate::schemas::project::ResolvableConfig;
 use crate::schemas::project::TypedRecursiveConfig;
 use crate::schemas::project::configs::common::WarehouseSpecificNodeConfig;
-use crate::schemas::project::configs::config_merge::Tags;
+use crate::schemas::project::configs::config_merge::{Tags, TblProperties};
 use crate::schemas::serde::PartitionsConfig;
 use crate::schemas::serde::StringOrArrayOfStrings;
 use crate::schemas::serde::bool_or_string_bool;
@@ -210,7 +210,7 @@ pub struct ProjectSeedConfig {
     #[serde(rename = "+location_root")]
     pub location_root: Option<String>,
     #[serde(rename = "+tblproperties")]
-    pub tblproperties: Option<BTreeMap<String, YmlValue>>,
+    pub tblproperties: Option<TblProperties>,
     #[serde(
         default,
         rename = "+include_full_name_in_path",

--- a/crates/dbt-schemas/src/schemas/project/configs/snapshot_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/snapshot_config.rs
@@ -32,7 +32,7 @@ use crate::schemas::manifest::GrantAccessToTarget;
 use crate::schemas::project::ResolvableConfig;
 use crate::schemas::project::TypedRecursiveConfig;
 use crate::schemas::project::configs::common::WarehouseSpecificNodeConfig;
-use crate::schemas::project::configs::config_merge::Tags;
+use crate::schemas::project::configs::config_merge::{Tags, TblProperties};
 use crate::schemas::properties::ModelState;
 use crate::schemas::serde::PartitionsConfig;
 use crate::schemas::serde::StringOrArrayOfStrings;
@@ -327,7 +327,7 @@ pub struct ProjectSnapshotConfig {
     #[serde(rename = "+target_alias")]
     pub target_alias: Option<String>,
     #[serde(rename = "+tblproperties")]
-    pub tblproperties: Option<BTreeMap<String, YmlValue>>,
+    pub tblproperties: Option<TblProperties>,
     // Adapter-specific fields (Redshift)
     #[serde(default, rename = "+bind", deserialize_with = "bool_or_string_bool")]
     pub bind: Option<bool>,

--- a/crates/dbt-schemas/src/schemas/project/configs/source_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/source_config.rs
@@ -16,7 +16,7 @@ use crate::schemas::common::{
 };
 use crate::schemas::manifest::GrantAccessToTarget;
 use crate::schemas::project::configs::common::WarehouseSpecificNodeConfig;
-use crate::schemas::project::configs::config_merge::Tags;
+use crate::schemas::project::configs::config_merge::{Tags, TblProperties};
 use crate::schemas::project::{ResolvableConfig, TypedRecursiveConfig};
 use crate::schemas::serde::{
     IndexesConfig, PartitionsConfig, PrimaryKeyConfig, StringOrArrayOfStrings, StringOrInteger,
@@ -120,7 +120,7 @@ pub struct ProjectSourceConfig {
     #[serde(rename = "+location_root")]
     pub location_root: Option<String>,
     #[serde(rename = "+tblproperties")]
-    pub tblproperties: Option<BTreeMap<String, YmlValue>>,
+    pub tblproperties: Option<TblProperties>,
     #[serde(
         default,
         rename = "+include_full_name_in_path",

--- a/crates/dbt-schemas/src/schemas/project/configs/unit_test_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/unit_test_config.rs
@@ -16,7 +16,9 @@ use crate::schemas::{
     project::{
         ResolvableConfig, TypedRecursiveConfig,
         configs::{
-            common::WarehouseSpecificNodeConfig, config_keys::ConfigKeys, config_merge::Tags,
+            common::WarehouseSpecificNodeConfig,
+            config_keys::ConfigKeys,
+            config_merge::{Tags, TblProperties},
         },
     },
     serde::{
@@ -169,7 +171,7 @@ pub struct ProjectUnitTestConfig {
     #[serde(rename = "+location_root")]
     pub location_root: Option<String>,
     #[serde(rename = "+tblproperties")]
-    pub tblproperties: Option<BTreeMap<String, YmlValue>>,
+    pub tblproperties: Option<TblProperties>,
     #[serde(
         default,
         rename = "+include_full_name_in_path",


### PR DESCRIPTION
Resolves #16036

### Problem

Databricks `tblproperties` were stored in a `BTreeMap`, so keys were sorted alphabetically before rendering `TBLPROPERTIES`. That could change the clause order from the YAML/config declaration order and trigger unnecessary relation rebuilds.

### Solution

Wrap `tblproperties` in an insertion-ordered `TblProperties` newtype (`IndexMap`) so declaration order is preserved through project → model config, inheritance (`ReplaceIfNone` / clobber-or-inherit), and the Databricks `tblproperties` clause renderer. Empty maps still clobber parent config; unset maps still inherit. Tests cover config round-trip, inheritance, and rendered SQL key order.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.