### PR TITLE
Emit OSC 8 hyperlinks for diagnostic file paths in TTY terminals.

### DIFF
--- a/.changes/unreleased/Features-20260826-osc8-diagnostic-hyperlinks.yaml
+++ b/.changes/unreleased/Features-20260826-osc8-diagnostic-hyperlinks.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Emit OSC 8 terminal hyperlinks for file paths in compiler diagnostics so locations are cmd+clickable in Ghostty, iTerm2, WezTerm, and kitty
+time: 2026-08-26T11:13:00+05:30
+custom:
+    author: TensorDevLJ
+    issue: "14504"
+    project: dbt-core

--- a/crates/dbt-common/src/pretty_string.rs
+++ b/crates/dbt-common/src/pretty_string.rs
@@ -1,5 +1,7 @@
 use console::Style;
+use dbt_error::strip_osc8_hyperlinks;
 use regex::Regex;
+use std::borrow::Cow;
 use std::error::Error;
 use std::fmt::Display;
 use std::sync::LazyLock;
@@ -278,6 +280,19 @@ pub fn remove_ansi_codes(input: &str) -> String {
     RE.replace_all(input, "").to_string()
 }
 
+/// Strips CSI color codes and OSC 8 hyperlinks from log text.
+///
+/// `console::strip_ansi_codes` does not remove OSC 8 (`ESC ] 8 ; ; …`), so file
+/// and JSON sinks must run this instead when diagnostic locations may be
+/// hyperlinked.
+pub fn strip_ansi_codes_and_hyperlinks(s: &str) -> Cow<'_, str> {
+    let after_ansi = console::strip_ansi_codes(s);
+    match strip_osc8_hyperlinks(after_ansi.as_ref()) {
+        Cow::Borrowed(_) => after_ansi,
+        Cow::Owned(stripped) => Cow::Owned(stripped),
+    }
+}
+
 pub fn make_title(title: &str, description: &str) -> String {
     format!("{} {}", BLUE.apply_to(title), BOLD.apply_to(description))
 }
@@ -287,4 +302,32 @@ pub fn make_error_title(title: &str, description: &str) -> String {
         return format!("{}", RED.apply_to(title));
     }
     format!("{} {}", RED.apply_to(title), BOLD.apply_to(description))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dbt_error::with_terminal_hyperlinks;
+
+    #[test]
+    fn strip_ansi_codes_and_hyperlinks_removes_osc8() {
+        let hyperlinked = with_terminal_hyperlinks(true, || {
+            dbt_error::CodeLocationWithFile::new(43, 9, 0, "models/foo.sql").to_string()
+        });
+        assert!(hyperlinked.contains("\x1b]8;;"));
+        let stripped = strip_ansi_codes_and_hyperlinks(&hyperlinked);
+        assert!(stripped.contains("foo.sql"));
+        assert!(!stripped.contains('\x1b'));
+    }
+
+    #[test]
+    fn strip_ansi_codes_and_hyperlinks_removes_csi_and_osc8() {
+        let hyperlinked = with_terminal_hyperlinks(true, || {
+            dbt_error::CodeLocationWithFile::new(1, 1, 0, "models/foo.sql").to_string()
+        });
+        let colored = format!("\x1b[31m{hyperlinked}\x1b[0m");
+        let stripped = strip_ansi_codes_and_hyperlinks(&colored);
+        assert!(stripped.contains("foo.sql"));
+        assert!(!stripped.contains('\x1b'));
+    }
 }

--- a/crates/dbt-common/src/tracing/config.rs
+++ b/crates/dbt-common/src/tracing/config.rs
@@ -33,6 +33,7 @@ use crate::{
     },
     io_args::{FsCommand, IoArgs, LogFormat, ShowOptions},
     io_utils::determine_project_dir,
+    pretty_string::strip_ansi_codes_and_hyperlinks,
     tracing::middlewares::parse_error_filter::TelemetryParsingErrorFilter,
     warn_error_options::WarnErrorOptions,
 };
@@ -162,7 +163,7 @@ fn dbt_log_preprocessor_hook(record: &LogRecordInfo) -> Cow<'_, LogRecordInfo> {
         return Cow::Borrowed(record);
     }
 
-    match console::strip_ansi_codes(record.body.as_str()) {
+    match strip_ansi_codes_and_hyperlinks(record.body.as_str()) {
         Cow::Owned(stripped) => Cow::Owned(LogRecordInfo {
             body: stripped,
             ..record.clone()

--- a/crates/dbt-common/src/tracing/layers/file_log_layer.rs
+++ b/crates/dbt-common/src/tracing/layers/file_log_layer.rs
@@ -55,6 +55,8 @@ use super::super::{
     fs_error_log::get_log_message,
 };
 
+use crate::pretty_string::strip_ansi_codes_and_hyperlinks;
+
 const HEADER_SEPARATOR: &str = "====================";
 
 /// Build file log layer with a background writer. This is preferred for writing to
@@ -454,9 +456,9 @@ impl FileLogLayer {
                 .code
                 .and_then(|c| u16::try_from(c).ok())
                 .and_then(|c| ErrorCode::try_from(c).ok()),
-            // Unfortunately, we do not currently enforce log body to not contain ANSI codes,
-            // so we need to make sure to strip them
-            console::strip_ansi_codes(log_record.body.as_str()),
+            // Unfortunately, we do not currently enforce log body to not contain ANSI codes
+            // or OSC 8 hyperlinks, so we need to make sure to strip them
+            strip_ansi_codes_and_hyperlinks(log_record.body.as_str()),
             log_record.severity_number,
             false,
             false, // Don't include level prefix, we add it via write_log_lines
@@ -506,7 +508,7 @@ impl FileLogLayer {
         // Write title and content to file log (without color codes for file output)
         let lines = vec![
             show_result.title.clone(),
-            console::strip_ansi_codes(show_result.content.as_str()).to_string(),
+            strip_ansi_codes_and_hyperlinks(show_result.content.as_str()).into_owned(),
         ];
         self.write_log_lines(
             log_record.time_unix_nano,

--- a/crates/dbt-common/src/tracing/layers/json_compat_layer.rs
+++ b/crates/dbt-common/src/tracing/layers/json_compat_layer.rs
@@ -43,6 +43,7 @@ use super::super::{
 };
 
 use crate::io_args::FsCommand;
+use crate::pretty_string::strip_ansi_codes_and_hyperlinks;
 use proto_rust::v1::public::fields::core_types::CoreEventInfo;
 
 /// Build a JSON compatibility layer. This will write directly to the writer.
@@ -450,9 +451,7 @@ impl JsonCompatLayer {
                 .code
                 .and_then(|c| u16::try_from(c).ok())
                 .and_then(|c| ErrorCode::try_from(c).ok()),
-            // Unfortunately, we do not currently enforce log body to not contain ANSI codes,
-            // so we need to make sure to strip them
-            console::strip_ansi_codes(log_record.body.as_str()),
+            strip_ansi_codes_and_hyperlinks(log_record.body.as_str()),
             log_record.severity_number,
             false,
             true,
@@ -602,7 +601,7 @@ impl JsonCompatLayer {
             format!(
                 "{}\n{}",
                 show_result.title,
-                console::strip_ansi_codes(show_result.content.as_str())
+                strip_ansi_codes_and_hyperlinks(show_result.content.as_str())
             ),
         ))
         .expect("Failed to serialize core event info to JSON");

--- a/crates/dbt-error/src/code_location.rs
+++ b/crates/dbt-error/src/code_location.rs
@@ -3,6 +3,7 @@ use std::{path::PathBuf, sync::Arc};
 use dbt_yaml::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use crate::terminal_hyperlinks::wrap_file_hyperlink;
 use crate::utils;
 
 use super::preprocessor_location;
@@ -217,6 +218,26 @@ impl CodeLocationWithFile {
     pub fn expanded(&self) -> Option<&CodeLocationWithFile> {
         self.expanded.as_deref()
     }
+
+    #[cfg(test)]
+    pub(crate) fn with_expanded_location(self, expanded: CodeLocationWithFile) -> Self {
+        CodeLocationWithFile {
+            expanded: Some(Box::new(expanded)),
+            ..self
+        }
+    }
+
+    /// Formats this location as `path`, `path:line`, or `path:line:col`.
+    fn displayed_span(&self) -> String {
+        let relative_path = self.relative_path();
+        if !self.has_position() {
+            relative_path.display().to_string()
+        } else if self.col == 0 {
+            format!("{}:{}", relative_path.display(), self.line)
+        } else {
+            format!("{}:{}:{}", relative_path.display(), self.line, self.col)
+        }
+    }
 }
 
 impl From<PathBuf> for CodeLocationWithFile {
@@ -263,15 +284,11 @@ impl From<MiniJinjaErrorWrapper> for CodeLocationWithFile {
 
 impl std::fmt::Display for CodeLocationWithFile {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let relative_path = self.relative_path();
-
-        if !self.has_position() {
-            write!(f, "{}", relative_path.display())?;
-        } else if self.col == 0 {
-            write!(f, "{}:{}", relative_path.display(), self.line)?;
-        } else {
-            write!(f, "{}:{}:{}", relative_path.display(), self.line, self.col)?;
-        }
+        write!(
+            f,
+            "{}",
+            wrap_file_hyperlink(self.file.as_ref(), &self.displayed_span())
+        )?;
         if let Some(expanded) = &self.expanded {
             write!(f, " ({expanded})")?;
         }
@@ -395,5 +412,69 @@ impl AbstractSpan for dbt_frontend_common::span::Span {
             start: self.start.with_arc_file(file),
             stop: self.stop,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::terminal_hyperlinks::{strip_osc8_hyperlinks, with_terminal_hyperlinks};
+
+    #[test]
+    fn display_is_plain_without_hyperlinks() {
+        let loc = CodeLocationWithFile::new(43, 9, 100, "models/foo.sql");
+        assert_eq!(loc.to_string(), loc.displayed_span());
+        with_terminal_hyperlinks(false, || {
+            assert_eq!(loc.to_string(), loc.displayed_span());
+        });
+    }
+
+    #[test]
+    fn display_wraps_path_in_osc8_when_enabled() {
+        let loc = CodeLocationWithFile::new(43, 9, 100, "models/foo.sql");
+        let plain = loc.displayed_span();
+        with_terminal_hyperlinks(true, || {
+            let rendered = loc.to_string();
+            assert!(
+                rendered.contains("\x1b]8;;file://"),
+                "expected OSC 8 file URI, got {rendered:?}"
+            );
+            assert!(rendered.contains(&plain));
+            assert_eq!(strip_osc8_hyperlinks(&rendered).as_ref(), plain);
+        });
+    }
+
+    #[test]
+    fn display_hyperlinks_expanded_location_separately() {
+        let loc = CodeLocationWithFile::new(43, 9, 100, "models/foo.sql").with_expanded_location(
+            CodeLocationWithFile::new(44, 19, 0, "target/compiled/models/foo.sql"),
+        );
+        let expected_plain = format!(
+            "{} ({})",
+            CodeLocationWithFile::new(43, 9, 100, "models/foo.sql").displayed_span(),
+            CodeLocationWithFile::new(44, 19, 0, "target/compiled/models/foo.sql").displayed_span()
+        );
+        with_terminal_hyperlinks(true, || {
+            let rendered = loc.to_string();
+            let file_uri_count = rendered.matches("\x1b]8;;file://").count();
+            assert_eq!(
+                file_uri_count, 2,
+                "source and expanded locations should each be hyperlinked, got {rendered:?}"
+            );
+            assert_eq!(strip_osc8_hyperlinks(&rendered).as_ref(), expected_plain);
+        });
+    }
+
+    #[test]
+    fn display_omits_column_when_zero() {
+        let loc = CodeLocationWithFile::new(12, 0, 0, "models/foo.sql");
+        with_terminal_hyperlinks(false, || {
+            assert_eq!(loc.to_string(), loc.displayed_span());
+            assert!(
+                !loc.displayed_span().contains(":12:"),
+                "column 0 should be omitted, got {}",
+                loc.displayed_span()
+            );
+        });
     }
 }

--- a/crates/dbt-error/src/lib.rs
+++ b/crates/dbt-error/src/lib.rs
@@ -6,6 +6,7 @@ mod code_location;
 mod codes;
 mod compiled_spans;
 mod preprocessor_location;
+mod terminal_hyperlinks;
 mod tracing;
 mod types;
 mod utils;
@@ -19,6 +20,10 @@ pub use codes::ErrorCode;
 pub use codes::Warnings;
 pub use compiled_spans::{CompiledSpans, MacroSpansOnly};
 pub use preprocessor_location::MacroSpan;
+pub use terminal_hyperlinks::{
+    init_terminal_hyperlinks_from_stderr, set_terminal_hyperlinks_enabled, strip_osc8_hyperlinks,
+    with_terminal_hyperlinks,
+};
 pub use types::{
     ContextableResult, ErrContext, FsError, FsResult, GenericNameError, LiftableResult,
     MAX_DISPLAY_TOKENS, NameError, WrappedError,

--- a/crates/dbt-error/src/terminal_hyperlinks.rs
+++ b/crates/dbt-error/src/terminal_hyperlinks.rs
@@ -1,0 +1,328 @@
+//! OSC 8 terminal hyperlinks for diagnostic file paths.
+//!
+//! [`CodeLocationWithFile`] formatting does not know which stream it is writing
+//! to, so hyperlink emission is gated by a process-wide flag (with a thread-local
+//! override for tests). The CLI enables the flag at startup when stderr is a TTY.
+//! Non-TTY sinks must strip OSC 8 sequences; `console::strip_ansi_codes` does not.
+
+use std::borrow::Cow;
+use std::cell::Cell;
+use std::io::IsTerminal;
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// OSC 8 introducer: `ESC ] 8 ; ;`
+const OSC8_START: &str = "\x1b]8;;";
+/// OSC 8 / ST terminator: `ESC \`
+const OSC8_ST: &str = "\x1b\\";
+/// OSC 8 closer: `ESC ] 8 ; ; ESC \`
+const OSC8_END: &str = "\x1b]8;;\x1b\\";
+
+static ENABLED: AtomicBool = AtomicBool::new(false);
+
+thread_local! {
+    static OVERRIDE: Cell<Option<bool>> = const { Cell::new(None) };
+}
+
+/// Enables or disables OSC 8 hyperlinks in diagnostic location formatting.
+pub fn set_terminal_hyperlinks_enabled(enabled: bool) {
+    ENABLED.store(enabled, Ordering::Relaxed);
+}
+
+/// Whether diagnostic locations should be wrapped in OSC 8 hyperlinks.
+pub(crate) fn terminal_hyperlinks_enabled() -> bool {
+    OVERRIDE.with(|cell| {
+        cell.get()
+            .unwrap_or_else(|| ENABLED.load(Ordering::Relaxed))
+    })
+}
+
+/// Runs `f` with a thread-local hyperlink override, restoring the previous value after.
+pub fn with_terminal_hyperlinks<F, R>(enabled: bool, f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    OVERRIDE.with(|cell| {
+        let prev = cell.replace(Some(enabled));
+        struct Reset(Option<bool>);
+        impl Drop for Reset {
+            fn drop(&mut self) {
+                OVERRIDE.with(|cell| cell.set(self.0));
+            }
+        }
+        let _reset = Reset(prev);
+        f()
+    })
+}
+
+/// Enables hyperlinks when stderr is an interactive TTY (and `TERM` is not `dumb`).
+pub fn init_terminal_hyperlinks_from_stderr() {
+    let dumb_term = std::env::var_os("TERM").is_some_and(|term| term == "dumb");
+    set_terminal_hyperlinks_enabled(std::io::stderr().is_terminal() && !dumb_term);
+}
+
+/// Wraps `displayed` in an OSC 8 `file://` hyperlink targeting `path`.
+///
+/// Returns `displayed` unchanged when hyperlinks are disabled, `path` is not a
+/// usable filesystem path, or a `file://` URI cannot be built.
+pub(crate) fn wrap_file_hyperlink(path: &Path, displayed: &str) -> String {
+    if !terminal_hyperlinks_enabled() {
+        return displayed.to_string();
+    }
+    let Some(uri) = path_to_file_uri(path) else {
+        return displayed.to_string();
+    };
+    format!("{OSC8_START}{uri}{OSC8_ST}{displayed}{OSC8_END}")
+}
+
+/// Converts `path` to a percent-encoded `file://` URI.
+///
+/// Relative paths are resolved against the current directory (the file does not
+/// need to exist). Returns `None` for empty or placeholder paths.
+pub(crate) fn path_to_file_uri(path: &Path) -> Option<String> {
+    if !is_hyperlinkable_path(path) {
+        return None;
+    }
+    let absolute = std::path::absolute(path).ok()?;
+    #[cfg(windows)]
+    let absolute = dunce::simplified(&absolute).to_path_buf();
+    if !is_hyperlinkable_path(&absolute) {
+        return None;
+    }
+    Some(encode_file_uri(&absolute))
+}
+
+fn is_hyperlinkable_path(path: &Path) -> bool {
+    let s = path.to_string_lossy();
+    !s.is_empty() && !s.contains('<') && !s.contains('>')
+}
+
+fn encode_file_uri(path: &Path) -> String {
+    #[cfg(windows)]
+    {
+        encode_file_uri_windows(path)
+    }
+    #[cfg(not(windows))]
+    {
+        encode_file_uri_unix(path)
+    }
+}
+
+#[cfg(not(windows))]
+fn encode_file_uri_unix(path: &Path) -> String {
+    use std::os::unix::ffi::OsStrExt;
+
+    let bytes = path.as_os_str().as_bytes();
+    let mut uri = String::from("file://");
+    if !bytes.starts_with(b"/") {
+        uri.push('/');
+    }
+    append_encoded_bytes(&mut uri, bytes);
+    uri
+}
+
+#[cfg(windows)]
+fn encode_file_uri_windows(path: &Path) -> String {
+    let mut normalized = path.to_string_lossy().replace('\\', "/");
+    if let Some(rest) = normalized.strip_prefix("//?/") {
+        normalized = rest.to_string();
+    }
+    if let Some(unc) = normalized.strip_prefix("//") {
+        let mut uri = String::from("file://");
+        append_encoded_bytes(&mut uri, unc.as_bytes());
+        return uri;
+    }
+    let mut uri = String::from("file:///");
+    append_encoded_bytes(&mut uri, normalized.as_bytes());
+    uri
+}
+
+fn append_encoded_bytes(out: &mut String, bytes: &[u8]) {
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+    for &b in bytes {
+        if is_path_uri_byte(b) {
+            out.push(b as char);
+        } else {
+            out.push('%');
+            out.push(HEX[(b >> 4) as usize] as char);
+            out.push(HEX[(b & 0x0F) as usize] as char);
+        }
+    }
+}
+
+/// Unreserved RFC 3986 bytes, plus `/` and `:` (Windows drive letters).
+const fn is_path_uri_byte(b: u8) -> bool {
+    matches!(
+        b,
+        b'A'..=b'Z'
+            | b'a'..=b'z'
+            | b'0'..=b'9'
+            | b'-'
+            | b'.'
+            | b'_'
+            | b'~'
+            | b'/'
+            | b':'
+    )
+}
+
+/// Removes OSC 8 wrappers, keeping the visible hyperlink text.
+///
+/// `console::strip_ansi_codes` only matches CSI sequences (`ESC [`), not OSC 8
+/// (`ESC ] 8 ; ; …`).
+pub fn strip_osc8_hyperlinks(input: &str) -> Cow<'_, str> {
+    if !input.contains(OSC8_START) {
+        return Cow::Borrowed(input);
+    }
+
+    let bytes = input.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if let Some(uri_end) = osc8_open_end(bytes, i) {
+            i = uri_end;
+            continue;
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    Cow::Owned(String::from_utf8(out).expect("OSC 8 wrappers are ASCII, so UTF-8 is preserved"))
+}
+
+/// If `bytes[i..]` starts an OSC 8 sequence, returns the index after its terminator.
+fn osc8_open_end(bytes: &[u8], i: usize) -> Option<usize> {
+    const PREFIX: &[u8] = b"\x1b]8;";
+    if !bytes[i..].starts_with(PREFIX) {
+        return None;
+    }
+    // Skip params (`id=…`) until the URI-separating `;`, then skip the URI.
+    let mut j = i + PREFIX.len();
+    while j < bytes.len() && bytes[j] != b';' {
+        j += 1;
+    }
+    if j >= bytes.len() {
+        return None;
+    }
+    j += 1; // skip ';'
+    while j < bytes.len() {
+        if bytes[j] == 0x07 {
+            return Some(j + 1);
+        }
+        if bytes[j] == 0x1b && j + 1 < bytes.len() && bytes[j + 1] == b'\\' {
+            return Some(j + 2);
+        }
+        j += 1;
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn disabled_by_default() {
+        with_terminal_hyperlinks(false, || {
+            assert!(!terminal_hyperlinks_enabled());
+            let wrapped = wrap_file_hyperlink(Path::new("models/foo.sql"), "models/foo.sql:1:1");
+            assert_eq!(wrapped, "models/foo.sql:1:1");
+        });
+    }
+
+    #[test]
+    fn wrap_emits_osc8_and_file_uri() {
+        with_terminal_hyperlinks(true, || {
+            let displayed = "models/foo.sql:43:9";
+            let wrapped = wrap_file_hyperlink(Path::new("models/foo.sql"), displayed);
+            assert!(
+                wrapped.starts_with(OSC8_START),
+                "expected OSC 8 start, got {wrapped:?}"
+            );
+            assert!(
+                wrapped.ends_with(OSC8_END),
+                "expected OSC 8 end, got {wrapped:?}"
+            );
+            assert!(wrapped.contains(displayed));
+            assert!(wrapped.contains("file://"));
+            assert!(
+                wrapped.contains("/models/foo.sql"),
+                "URI should include absolute path, got {wrapped:?}"
+            );
+        });
+    }
+
+    #[test]
+    fn spaces_are_percent_encoded() {
+        with_terminal_hyperlinks(true, || {
+            let wrapped =
+                wrap_file_hyperlink(Path::new("models/my model.sql"), "models/my model.sql:1:1");
+            assert!(
+                wrapped.contains("my%20model.sql"),
+                "expected percent-encoded space, got {wrapped:?}"
+            );
+            let uri_end = wrapped.find(OSC8_ST).expect("OSC 8 terminator");
+            assert!(
+                !wrapped[..uri_end].contains("my model.sql"),
+                "URI must not contain a raw space, got {wrapped:?}"
+            );
+        });
+    }
+
+    #[test]
+    fn placeholder_paths_are_not_hyperlinked() {
+        with_terminal_hyperlinks(true, || {
+            let wrapped = wrap_file_hyperlink(Path::new("<unknown>"), "<unknown>");
+            assert_eq!(wrapped, "<unknown>");
+        });
+    }
+
+    #[test]
+    fn strip_removes_wrappers_keeps_text() {
+        let wrapped = with_terminal_hyperlinks(true, || {
+            wrap_file_hyperlink(Path::new("models/foo.sql"), "models/foo.sql:43:9")
+        });
+        let stripped = strip_osc8_hyperlinks(&wrapped);
+        assert_eq!(stripped.as_ref(), "models/foo.sql:43:9");
+        assert!(!stripped.contains('\x1b'));
+    }
+
+    #[test]
+    fn strip_is_borrowed_when_absent() {
+        let s = "models/foo.sql:43:9";
+        match strip_osc8_hyperlinks(s) {
+            Cow::Borrowed(b) => assert_eq!(b, s),
+            Cow::Owned(_) => panic!("expected borrowed"),
+        }
+    }
+
+    #[test]
+    fn file_uri_is_absolute() {
+        let uri = path_to_file_uri(Path::new("models/foo.sql")).expect("uri");
+        assert!(uri.starts_with("file://"));
+        assert!(uri.contains("/models/foo.sql"));
+        assert!(!uri.contains(' '));
+    }
+
+    #[test]
+    fn strip_preserves_utf8_text() {
+        let wrapped = with_terminal_hyperlinks(true, || {
+            wrap_file_hyperlink(Path::new("models/café.sql"), "models/café.sql:1:1")
+        });
+        assert_eq!(
+            strip_osc8_hyperlinks(&wrapped).as_ref(),
+            "models/café.sql:1:1"
+        );
+    }
+
+    #[test]
+    fn thread_local_override_restores() {
+        with_terminal_hyperlinks(false, || {
+            assert!(!terminal_hyperlinks_enabled());
+            with_terminal_hyperlinks(true, || {
+                assert!(terminal_hyperlinks_enabled());
+            });
+            assert!(!terminal_hyperlinks_enabled());
+        });
+    }
+}

--- a/crates/dbt-error/src/terminal_hyperlinks.rs
+++ b/crates/dbt-error/src/terminal_hyperlinks.rs
@@ -196,24 +196,24 @@ fn osc8_open_end(bytes: &[u8], i: usize) -> Option<usize> {
         return None;
     }
     // Skip params (`id=…`) until the URI-separating `;`, then skip the URI.
-    let mut j = i + PREFIX.len();
-    while j < bytes.len() && bytes[j] != b';' {
-        j += 1;
+    let after_params = find_byte(bytes, i + PREFIX.len(), b';')? + 1;
+    (after_params..bytes.len()).find_map(|j| osc_terminator_end(bytes, j))
+}
+
+fn find_byte(bytes: &[u8], start: usize, needle: u8) -> Option<usize> {
+    bytes[start..]
+        .iter()
+        .position(|&b| b == needle)
+        .map(|offset| start + offset)
+}
+
+/// BEL (`0x07`) or ST (`ESC \`) that ends an OSC 8 introducer.
+fn osc_terminator_end(bytes: &[u8], j: usize) -> Option<usize> {
+    match bytes.get(j..) {
+        Some([0x07, ..]) => Some(j + 1),
+        Some([0x1b, b'\\', ..]) => Some(j + 2),
+        _ => None,
     }
-    if j >= bytes.len() {
-        return None;
-    }
-    j += 1; // skip ';'
-    while j < bytes.len() {
-        if bytes[j] == 0x07 {
-            return Some(j + 1);
-        }
-        if bytes[j] == 0x1b && j + 1 < bytes.len() && bytes[j + 1] == b'\\' {
-            return Some(j + 2);
-        }
-        j += 1;
-    }
-    None
 }
 
 #[cfg(test)]
@@ -285,6 +285,12 @@ mod tests {
         let stripped = strip_osc8_hyperlinks(&wrapped);
         assert_eq!(stripped.as_ref(), "models/foo.sql:43:9");
         assert!(!stripped.contains('\x1b'));
+    }
+
+    #[test]
+    fn strip_handles_bel_terminator() {
+        let input = "\x1b]8;;file:///tmp/a.sql\x07a.sql:1:1\x1b]8;;\x07";
+        assert_eq!(strip_osc8_hyperlinks(input).as_ref(), "a.sql:1:1");
     }
 
     #[test]

--- a/crates/dbt-error/src/types.rs
+++ b/crates/dbt-error/src/types.rs
@@ -1666,6 +1666,34 @@ mod tests {
             Path::new("run/test/models/test_fail.sql")
         );
     }
+
+    #[test]
+    fn pretty_includes_hyperlinked_location_when_enabled() {
+        use crate::with_terminal_hyperlinks;
+
+        let err = FsError::new_no_backtrace(ErrorCode::Generic, "Ambiguous column")
+            .with_location(CodeLocationWithFile::new(43, 9, 100, "models/foo.sql"));
+
+        with_terminal_hyperlinks(false, || {
+            let pretty = err.pretty();
+            assert!(
+                pretty.starts_with("[Generic (dbt1000)]: Ambiguous column"),
+                "{pretty}"
+            );
+            assert!(pretty.contains(" --> "));
+            assert!(pretty.contains("foo.sql"));
+            assert!(!pretty.contains("\x1b]8;;"));
+        });
+        with_terminal_hyperlinks(true, || {
+            let pretty = err.pretty();
+            assert!(pretty.contains("\x1b]8;;file://"));
+            assert!(pretty.contains("foo.sql"));
+            let stripped = crate::strip_osc8_hyperlinks(&pretty);
+            assert!(stripped.starts_with("[Generic (dbt1000)]: Ambiguous column"));
+            assert!(stripped.contains(" --> "));
+            assert!(!stripped.contains("\x1b"));
+        });
+    }
 }
 
 mod private {

--- a/crates/dbt-main/src/lib.rs
+++ b/crates/dbt-main/src/lib.rs
@@ -20,6 +20,7 @@ pub mod update;
 mod utils;
 
 mod main_impl;
+pub use dbt_error::init_terminal_hyperlinks_from_stderr;
 pub use main_impl::{
     init_env_before_parse, prepare_cli_or_exit, print_trimmed_error, run_cli, run_cli_with_code,
 };

--- a/crates/dbt-main/src/main_impl.rs
+++ b/crates/dbt-main/src/main_impl.rs
@@ -117,6 +117,9 @@ pub fn prepare_cli_or_exit(cli_parser: &CliParser) -> Box<Cli> {
 }
 
 pub fn run_cli(cli: Box<Cli>, arg: SystemArgs, feature_stack: Arc<FeatureStack>) -> ExitCode {
+    // Display of diagnostic locations does not know which stream it writes to.
+    // Enable OSC 8 only when stderr is a TTY so piped/CI output stays plain.
+    init_terminal_hyperlinks_from_stderr();
     ExitCode::from(run_cli_with_code(cli, arg, feature_stack))
 }
 
@@ -124,10 +127,6 @@ pub fn run_cli(cli: Box<Cli>, arg: SystemArgs, feature_stack: Arc<FeatureStack>)
 /// so embedders (e.g. the `dbt-core` Python extension's console entrypoint) can
 /// pass it to `std::process::exit`.
 pub fn run_cli_with_code(cli: Box<Cli>, arg: SystemArgs, feature_stack: Arc<FeatureStack>) -> u8 {
-    // Display of diagnostic locations does not know which stream it writes to.
-    // Enable OSC 8 only when stderr is a TTY so piped/CI output stays plain.
-    init_terminal_hyperlinks_from_stderr();
-
     let event_emitter = feature_stack.instrumentation.event_emitter.as_ref();
     let fail_fast_flag = cli.common_args.fail_fast;
 

--- a/crates/dbt-main/src/main_impl.rs
+++ b/crates/dbt-main/src/main_impl.rs
@@ -15,7 +15,7 @@ use dbt_common::{
     constants::{ERROR, PANIC},
     pretty_string::{GREEN, RED},
 };
-use dbt_error::FsError;
+use dbt_error::{FsError, init_terminal_hyperlinks_from_stderr};
 use dbt_features::feature_stack::FeatureStack;
 
 use crate::ctrl_c::run_future_with_ctrlc_support;
@@ -124,6 +124,10 @@ pub fn run_cli(cli: Box<Cli>, arg: SystemArgs, feature_stack: Arc<FeatureStack>)
 /// so embedders (e.g. the `dbt-core` Python extension's console entrypoint) can
 /// pass it to `std::process::exit`.
 pub fn run_cli_with_code(cli: Box<Cli>, arg: SystemArgs, feature_stack: Arc<FeatureStack>) -> u8 {
+    // Display of diagnostic locations does not know which stream it writes to.
+    // Enable OSC 8 only when stderr is a TTY so piped/CI output stays plain.
+    init_terminal_hyperlinks_from_stderr();
+
     let event_emitter = feature_stack.instrumentation.event_emitter.as_ref();
     let fail_fast_flag = cli.common_args.fail_fast;
 

--- a/crates/dbt-python-core/src/lib.rs
+++ b/crates/dbt-python-core/src/lib.rs
@@ -13,7 +13,7 @@ use dbt_common::tracing::dbt_init::{
 };
 use dbt_features::feature_stack::FeatureStack;
 use dbt_features::tracing::TracingFeature;
-use dbt_main::{print_trimmed_error, run_cli_with_code};
+use dbt_main::{init_terminal_hyperlinks_from_stderr, print_trimmed_error, run_cli_with_code};
 use dbt_schemas::schemas::DbtCommandExecutionArtifacts;
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
@@ -427,6 +427,7 @@ where
 fn run_cli(py: Python<'_>, argv: Vec<String>) -> PyResult<()> {
     let distribution = distribution();
     let code = py.detach(|| {
+        init_terminal_hyperlinks_from_stderr();
         run_cli_inner(
             argv,
             &(distribution.cli_parser)(),


### PR DESCRIPTION
## Summary
- Wrap compiler diagnostic file locations in OSC 8 `file://` hyperlinks so `path:line:col` is cmd+clickable in Ghostty, iTerm2, WezTerm, and kitty (VS Code already parses the plain span).
- Hyperlinks are enabled only when stderr is a TTY (`TERM` is not `dumb`). Display text stays relative `path:line:col`; the URI is an absolute percent-encoded `file://` path.
- Strip OSC 8 from file and JSON log sinks (`console::strip_ansi_codes` does not remove OSC 8).
- Closes #14504

## Test plan
- [x] `cargo test -p dbt-error`
- [x] `cargo test -p dbt-common --lib pretty_string`
- [ ] Trigger a compile error in a real project in Ghostty/iTerm2 and cmd+click the `-->` paths
- [ ] Confirm piped output (`dbt parse 2>&1 | cat`) has no escape sequences
- [ ] Confirm `logs/dbt.log` / JSON logs contain plain `path:line:col` with no OSC 8