### PR TITLE
[ClickHouse] Model settings and query_settings, fix contract validations, sync macros changes from dbt-clickhouse

### DIFF
--- a/.changes/unreleased/Features-20260825-152017.yaml
+++ b/.changes/unreleased/Features-20260825-152017.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: '[ClickHouse] Model settings and query_settings configs now render into DDL, and version-gated DDL uses the real server version via a once-per-process probe.'
+time: 2026-08-25T15:20:17.913808+02:00
+custom:
+    author: koletzilla
+    issue: "14585"
+    project: dbt-core

--- a/crates/dbt-adapter/src/adapter/adapter_impl.rs
+++ b/crates/dbt-adapter/src/adapter/adapter_impl.rs
@@ -3938,6 +3938,8 @@ impl AdapterImpl {
         conn: &mut dyn Connection,
         ctx: &QueryCtx,
         sql: &str,
+        // ClickHouse only, empty = none: see metadata::clickhouse::describe_query_columns.
+        settings_clause: &str,
         token: CancellationToken,
     ) -> AdapterResult<Vec<Column>> {
         match self.inner_adapter() {
@@ -3961,6 +3963,26 @@ impl AdapterImpl {
                 let flattened_columns =
                     columns.iter().flat_map(|column| column.flatten()).collect();
                 Ok(flattened_columns)
+            }
+            Impl(ClickHouse, engine) => {
+                // Server-typed schema via DESCRIBE; the rationale lives on
+                // metadata::clickhouse::describe_query_columns.
+                let engine = Arc::clone(engine);
+                let pairs = metadata::clickhouse::describe_query_columns(
+                    engine.as_ref(),
+                    Some(state),
+                    conn,
+                    ctx,
+                    sql,
+                    settings_clause,
+                    token,
+                )?;
+                Ok(pairs
+                    .into_iter()
+                    .map(|(name, type_text)| {
+                        Column::new(self.adapter_type(), name, type_text, None, None, None)
+                    })
+                    .collect())
             }
             Impl(_, engine) => {
                 let (_, table) = self.execute_inner(
@@ -3992,7 +4014,9 @@ impl AdapterImpl {
     ) -> AdapterResult<Vec<Column>> {
         match self.inner_adapter() {
             Replay(_, replay) => replay.replay_get_columns_in_select_sql(state),
-            Impl(Bigquery, _) => self.get_column_schema_from_query(state, conn, ctx, sql, token),
+            Impl(Bigquery, _) => {
+                self.get_column_schema_from_query(state, conn, ctx, sql, "", token)
+            }
             Impl(_, _) => unimplemented!("only available with BigQuery adapter"),
         }
     }
@@ -5721,6 +5745,81 @@ impl AdapterImpl {
         match self.inner_adapter() {
             Replay(_, replay) => Some(replay),
             Impl(..) => None,
+        }
+    }
+
+    /// ClickHouse `adapter.is_before_version(version)` — see
+    /// [`metadata::clickhouse::ClickHouseCapabilities::is_before`].
+    pub fn is_before_version(
+        &self,
+        state: &State,
+        version: &str,
+        token: CancellationToken,
+    ) -> AdapterResult<bool> {
+        metadata::clickhouse::server_capabilities(self, state, token).is_before(version)
+    }
+
+    /// ClickHouse `adapter.is_at_or_after_version(version)` — see
+    /// [`metadata::clickhouse::ClickHouseCapabilities::is_at_or_after`].
+    pub fn is_at_or_after_version(
+        &self,
+        state: &State,
+        version: &str,
+        token: CancellationToken,
+    ) -> AdapterResult<bool> {
+        metadata::clickhouse::server_capabilities(self, state, token).is_at_or_after(version)
+    }
+
+    /// ClickHouse: render the model's `settings` config as a table-level `SETTINGS ...`
+    /// block for CREATE TABLE DDL. The leading `-- end_of_sql` marker is what
+    /// `clickhouse__place_limit` (utils/utils.sql) splits on to inject LIMIT ahead of
+    /// the SETTINGS clause. Mirrors impl.py `get_model_settings`, including dbclient.py's
+    /// `replicated_deduplication_window='0'` default (profile flag
+    /// `allow_automatic_deduplication` opts out; a user-provided value wins).
+    pub fn get_model_settings(&self, model: &Value, engine: &str) -> String {
+        // dbclient.py DEDUP_WINDOW_SETTING_SUPPORTED_MATERIALIZATION
+        const DEDUP_SUPPORTED_MATERIALIZATIONS: &[&str] =
+            &["table", "incremental", "ephemeral", "materialized_view"];
+        const DEDUP_WINDOW_SETTING: &str = "replicated_deduplication_window";
+
+        let mut settings = metadata::clickhouse::model_config_map(model, "settings");
+
+        let materialized = model
+            .get_attr("config")
+            .ok()
+            .and_then(|config| config.get_attr("materialized").ok())
+            .and_then(|v| v.as_str().map(str::to_string))
+            .unwrap_or_default();
+        let allow_automatic_deduplication = self
+            .get_db_config_value("allow_automatic_deduplication")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false);
+        if DEDUP_SUPPORTED_MATERIALIZATIONS.contains(&materialized.as_str())
+            && !allow_automatic_deduplication
+            && !settings.iter().any(|(key, _)| key == DEDUP_WINDOW_SETTING)
+        {
+            // Upstream sets the string '0', which _build_settings_str single-quotes.
+            settings.push((DEDUP_WINDOW_SETTING.to_string(), Value::from("0")));
+        }
+
+        // filter_settings_by_engine: replicated_deduplication_window is MergeTree-only.
+        settings.retain(|(key, _)| engine.contains("MergeTree") || key != DEDUP_WINDOW_SETTING);
+
+        let settings_str = metadata::clickhouse::build_settings_str(&settings);
+        format!("\n-- end_of_sql\n{settings_str}\n")
+    }
+
+    /// ClickHouse: render the model's `query_settings` config as a query-level
+    /// `SETTINGS ...` clause appended to the SELECT; empty string when unset.
+    /// The lightweight-delete query-settings injection arrives with the
+    /// incremental-strategies port.
+    pub fn get_model_query_settings(&self, model: &Value) -> String {
+        let settings = metadata::clickhouse::model_config_map(model, "query_settings");
+        let settings_str = metadata::clickhouse::build_settings_str(&settings);
+        if settings_str.is_empty() {
+            String::new()
+        } else {
+            format!("\n-- settings_section\n{settings_str}\n")
         }
     }
 

--- a/crates/dbt-adapter/src/adapter/adapter_impl.rs
+++ b/crates/dbt-adapter/src/adapter/adapter_impl.rs
@@ -3938,8 +3938,8 @@ impl AdapterImpl {
         conn: &mut dyn Connection,
         ctx: &QueryCtx,
         sql: &str,
-        // ClickHouse only, empty = none: see metadata::clickhouse::describe_query_columns.
-        settings_clause: &str,
+        // ClickHouse only: see metadata::clickhouse::describe_query_columns.
+        query_settings: Option<&Value>,
         token: CancellationToken,
     ) -> AdapterResult<Vec<Column>> {
         match self.inner_adapter() {
@@ -3967,14 +3967,14 @@ impl AdapterImpl {
             Impl(ClickHouse, engine) => {
                 // Server-typed schema via DESCRIBE; the rationale lives on
                 // metadata::clickhouse::describe_query_columns.
-                let engine = Arc::clone(engine);
+                let settings_clause = metadata::clickhouse::query_settings_clause(query_settings);
                 let pairs = metadata::clickhouse::describe_query_columns(
                     engine.as_ref(),
                     Some(state),
                     conn,
                     ctx,
                     sql,
-                    settings_clause,
+                    &settings_clause,
                     token,
                 )?;
                 Ok(pairs
@@ -4015,7 +4015,7 @@ impl AdapterImpl {
         match self.inner_adapter() {
             Replay(_, replay) => replay.replay_get_columns_in_select_sql(state),
             Impl(Bigquery, _) => {
-                self.get_column_schema_from_query(state, conn, ctx, sql, "", token)
+                self.get_column_schema_from_query(state, conn, ctx, sql, None, token)
             }
             Impl(_, _) => unimplemented!("only available with BigQuery adapter"),
         }

--- a/crates/dbt-adapter/src/adapter/mod.rs
+++ b/crates/dbt-adapter/src/adapter/mod.rs
@@ -1756,7 +1756,11 @@ impl Adapter {
             Typed { adapter, .. } => {
                 let iter = ArgsIter::new("get_column_schema_from_query", &["sql"], args);
                 let sql = iter.next_arg::<&str>()?;
+                // dbt-clickhouse: column_spec_ddl.sql passes the model's
+                // query_settings so introspected types match runtime settings.
+                let query_settings = iter.next_kwarg::<Option<&Value>>("query_settings")?;
                 iter.finish()?;
+                let settings_clause = clickhouse::query_settings_clause(query_settings);
 
                 let ctx = query_ctx_from_state(state)?
                     .with_desc("get_column_schema_from_query adapter call");
@@ -1767,6 +1771,7 @@ impl Adapter {
                     conn.as_mut(),
                     &ctx,
                     sql,
+                    &settings_clause,
                     self.cancellation_token.clone(),
                 )?;
                 Ok(Value::from(result))
@@ -3286,6 +3291,77 @@ impl Adapter {
         }
     }
 
+    /// ClickHouse: see [AdapterImpl::get_model_settings].
+    pub fn get_model_settings(
+        &self,
+        _state: &State,
+        args: &[Value],
+    ) -> Result<Value, minijinja::Error> {
+        let iter = ArgsIter::new("get_model_settings", &["model", "engine"], args);
+        let model = iter.next_arg::<&Value>()?;
+        let engine = iter.next_arg::<Option<&str>>()?.unwrap_or("MergeTree");
+        iter.finish()?;
+        match &self.inner {
+            Typed { adapter, .. } => Ok(Value::from(adapter.get_model_settings(model, engine))),
+            Parse(_) => Ok(empty_string_value()),
+        }
+    }
+
+    /// ClickHouse: see [AdapterImpl::get_model_query_settings].
+    pub fn get_model_query_settings(
+        &self,
+        _state: &State,
+        args: &[Value],
+    ) -> Result<Value, minijinja::Error> {
+        let iter = ArgsIter::new("get_model_query_settings", &["model"], args);
+        let model = iter.next_arg::<&Value>()?;
+        iter.finish()?;
+        match &self.inner {
+            Typed { adapter, .. } => {
+                Ok(Value::from(adapter.get_model_query_settings(model)))
+            }
+            Parse(_) => Ok(empty_string_value()),
+        }
+    }
+
+    /// ClickHouse: see [AdapterImpl::is_before_version].
+    pub fn is_before_version(
+        &self,
+        state: &State,
+        args: &[Value],
+    ) -> Result<Value, minijinja::Error> {
+        let iter = ArgsIter::new("is_before_version", &["version"], args);
+        let version = iter.next_arg::<&str>()?;
+        iter.finish()?;
+        match &self.inner {
+            Typed { adapter, .. } => Ok(Value::from(adapter.is_before_version(
+                state,
+                version,
+                self.cancellation_token.clone(),
+            )?)),
+            Parse(_) => Ok(Value::from(false)),
+        }
+    }
+
+    /// ClickHouse: see [AdapterImpl::is_at_or_after_version].
+    pub fn is_at_or_after_version(
+        &self,
+        state: &State,
+        args: &[Value],
+    ) -> Result<Value, minijinja::Error> {
+        let iter = ArgsIter::new("is_at_or_after_version", &["version"], args);
+        let version = iter.next_arg::<&str>()?;
+        iter.finish()?;
+        match &self.inner {
+            Typed { adapter, .. } => Ok(Value::from(adapter.is_at_or_after_version(
+                state,
+                version,
+                self.cancellation_token.clone(),
+            )?)),
+            Parse(_) => Ok(Value::from(true)),
+        }
+    }
+
     /// Get configuration from a model node.
     ///
     /// Given a model, parse and build its configurations.
@@ -4087,21 +4163,15 @@ impl Adapter {
                 // (no args) -> None (no ON CLUSTER usage)
                 Ok(Value::from(()))
             }
-            "get_model_settings" => {
-                // model: dict, engine: str = "MergeTree"  -> "" (no settings)
-                Ok(Value::from(""))
-            }
-            "get_model_query_settings" => {
-                // model: dict -> SETTINGS clause appended to CREATE TABLE ... AS (SELECT ...)
-                // Default join_use_nulls=1 makes unmatched LEFT JOIN rows produce NULL
-                // instead of ClickHouse's default type-zero values (0 for Int64, etc.),
-                // restoring standard SQL semantics.
-                // Users can override via model config `query_settings`.
-                Ok(Value::from("SETTINGS join_use_nulls = 1"))
-            }
-            "is_before_version" => {
-                // version: str -> false (assume modern server)
-                Ok(Value::from(false))
+            "get_model_settings" => self.get_model_settings(state, args),
+            "get_model_query_settings" => self.get_model_query_settings(state, args),
+            "is_before_version" => self.is_before_version(state, args),
+            "is_at_or_after_version" => self.is_at_or_after_version(state, args),
+            "format_columns" => {
+                let iter = ArgsIter::new("format_columns", &["columns"], args);
+                let columns = iter.next_arg::<&Value>()?;
+                iter.finish()?;
+                Ok(clickhouse::format_columns(columns))
             }
             "can_exchange" => {
                 // schema: str, type: str -> false (don't use EXCHANGE TABLES)

--- a/crates/dbt-adapter/src/adapter/mod.rs
+++ b/crates/dbt-adapter/src/adapter/mod.rs
@@ -3316,9 +3316,7 @@ impl Adapter {
         let model = iter.next_arg::<&Value>()?;
         iter.finish()?;
         match &self.inner {
-            Typed { adapter, .. } => {
-                Ok(Value::from(adapter.get_model_query_settings(model)))
-            }
+            Typed { adapter, .. } => Ok(Value::from(adapter.get_model_query_settings(model))),
             Parse(_) => Ok(empty_string_value()),
         }
     }

--- a/crates/dbt-adapter/src/adapter/mod.rs
+++ b/crates/dbt-adapter/src/adapter/mod.rs
@@ -1760,7 +1760,6 @@ impl Adapter {
                 // query_settings so introspected types match runtime settings.
                 let query_settings = iter.next_kwarg::<Option<&Value>>("query_settings")?;
                 iter.finish()?;
-                let settings_clause = clickhouse::query_settings_clause(query_settings);
 
                 let ctx = query_ctx_from_state(state)?
                     .with_desc("get_column_schema_from_query adapter call");
@@ -1771,7 +1770,7 @@ impl Adapter {
                     conn.as_mut(),
                     &ctx,
                     sql,
-                    &settings_clause,
+                    query_settings,
                     self.cancellation_token.clone(),
                 )?;
                 Ok(Value::from(result))

--- a/crates/dbt-adapter/src/adapter/mod.rs
+++ b/crates/dbt-adapter/src/adapter/mod.rs
@@ -4162,11 +4162,24 @@ impl Adapter {
                 // (no args) -> None (no ON CLUSTER usage)
                 Ok(Value::from(()))
             }
-            "get_model_settings" => self.get_model_settings(state, args),
-            "get_model_query_settings" => self.get_model_query_settings(state, args),
-            "is_before_version" => self.is_before_version(state, args),
-            "is_at_or_after_version" => self.is_at_or_after_version(state, args),
+            "get_model_settings" => {
+                // model: dict, engine: str = "MergeTree" -> SETTINGS section of CREATE DDL
+                self.get_model_settings(state, args)
+            }
+            "get_model_query_settings" => {
+                // model: dict -> SETTINGS clause appended to CREATE TABLE ... AS (SELECT ...)
+                self.get_model_query_settings(state, args)
+            }
+            "is_before_version" => {
+                // version: str -> bool (server version < given version)
+                self.is_before_version(state, args)
+            }
+            "is_at_or_after_version" => {
+                // version: str -> bool (server version >= given version)
+                self.is_at_or_after_version(state, args)
+            }
             "format_columns" => {
+                // columns: List[Column] -> List[dict] of {name, data_type}
                 let iter = ArgsIter::new("format_columns", &["columns"], args);
                 let columns = iter.next_arg::<&Value>()?;
                 iter.finish()?;

--- a/crates/dbt-adapter/src/metadata/clickhouse/mod.rs
+++ b/crates/dbt-adapter/src/metadata/clickhouse/mod.rs
@@ -1,7 +1,7 @@
 use crate::AdapterEngine;
 use crate::adapter::adapter_impl::{AdapterImpl, InnerAdapter};
-use crate::query_ctx::{node_id_from_state, query_ctx_from_state};
 use crate::connection::AdapterConnectionFactory;
+use crate::query_ctx::{node_id_from_state, query_ctx_from_state};
 use crate::record_batch::RecordBatchExt;
 use crate::relation::do_create_relation;
 use crate::sql_types::{TypeOps, make_arrow_field_v2};

--- a/crates/dbt-adapter/src/metadata/clickhouse/mod.rs
+++ b/crates/dbt-adapter/src/metadata/clickhouse/mod.rs
@@ -1,5 +1,6 @@
 use crate::AdapterEngine;
-use crate::adapter::adapter_impl::AdapterImpl;
+use crate::adapter::adapter_impl::{AdapterImpl, InnerAdapter};
+use crate::query_ctx::{node_id_from_state, query_ctx_from_state};
 use crate::connection::AdapterConnectionFactory;
 use crate::record_batch::RecordBatchExt;
 use crate::relation::do_create_relation;
@@ -20,6 +21,7 @@ use dbt_schemas::schemas::{
 };
 use indexmap::IndexMap;
 use minijinja::State;
+use minijinja::Value;
 use std::collections::btree_map::Entry;
 
 use std::collections::{BTreeMap, HashMap};
@@ -402,30 +404,238 @@ pub fn relation_type_from_engine(engine_name: &str) -> RelationType {
     }
 }
 
+/// The `(name, type)` pairs from a `DESCRIBE TABLE` result batch (which also
+/// carries default/comment/codec/ttl columns; only name/type are consumed).
+fn describe_name_type_pairs(batch: &RecordBatch) -> AdapterResult<Vec<(String, String)>> {
+    let names = batch.column_values::<StringArray>("name")?;
+    let types = batch.column_values::<StringArray>("type")?;
+    Ok((0..batch.num_rows())
+        .map(|i| (names.value(i).to_string(), types.value(i).to_string()))
+        .collect())
+}
+
+/// Column names and ClickHouse type text of an arbitrary SELECT, via
+/// `DESCRIBE TABLE (<sql>)`. DESCRIBE preserves the server's own type text —
+/// the ADBC/Arrow result schema marks every column Nullable, which breaks
+/// downstream DDL and contract/type comparisons. `settings_clause` (rendered
+/// by [`query_settings_clause`]) makes introspected types match runtime
+/// settings such as `join_use_nulls`.
+pub fn describe_query_columns(
+    engine: &dyn AdapterEngine,
+    state: Option<&State>,
+    conn: &mut dyn Connection,
+    ctx: &QueryCtx,
+    sql: &str,
+    settings_clause: &str,
+    token: CancellationToken,
+) -> AdapterResult<Vec<(String, String)>> {
+    // The closing paren goes on its own line: model SQL routinely ends with a
+    // `-- line comment` (no trailing newline), which would otherwise swallow
+    // the `)` and break the query.
+    let batch = engine.execute(
+        state,
+        conn,
+        ctx,
+        &format!("DESCRIBE TABLE ({sql}\n){settings_clause}"),
+        token,
+    )?;
+    describe_name_type_pairs(&batch)
+}
+
 /// Build an Arrow Schema from ClickHouse's `DESCRIBE TABLE` output.
-///
-/// ClickHouse `DESCRIBE TABLE` returns columns: name, type, default_type,
-/// default_expression, comment, codec_expression, ttl_expression.
 fn build_schema_from_clickhouse_describe(
     describe_result: Arc<RecordBatch>,
     type_ops: &dyn TypeOps,
 ) -> AdapterResult<Arc<Schema>> {
-    let column_names = describe_result.column_values::<StringArray>("name")?;
-    let data_types = describe_result.column_values::<StringArray>("type")?;
-
     let mut fields = vec![];
-    for i in 0..describe_result.num_rows() {
-        let name = column_names.value(i);
-        let text_data_type = data_types.value(i);
+    for (name, text_data_type) in describe_name_type_pairs(&describe_result)? {
         // ClickHouse encodes nullability via the `Nullable(...)` wrapper in the
         // type text; the type parser handles that and the Arrow nullable bit is
         // derived from there.
-        let field = make_arrow_field_v2(type_ops, name.to_string(), text_data_type, None, None)?;
+        let field = make_arrow_field_v2(type_ops, name, &text_data_type, None, None)?;
         fields.push(field);
     }
 
     let schema = Schema::new(fields);
     Ok(Arc::new(schema))
+}
+
+/// ClickHouse server capabilities, probed once per process and reused for every
+/// model/thread afterwards (as the Python client does at connection init).
+/// Later capability probes (atomic exchange, lightweight deletes) extend this
+/// struct.
+#[derive(Debug, Clone)]
+pub struct ClickHouseCapabilities {
+    /// `SELECT version()` result; empty when the probe failed (callers treat
+    /// unknown as "modern server").
+    pub server_version: String,
+}
+
+impl ClickHouseCapabilities {
+    /// Whether the connected server is older than `version`; an unknown
+    /// server version is treated as modern (false).
+    pub fn is_before(&self, version: &str) -> AdapterResult<bool> {
+        if self.server_version.is_empty() {
+            return Ok(false);
+        }
+        Ok(compare_versions(version, &self.server_version)? > 0)
+    }
+
+    /// Inclusive counterpart of [`ClickHouseCapabilities::is_before`]; an
+    /// unknown server version is treated as modern (true).
+    pub fn is_at_or_after(&self, version: &str) -> AdapterResult<bool> {
+        if self.server_version.is_empty() {
+            return Ok(true);
+        }
+        Ok(compare_versions(&self.server_version, version)? >= 0)
+    }
+}
+
+/// Mirrors dbt-clickhouse util.py `compare_versions`: 1/-1/0 comparing dotted
+/// numeric versions segment by segment; errors on non-numeric segments.
+fn compare_versions(v1: &str, v2: &str) -> AdapterResult<i32> {
+    for (part1, part2) in v1.split('.').zip(v2.split('.')) {
+        match (part1.parse::<i64>(), part2.parse::<i64>()) {
+            (Ok(a), Ok(b)) => {
+                if a != b {
+                    return Ok(if a > b { 1 } else { -1 });
+                }
+            }
+            _ => {
+                return Err(AdapterError::new(
+                    AdapterErrorKind::Configuration,
+                    "Version must consist of only numbers separated by '.'",
+                ));
+            }
+        }
+    }
+    Ok(0)
+}
+
+/// Read a dict-valued key (e.g. `settings`, `query_settings`) from
+/// `model['config']`, preserving iteration order. Missing/undefined -> empty.
+pub(crate) fn model_config_map(model: &Value, key: &str) -> Vec<(String, Value)> {
+    let Ok(config) = model.get_attr("config") else {
+        return Vec::new();
+    };
+    let Ok(map) = config.get_attr(key) else {
+        return Vec::new();
+    };
+    if map.is_none() || map.is_undefined() {
+        return Vec::new();
+    }
+    let Ok(keys) = map.try_iter() else {
+        return Vec::new();
+    };
+    keys.filter_map(|k| {
+        let name = k.as_str()?.to_string();
+        let value = map.get_item(&k).ok()?;
+        Some((name, value))
+    })
+    .collect()
+}
+
+/// Mirrors dbt-clickhouse impl.py `_build_settings_str`: string values not
+/// already single-quoted get single-quoted, other values are emitted verbatim;
+/// '' for no entries, otherwise newline-terminated.
+pub(crate) fn build_settings_str(settings: &[(String, Value)]) -> String {
+    let res: Vec<String> = settings
+        .iter()
+        .map(|(key, value)| match value.as_str() {
+            Some(s) if !s.starts_with('\'') => format!("{key}='{s}'"),
+            _ => format!("{key}={value}"),
+        })
+        .collect();
+    if res.is_empty() {
+        String::new()
+    } else {
+        format!("SETTINGS {}\n", res.join(", "))
+    }
+}
+
+/// Mirrors ClickHouse impl.py `format_columns`:
+/// `[{'name': c.name, 'data_type': c.data_type}, ...]`.
+pub(crate) fn format_columns(columns: &Value) -> Value {
+    let mut out: Vec<Value> = Vec::new();
+    if let Ok(items) = columns.try_iter() {
+        for column in items {
+            let mut map: BTreeMap<String, Value> = BTreeMap::new();
+            map.insert(
+                "name".to_string(),
+                column.get_attr("name").unwrap_or_default(),
+            );
+            map.insert(
+                "data_type".to_string(),
+                column.get_attr("data_type").unwrap_or_default(),
+            );
+            out.push(Value::from(map));
+        }
+    }
+    Value::from(out)
+}
+
+/// Render a `query_settings` map (from macro kwargs) into a `" SETTINGS k=v, ..."`
+/// suffix for introspection queries; empty string when absent or empty.
+pub(crate) fn query_settings_clause(query_settings: Option<&Value>) -> String {
+    let Some(qs) = query_settings else {
+        return String::new();
+    };
+    let mut pairs: Vec<(String, Value)> = Vec::new();
+    if let Ok(keys) = qs.try_iter() {
+        for key in keys {
+            if let (Some(name), Ok(value)) = (key.as_str(), qs.get_item(&key)) {
+                pairs.push((name.to_string(), value));
+            }
+        }
+    }
+    let rendered = build_settings_str(&pairs);
+    if rendered.is_empty() {
+        String::new()
+    } else {
+        format!(" {}", rendered.trim_end())
+    }
+}
+
+static CLICKHOUSE_CAPABILITIES: std::sync::OnceLock<ClickHouseCapabilities> =
+    std::sync::OnceLock::new();
+
+/// Return the server capabilities, probing only on the very first call
+/// process-wide (concurrent callers block until it completes).
+pub fn server_capabilities(
+    adapter: &AdapterImpl,
+    state: &State,
+    token: CancellationToken,
+) -> &'static ClickHouseCapabilities {
+    CLICKHOUSE_CAPABILITIES.get_or_init(|| ClickHouseCapabilities {
+        server_version: probe_server_version(adapter, state, token).unwrap_or_default(),
+    })
+}
+
+/// `SELECT version()`; None when the probe cannot run (replay has no live
+/// connection) or fails, leaving the version unknown -> "assume modern server".
+fn probe_server_version(
+    adapter: &AdapterImpl,
+    state: &State,
+    token: CancellationToken,
+) -> Option<String> {
+    let InnerAdapter::Impl(_, engine) = adapter.inner_adapter() else {
+        return None;
+    };
+    let engine = Arc::clone(engine);
+    let ctx = query_ctx_from_state(state)
+        .ok()?
+        .with_desc("clickhouse capability probe");
+    let mut conn = adapter
+        .borrow_tlocal_connection(Some(state), node_id_from_state(state))
+        .ok()?;
+    let batch = engine
+        .execute(None, conn.as_mut(), &ctx, "SELECT version() AS v", token)
+        .ok()?;
+    if batch.num_rows() == 0 {
+        return None;
+    }
+    let values = batch.column_values::<StringArray>("v").ok()?;
+    Some(values.value(0).to_string())
 }
 
 #[cfg(test)]
@@ -435,6 +645,50 @@ mod tests {
     use crate::stmt_splitter::DefaultStmtSplitter;
     use arrow_schema::{DataType, Field};
     use dbt_schemas::schemas::relations::DEFAULT_RESOLVED_QUOTING;
+
+    #[test]
+    fn test_build_settings_str_mirrors_python() {
+        // Mirrors dbt-clickhouse _build_settings_str: unquoted strings get
+        // single-quoted, other values verbatim; trailing newline; '' when empty.
+        assert_eq!(build_settings_str(&[]), "");
+        assert_eq!(
+            build_settings_str(&[
+                ("index_granularity".to_string(), Value::from(4096)),
+                (
+                    "replicated_deduplication_window".to_string(),
+                    Value::from("0")
+                ),
+                ("prequoted".to_string(), Value::from("'x'")),
+            ]),
+            "SETTINGS index_granularity=4096, replicated_deduplication_window='0', prequoted='x'\n"
+        );
+    }
+
+    #[test]
+    fn test_model_config_map_reads_model_config() {
+        let model = Value::from_serialize(serde_json::json!({
+            "config": {
+                "settings": {"index_granularity": 4096},
+                "query_settings": {"join_use_nulls": 1},
+            }
+        }));
+        let settings = model_config_map(&model, "settings");
+        assert_eq!(settings.len(), 1);
+        assert_eq!(settings[0].0, "index_granularity");
+
+        // missing key -> empty
+        assert!(model_config_map(&model, "not_there").is_empty());
+        // model without config -> empty
+        assert!(model_config_map(&Value::from(()), "settings").is_empty());
+    }
+
+    #[test]
+    fn test_compare_versions_mirrors_python() {
+        assert_eq!(compare_versions("26.6", "26.3.12.3").unwrap(), 1);
+        assert_eq!(compare_versions("22.7.1.2484", "26.3.12.3").unwrap(), -1);
+        assert_eq!(compare_versions("26.3", "26.3.12.3").unwrap(), 0); // zip stops at shorter
+        assert!(compare_versions("26.x", "26.3").is_err());
+    }
 
     /// A ClickHouse metadata adapter backed by a mock engine (no live
     /// connection); the catalog batch parsers never touch the engine.

--- a/crates/dbt-adapter/src/time_machine/semantic.rs
+++ b/crates/dbt-adapter/src/time_machine/semantic.rs
@@ -141,6 +141,8 @@ impl SemanticCategory {
             | "get_clickhouse_local_db_prefix"
             | "clickhouse_db_engine_clause"
             | "is_before_version"
+            | "is_at_or_after_version"
+            | "format_columns"
             | "supports_atomic_exchange"
             | "can_exchange"
             | "should_on_cluster"

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-clickhouse/macros/adapters.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-clickhouse/macros/adapters.sql
@@ -25,18 +25,6 @@
   {%- endif -%}
 {% endmacro %}
 
-{% macro clickhouse_model_settings(model, engine) %}
-  {{ return('') }}
-{% endmacro %}
-
-{% macro clickhouse_model_query_settings(model) %}
-  {{ return('') }}
-{% endmacro %}
-
-{% macro clickhouse_is_before_version(version) %}
-  {{ return(false) }}
-{% endmacro %}
-
 {% macro clickhouse_can_exchange(schema, relation_type) %}
   {{ return(false) }}
 {% endmacro %}
@@ -81,7 +69,8 @@
         name as mv_name,
         database as mv_database,
         any(as_select) as mv_sql,
-        any(replaceRegexpOne(create_table_query, '.*TO\\s+`?([^`\\s(]+)`?\\.`?([^`\\s(]+)`?.*', '\\1.\\2')) as target_fqn
+        {#- '\x3F' is the ClickHouse string-literal escape for '?' (regex quantifier); some drivers treat a literal '?' in query text as a bind parameter -#}
+        any(replaceRegexpOne(create_table_query, '.*TO\\s+`\x3F([^`\\s(]+)`\x3F\\.`\x3F([^`\\s(]+)`\x3F.*', '\\1.\\2')) as target_fqn
       {% if get_clickhouse_cluster_name() -%}
       from clusterAllReplicas({{ get_clickhouse_cluster_name() }}, system.tables)
       {% else %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-clickhouse/macros/column_spec_ddl.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-clickhouse/macros/column_spec_ddl.sql
@@ -7,7 +7,10 @@
 
   {%- set yaml_columns = user_defined_columns.values() -%}
 
-  {%- set sql_file_provided_columns = adapter.get_column_schema_from_query(sql) -%}
+  {# Apply model query_settings so schema introspection matches runtime types
+     (e.g. Nullable results when join_use_nulls=1). Fixes #667. #}
+  {%- set query_settings = config.get('query_settings', {}) or {} -%}
+  {%- set sql_file_provided_columns = adapter.get_column_schema_from_query(sql, query_settings=query_settings) -%}
   {%- set sql_columns = adapter.format_columns(sql_file_provided_columns) -%}
 
   {%- if sql_columns|length != yaml_columns|length -%}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-clickhouse/macros/materializations/distributed_table.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-clickhouse/macros/materializations/distributed_table.sql
@@ -130,7 +130,7 @@
   {{ primary_key_clause(label="primary key") }}
   {{ partition_cols(label="partition by") }}
   {{ ttl_config(label="ttl")}}
-  {{ clickhouse_model_settings(model, config.get('engine', default='MergeTree')) }}
+  {{ adapter.get_model_settings(model, config.get('engine', default='MergeTree')) }}
 {%- endmacro %}
 
 {% macro create_distributed_local_table(distributed_relation, shard_relation, structure_relation, sql_query=none, has_contract=false) -%}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-clickhouse/macros/materializations/incremental/incremental.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-clickhouse/macros/materializations/incremental/incremental.sql
@@ -184,7 +184,7 @@
             select {{ unique_key }}
             from {{ inserting_relation }}
           )
-       {{ clickhouse_model_query_settings(model) }}
+       {{ adapter.get_model_query_settings(model) }}
     {% endcall %}
 
     -- Insert all of the new data into the temporary table
@@ -198,7 +198,7 @@
      insert into {{ inserted_relation }} ({{ dest_columns_csv }})
         select {{ dest_columns_csv }}
         from {{ inserting_relation }}
-      {{ clickhouse_model_query_settings(model) }}
+      {{ adapter.get_model_query_settings(model) }}
     {% endcall %}
 
     {% do adapter.drop_relation(new_data_relation) %}
@@ -232,26 +232,29 @@
     {% endif %}
 
     {% call statement('delete_existing_data') %}
+      {#- The delete mutation may run on a replica that has not yet synced the new data;
+          embedding the setting in the subquery makes it read a fresh snapshot. -#}
+      {%- set subquery_settings = ' settings select_sequential_consistency = 1' if target.database_engine == 'Shared' else '' -%}
       {% if is_distributed %}
           {% set existing_local = existing_relation.incorporate(path={"identifier": this.identifier + local_suffix, "schema": local_db_prefix + this.schema}) if existing_relation is not none else none %}
             delete from {{ existing_local }} {{ on_cluster_clause(existing_relation) }} where ({{ unique_key }}) in (select {{ unique_key }}
-                                          from {{ inserting_relation }})
+                                          from {{ inserting_relation }}{{ subquery_settings }})
       {% else %}
             delete from {{ existing_relation }} where ({{ unique_key }}) in (select {{ unique_key }}
-                                          from {{ inserting_relation }})
+                                          from {{ inserting_relation }}{{ subquery_settings }})
       {% endif %}
       {%- if incremental_predicates %}
         {% for predicate in incremental_predicates %}
             and {{ predicate }}
         {% endfor %}
       {%- endif -%}
-      {{ clickhouse_model_query_settings(model) }}
+      {{ adapter.get_model_query_settings(model) }}
     {% endcall %}
 
     {%- set dest_columns = adapter.get_columns_in_relation(existing_relation) -%}
     {%- set dest_cols_csv = dest_columns | map(attribute='quoted') | join(', ') -%}
     {% call statement('insert_new_data') %}
-        insert into {{ existing_relation }} select {{ dest_cols_csv }} from {{ inserting_relation }} {{ clickhouse_model_query_settings(model) }}
+        insert into {{ existing_relation }} select {{ dest_cols_csv }} from {{ inserting_relation }} {{ adapter.get_model_query_settings(model) }}
     {% endcall %}
     {% do adapter.drop_relation(new_data_relation) %}
     {{ drop_relation_if_exists(distributed_new_data_relation) }}
@@ -306,6 +309,12 @@
                 from {{ new_data_relation }}
                 {{- ', ' if not loop.last }}
             {%- endfor %}
+            {#- The strategy relies on REPLACE PARTITION from a source with no parts in the partition
+                to clear shards that received no new data. ClickHouse 26.6+ refuses that by default,
+                so opt back in. Older servers don't know the setting and would reject the query. -#}
+            {%- if adapter.is_at_or_after_version('26.6') %}
+                settings allow_replace_partition_from_empty_source = 1
+            {%- endif %}
       {% endcall %}
     {% endif %}
 

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-clickhouse/macros/materializations/table.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-clickhouse/macros/materializations/table.sql
@@ -16,11 +16,11 @@
     {{ primary_key_clause(label='primary key') }}
     {{ partition_cols(label='partition by') }}
     {{ ttl_config(label='ttl') }}
-    {{ clickhouse_model_settings(model, config.get('engine', default='MergeTree')) }}
+    {{ adapter.get_model_settings(model, config.get('engine', default='MergeTree')) }}
     as (
       {{ sql }}
     )
-    {{ clickhouse_model_query_settings(model) }}
+    {{ adapter.get_model_query_settings(model) }}
   {%- endcall %}
 
   {{ run_hooks(post_hooks, inside_transaction=True) }}
@@ -92,9 +92,9 @@
   {%- set primary_key = config.get('primary_key', validator=validation.any[list, basestring]) -%}
   {#- An empty value ('' or []) would emit "PRIMARY KEY" with no columns,
       which is invalid DDL - treat it as unset instead. -#}
-{%- if primary_key is not none and ((primary_key is string and primary_key | trim | length == 0) or (primary_key is not string and primary_key | length == 0)) -%}
-  {%- set primary_key = none -%}
-{%- endif -%}
+  {%- if primary_key is not none and primary_key | length == 0 -%}
+    {%- set primary_key = none -%}
+  {%- endif -%}
   {#- v2 compatibility: v2's typed primary_key config arrives as a list
       (scalar inputs are listified). Render it as a single parenthesized
       expression, since bare "PRIMARY KEY a, b" is a ClickHouse syntax error.
@@ -155,18 +155,23 @@
 
 {% macro clickhouse__create_table_as(temporary, relation, sql) -%}
     {% set has_contract = config.get('contract').enforced %}
-    {% set create_table = create_table_or_empty(temporary, relation, sql, has_contract) %}
-    {% if clickhouse_is_before_version('22.7.1.2484') or temporary -%}
-        {{ create_table }}
-    {%- else %}
-        {% call statement('create_table_empty') %}
-            {{ create_table }}
-        {% endcall %}
-         {{ add_index_and_projections(relation) }}
-
+    {{ clickhouse__create_empty_table(temporary, relation, sql, has_contract) }}
+    {%- if not temporary %}
         {{ clickhouse__insert_into(relation, sql, has_contract) }}
     {%- endif %}
 {%- endmacro %}
+
+{#
+    "CREATE TABLE" step extracted from clickhouse__create_table_as so it can be used by other macros.
+#}
+{% macro clickhouse__create_empty_table(temporary, relation, sql, has_contract, statement_name='create_table_empty') %}
+    {% call statement(statement_name) %}
+        {{ create_table_or_empty(temporary, relation, sql, has_contract) }}
+    {% endcall %}
+    {%- if not temporary %}
+        {{ add_index_and_projections(relation) }}
+    {%- endif %}
+{% endmacro %}
 
 {#
     A macro that adds any configured projections or indexes at the same time.
@@ -211,7 +216,7 @@
     {% if temporary -%}
         create temporary table {{ relation.identifier }}
         engine Memory
-        {{ clickhouse_model_settings(model, 'Memory') }}
+        {{ adapter.get_model_settings(model, 'Memory') }}
         as (
           {{ sql }}
         )
@@ -227,17 +232,15 @@
         {{ primary_key_clause(label="primary key") }}
         {{ partition_cols(label="partition by") }}
         {{ ttl_config(label="ttl")}}
-        {{ clickhouse_model_settings(model, config.get('engine', default='MergeTree')) }}
+        {{ adapter.get_model_settings(model, config.get('engine', default='MergeTree')) }}
 
         {%- if not has_contract %}
-          {%- if not clickhouse_is_before_version('22.7.1.2484') %}
-            empty
-          {%- endif %}
+          empty
           as (
             {{ sql }}
           )
         {%- endif %}
-        {{ clickhouse_model_query_settings(model) }}
+        {{ adapter.get_model_query_settings(model) }}
     {%- endif %}
 
 {%- endmacro %}
@@ -266,7 +269,7 @@
   {%- else -%}
       {{ sql }}
   {%- endif -%}
-  {{ clickhouse_model_query_settings(model) }}
+  {{ adapter.get_model_query_settings(model) }}
 {%- endmacro %}
 
 {% macro codec_clause(codec_name) %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-clickhouse/macros/materializations/table.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-clickhouse/macros/materializations/table.sql
@@ -90,17 +90,27 @@
 
 {% macro primary_key_clause(label) %}
   {%- set primary_key = config.get('primary_key', validator=validation.any[list, basestring]) -%}
-  {#- An empty value ('' or []) would emit "PRIMARY KEY" with no columns,
+  {#- An empty value ('', '   ' or []) would emit "PRIMARY KEY" with no columns,
       which is invalid DDL - treat it as unset instead. -#}
+  {%- if primary_key is string -%}
+    {%- set primary_key = primary_key | trim -%}
+  {%- endif -%}
   {%- if primary_key is not none and primary_key | length == 0 -%}
     {%- set primary_key = none -%}
   {%- endif -%}
   {#- v2 compatibility: v2's typed primary_key config arrives as a list
       (scalar inputs are listified). Render it as a single parenthesized
       expression, since bare "PRIMARY KEY a, b" is a ClickHouse syntax error.
+      Whitespace-only entries are dropped like the scalar case above.
       Guarded like the incremental macros' unique_key handling. -#}
   {%- if primary_key is not none and primary_key is iterable and (primary_key is not string and primary_key is not mapping) -%}
-    {%- set primary_key = '(' ~ (primary_key | join(', ')) ~ ')' -%}
+    {%- set pk_cols = [] -%}
+    {%- for col in primary_key -%}
+      {%- if col | trim | length > 0 -%}
+        {%- do pk_cols.append(col | trim) -%}
+      {%- endif -%}
+    {%- endfor -%}
+    {%- set primary_key = '(' ~ (pk_cols | join(', ')) ~ ')' if pk_cols else none -%}
   {%- endif %}
 
   {%- if primary_key is not none %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-clickhouse/macros/materializations/view.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-clickhouse/macros/materializations/view.sql
@@ -68,10 +68,10 @@
     {%- endif %}
   as (
     {{ sql }}
-    {{ clickhouse_model_query_settings(model) }}
+    {{ adapter.get_model_query_settings(model) }}
   )
       {% if model.get('config').get('materialized') == 'view' %}
-      {{ clickhouse_model_settings(model, config.get('engine', default='MergeTree')) }}
+      {{ adapter.get_model_settings(model, config.get('engine', default='MergeTree')) }}
     {%- endif %}
 
 {%- endmacro %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-clickhouse/macros/persist_docs.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-clickhouse/macros/persist_docs.sql
@@ -41,9 +41,6 @@
   label. It would be nice to just pick a new one but eventually you do have to give up.
 #}
 {% macro clickhouse_escape_comment(comment) -%}
-  {% if clickhouse_is_before_version('21.9.2.17') %}
-    {% do exceptions.raise_compiler_error('Unsupported ClickHouse version for using heredoc syntax') %}
-  {% endif %}
   {% if comment is not string %}
     {% do exceptions.raise_compiler_error('cannot escape a non-string: ' ~ comment) %}
   {% endif %}


### PR DESCRIPTION
### `settings` model config now renders (table/engine settings).
Rendered in CREATE TABLE after the engine clause; these configure MergeTree storage and persist with the table. Includes upstream dbt-clickhouse's `replicated_deduplication_window='0'` default (opt out via the `allow_automatic_deduplication` profile flag; an explicit user value always wins).

```sql
{{ config(materialized='table', order_by='id', settings={'index_granularity': 8192}) }}
```
```sql
create table my_model engine = MergeTree order by id
-- end_of_sql
SETTINGS index_granularity=8192, replicated_deduplication_window='0'
as ( select 1 as id )
```

### `query_settings` model config now renders (query/session settings).
Appended to the SQL dbt executes for the model (the SELECT body, incremental inserts); they change how the query runs and persist nothing.

```sql
{{ config(materialized='table', query_settings={'join_use_nulls': 1}) }}
select t1.id, t2.value from t1 left join t2 on t1.id = t2.id
```
```sql
as ( select ... )
-- settings_section
SETTINGS join_use_nulls=1   -- unmatched LEFT JOIN rows produce NULL, not type-zero values
```

### Real server-version detection.
`adapter.is_before_version()` / `is_at_or_after_version()` compare against the connected server (one `SELECT version()` probe per process), so version-gated DDL is correct — e.g. `insert_overwrite` emits `allow_replace_partition_from_empty_source = 1` on ClickHouse ≥ 26.6 and omits it on older servers instead of erroring on an unknown setting.

### Model contracts validate against real column types.
Contract introspection runs `DESCRIBE TABLE (<model sql>)` with the model's `query_settings` applied, instead of reading the driver's Arrow schema (which marks every column Nullable). Contracts like this now pass, and wrong-column-name contract errors report correctly:

  ```yaml
  columns:
    - {name: id, data_type: Int32}
    - {name: last_value, data_type: Nullable(Int32)}  # Nullable because
  ```

### Macro parity with upstream dbt-clickhouse:
- `?` regex quantifiers eon-listing SQL (drivers that treat a literal `?` as a bind parameter no
longer fail)
- Empty `primary_key` no longer renders an invalid bare `PRIMARY KEY`
- `delete+insert` on ClickHouse Cloud reads its subquery with `select_sequential_consistency=1` (upstream #715);
- pre-22.7 code paths removed (upstream #678).
