### PR TITLE
fix(databricks): gate BY NAME REPLACE WHERE on DBR 18.0+

### DIFF
--- a/.changes/unreleased/Fixes-20260826-015755.yaml
+++ b/.changes/unreleased/Fixes-20260826-015755.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: 'Databricks: emit INSERT BY NAME REPLACE WHERE only when DBR 18.0+ supports the combination, and warn when insert_overwrite cannot honor REPLACE ON on older clusters'
+time: 2026-08-26T01:57:55.110563+05:30
+custom:
+    author: sd-db
+    issue: "15999"
+    project: dbt-core

--- a/crates/dbt-adapter/src/metadata/databricks/dbr_capabilities.rs
+++ b/crates/dbt-adapter/src/metadata/databricks/dbr_capabilities.rs
@@ -18,6 +18,7 @@ pub enum DbrCapability {
     JsonColumnMetadata,
     StreamingTableJsonMetadata,
     InsertByName,
+    InsertByNameReplaceWhere,
     ReplaceOn,
 }
 
@@ -30,6 +31,7 @@ impl DbrCapability {
             Self::JsonColumnMetadata => "json_column_metadata",
             Self::StreamingTableJsonMetadata => "streaming_table_json_metadata",
             Self::InsertByName => "insert_by_name",
+            Self::InsertByNameReplaceWhere => "insert_by_name_replace_where",
             Self::ReplaceOn => "replace_on",
         }
     }
@@ -42,6 +44,7 @@ impl DbrCapability {
             "json_column_metadata",
             "streaming_table_json_metadata",
             "insert_by_name",
+            "insert_by_name_replace_where",
             "replace_on",
         ]
     }
@@ -58,6 +61,7 @@ impl FromStr for DbrCapability {
             "json_column_metadata" => Ok(Self::JsonColumnMetadata),
             "streaming_table_json_metadata" => Ok(Self::StreamingTableJsonMetadata),
             "insert_by_name" => Ok(Self::InsertByName),
+            "insert_by_name_replace_where" => Ok(Self::InsertByNameReplaceWhere),
             "replace_on" => Ok(Self::ReplaceOn),
             _ => Err(format!(
                 "Unknown DBR capability: '{}'. Valid capabilities are: {}",
@@ -104,6 +108,13 @@ fn capability_spec(capability: DbrCapability) -> CapabilitySpec {
             min_version: (12, 2),
             sql_warehouse_supported: true,
         },
+        // `BY NAME REPLACE WHERE` was added in DBR 18.0 (SPARK-54803); plain
+        // `BY NAME` retains its DBR 12.2 floor. v1 reference:
+        // https://github.com/databricks/dbt-databricks/blob/45351e11517d3f37c5ac7a736b5fcba453d3f368/dbt/adapters/databricks/dbr_capabilities.py#L63-L68
+        DbrCapability::InsertByNameReplaceWhere => CapabilitySpec {
+            min_version: (18, 0),
+            sql_warehouse_supported: true,
+        },
         DbrCapability::ReplaceOn => CapabilitySpec {
             min_version: (17, 1),
             sql_warehouse_supported: true,
@@ -138,4 +149,34 @@ pub fn has_capability(
 
     let min_version = EngineVersion::Full(spec.min_version.0, spec.min_version.1);
     dbr_version >= min_version
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_insert_by_name_replace_where() {
+        assert_eq!(
+            DbrCapability::from_str("insert_by_name_replace_where"),
+            Ok(DbrCapability::InsertByNameReplaceWhere)
+        );
+    }
+
+    #[test]
+    fn insert_by_name_replace_where_requires_dbr_18_on_clusters() {
+        let capability = DbrCapability::InsertByNameReplaceWhere;
+
+        assert!(!has_capability(
+            capability,
+            EngineVersion::Full(17, 3),
+            false
+        ));
+        assert!(has_capability(
+            capability,
+            EngineVersion::Full(18, 0),
+            false
+        ));
+        assert!(has_capability(capability, EngineVersion::Unset, true));
+    }
 }

--- a/crates/dbt-adapter/src/metadata/databricks/dbr_capabilities.rs
+++ b/crates/dbt-adapter/src/metadata/databricks/dbr_capabilities.rs
@@ -150,33 +150,3 @@ pub fn has_capability(
     let min_version = EngineVersion::Full(spec.min_version.0, spec.min_version.1);
     dbr_version >= min_version
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn parses_insert_by_name_replace_where() {
-        assert_eq!(
-            DbrCapability::from_str("insert_by_name_replace_where"),
-            Ok(DbrCapability::InsertByNameReplaceWhere)
-        );
-    }
-
-    #[test]
-    fn insert_by_name_replace_where_requires_dbr_18_on_clusters() {
-        let capability = DbrCapability::InsertByNameReplaceWhere;
-
-        assert!(!has_capability(
-            capability,
-            EngineVersion::Full(17, 3),
-            false
-        ));
-        assert!(has_capability(
-            capability,
-            EngineVersion::Full(18, 0),
-            false
-        ));
-        assert!(has_capability(capability, EngineVersion::Unset, true));
-    }
-}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-databricks/macros/materializations/incremental/strategies.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-databricks/macros/materializations/incremental/strategies.sql
@@ -35,7 +35,9 @@
         {%- if adapter.has_dbr_capability('replace_on') -%}
             {{ get_insert_replace_on_sql(source_relation, target_relation) }}
         {%- else -%}
-            {#-- Use legacy DPO INSERT OVERWRITE for older DBR versions --#}
+            {%- if adapter.behavior.use_replace_on_for_insert_overwrite -%}
+                {{ exceptions.warn("insert_overwrite: use_replace_on_for_insert_overwrite is enabled but this cluster's DBR version does not support REPLACE ON (requires DBR 17.1+). Falling back to legacy INSERT OVERWRITE.") }}
+            {%- endif -%}
             {%- set has_insert_by_name = adapter.has_dbr_capability('insert_by_name') -%}
             insert overwrite table {{ target_relation }}
             {{ partition_cols(label="partition") }}
@@ -43,10 +45,7 @@
             select * from {{ source_relation }}
         {%- endif -%}
     {%- else -%}
-        {#-- SQL Warehouses: Check behavior flag first --#}
         {%- if adapter.behavior.use_replace_on_for_insert_overwrite -%}
-            {#-- Behavior flag enabled, SQL warehouses are assumed capable --#}
-            {{ exceptions.warn("insert_overwrite will perform a dynamic insert overwrite. If you depended on the legacy truncation behavior, consider disabling the behavior flag use_replace_on_for_insert_overwrite.") }}
             {{ get_insert_replace_on_sql(source_relation, target_relation) }}
         {%- else -%}
             {#-- Behavior flag disabled, use legacy DPO INSERT OVERWRITE --#}
@@ -121,7 +120,11 @@
   {%- set predicates = args_dict['incremental_predicates'] -%}
   {%- set target_relation = args_dict['target_relation'] -%}
   {%- set temp_relation = args_dict['temp_relation'] -%}
+  {#-- BY NAME + REPLACE WHERE needs DBR 18.0+ on clusters (SPARK-54803), a higher floor than
+       plain insert_by_name; emitting it on older clusters fails to parse (issue #1532). --#}
+  {%- set has_by_name = adapter.has_dbr_capability('insert_by_name_replace_where') -%}
 INSERT INTO {{ target_relation.render() }}
+{%- if has_by_name %} BY NAME{% endif %}
 {%- if predicates %}
   {%- if predicates is sequence and predicates is not string %}
  REPLACE WHERE {{ predicates | join(' and ') }}

--- a/crates/dbt-loader/tests/materializations/incremental.rs
+++ b/crates/dbt-loader/tests/materializations/incremental.rs
@@ -238,6 +238,174 @@ mod databricks {
     mod append;
 }
 
+mod databricks_strategies {
+    use super::*;
+
+    fn build_harness(
+        use_replace_on_for_insert_overwrite: bool,
+    ) -> (MacroTestHarness, Arc<MockJinjaObject>) {
+        let exceptions = Arc::new(MockJinjaObject::new());
+        exceptions.on("warn", |_| Ok(Value::UNDEFINED));
+
+        let harness = MacroTestHarness::for_adapter(AdapterType::Databricks)
+            .load_all_macros()
+            .with_stub_functions()
+            .with_behavior_flag(
+                "use_replace_on_for_insert_overwrite",
+                use_replace_on_for_insert_overwrite,
+            )
+            .with_global(
+                "exceptions",
+                Value::from_dyn_object(Arc::clone(&exceptions)),
+            )
+            .build()
+            .expect("harness should build");
+
+        harness.mock().on("quote", |args| {
+            let identifier = args
+                .first()
+                .and_then(Value::as_str)
+                .expect("quote requires an identifier");
+            Ok(Value::from(format!("`{}`", identifier.replace('`', "``"))))
+        });
+
+        (harness, exceptions)
+    }
+
+    fn relation_value(harness: &MacroTestHarness, identifier: &str) -> Value {
+        RelationObject::new(harness.relation(
+            "TEST_DB",
+            "TEST_SCHEMA",
+            identifier,
+            Some(RelationType::Table),
+        ))
+        .into_value()
+    }
+
+    fn normalize_sql(sql: &str) -> String {
+        sql.split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ")
+            .to_lowercase()
+    }
+
+    #[test]
+    fn replace_where_emits_by_name_only_when_by_name_plus_replace_where_is_supported() {
+        for (has_combination_capability, expected_by_name) in [(true, true), (false, false)] {
+            let (harness, _) = build_harness(false);
+            harness.mock().on("has_dbr_capability", move |args| {
+                let capability = args.first().and_then(Value::as_str);
+                Ok(Value::from(match capability {
+                    Some("insert_by_name") => true,
+                    Some("insert_by_name_replace_where") => has_combination_capability,
+                    _ => false,
+                }))
+            });
+
+            let args = Value::from_serialize(BTreeMap::from([
+                (
+                    "target_relation".to_string(),
+                    relation_value(&harness, "target_table"),
+                ),
+                (
+                    "temp_relation".to_string(),
+                    relation_value(&harness, "temp_table"),
+                ),
+                ("incremental_predicates".to_string(), Value::from("id >= 2")),
+            ]));
+
+            let sql = harness
+                .render(
+                    "{{ get_replace_where_sql(args) }}",
+                    BTreeMap::from([("args", args)]),
+                )
+                .expect("replace_where SQL should render");
+            assert_eq!(
+                normalize_sql(&sql).contains(" by name replace where "),
+                expected_by_name,
+                "unexpected replace_where SQL: {sql}",
+            );
+        }
+    }
+
+    #[test]
+    fn insert_overwrite_warns_only_when_an_old_cluster_cannot_honor_opt_in() {
+        const FALLBACK_WARNING: &str = "insert_overwrite: use_replace_on_for_insert_overwrite is enabled but this cluster's DBR version does not support REPLACE ON (requires DBR 17.1+). Falling back to legacy INSERT OVERWRITE.";
+
+        // partition_by is required so the REPLACE ON path emits `replace on` instead of
+        // falling back to INSERT OVERWRITE when no replace columns are configured.
+        for (is_cluster, has_replace_on, behavior_enabled, expect_warning, expect_replace_on) in [
+            (true, false, false, false, false),
+            (true, false, true, true, false),
+            (true, true, true, false, true),
+            (false, true, true, false, true),
+            (false, false, false, false, false),
+        ] {
+            let (harness, exceptions) = build_harness(behavior_enabled);
+            harness
+                .mock()
+                .on("is_cluster", move |_| Ok(Value::from(is_cluster)));
+            harness.mock().on("has_dbr_capability", move |args| {
+                let capability = args.first().and_then(Value::as_str);
+                Ok(Value::from(match capability {
+                    Some("replace_on") => has_replace_on,
+                    Some("insert_by_name") => true,
+                    _ => false,
+                }))
+            });
+            harness.mock().on("get_columns_in_relation", |_| {
+                Ok(Value::from_serialize(vec![BTreeMap::from([(
+                    "name",
+                    Value::from("dt"),
+                )])]))
+            });
+
+            let config = default_mock_config();
+            config.on("get", |args| {
+                let key = args.first().and_then(Value::as_str);
+                let default = args.get(1).cloned().unwrap_or(Value::UNDEFINED);
+                Ok(match key {
+                    Some("partition_by") => Value::from(vec![Value::from("dt")]),
+                    Some("liquid_clustered_by") => Value::UNDEFINED,
+                    _ => default,
+                })
+            });
+
+            let sql = harness
+                .render(
+                    "{{ get_insert_overwrite_sql('source_table', 'target_table') }}",
+                    BTreeMap::from([("config", Value::from_dyn_object(config))]),
+                )
+                .expect("insert_overwrite SQL should render");
+            let sql = normalize_sql(&sql);
+            assert_eq!(
+                sql.contains("replace on"),
+                expect_replace_on,
+                "unexpected REPLACE ON usage: {sql}",
+            );
+            assert_eq!(
+                sql.contains("insert overwrite"),
+                !expect_replace_on,
+                "unexpected INSERT OVERWRITE usage: {sql}",
+            );
+
+            let warnings: Vec<String> = exceptions
+                .observed_calls()
+                .to("warn")
+                .filter_map(|call| call.args.first().and_then(Value::as_str).map(str::to_owned))
+                .collect();
+            if expect_warning {
+                assert_eq!(warnings, [FALLBACK_WARNING], "unexpected warning for {sql}");
+            } else {
+                assert!(
+                    warnings.is_empty(),
+                    "expected no warnings, got {warnings:?} for {sql}",
+                );
+            }
+        }
+    }
+}
+
 mod spark {
     use super::*;
     const ADAPTER: AdapterType = AdapterType::Spark;


### PR DESCRIPTION
Resolves #15999

### Problem

Fusion emitted `INSERT … BY NAME REPLACE WHERE` whenever plain `insert_by_name` was available (DBR 12.2+). The combined syntax is only valid on DBR 18.0+ (SPARK-54803); older clusters fail to parse. SQL warehouses with `use_replace_on_for_insert_overwrite` also warned about legacy truncation even when REPLACE ON was actually used.

### Solution

- Add a Databricks runtime capability `insert_by_name_replace_where` (DBR 18.0+, warehouses supported) and gate `BY NAME` in `get_replace_where_sql` on that capability, matching dbt-databricks.
- On clusters that cannot honor REPLACE ON, warn and fall back to legacy INSERT OVERWRITE. Stop warning on warehouses when the behavior flag is on.
- Macro tests cover the `BY NAME` gate and the insert-overwrite warning/SQL-shape matrix.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.