### PR TITLE
ci(release): publish dbt-oss as an identical rebrand of dbt-core

### DIFF
--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -428,6 +428,14 @@ jobs:
       # install anything, unlike `maturin develop`), so the venv only needs
       # to hold the `maturin` CLI itself — `--interpreter "$PY"` is what
       # actually controls which Python's ABI the wheel targets.
+      # rust-cache (above) restores the whole `target/` dir, and these wheel
+      # output dirs aren't cargo-managed, so nothing prunes them — a stale
+      # wheel from a previous cached run (e.g. re-running this job without a
+      # version bump) could otherwise sit alongside this run's and get
+      # uploaded/published too.
+      - name: Clean stale wheel output dirs
+        run: rm -rf target/wheels target/wheels-oss
+
       - name: Build maturin wheel (dbt-core)
         env:
           TARGET: ${{ matrix.target }}
@@ -488,11 +496,16 @@ jobs:
       # cache hits mean this recompiles nothing, just repackages), and
       # restore it. Python does the in-place edit rather than `sed -i` since
       # this step runs across Linux/macOS/Windows and BSD sed (macOS) and
-      # GNU sed take incompatible `-i` syntax.
+      # GNU sed take incompatible `-i` syntax. Uses `$MATURIN_PY` (exported
+      # above), not a bare `python3` — the manylinux container legs of this
+      # matrix don't put any Python on PATH by default. `grep -qx` asserts
+      # the exact expected line landed, since a silent no-op replace (grep
+      # would otherwise still match the unchanged `dbt-core` line) would
+      # mean the "oss" wheel gets built and uploaded under the wrong name.
       - name: Rename pyproject for oss wheel
         run: |
-          python3 -c 'import pathlib; p = pathlib.Path("crates/dbt-python/pyproject.toml"); p.write_text(p.read_text().replace("name = \"dbt-core\"", "name = \"dbt-oss\"", 1))'
-          grep '^name = ' crates/dbt-python/pyproject.toml
+          "$MATURIN_PY" -c 'import pathlib; p = pathlib.Path("crates/dbt-python/pyproject.toml"); p.write_text(p.read_text().replace("name = \"dbt-core\"", "name = \"dbt-oss\"", 1))'
+          grep -qx 'name = "dbt-oss"' crates/dbt-python/pyproject.toml
 
       - name: Build maturin wheel (dbt-oss)
         env:
@@ -508,8 +521,8 @@ jobs:
       - name: Restore pyproject name after oss wheel
         if: always()
         run: |
-          python3 -c 'import pathlib; p = pathlib.Path("crates/dbt-python/pyproject.toml"); p.write_text(p.read_text().replace("name = \"dbt-oss\"", "name = \"dbt-core\"", 1))'
-          grep '^name = ' crates/dbt-python/pyproject.toml
+          "$MATURIN_PY" -c 'import pathlib; p = pathlib.Path("crates/dbt-python/pyproject.toml"); p.write_text(p.read_text().replace("name = \"dbt-oss\"", "name = \"dbt-core\"", 1))'
+          grep -qx 'name = "dbt-core"' crates/dbt-python/pyproject.toml
 
       - name: Upload wheel artifact (dbt-oss)
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # actions/upload-artifact@v4
@@ -891,12 +904,15 @@ jobs:
       # dbt-oss is the identical rebrand of dbt-core (see the `build` job) —
       # published as its own PyPI distribution from the same maturin abi3
       # wheels (cp311-abi3), so it uses the same tags as the dbt-core publish
-      # step above.
+      # step above. `grep -qx` asserts the exact expected line landed —
+      # `sed -i` exits 0 even on a no-op match, which would otherwise let
+      # this silently publish dbt-core's sdist a second time under the
+      # dbt-oss step.
       - name: Rename pyproject for oss publish
         if: inputs.release_target == 'all' || inputs.release_target == 'oss'
         run: |
           sed -i 's/^name = "dbt-core"$/name = "dbt-oss"/' pyproject.toml
-          grep '^name = ' pyproject.toml
+          grep -qx 'name = "dbt-oss"' pyproject.toml
 
       - name: Publish (dbt-oss)
         if: inputs.release_target == 'all' || inputs.release_target == 'oss'
@@ -917,7 +933,7 @@ jobs:
         if: ${{ always() && (inputs.release_target == 'all' || inputs.release_target == 'oss') }}
         run: |
           sed -i 's/^name = "dbt-oss"$/name = "dbt-core"/' pyproject.toml
-          grep '^name = ' pyproject.toml
+          grep -qx 'name = "dbt-core"' pyproject.toml
 
   # ------------------------------------------------------------------
   # Create the GitHub Release with all assets. Skipped on dry-run.

--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -58,11 +58,9 @@
 # `py3`/`none` tags are for the binary-CLI wheel, used for the parser publish
 # step instead).
 #
-# `dbt-oss` is the identical rebrand of `dbt-core` — same compiled
-# extension, same maturin invocation, only `crates/dbt-python/pyproject.
-# toml`'s `[project].name` differs — built by a second `maturin build` in
-# the `build` job (see "Build maturin wheel (dbt-oss)") and published with
-# the same `cp311`/`abi3` tags as `dbt-core`.
+# `dbt-oss` is the identical rebrand of `dbt-core` — same extension, only
+# `[project].name` differs — built by a second `maturin build` in the
+# `build` job and published with the same `cp311`/`abi3` tags.
 #
 # **Homebrew publishing**
 # `publish-homebrew` renders `Formula/dbt-core.rb` from the SHA256SUMS the
@@ -428,11 +426,8 @@ jobs:
       # install anything, unlike `maturin develop`), so the venv only needs
       # to hold the `maturin` CLI itself — `--interpreter "$PY"` is what
       # actually controls which Python's ABI the wheel targets.
-      # rust-cache (above) restores the whole `target/` dir, and these wheel
-      # output dirs aren't cargo-managed, so nothing prunes them — a stale
-      # wheel from a previous cached run (e.g. re-running this job without a
-      # version bump) could otherwise sit alongside this run's and get
-      # uploaded/published too.
+      # rust-cache restores `target/`; these wheel dirs aren't cargo-managed
+      # so nothing else prunes stale wheels left from a prior cached run.
       - name: Clean stale wheel output dirs
         run: rm -rf target/wheels target/wheels-oss
 
@@ -489,19 +484,13 @@ jobs:
           path: target/wheels/*.whl
           if-no-files-found: error
 
-      # dbt-oss is an identical rebrand of dbt-core, published as a separate
-      # PyPI distribution — same crate, same compiled extension, only
-      # [project].name in crates/dbt-python/pyproject.toml differs. maturin
-      # reads that file to name the wheel, so swap it, rebuild (cargo/sccache
-      # cache hits mean this recompiles nothing, just repackages), and
-      # restore it. Python does the in-place edit rather than `sed -i` since
-      # this step runs across Linux/macOS/Windows and BSD sed (macOS) and
-      # GNU sed take incompatible `-i` syntax. Uses `$MATURIN_PY` (exported
-      # above), not a bare `python3` — the manylinux container legs of this
-      # matrix don't put any Python on PATH by default. `grep -qx` asserts
-      # the exact expected line landed, since a silent no-op replace (grep
-      # would otherwise still match the unchanged `dbt-core` line) would
-      # mean the "oss" wheel gets built and uploaded under the wrong name.
+      # dbt-oss is an identical rebrand of dbt-core (same compiled extension,
+      # only [project].name differs) — swap it, rebuild (cache hits mean this
+      # just repackages, no recompile), restore. Python, not `sed -i`: BSD
+      # sed (macOS) and GNU sed disagree on `-i`. `$MATURIN_PY`, not `python3`:
+      # the manylinux container legs don't put Python on PATH by default.
+      # `grep -qx` asserts the swap actually landed, not just that some
+      # `name =` line exists.
       - name: Rename pyproject for oss wheel
         run: |
           "$MATURIN_PY" -c 'import pathlib; p = pathlib.Path("crates/dbt-python/pyproject.toml"); p.write_text(p.read_text().replace("name = \"dbt-core\"", "name = \"dbt-oss\"", 1))'
@@ -683,16 +672,10 @@ jobs:
       - name: List binaries
         run: ls -la binaries/
 
-      # Three distributions are produced, two mechanisms:
-      #   - dbt-core                     → maturin abi3 wheel, built in `build`
-      #                                    (artifact `wheel-<target>`) and
-      #                                    downloaded here into target/wheels.
-      #   - dbt-oss                      → identical rebrand of dbt-core, same
-      #                                    maturin mechanism (artifact
-      #                                    `wheel-oss-<target>`), also matched
-      #                                    by the `wheel-*` pattern below.
-      #   - dbt-core-experimental-parser → packed from the binary via
-      #                                    `cargo ci pypi pack` (unchanged).
+      # dbt-core and dbt-oss are maturin wheels built in `build` (artifacts
+      # `wheel-<target>`/`wheel-oss-<target>`, both matched below);
+      # dbt-core-experimental-parser is packed from the binary further down
+      # via `cargo ci pypi pack`.
       - name: Download all wheels (dbt-core, dbt-oss, maturin)
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # actions/download-artifact@v4
         with:
@@ -901,13 +884,9 @@ jobs:
           sed -i 's/^name = "dbt-core-experimental-parser"$/name = "dbt-core"/' pyproject.toml
           grep '^name = ' pyproject.toml
 
-      # dbt-oss is the identical rebrand of dbt-core (see the `build` job) —
-      # published as its own PyPI distribution from the same maturin abi3
-      # wheels (cp311-abi3), so it uses the same tags as the dbt-core publish
-      # step above. `grep -qx` asserts the exact expected line landed —
-      # `sed -i` exits 0 even on a no-op match, which would otherwise let
-      # this silently publish dbt-core's sdist a second time under the
-      # dbt-oss step.
+      # dbt-oss is the identical rebrand of dbt-core (see the `build` job),
+      # so it uses the same cp311/abi3 tags. `grep -qx` guards against a
+      # silent no-op `sed` (exits 0 either way).
       - name: Rename pyproject for oss publish
         if: inputs.release_target == 'all' || inputs.release_target == 'oss'
         run: |

--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -45,9 +45,9 @@
 # assembles an sdist pinning those filenames + sha256s; pip fetches the
 # matching wheel from the Release at install time. Runs with
 # `--environment prod`, authenticating with the repo-level `PYPI_API_TOKEN`
-# secret (passed to the tool as `DBT_PYPI_PROD_TOKEN`). Two distributions
-# are published — `dbt-core` and `dbt-core-experimental-parser` — selected
-# by the `release_target` input.
+# secret (passed to the tool as `DBT_PYPI_PROD_TOKEN`). Three distributions
+# are published — `dbt-core`, `dbt-core-experimental-parser`, and `dbt-oss`
+# — selected by the `release_target` input.
 #
 # `dbt-core`'s wheels are built by `maturin build` in the `build` job
 # (abi3-py311, one cp311-abi3 wheel per platform) — not `cargo ci pypi pack`,
@@ -57,6 +57,12 @@
 # filenames actually sitting at the GitHub Release download URL (the default
 # `py3`/`none` tags are for the binary-CLI wheel, used for the parser publish
 # step instead).
+#
+# `dbt-oss` is the identical rebrand of `dbt-core` — same compiled
+# extension, same maturin invocation, only `crates/dbt-python/pyproject.
+# toml`'s `[project].name` differs — built by a second `maturin build` in
+# the `build` job (see "Build maturin wheel (dbt-oss)") and published with
+# the same `cp311`/`abi3` tags as `dbt-core`.
 #
 # **Homebrew publishing**
 # `publish-homebrew` renders `Formula/dbt-core.rb` from the SHA256SUMS the
@@ -125,14 +131,15 @@ on:
         type: string
         default: "main"
       release_target:
-        description: "Which package(s) to publish to PyPI. Pack always builds both; no effect on dry runs or Homebrew publish."
+        description: "Which package(s) to publish to PyPI. Pack always builds all three; no effect on dry runs or Homebrew publish."
         required: false
         type: choice
         options:
-          - both
+          - all
           - core
           - parser
-        default: both
+          - oss
+        default: all
 
 concurrency:
   group: >-
@@ -448,6 +455,11 @@ jobs:
             --out target/wheels
           ls -la target/wheels/
 
+          # Reused by the dbt-oss build below so it doesn't need to re-detect
+          # the interpreter/venv.
+          echo "MATURIN_PY=$PY" >> "$GITHUB_ENV"
+          echo "MATURIN_VENV_BIN=$VENV_BIN" >> "$GITHUB_ENV"
+
       - name: Upload binary artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # actions/upload-artifact@v4
         with:
@@ -467,6 +479,43 @@ jobs:
         with:
           name: wheel-${{ matrix.target }}
           path: target/wheels/*.whl
+          if-no-files-found: error
+
+      # dbt-oss is an identical rebrand of dbt-core, published as a separate
+      # PyPI distribution — same crate, same compiled extension, only
+      # [project].name in crates/dbt-python/pyproject.toml differs. maturin
+      # reads that file to name the wheel, so swap it, rebuild (cargo/sccache
+      # cache hits mean this recompiles nothing, just repackages), and
+      # restore it. Python does the in-place edit rather than `sed -i` since
+      # this step runs across Linux/macOS/Windows and BSD sed (macOS) and
+      # GNU sed take incompatible `-i` syntax.
+      - name: Rename pyproject for oss wheel
+        run: |
+          python3 -c 'import pathlib; p = pathlib.Path("crates/dbt-python/pyproject.toml"); p.write_text(p.read_text().replace("name = \"dbt-core\"", "name = \"dbt-oss\"", 1))'
+          grep '^name = ' crates/dbt-python/pyproject.toml
+
+      - name: Build maturin wheel (dbt-oss)
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          "$MATURIN_VENV_BIN/maturin" build --release --locked \
+            --target "$TARGET" \
+            --interpreter "$MATURIN_PY" \
+            -m crates/dbt-python/Cargo.toml \
+            --out target/wheels-oss
+          ls -la target/wheels-oss/
+
+      - name: Restore pyproject name after oss wheel
+        if: always()
+        run: |
+          python3 -c 'import pathlib; p = pathlib.Path("crates/dbt-python/pyproject.toml"); p.write_text(p.read_text().replace("name = \"dbt-oss\"", "name = \"dbt-core\"", 1))'
+          grep '^name = ' crates/dbt-python/pyproject.toml
+
+      - name: Upload wheel artifact (dbt-oss)
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # actions/upload-artifact@v4
+        with:
+          name: wheel-oss-${{ matrix.target }}
+          path: target/wheels-oss/*.whl
           if-no-files-found: error
 
   # ------------------------------------------------------------------
@@ -621,12 +670,17 @@ jobs:
       - name: List binaries
         run: ls -la binaries/
 
-      # Two distributions are produced by different mechanisms:
+      # Three distributions are produced, two mechanisms:
       #   - dbt-core                     → maturin abi3 wheel, built in `build`
-      #                                    and downloaded here into target/wheels.
+      #                                    (artifact `wheel-<target>`) and
+      #                                    downloaded here into target/wheels.
+      #   - dbt-oss                      → identical rebrand of dbt-core, same
+      #                                    maturin mechanism (artifact
+      #                                    `wheel-oss-<target>`), also matched
+      #                                    by the `wheel-*` pattern below.
       #   - dbt-core-experimental-parser → packed from the binary via
       #                                    `cargo ci pypi pack` (unchanged).
-      - name: Download all wheels (dbt-core, maturin)
+      - name: Download all wheels (dbt-core, dbt-oss, maturin)
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # actions/download-artifact@v4
         with:
           path: target/wheels
@@ -743,8 +797,8 @@ jobs:
   # Release at install time. Authenticates with the repo-level
   # `PYPI_API_TOKEN`/`TEST_PYPI_API_TOKEN` secret depending on mode
   # (passed to the tool as `DBT_PYPI_PROD_TOKEN`/`DBT_PYPI_TEST_TOKEN`).
-  # `release_target` selects which of the two distributions (`dbt-core`,
-  # `dbt-core-experimental-parser`) to publish, in both modes.
+  # `release_target` selects which of the three distributions (`dbt-core`,
+  # `dbt-core-experimental-parser`, `dbt-oss`) to publish, in both modes.
   # ------------------------------------------------------------------
   publish-pypi:
     name: Publish to PyPI
@@ -795,7 +849,7 @@ jobs:
       # the matching python/abi tags so the sdist manifest's filenames match
       # what's actually sitting at BASE_URL.
       - name: Publish (dbt-core)
-        if: inputs.release_target != 'parser'
+        if: inputs.release_target == 'all' || inputs.release_target == 'core'
         run: |
           cargo ci pypi publish \
             --environment ${{ inputs.dry_run_with_test_pypi && 'test-pypi' || 'prod' }} \
@@ -810,13 +864,13 @@ jobs:
             --target x86_64-pc-windows-msvc
 
       - name: Rename pyproject for parser publish
-        if: inputs.release_target != 'core'
+        if: inputs.release_target == 'all' || inputs.release_target == 'parser'
         run: |
           sed -i 's/^name = "dbt-core"$/name = "dbt-core-experimental-parser"/' pyproject.toml
           grep '^name = ' pyproject.toml
 
       - name: Publish (dbt-core-experimental-parser)
-        if: inputs.release_target != 'core'
+        if: inputs.release_target == 'all' || inputs.release_target == 'parser'
         run: |
           cargo ci pypi publish \
             --environment ${{ inputs.dry_run_with_test_pypi && 'test-pypi' || 'prod' }} \
@@ -829,9 +883,40 @@ jobs:
             --target x86_64-pc-windows-msvc
 
       - name: Restore pyproject name after parser publish
-        if: ${{ always() && inputs.release_target != 'core' }}
+        if: ${{ always() && (inputs.release_target == 'all' || inputs.release_target == 'parser') }}
         run: |
           sed -i 's/^name = "dbt-core-experimental-parser"$/name = "dbt-core"/' pyproject.toml
+          grep '^name = ' pyproject.toml
+
+      # dbt-oss is the identical rebrand of dbt-core (see the `build` job) —
+      # published as its own PyPI distribution from the same maturin abi3
+      # wheels (cp311-abi3), so it uses the same tags as the dbt-core publish
+      # step above.
+      - name: Rename pyproject for oss publish
+        if: inputs.release_target == 'all' || inputs.release_target == 'oss'
+        run: |
+          sed -i 's/^name = "dbt-core"$/name = "dbt-oss"/' pyproject.toml
+          grep '^name = ' pyproject.toml
+
+      - name: Publish (dbt-oss)
+        if: inputs.release_target == 'all' || inputs.release_target == 'oss'
+        run: |
+          cargo ci pypi publish \
+            --environment ${{ inputs.dry_run_with_test_pypi && 'test-pypi' || 'prod' }} \
+            --version "${{ needs.prepare-release.outputs.version }}" \
+            --download-base-url "$BASE_URL" \
+            --python-tag cp311 \
+            --abi-tag abi3 \
+            --target x86_64-unknown-linux-gnu \
+            --target aarch64-unknown-linux-gnu \
+            --target x86_64-apple-darwin \
+            --target aarch64-apple-darwin \
+            --target x86_64-pc-windows-msvc
+
+      - name: Restore pyproject name after oss publish
+        if: ${{ always() && (inputs.release_target == 'all' || inputs.release_target == 'oss') }}
+        run: |
+          sed -i 's/^name = "dbt-oss"$/name = "dbt-core"/' pyproject.toml
           grep '^name = ' pyproject.toml
 
   # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `dbt-oss` as a third PyPI distribution built from the same maturin extension as `dbt-core` — only `crates/dbt-python/pyproject.toml`'s `[project].name` is swapped before rebuilding, so it's an identical rebrand (verified locally: compiled `.so` is byte-identical between variants).
- `release_target` input gains a fourth choice (`all`/`core`/`parser`/`oss`); `build` and `publish-pypi` jobs each get a mirrored dbt-oss step, following the existing dbt-core-experimental-parser pattern.

## Test plan
- [x] YAML validated (`python3 -c "yaml.safe_load(...)"`)
- [x] Locally rebuilt both wheels via `maturin build`, confirming the name swap/restore and that only dist-info metadata (not the compiled extension) differs
- [ ] Dry-run the actual workflow before the next real release