### PR TITLE
Support Iceberg snapshot configuration

### DIFF
--- a/.changes/unreleased/Fixes-20260826-073202.yaml
+++ b/.changes/unreleased/Fixes-20260826-073202.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Support Iceberg snapshots by preserving table format metadata and Snowflake-compatible timestamp precision
+time: 2026-08-26T07:32:02.392968+10:00
+custom:
+    author: mattevans
+    issue: "15776"
+    project: dbt-core

--- a/crates/dbt-adapter/src/catalog_relation.rs
+++ b/crates/dbt-adapter/src/catalog_relation.rs
@@ -1687,6 +1687,9 @@ impl Object for LinkedCatalogProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use dbt_common::serde_utils::convert_yml_to_value_map;
+    use dbt_schemas::schemas::project::SnapshotConfig;
+    use dbt_schemas::schemas::{DbtSnapshot, InternalDbtNode};
     use minijinja::Value as JVal;
     use serde_json::json;
 
@@ -1752,6 +1755,21 @@ mod tests {
         } else {
             panic!("Config is not a JSON object");
         }
+    }
+
+    fn snapshot(config: SnapshotConfig) -> JVal {
+        let mut snapshot = DbtSnapshot {
+            deprecated_config: config,
+            ..Default::default()
+        };
+        snapshot.__snapshot_attr__.catalog_name = snapshot
+            .deprecated_config
+            .__warehouse_specific_config__
+            .catalog_name
+            .clone();
+        snapshot.__snapshot_attr__.table_format = snapshot.deprecated_config.table_format.clone();
+
+        JVal::from_object(convert_yml_to_value_map(snapshot.serialize()))
     }
 
     fn s(s: &str) -> YmlValue {
@@ -1897,6 +1915,37 @@ mod tests {
             assert_eq!(r.external_volume.as_deref(), Some("EV"));
             assert_eq!(r.base_location.as_deref(), Some("_root/SCH/ID/sub"));
         }
+    }
+
+    #[test]
+    fn snapshot_config_selects_snowflake_iceberg_relation() {
+        let mut config = SnapshotConfig {
+            schema: Some("SCH".to_string()),
+            alias: Some("SNAPSHOT".to_string()),
+            table_format: Some("iceberg".to_string()),
+            ..Default::default()
+        };
+        config.__warehouse_specific_config__.external_volume = Some("EV".to_string());
+        config.__warehouse_specific_config__.iceberg_version = Some(2);
+        let snapshot = snapshot(config);
+
+        let relation = CatalogRelation::from_model_config_and_catalogs(
+            AdapterType::Snowflake,
+            &snapshot,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(relation.catalog_type, CatalogType::SnowflakeBuiltIn);
+        assert_eq!(relation.table_format, TableFormat::Iceberg);
+        assert_eq!(relation.external_volume.as_deref(), Some("EV"));
+        assert_eq!(
+            relation
+                .adapter_properties
+                .get("iceberg_version")
+                .map(String::as_str),
+            Some("2")
+        );
     }
 
     #[test]
@@ -2558,6 +2607,35 @@ mod tests {
             );
             assert!(r.is_transient.is_none());
         }
+    }
+
+    #[test]
+    fn snapshot_config_selects_databricks_iceberg_relation() {
+        let cats = catalogs_yaml_one(
+            "UC",
+            "WIN",
+            "unity",
+            "ICEBERG",
+            &[("file_format", s("delta"))],
+        );
+        let mut config = SnapshotConfig {
+            table_format: Some("iceberg".to_string()),
+            ..Default::default()
+        };
+        config.__warehouse_specific_config__.catalog_name = Some("UC".to_string());
+        let snapshot = snapshot(config);
+
+        let relation = CatalogRelation::from_model_config_and_catalogs(
+            AdapterType::Databricks,
+            &snapshot,
+            Some(Arc::new(DbtCatalogs::new(cats, Default::default()))),
+        )
+        .unwrap();
+
+        assert_eq!(relation.catalog_name.as_deref(), Some("UC"));
+        assert_eq!(relation.catalog_type, CatalogType::Unity);
+        assert_eq!(relation.table_format, TableFormat::Iceberg);
+        assert_eq!(relation.file_format.as_deref(), Some("delta"));
     }
 
     #[test]

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-snowflake/macros/materializations/snapshot.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-snowflake/macros/materializations/snapshot.sql
@@ -6,3 +6,10 @@
 
     {{ return(relations) }}
 {% endmaterialization %}
+
+
+{% macro snowflake__create_columns(relation, columns) %}
+    {% if columns %}
+        {% do alter_relation_add_remove_columns(relation, columns, []) %}
+    {% endif %}
+{% endmacro %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-snowflake/macros/utils/timestamps.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-snowflake/macros/utils/timestamps.sql
@@ -8,7 +8,8 @@
 {%- endmacro %}
 
 {% macro snowflake__snapshot_get_time() -%}
-  to_timestamp_ntz({{ current_timestamp() }})
+  {#- Cast to microsecond precision because Iceberg tables reject TIMESTAMP_NTZ(9). -#}
+  to_timestamp_ntz({{ current_timestamp() }})::timestamp_ntz(6)
 {%- endmacro %}
 
 {% macro snowflake__current_timestamp_backcompat() %}

--- a/crates/dbt-loader/tests/macros/snowflake.rs
+++ b/crates/dbt-loader/tests/macros/snowflake.rs
@@ -1,11 +1,16 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
+use dbt_adapter::relation::{Relation, RelationObject};
 use dbt_adapter_core::AdapterType;
 use dbt_jinja_utils::mock_object::MockJinjaObject;
+use dbt_schemas::dbt_types::RelationType;
+use dbt_schemas::schemas::relations::base::{BaseRelation, TableFormat};
 use minijinja::Value;
 
-use crate::macro_test_harness::{MacroTestHarness, default_mock_config};
+use crate::macro_test_harness::{
+    MacroTestHarness, assert_executed_contains, default_mock_config, resolved_quoting_for,
+};
 
 #[test]
 fn snapshot_time_uses_iceberg_compatible_precision() {
@@ -26,6 +31,59 @@ fn snapshot_time_uses_iceberg_compatible_precision() {
         normalized,
         "to_timestamp_ntz(convert_timezone('UTC', current_timestamp()))::timestamp_ntz(6)"
     );
+}
+
+#[test]
+fn snapshot_schema_evolution_uses_iceberg_alter() {
+    let harness = MacroTestHarness::for_adapter(AdapterType::Snowflake)
+        .load_all_macros()
+        .with_stub_functions()
+        .build()
+        .expect("harness should build");
+    harness.mock().on("quote", |args| {
+        let identifier = args
+            .first()
+            .and_then(Value::as_str)
+            .expect("quote should receive an identifier");
+        Ok(Value::from(format!("\"{identifier}\"")))
+    });
+
+    let relation: Arc<dyn BaseRelation> = Arc::new(
+        Relation::new(
+            AdapterType::Snowflake,
+            "TEST_DB".to_string(),
+            "TEST_SCHEMA".to_string(),
+            "SNAPSHOT".to_string(),
+        )
+        .with_relation_type(RelationType::Table)
+        .with_quoting(resolved_quoting_for(AdapterType::Snowflake))
+        .with_table_format(TableFormat::Iceberg),
+    );
+    let column = Arc::new(MockJinjaObject::new());
+    column.set_attr("name", Value::from("NEW_COLUMN"));
+    column.set_attr("data_type", Value::from("NUMBER"));
+    column.on("is_string", |_| Ok(Value::from(false)));
+    let context = BTreeMap::from([
+        (
+            "relation".to_string(),
+            RelationObject::new(relation).into_value(),
+        ),
+        (
+            "columns".to_string(),
+            Value::from(vec![Value::from_dyn_object(column)]),
+        ),
+        ("execute".to_string(), Value::from(true)),
+    ]);
+
+    harness
+        .render("{{ create_columns(relation, columns) }}", context)
+        .expect("snapshot column creation should render");
+
+    assert_executed_contains(
+        harness.mock(),
+        "alter iceberg table TEST_DB.TEST_SCHEMA.SNAPSHOT add column",
+    );
+    assert_executed_contains(harness.mock(), "\"NEW_COLUMN\"");
 }
 
 #[test]

--- a/crates/dbt-loader/tests/macros/snowflake.rs
+++ b/crates/dbt-loader/tests/macros/snowflake.rs
@@ -8,6 +8,27 @@ use minijinja::Value;
 use crate::macro_test_harness::{MacroTestHarness, default_mock_config};
 
 #[test]
+fn snapshot_time_uses_iceberg_compatible_precision() {
+    let harness = MacroTestHarness::for_adapter(AdapterType::Snowflake)
+        .load_all_macros()
+        .build()
+        .expect("harness should build");
+
+    let rendered = harness
+        .render(
+            "{{ snapshot_get_time() }}",
+            BTreeMap::<String, Value>::new(),
+        )
+        .expect("snapshot_get_time should render");
+    let normalized = rendered.split_whitespace().collect::<Vec<_>>().join(" ");
+
+    assert_eq!(
+        normalized,
+        "to_timestamp_ntz(convert_timezone('UTC', current_timestamp()))::timestamp_ntz(6)"
+    );
+}
+
+#[test]
 fn python_table_tmp_relation_type_is_allowed() {
     let harness = MacroTestHarness::for_adapter(AdapterType::Snowflake)
         .load_all_macros()

--- a/crates/dbt-parser/src/resolve/resolve_snapshots.rs
+++ b/crates/dbt-parser/src/resolve/resolve_snapshots.rs
@@ -605,6 +605,11 @@ pub async fn resolve_snapshots(
                     },
                     sync: snapshot_config.sync.clone(),
                     state: snapshot_config.state.clone(),
+                    catalog_name: snapshot_config
+                        .__warehouse_specific_config__
+                        .catalog_name
+                        .clone(),
+                    table_format: snapshot_config.table_format.clone(),
                 },
                 __adapter_attr__: AdapterAttr::from_config_and_dialect(
                     &snapshot_config.__warehouse_specific_config__,

--- a/crates/dbt-schemas/src/schemas/manifest/manifest.rs
+++ b/crates/dbt-schemas/src/schemas/manifest/manifest.rs
@@ -1367,6 +1367,12 @@ pub fn nodes_from_dbt_manifest(manifest: DbtManifest, dbt_quoting: DbtQuoting) -
                             introspection: IntrospectionKind::None,
                             sync: snapshot.config.sync.clone(),
                             state: snapshot.config.state.clone(),
+                            catalog_name: snapshot
+                                .config
+                                .__warehouse_specific_config__
+                                .catalog_name
+                                .clone(),
+                            table_format: snapshot.config.table_format.clone(),
                         },
                         __adapter_attr__: AdapterAttr::from_config_and_dialect(
                             &snapshot.config.__warehouse_specific_config__,

--- a/crates/dbt-schemas/src/schemas/manifest/manifest_nodes.rs
+++ b/crates/dbt-schemas/src/schemas/manifest/manifest_nodes.rs
@@ -496,6 +496,8 @@ pub struct ManifestSnapshotConfig {
     pub sync: Option<SyncConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub state: Option<ModelState>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub table_format: Option<String>,
     pub __warehouse_specific_config__: WarehouseSpecificNodeConfig,
 }
 
@@ -540,6 +542,7 @@ impl From<SnapshotConfig> for ManifestSnapshotConfig {
             docs: config.docs,
             sync: config.sync,
             state: config.state,
+            table_format: config.table_format,
             __warehouse_specific_config__: config.__warehouse_specific_config__,
         }
     }
@@ -588,6 +591,7 @@ impl From<ManifestSnapshotConfig> for SnapshotConfig {
             docs: config.docs,
             sync: config.sync,
             state: config.state,
+            table_format: config.table_format,
             __warehouse_specific_config__: config.__warehouse_specific_config__,
         }
     }
@@ -2216,14 +2220,31 @@ mod node_adapter_manifest_round_trip_tests {
     fn snapshot_config_adapter_round_trips_through_manifest_snapshot_config() {
         let snapshot_config = SnapshotConfig {
             adapter: Some(AdapterType::Bigquery),
+            table_format: Some("iceberg".to_string()),
+            __warehouse_specific_config__: super::WarehouseSpecificNodeConfig {
+                iceberg_version: Some(2),
+                ..Default::default()
+            },
             ..Default::default()
         };
 
         let manifest_config: ManifestSnapshotConfig = snapshot_config.into();
         assert_eq!(manifest_config.adapter, Some(AdapterType::Bigquery));
+        assert_eq!(manifest_config.table_format.as_deref(), Some("iceberg"));
+        assert_eq!(
+            manifest_config
+                .__warehouse_specific_config__
+                .iceberg_version,
+            Some(2)
+        );
 
         let round_tripped: SnapshotConfig = manifest_config.into();
         assert_eq!(round_tripped.adapter, Some(AdapterType::Bigquery));
+        assert_eq!(round_tripped.table_format.as_deref(), Some("iceberg"));
+        assert_eq!(
+            round_tripped.__warehouse_specific_config__.iceberg_version,
+            Some(2)
+        );
     }
 
     #[test]

--- a/crates/dbt-schemas/src/schemas/nodes.rs
+++ b/crates/dbt-schemas/src/schemas/nodes.rs
@@ -2550,6 +2550,7 @@ impl InternalDbtNode for DbtSnapshot {
                 self_config.invalidate_hard_deletes == other_config.invalidate_hard_deletes;
             // dbt State configs (mirror `ModelConfig::same_config`).
             let state_eq = self_config.state == other_config.state;
+            let table_format_eq = self_config.table_format == other_config.table_format;
 
             // Adapter specific configs
             let warehouse_config_eq = same_warehouse_config(
@@ -2580,6 +2581,7 @@ impl InternalDbtNode for DbtSnapshot {
                 && quote_columns_eq
                 && invalidate_hard_deletes_eq
                 && state_eq
+                && table_format_eq
                 // Adapter specific configs
                 && warehouse_config_eq;
 
@@ -2755,6 +2757,14 @@ impl InternalDbtNode for DbtSnapshot {
                             Some((
                                 format!("{:?}", &self_config.state),
                                 format!("{:?}", &other_config.state),
+                            )),
+                        ),
+                        (
+                            "table_format",
+                            table_format_eq,
+                            Some((
+                                format!("{:?}", &self_config.table_format),
+                                format!("{:?}", &other_config.table_format),
                             )),
                         ),
                         ("warehouse_config", warehouse_config_eq, None),
@@ -4991,6 +5001,10 @@ pub struct DbtSnapshotAttr {
     pub sync: Option<SyncConfig>,
     /// dbt State configs, read by the run-cache at run time.
     pub state: Option<crate::schemas::properties::ModelState>,
+    // Exposed top-level on the node (like DbtModelAttr) so catalog resolution
+    // can classify snapshot targets such as Snowflake-managed Iceberg.
+    pub catalog_name: Option<String>,
+    pub table_format: Option<String>,
 }
 
 #[skip_serializing_none]

--- a/crates/dbt-schemas/src/schemas/project/configs/snapshot_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/snapshot_config.rs
@@ -147,6 +147,14 @@ pub struct ProjectSnapshotConfig {
     pub base_location_subpath: Option<String>,
     #[serde(
         default,
+        rename = "+iceberg_version",
+        deserialize_with = "u64_or_string_u64"
+    )]
+    pub iceberg_version: Option<u64>,
+    #[serde(rename = "+table_format")]
+    pub table_format: Option<String>,
+    #[serde(
+        default,
         rename = "+copy_grants",
         deserialize_with = "bool_or_string_bool"
     )]
@@ -418,6 +426,8 @@ impl TypedRecursiveConfig for ProjectSnapshotConfig {
             || self.backup.is_some()
             || self.base_location_root.is_some()
             || self.base_location_subpath.is_some()
+            || self.iceberg_version.is_some()
+            || self.table_format.is_some()
             || self.copy_grants.is_some()
             || self.copy_tags.is_some()
             || self.external_volume.is_some()
@@ -550,6 +560,7 @@ pub struct SnapshotConfig {
     pub sync: Option<SyncConfig>,
     // dbt State configs (state-aware run-cache behavior)
     pub state: Option<ModelState>,
+    pub table_format: Option<String>,
     // Adapter specific configs
     pub __warehouse_specific_config__: WarehouseSpecificNodeConfig,
 }
@@ -705,6 +716,7 @@ impl From<ProjectSnapshotConfig> for SnapshotConfig {
             docs: config.docs,
             sync: config.sync,
             state: config.state,
+            table_format: config.table_format,
             __warehouse_specific_config__: WarehouseSpecificNodeConfig {
                 description: None, // Only for Bigquery models
                 adapter_properties: config.adapter_properties,
@@ -733,7 +745,7 @@ impl From<ProjectSnapshotConfig> for SnapshotConfig {
                 copy_tags: config.copy_tags,
                 secure: config.secure,
                 transient: config.transient,
-                iceberg_version: None,
+                iceberg_version: config.iceberg_version,
 
                 partition_by: config.partition_by,
                 cluster_by: config.cluster_by,
@@ -876,6 +888,8 @@ impl From<SnapshotConfig> for ProjectSnapshotConfig {
             external_volume: config.__warehouse_specific_config__.external_volume,
             base_location_root: config.__warehouse_specific_config__.base_location_root,
             base_location_subpath: config.__warehouse_specific_config__.base_location_subpath,
+            iceberg_version: config.__warehouse_specific_config__.iceberg_version,
+            table_format: config.table_format,
             target_lag: config.__warehouse_specific_config__.target_lag,
             snowflake_initialization_warehouse: config
                 .__warehouse_specific_config__
@@ -1048,9 +1062,55 @@ impl ConfigKeys for SnapshotConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::{AdapterType, ProjectSnapshotConfig, SnapshotConfig};
+    use super::{AdapterType, ProjectSnapshotConfig, SnapshotConfig, WarehouseSpecificNodeConfig};
     use crate::schemas::common::{FreshnessPeriod, UpdatesOn};
+    use crate::schemas::project::{ResolvableConfig, TypedRecursiveConfig};
     use crate::schemas::properties::{ModelState, StatePreClone};
+
+    #[test]
+    fn test_project_snapshot_iceberg_config_parses_and_round_trips() {
+        let project_config: ProjectSnapshotConfig = dbt_yaml::from_str(
+            r#"
++table_format: iceberg
++iceberg_version: "2"
+__additional_properties__: {}
+"#,
+        )
+        .unwrap();
+
+        assert!(project_config.has_set_fields());
+
+        let snapshot_config: SnapshotConfig = project_config.into();
+        assert_eq!(snapshot_config.table_format.as_deref(), Some("iceberg"));
+        assert_eq!(
+            snapshot_config
+                .__warehouse_specific_config__
+                .iceberg_version,
+            Some(2)
+        );
+
+        let round_tripped: ProjectSnapshotConfig = snapshot_config.into();
+        assert_eq!(round_tripped.table_format.as_deref(), Some("iceberg"));
+        assert_eq!(round_tripped.iceberg_version, Some(2));
+    }
+
+    #[test]
+    fn test_snapshot_iceberg_config_inherits_from_parent() {
+        let parent = SnapshotConfig {
+            table_format: Some("iceberg".to_string()),
+            __warehouse_specific_config__: WarehouseSpecificNodeConfig {
+                iceberg_version: Some(2),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let mut child = SnapshotConfig::default();
+
+        child.default_to(&parent);
+
+        assert_eq!(child.table_format.as_deref(), Some("iceberg"));
+        assert_eq!(child.__warehouse_specific_config__.iceberg_version, Some(2));
+    }
 
     #[test]
     fn test_project_snapshot_config_resource_tags_parses() {


### PR DESCRIPTION
Resolves #15776

### Problem

Snapshot configuration does not preserve `table_format` and `iceberg_version` through parsing and manifest generation. The catalog relation therefore classifies an Iceberg snapshot target as a standard table.

On Snowflake, the snapshot timestamp also defaults to nanosecond precision (`TIMESTAMP_NTZ(9)`), while Iceberg v2 timestamps use microsecond precision. Together, these prevent snapshots from targeting Snowflake-managed Iceberg tables.

Additive snapshot schema evolution also uses the generic `ALTER TABLE` path. Snowflake requires `ALTER ICEBERG TABLE` when adding a source column to an existing managed Iceberg snapshot target.

### Solution

- Accept `table_format` and `iceberg_version` in snapshot configuration and preserve them through project config, parsing, manifest conversion, and state comparison.
- Expose the resolved snapshot metadata to catalog relation selection so Snowflake and Databricks choose their existing Iceberg paths.
- Cast Snowflake snapshot timestamps to `TIMESTAMP_NTZ(6)` for Iceberg-compatible precision.
- Route Snowflake snapshot column additions through the existing relation-aware alter macro so managed Iceberg targets use `ALTER ICEBERG TABLE`.
- Add focused configuration, manifest, catalog relation, timestamp and schema-evolution tests.

This does not change snapshot/SCD logic. It supplies the missing Iceberg metadata, compatible Snowflake timestamp precision and correct Snowflake DDL for additive schema evolution. Snapshot staging behaviour is unchanged.

### Validation

- `cargo fmt --all --check`
- `cargo test -p dbt-schemas`
- `cargo test -p dbt-loader snapshot_time_uses_iceberg_compatible_precision`
- `cargo test -p dbt-loader snapshot_schema_evolution_uses_iceberg_alter`
- `cargo test -p dbt-adapter snapshot_config_selects_`
- `cargo check -p dbt-parser`
- `cargo clippy -p dbt-schemas -p dbt-adapter -p dbt-loader -p dbt-parser --all-targets --all-features -- -D warnings`

A live Snowflake-managed Iceberg integration proof also passed initial snapshot creation, changed/inserted/hard-deleted rows, scalar and composite keys, an idempotent rerun, additive source schema evolution, target storage checks and standard Snowflake Stream metadata assertions.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (this PR intentionally extends accepted snapshot configuration and needs maintainer review).
