### PR TITLE
[ClickHouse] Add incremental internal logic and schema evolution logic

### DIFF
--- a/.changes/unreleased/Features-20260826-164408.yaml
+++ b/.changes/unreleased/Features-20260826-164408.yaml
@@ -1,5 +1,5 @@
 kind: Features
-body: '[ClickHouse] Incremental strategies now resolve and validate exactly like the Python adapter (delete+insert with lightweight-delete settings sent per query, insert_overwrite, microbatch), and on_schema_change (fail/append_new_columns/sync_all_columns) works on incremental models with codec-aware ALTERs.'
+body: '[ClickHouse] Incremental strategies now resolve and validate exactly like the Python adapter (delete+insert, insert_overwrite, microbatch), and on_schema_change (fail/append_new_columns/sync_all_columns) works on incremental models with codec-aware ALTERs.'
 time: 2026-08-26T16:44:08.411476+02:00
 custom:
     author: koletzilla

--- a/.changes/unreleased/Features-20260826-164408.yaml
+++ b/.changes/unreleased/Features-20260826-164408.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: '[ClickHouse] Incremental strategies now resolve and validate exactly like the Python adapter (delete+insert with lightweight-delete settings sent per query, insert_overwrite, microbatch), and on_schema_change (fail/append_new_columns/sync_all_columns) works on incremental models with codec-aware ALTERs.'
+time: 2026-08-26T16:44:08.411476+02:00
+custom:
+    author: koletzilla
+    issue: "14585"
+    project: dbt-core

--- a/crates/dbt-adapter/src/adapter/adapter_impl.rs
+++ b/crates/dbt-adapter/src/adapter/adapter_impl.rs
@@ -5825,38 +5825,8 @@ impl AdapterImpl {
 
     /// ClickHouse: render the model's `query_settings` config as a query-level
     /// `SETTINGS ...` clause appended to the SELECT; empty string when unset.
-    pub fn get_model_query_settings(
-        &self,
-        state: &State,
-        model: &Value,
-        token: CancellationToken,
-    ) -> String {
-        let mut settings = metadata::clickhouse::model_config_map(model, "query_settings");
-
-        // Lightweight-delete strategies carry the probed
-        // `lw_deletes_query_settings` per query; explicit query_settings win.
-        let config = model.get_attr("config").ok();
-        let materialized = config
-            .as_ref()
-            .and_then(|c| c.get_attr("materialized").ok())
-            .and_then(|v| v.as_str().map(str::to_string))
-            .unwrap_or_default();
-        if materialized == "incremental" {
-            let strategy = config
-                .and_then(|c| c.get_attr("incremental_strategy").ok())
-                .and_then(|v| v.as_str().map(str::to_string));
-            let resolved =
-                self.calculate_incremental_strategy(state, strategy.as_deref(), token.clone());
-            if matches!(resolved.as_str(), "delete_insert" | "microbatch") {
-                let caps = metadata::clickhouse::server_capabilities(self, state, token);
-                for (setting, value) in &caps.lw_deletes_query_settings {
-                    if !settings.iter().any(|(key, _)| key == setting) {
-                        settings.push((setting.clone(), value.clone()));
-                    }
-                }
-            }
-        }
-
+    pub fn get_model_query_settings(&self, model: &Value) -> String {
+        let settings = metadata::clickhouse::model_config_map(model, "query_settings");
         let settings_str = metadata::clickhouse::build_settings_str(&settings);
         if settings_str.is_empty() {
             String::new()

--- a/crates/dbt-adapter/src/adapter/adapter_impl.rs
+++ b/crates/dbt-adapter/src/adapter/adapter_impl.rs
@@ -5825,16 +5825,130 @@ impl AdapterImpl {
 
     /// ClickHouse: render the model's `query_settings` config as a query-level
     /// `SETTINGS ...` clause appended to the SELECT; empty string when unset.
-    /// The lightweight-delete query-settings injection arrives with the
-    /// incremental-strategies port.
-    pub fn get_model_query_settings(&self, model: &Value) -> String {
-        let settings = metadata::clickhouse::model_config_map(model, "query_settings");
+    pub fn get_model_query_settings(
+        &self,
+        state: &State,
+        model: &Value,
+        token: CancellationToken,
+    ) -> String {
+        let mut settings = metadata::clickhouse::model_config_map(model, "query_settings");
+
+        // Lightweight-delete strategies carry the probed
+        // `lw_deletes_query_settings` per query; explicit query_settings win.
+        let config = model.get_attr("config").ok();
+        let materialized = config
+            .as_ref()
+            .and_then(|c| c.get_attr("materialized").ok())
+            .and_then(|v| v.as_str().map(str::to_string))
+            .unwrap_or_default();
+        if materialized == "incremental" {
+            let strategy = config
+                .and_then(|c| c.get_attr("incremental_strategy").ok())
+                .and_then(|v| v.as_str().map(str::to_string));
+            let resolved =
+                self.calculate_incremental_strategy(state, strategy.as_deref(), token.clone());
+            if matches!(resolved.as_str(), "delete_insert" | "microbatch") {
+                let caps = metadata::clickhouse::server_capabilities(self, state, token);
+                for (setting, value) in &caps.lw_deletes_query_settings {
+                    if !settings.iter().any(|(key, _)| key == setting) {
+                        settings.push((setting.clone(), value.clone()));
+                    }
+                }
+            }
+        }
+
         let settings_str = metadata::clickhouse::build_settings_str(&settings);
         if settings_str.is_empty() {
             String::new()
         } else {
             format!("\n-- settings_section\n{settings_str}\n")
         }
+    }
+
+    /// ClickHouse `adapter.calculate_incremental_strategy(strategy)` — see
+    /// [`metadata::clickhouse::calculate_incremental_strategy`].
+    pub fn calculate_incremental_strategy(
+        &self,
+        state: &State,
+        strategy: Option<&str>,
+        token: CancellationToken,
+    ) -> String {
+        metadata::clickhouse::calculate_incremental_strategy(
+            strategy,
+            metadata::clickhouse::server_capabilities(self, state, token).use_lw_deletes,
+        )
+    }
+
+    /// ClickHouse `adapter.validate_incremental_strategy(strategy, predicates,
+    /// unique_key, partition_by)` — see
+    /// [`metadata::clickhouse::validate_incremental_strategy`].
+    pub fn validate_incremental_strategy(
+        &self,
+        state: &State,
+        strategy: &str,
+        has_predicates: bool,
+        has_unique_key: bool,
+        has_partition_by: bool,
+        token: CancellationToken,
+    ) -> AdapterResult<()> {
+        metadata::clickhouse::validate_incremental_strategy(
+            strategy,
+            has_predicates,
+            has_unique_key,
+            has_partition_by,
+            metadata::clickhouse::server_capabilities(self, state, token).has_lw_deletes,
+        )
+    }
+
+    /// ClickHouse `adapter.check_incremental_schema_changes(...)` — see
+    /// [`metadata::clickhouse::column_changes_value`]. Returns none when the
+    /// relation does not exist yet.
+    #[allow(clippy::too_many_arguments)]
+    pub fn check_incremental_schema_changes(
+        &self,
+        state: &State,
+        on_schema_change: &str,
+        existing: Option<Arc<dyn BaseRelation>>,
+        target_sql: &str,
+        materialization: &str,
+        // dbt-clickhouse #689: applied to the DESCRIBE probe so introspected
+        // types match runtime (e.g. join_use_nulls).
+        query_settings: Option<&Value>,
+        token: CancellationToken,
+    ) -> AdapterResult<Value> {
+        if !matches!(
+            on_schema_change,
+            "fail" | "ignore" | "append_new_columns" | "sync_all_columns"
+        ) {
+            return Err(AdapterError::new(
+                AdapterErrorKind::Configuration,
+                "Only `fail`, `ignore`, `append_new_columns`, and `sync_all_columns` supported for `on_schema_change`.",
+            ));
+        }
+        let Some(existing) = existing else {
+            return Ok(none_value());
+        };
+
+        let source = self.get_columns_in_relation(state, existing.as_ref())?;
+        let target = {
+            let ctx = query_ctx_from_state(state)?.with_desc("check_incremental_schema_changes");
+            let mut conn = self.borrow_tlocal_connection(Some(state), node_id_from_state(state))?;
+            self.get_column_schema_from_query(
+                state,
+                conn.as_mut(),
+                &ctx,
+                target_sql,
+                query_settings,
+                token,
+            )?
+        };
+
+        metadata::clickhouse::column_changes_value(
+            on_schema_change,
+            source,
+            target,
+            materialization,
+        )
     }
 
     pub fn engine(&self) -> &Arc<dyn AdapterEngine> {

--- a/crates/dbt-adapter/src/adapter/adapter_impl.rs
+++ b/crates/dbt-adapter/src/adapter/adapter_impl.rs
@@ -5784,57 +5784,6 @@ impl AdapterImpl {
         metadata::clickhouse::server_capabilities(self, state, token).is_at_or_after(version)
     }
 
-    /// ClickHouse: render the model's `settings` config as a table-level `SETTINGS ...`
-    /// block for CREATE TABLE DDL. The leading `-- end_of_sql` marker is what
-    /// `clickhouse__place_limit` (utils/utils.sql) splits on to inject LIMIT ahead of
-    /// the SETTINGS clause. Mirrors impl.py `get_model_settings`, including dbclient.py's
-    /// `replicated_deduplication_window='0'` default (profile flag
-    /// `allow_automatic_deduplication` opts out; a user-provided value wins).
-    pub fn get_model_settings(&self, model: &Value, engine: &str) -> String {
-        // dbclient.py DEDUP_WINDOW_SETTING_SUPPORTED_MATERIALIZATION
-        const DEDUP_SUPPORTED_MATERIALIZATIONS: &[&str] =
-            &["table", "incremental", "ephemeral", "materialized_view"];
-        const DEDUP_WINDOW_SETTING: &str = "replicated_deduplication_window";
-
-        let mut settings = metadata::clickhouse::model_config_map(model, "settings");
-
-        let materialized = model
-            .get_attr("config")
-            .ok()
-            .and_then(|config| config.get_attr("materialized").ok())
-            .and_then(|v| v.as_str().map(str::to_string))
-            .unwrap_or_default();
-        let allow_automatic_deduplication = self
-            .get_db_config_value("allow_automatic_deduplication")
-            .and_then(|value| value.as_bool())
-            .unwrap_or(false);
-        if DEDUP_SUPPORTED_MATERIALIZATIONS.contains(&materialized.as_str())
-            && !allow_automatic_deduplication
-            && !settings.iter().any(|(key, _)| key == DEDUP_WINDOW_SETTING)
-        {
-            // Upstream sets the string '0', which _build_settings_str single-quotes.
-            settings.push((DEDUP_WINDOW_SETTING.to_string(), Value::from("0")));
-        }
-
-        // filter_settings_by_engine: replicated_deduplication_window is MergeTree-only.
-        settings.retain(|(key, _)| engine.contains("MergeTree") || key != DEDUP_WINDOW_SETTING);
-
-        let settings_str = metadata::clickhouse::build_settings_str(&settings);
-        format!("\n-- end_of_sql\n{settings_str}\n")
-    }
-
-    /// ClickHouse: render the model's `query_settings` config as a query-level
-    /// `SETTINGS ...` clause appended to the SELECT; empty string when unset.
-    pub fn get_model_query_settings(&self, model: &Value) -> String {
-        let settings = metadata::clickhouse::model_config_map(model, "query_settings");
-        let settings_str = metadata::clickhouse::build_settings_str(&settings);
-        if settings_str.is_empty() {
-            String::new()
-        } else {
-            format!("\n-- settings_section\n{settings_str}\n")
-        }
-    }
-
     /// ClickHouse `adapter.calculate_incremental_strategy(strategy)` — see
     /// [`metadata::clickhouse::calculate_incremental_strategy`].
     pub fn calculate_incremental_strategy(
@@ -5919,6 +5868,57 @@ impl AdapterImpl {
             target,
             materialization,
         )
+    }
+
+    /// ClickHouse: render the model's `settings` config as a table-level `SETTINGS ...`
+    /// block for CREATE TABLE DDL. The leading `-- end_of_sql` marker is what
+    /// `clickhouse__place_limit` (utils/utils.sql) splits on to inject LIMIT ahead of
+    /// the SETTINGS clause. Mirrors impl.py `get_model_settings`, including dbclient.py's
+    /// `replicated_deduplication_window='0'` default (profile flag
+    /// `allow_automatic_deduplication` opts out; a user-provided value wins).
+    pub fn get_model_settings(&self, model: &Value, engine: &str) -> String {
+        // dbclient.py DEDUP_WINDOW_SETTING_SUPPORTED_MATERIALIZATION
+        const DEDUP_SUPPORTED_MATERIALIZATIONS: &[&str] =
+            &["table", "incremental", "ephemeral", "materialized_view"];
+        const DEDUP_WINDOW_SETTING: &str = "replicated_deduplication_window";
+
+        let mut settings = metadata::clickhouse::model_config_map(model, "settings");
+
+        let materialized = model
+            .get_attr("config")
+            .ok()
+            .and_then(|config| config.get_attr("materialized").ok())
+            .and_then(|v| v.as_str().map(str::to_string))
+            .unwrap_or_default();
+        let allow_automatic_deduplication = self
+            .get_db_config_value("allow_automatic_deduplication")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false);
+        if DEDUP_SUPPORTED_MATERIALIZATIONS.contains(&materialized.as_str())
+            && !allow_automatic_deduplication
+            && !settings.iter().any(|(key, _)| key == DEDUP_WINDOW_SETTING)
+        {
+            // Upstream sets the string '0', which _build_settings_str single-quotes.
+            settings.push((DEDUP_WINDOW_SETTING.to_string(), Value::from("0")));
+        }
+
+        // filter_settings_by_engine: replicated_deduplication_window is MergeTree-only.
+        settings.retain(|(key, _)| engine.contains("MergeTree") || key != DEDUP_WINDOW_SETTING);
+
+        let settings_str = metadata::clickhouse::build_settings_str(&settings);
+        format!("\n-- end_of_sql\n{settings_str}\n")
+    }
+
+    /// ClickHouse: render the model's `query_settings` config as a query-level
+    /// `SETTINGS ...` clause appended to the SELECT; empty string when unset.
+    pub fn get_model_query_settings(&self, model: &Value) -> String {
+        let settings = metadata::clickhouse::model_config_map(model, "query_settings");
+        let settings_str = metadata::clickhouse::build_settings_str(&settings);
+        if settings_str.is_empty() {
+            String::new()
+        } else {
+            format!("\n-- settings_section\n{settings_str}\n")
+        }
     }
 
     pub fn engine(&self) -> &Arc<dyn AdapterEngine> {

--- a/crates/dbt-adapter/src/adapter/mod.rs
+++ b/crates/dbt-adapter/src/adapter/mod.rs
@@ -3309,15 +3309,55 @@ impl Adapter {
     /// ClickHouse: see [AdapterImpl::get_model_query_settings].
     pub fn get_model_query_settings(
         &self,
-        _state: &State,
+        state: &State,
         args: &[Value],
     ) -> Result<Value, minijinja::Error> {
         let iter = ArgsIter::new("get_model_query_settings", &["model"], args);
         let model = iter.next_arg::<&Value>()?;
         iter.finish()?;
         match &self.inner {
-            Typed { adapter, .. } => Ok(Value::from(adapter.get_model_query_settings(model))),
+            Typed { adapter, .. } => Ok(Value::from(adapter.get_model_query_settings(
+                state,
+                model,
+                self.cancellation_token.clone(),
+            ))),
             Parse(_) => Ok(empty_string_value()),
+        }
+    }
+
+    /// ClickHouse: see [AdapterImpl::check_incremental_schema_changes].
+    pub fn check_incremental_schema_changes(
+        &self,
+        state: &State,
+        args: &[Value],
+    ) -> Result<Value, minijinja::Error> {
+        let iter = ArgsIter::new(
+            "check_incremental_schema_changes",
+            &["on_schema_change", "existing_relation", "target_sql"],
+            args,
+        );
+        let on_schema_change = iter.next_arg::<&str>()?;
+        let existing_relation = iter.next_arg::<&Value>()?;
+        let target_sql = iter.next_arg::<&str>()?;
+        let materialization = iter
+            .next_kwarg::<Option<&str>>("materialization")?
+            .unwrap_or("incremental");
+        let query_settings = iter.next_kwarg::<Option<&Value>>("query_settings")?;
+        iter.finish()?;
+        let existing = existing_relation
+            .downcast_object::<RelationObject>()
+            .map(|ro| ro.inner());
+        match &self.inner {
+            Typed { adapter, .. } => Ok(adapter.check_incremental_schema_changes(
+                state,
+                on_schema_change,
+                existing,
+                target_sql,
+                materialization,
+                query_settings,
+                self.cancellation_token.clone(),
+            )?),
+            Parse(_) => Ok(none_value()),
         }
     }
 
@@ -4192,23 +4232,51 @@ impl Adapter {
                 Ok(Value::from(false))
             }
             "calculate_incremental_strategy" => {
-                // strategy: Optional[str] -> str (default to "append" if not set)
-                let strategy = args
-                    .first()
-                    .and_then(|v| v.as_str())
-                    .filter(|s| !s.is_empty())
-                    .unwrap_or("append");
-                Ok(Value::from(strategy))
+                // strategy: str -> str (''/'default' resolves to delete_insert or legacy; '+' -> '_')
+                let iter = ArgsIter::new("calculate_incremental_strategy", &["strategy"], args);
+                let strategy = iter.next_arg::<Option<&str>>()?;
+                iter.finish()?;
+                match &self.inner {
+                    Typed { adapter, .. } => {
+                        Ok(Value::from(adapter.calculate_incremental_strategy(
+                            state,
+                            strategy,
+                            self.cancellation_token.clone(),
+                        )))
+                    }
+                    Parse(_) => Ok(Value::from("legacy")),
+                }
             }
             "validate_incremental_strategy" => {
-                // strategy: str, predicates: list, unique_key: ?, partition_by: ? -> None
-                // Stub: all strategies accepted for MVP
-                Ok(Value::from(()))
+                // strategy: str, predicates: list, unique_key: str, partition_by: str -> None (raises on invalid combos)
+                let iter = ArgsIter::new(
+                    "validate_incremental_strategy",
+                    &["strategy", "predicates", "unique_key", "partition_by"],
+                    args,
+                );
+                let strategy = iter.next_arg::<&str>()?;
+                let predicates = iter.next_arg::<&Value>()?;
+                let unique_key = iter.next_arg::<&Value>()?;
+                let partition_by = iter.next_arg::<&Value>()?;
+                iter.finish()?;
+                match &self.inner {
+                    Typed { adapter, .. } => {
+                        adapter.validate_incremental_strategy(
+                            state,
+                            strategy,
+                            predicates.is_true(),
+                            unique_key.is_true(),
+                            partition_by.is_true(),
+                            self.cancellation_token.clone(),
+                        )?;
+                        Ok(none_value())
+                    }
+                    Parse(_) => Ok(none_value()),
+                }
             }
             "check_incremental_schema_changes" => {
-                // on_schema_change: str, existing_relation: Relation, sql: str -> None
-                // Stub: return None (no schema changes tracked); only reached when on_schema_change != 'ignore'
-                Ok(Value::from(()))
+                // on_schema_change: str, existing: Relation, target_sql: str, materialization: str = 'incremental', query_settings: dict = None -> ClickHouseColumnChanges | none
+                self.check_incremental_schema_changes(state, args)
             }
             "filter_settings_by_engine" => {
                 // model: dict, settings: str -> str

--- a/crates/dbt-adapter/src/adapter/mod.rs
+++ b/crates/dbt-adapter/src/adapter/mod.rs
@@ -4240,7 +4240,9 @@ impl Adapter {
                             self.cancellation_token.clone(),
                         )))
                     }
-                    Parse(_) => Ok(Value::from("legacy")),
+                    Parse(_) => Ok(Value::from(clickhouse::calculate_incremental_strategy(
+                        strategy, false,
+                    ))),
                 }
             }
             "validate_incremental_strategy" => {

--- a/crates/dbt-adapter/src/adapter/mod.rs
+++ b/crates/dbt-adapter/src/adapter/mod.rs
@@ -3309,18 +3309,14 @@ impl Adapter {
     /// ClickHouse: see [AdapterImpl::get_model_query_settings].
     pub fn get_model_query_settings(
         &self,
-        state: &State,
+        _state: &State,
         args: &[Value],
     ) -> Result<Value, minijinja::Error> {
         let iter = ArgsIter::new("get_model_query_settings", &["model"], args);
         let model = iter.next_arg::<&Value>()?;
         iter.finish()?;
         match &self.inner {
-            Typed { adapter, .. } => Ok(Value::from(adapter.get_model_query_settings(
-                state,
-                model,
-                self.cancellation_token.clone(),
-            ))),
+            Typed { adapter, .. } => Ok(Value::from(adapter.get_model_query_settings(model))),
             Parse(_) => Ok(empty_string_value()),
         }
     }

--- a/crates/dbt-adapter/src/column/types.rs
+++ b/crates/dbt-adapter/src/column/types.rs
@@ -266,10 +266,9 @@ impl ColumnStatic {
                 Some(size) => format!("STRING({size})"),
                 _ => "STRING".to_string(),
             },
-            AdapterType::ClickHouse => match size {
-                Some(size) => format!("FixedString({size})"),
-                _ => "String".to_string(),
-            },
+            // ClickHouseColumn.string_type ignores the size: always plain String,
+            // never FixedString (would break contract comparisons and ALTERs).
+            AdapterType::ClickHouse => "String".to_string(),
             _ => match size {
                 Some(size) => format!("character varying({size})"),
                 _ => "character varying".to_string(),
@@ -1233,6 +1232,14 @@ impl Into<Value> for Column {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// string_type must never manufacture FixedString for ClickHouse.
+    #[test]
+    fn test_string_type_clickhouse_ignores_size() {
+        let col = ColumnStatic(AdapterType::ClickHouse);
+        assert_eq!(col.string_type(Some(256)), "String");
+        assert_eq!(col.string_type(None), "String");
+    }
 
     #[test]
     fn test_stripping_of_not_null_constraint() {

--- a/crates/dbt-adapter/src/column/types.rs
+++ b/crates/dbt-adapter/src/column/types.rs
@@ -1233,14 +1233,6 @@ impl Into<Value> for Column {
 mod tests {
     use super::*;
 
-    /// string_type must never manufacture FixedString for ClickHouse.
-    #[test]
-    fn test_string_type_clickhouse_ignores_size() {
-        let col = ColumnStatic(AdapterType::ClickHouse);
-        assert_eq!(col.string_type(Some(256)), "String");
-        assert_eq!(col.string_type(None), "String");
-    }
-
     #[test]
     fn test_stripping_of_not_null_constraint() {
         let (dtype, _) =

--- a/crates/dbt-adapter/src/metadata/clickhouse/mod.rs
+++ b/crates/dbt-adapter/src/metadata/clickhouse/mod.rs
@@ -1,5 +1,6 @@
 use crate::AdapterEngine;
 use crate::adapter::adapter_impl::{AdapterImpl, InnerAdapter};
+use crate::column::Column;
 use crate::connection::AdapterConnectionFactory;
 use crate::query_ctx::{node_id_from_state, query_ctx_from_state};
 use crate::record_batch::RecordBatchExt;
@@ -462,13 +463,23 @@ fn build_schema_from_clickhouse_describe(
 
 /// ClickHouse server capabilities, probed once per process and reused for every
 /// model/thread afterwards (as the Python client does at connection init).
-/// Later capability probes (atomic exchange, lightweight deletes) extend this
-/// struct.
+/// Later capability probes (atomic exchange) extend this struct.
 #[derive(Debug, Clone)]
 pub struct ClickHouseCapabilities {
     /// `SELECT version()` result; empty when the probe failed (callers treat
     /// unknown as "modern server").
     pub server_version: String,
+    /// Whether lightweight deletes are usable. Mirrors dbclient.py
+    /// `_check_lightweight_deletes`.
+    pub has_lw_deletes: bool,
+    /// `has_lw_deletes` gated by the profile `use_lw_deletes` flag; picks the
+    /// default incremental strategy.
+    pub use_lw_deletes: bool,
+    /// Settings sent as query-level `SETTINGS` on the statements of models
+    /// resolved to a lightweight-delete strategy — Fusion's replacement for
+    /// Python's per-session/per-connection settings, which don't persist
+    /// across the connection pool.
+    pub lw_deletes_query_settings: Vec<(String, Value)>,
 }
 
 impl ClickHouseCapabilities {
@@ -606,18 +617,30 @@ pub fn server_capabilities(
     state: &State,
     token: CancellationToken,
 ) -> &'static ClickHouseCapabilities {
-    CLICKHOUSE_CAPABILITIES.get_or_init(|| ClickHouseCapabilities {
-        server_version: probe_server_version(adapter, state, token).unwrap_or_default(),
+    CLICKHOUSE_CAPABILITIES.get_or_init(|| {
+        let (has_lw_deletes, lw_deletes_query_settings) =
+            probe_lightweight_deletes(adapter, state, token.clone());
+        let use_lw_deletes_requested = adapter
+            .get_db_config_value("use_lw_deletes")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false);
+        ClickHouseCapabilities {
+            server_version: probe_server_version(adapter, state, token).unwrap_or_default(),
+            has_lw_deletes,
+            use_lw_deletes: has_lw_deletes && use_lw_deletes_requested,
+            lw_deletes_query_settings,
+        }
     })
 }
 
-/// `SELECT version()`; None when the probe cannot run (replay has no live
-/// connection) or fails, leaving the version unknown -> "assume modern server".
-fn probe_server_version(
+/// Run a capability-probe query; None when the probe cannot run (replay has no
+/// live connection) or the query fails.
+fn probe_query(
     adapter: &AdapterImpl,
     state: &State,
+    sql: &str,
     token: CancellationToken,
-) -> Option<String> {
+) -> Option<RecordBatch> {
     let InnerAdapter::Impl(_, engine) = adapter.inner_adapter() else {
         return None;
     };
@@ -628,14 +651,238 @@ fn probe_server_version(
     let mut conn = adapter
         .borrow_tlocal_connection(Some(state), node_id_from_state(state))
         .ok()?;
-    let batch = engine
-        .execute(None, conn.as_mut(), &ctx, "SELECT version() AS v", token)
-        .ok()?;
+    engine.execute(None, conn.as_mut(), &ctx, sql, token).ok()
+}
+
+/// `SELECT version()`; None leaves the version unknown -> "assume modern server".
+fn probe_server_version(
+    adapter: &AdapterImpl,
+    state: &State,
+    token: CancellationToken,
+) -> Option<String> {
+    let batch = probe_query(adapter, state, "SELECT version() AS v", token)?;
     if batch.num_rows() == 0 {
         return None;
     }
     let values = batch.column_values::<StringArray>("v").ok()?;
     Some(values.value(0).to_string())
+}
+
+/// dbclient.py `ND_MUTATION_SETTING`.
+const ND_MUTATION_SETTING: &str = "allow_nondeterministic_mutations";
+
+/// Mirrors dbclient.py `_check_lightweight_deletes` (only
+/// `allow_nondeterministic_mutations` needs checking — lightweight deletes
+/// themselves are GA since ClickHouse 23.3). Divergence: Python raises a config
+/// error at connection time when the setting is readonly and the profile
+/// requested `use_lw_deletes`; here the probe just reports "unavailable" and
+/// `validate_incremental_strategy` errors when a lightweight-delete strategy is
+/// actually used.
+fn probe_lightweight_deletes(
+    adapter: &AdapterImpl,
+    state: &State,
+    token: CancellationToken,
+) -> (bool, Vec<(String, Value)>) {
+    // dbclient.py defaults `lightweight_deletes_sync='3'` per connection.
+    let sync_setting = ("lightweight_deletes_sync".to_string(), Value::from(3));
+    let sql = format!(
+        "SELECT value, toString(readonly) AS readonly FROM system.settings \
+         WHERE name = '{ND_MUTATION_SETTING}'"
+    );
+    let Some(batch) = probe_query(adapter, state, &sql, token.clone()) else {
+        return (false, Vec::new());
+    };
+    if batch.num_rows() == 0 {
+        return (false, Vec::new());
+    }
+    let (Ok(values), Ok(readonlys)) = (
+        batch.column_values::<StringArray>("value"),
+        batch.column_values::<StringArray>("readonly"),
+    ) else {
+        return (false, Vec::new());
+    };
+    let enabled = values
+        .value(0)
+        .parse::<i64>()
+        .map(|v| v > 0)
+        .unwrap_or(false);
+    if enabled {
+        return (true, vec![sync_setting]);
+    }
+    if readonlys.value(0) != "0" {
+        return (false, Vec::new());
+    }
+    // Python's `SET {setting} = 1` try/except: verify the user may override
+    // the setting per query.
+    let probe = format!("SELECT 1 SETTINGS {ND_MUTATION_SETTING} = 1");
+    if probe_query(adapter, state, &probe, token).is_none() {
+        return (false, Vec::new());
+    }
+    (
+        true,
+        vec![
+            (ND_MUTATION_SETTING.to_string(), Value::from(1)),
+            sync_setting,
+        ],
+    )
+}
+
+/// Mirrors impl.py `calculate_incremental_strategy`.
+pub(crate) fn calculate_incremental_strategy(
+    strategy: Option<&str>,
+    use_lw_deletes: bool,
+) -> String {
+    let strategy = match strategy {
+        None | Some("") | Some("default") => {
+            if use_lw_deletes {
+                "delete_insert"
+            } else {
+                "legacy"
+            }
+        }
+        Some(s) => s,
+    };
+    strategy.replace('+', "_")
+}
+
+/// Mirrors impl.py `validate_incremental_strategy`: ClickHouse-specific
+/// cross-config checks, with Python-exact messages.
+pub(crate) fn validate_incremental_strategy(
+    strategy: &str,
+    has_predicates: bool,
+    has_unique_key: bool,
+    has_partition_by: bool,
+    has_lw_deletes: bool,
+) -> AdapterResult<()> {
+    let err = |msg: String| Err(AdapterError::new(AdapterErrorKind::Configuration, msg));
+    if !matches!(
+        strategy,
+        "legacy" | "append" | "delete_insert" | "insert_overwrite" | "microbatch"
+    ) {
+        return err(format!(
+            "The incremental strategy '{strategy}' is not valid for ClickHouse."
+        ));
+    }
+    if matches!(strategy, "delete_insert" | "microbatch") && !has_lw_deletes {
+        return err(format!(
+            "'{strategy}' strategy requires lightweight deletes, but the required setting \
+             '{ND_MUTATION_SETTING}' could not be enabled on this ClickHouse server \
+             (see the warnings logged at connection time)."
+        ));
+    }
+    if matches!(strategy, "delete_insert" | "microbatch") && !has_unique_key {
+        return err(format!(
+            "'{strategy}' strategy requires a non-empty 'unique_key'."
+        ));
+    }
+    if !matches!(strategy, "delete_insert" | "microbatch") && has_predicates {
+        return err(format!(
+            "Cannot apply incremental predicates with '{strategy}' strategy."
+        ));
+    }
+    if strategy == "insert_overwrite" && !has_partition_by {
+        return err(format!(
+            "'{strategy}' strategy requires non-empty 'partition_by'. Current partition_by is None."
+        ));
+    }
+    if strategy == "insert_overwrite" && has_unique_key {
+        return err(format!(
+            "'{strategy}' strategy does not support unique_key."
+        ));
+    }
+    Ok(())
+}
+
+/// Mirrors column.py `ClickHouseColumnChanges` as a Jinja value: none when
+/// there are no changes (its `__bool__`, so `{% if column_changes %}` skips),
+/// else a map; errors when the strategy cannot reconcile the changes.
+pub(crate) fn column_changes_value(
+    on_schema_change: &str,
+    source: Vec<Column>,
+    target: Vec<Column>,
+    materialization: &str,
+) -> AdapterResult<Value> {
+    let in_target = |name: &str| target.iter().any(|c| c.name() == name);
+    let source_of = |name: &str| source.iter().find(|c| c.name() == name);
+
+    let columns_to_drop: Vec<Column> = source
+        .iter()
+        .filter(|c| !in_target(c.name()))
+        .cloned()
+        .collect();
+    let columns_to_add: Vec<Column> = target
+        .iter()
+        .filter(|c| source_of(c.name()).is_none())
+        .cloned()
+        .collect();
+    let columns_to_modify: Vec<Column> = target
+        .iter()
+        .filter(|c| source_of(c.name()).is_some_and(|s| s.dtype() != c.dtype()))
+        .cloned()
+        .collect();
+
+    let has_schema_changes =
+        !(columns_to_add.is_empty() && columns_to_drop.is_empty() && columns_to_modify.is_empty());
+    let has_sync_changes = !(columns_to_drop.is_empty() && columns_to_modify.is_empty());
+    let has_conflicting_changes = (on_schema_change == "fail" && has_schema_changes)
+        || (on_schema_change != "sync_all_columns" && has_sync_changes);
+
+    if has_conflicting_changes {
+        // Python list-repr of `[str(col), ...]` — tests assert on it.
+        let fmt = |cols: &[Column]| {
+            if cols.is_empty() {
+                "[]".to_string()
+            } else {
+                format!(
+                    "['{}']",
+                    cols.iter()
+                        .map(|c| format!("{} {}", c.name(), c.data_type()))
+                        .collect::<Vec<_>>()
+                        .join("', '")
+                )
+            }
+        };
+        // errors.py schema_change_fail_error
+        let config_name = if materialization == "table" {
+            "mv_on_schema_change"
+        } else {
+            "on_schema_change"
+        };
+        return Err(AdapterError::new(
+            AdapterErrorKind::Configuration,
+            format!(
+                "The source and target schemas on this {materialization} model are out of sync.\n\
+                 They can be reconciled in several ways:\n  \
+                 - set the `{config_name}` config to `append_new_columns` or `sync_all_columns`.\n  \
+                 - Re-run the {materialization} model with `full_refresh: True` to update the target schema.\n  \
+                 - update the schema manually and re-run the process.\n\n\
+                 Additional troubleshooting context:\n   \
+                 Source columns not in target: {}\n   \
+                 Target columns not in source: {}\n   \
+                 New column types: {}",
+                fmt(&columns_to_drop),
+                fmt(&columns_to_add),
+                fmt(&columns_to_modify),
+            ),
+        ));
+    }
+
+    if !has_schema_changes {
+        return Ok(Value::from(()));
+    }
+
+    let mut changes = BTreeMap::new();
+    changes.insert(
+        "on_schema_change".to_string(),
+        Value::from(on_schema_change),
+    );
+    changes.insert("columns_to_add".to_string(), Value::from(columns_to_add));
+    changes.insert("columns_to_drop".to_string(), Value::from(columns_to_drop));
+    changes.insert(
+        "columns_to_modify".to_string(),
+        Value::from(columns_to_modify),
+    );
+    Ok(Value::from(changes))
 }
 
 #[cfg(test)]
@@ -688,6 +935,179 @@ mod tests {
         assert_eq!(compare_versions("22.7.1.2484", "26.3.12.3").unwrap(), -1);
         assert_eq!(compare_versions("26.3", "26.3.12.3").unwrap(), 0); // zip stops at shorter
         assert!(compare_versions("26.x", "26.3").is_err());
+    }
+
+    #[test]
+    fn test_calculate_incremental_strategy_mirrors_python() {
+        for unset in [None, Some(""), Some("default")] {
+            assert_eq!(calculate_incremental_strategy(unset, true), "delete_insert");
+            assert_eq!(calculate_incremental_strategy(unset, false), "legacy");
+        }
+        // explicit strategies pass through regardless of the capability
+        assert_eq!(
+            calculate_incremental_strategy(Some("append"), true),
+            "append"
+        );
+        // '+' -> '_' (dbt-core spells it delete+insert)
+        assert_eq!(
+            calculate_incremental_strategy(Some("delete+insert"), false),
+            "delete_insert"
+        );
+    }
+
+    #[test]
+    fn test_validate_incremental_strategy_mirrors_python() {
+        let msg = |result: AdapterResult<()>| result.unwrap_err().to_string();
+
+        assert!(validate_incremental_strategy("legacy", false, true, false, true).is_ok());
+        assert!(validate_incremental_strategy("delete_insert", true, true, false, true).is_ok());
+        assert!(
+            validate_incremental_strategy("insert_overwrite", false, false, true, false).is_ok()
+        );
+
+        assert!(
+            msg(validate_incremental_strategy(
+                "merge", false, false, false, true
+            ))
+            .contains("The incremental strategy 'merge' is not valid for ClickHouse.")
+        );
+        assert!(
+            msg(validate_incremental_strategy(
+                "delete_insert",
+                false,
+                true,
+                false,
+                false
+            ))
+            .contains(
+                "'delete_insert' strategy requires lightweight deletes, but the required setting \
+                 'allow_nondeterministic_mutations' could not be enabled on this ClickHouse server \
+                 (see the warnings logged at connection time)."
+            )
+        );
+        assert!(
+            msg(validate_incremental_strategy(
+                "microbatch",
+                false,
+                false,
+                false,
+                true
+            ))
+            .contains("'microbatch' strategy requires a non-empty 'unique_key'.")
+        );
+        assert!(
+            msg(validate_incremental_strategy(
+                "append", true, false, false, true
+            ))
+            .contains("Cannot apply incremental predicates with 'append' strategy.")
+        );
+        assert!(
+            msg(validate_incremental_strategy(
+                "insert_overwrite",
+                false,
+                false,
+                false,
+                true
+            ))
+            .contains(
+                "'insert_overwrite' strategy requires non-empty 'partition_by'. \
+                     Current partition_by is None."
+            )
+        );
+        assert!(
+            msg(validate_incremental_strategy(
+                "insert_overwrite",
+                false,
+                true,
+                true,
+                true
+            ))
+            .contains("'insert_overwrite' strategy does not support unique_key.")
+        );
+    }
+
+    fn ch_column(name: &str, dtype: &str) -> Column {
+        Column::new(
+            AdapterType::ClickHouse,
+            name.to_string(),
+            dtype.to_string(),
+            None,
+            None,
+            None,
+        )
+    }
+
+    #[test]
+    fn test_column_changes_value_mirrors_python() {
+        let source = vec![ch_column("id", "UInt64"), ch_column("name", "String")];
+
+        // identical schemas -> none (ClickHouseColumnChanges.__bool__)
+        let unchanged = column_changes_value(
+            "append_new_columns",
+            source.clone(),
+            source.clone(),
+            "incremental",
+        )
+        .unwrap();
+        assert!(unchanged.is_none());
+
+        let target = vec![
+            ch_column("id", "UInt64"),
+            ch_column("name", "String"),
+            ch_column("age", "UInt8"),
+        ];
+        let changes = column_changes_value(
+            "append_new_columns",
+            source.clone(),
+            target.clone(),
+            "incremental",
+        )
+        .unwrap();
+        assert_eq!(
+            changes.get_attr("on_schema_change").unwrap().as_str(),
+            Some("append_new_columns")
+        );
+        let added = changes.get_attr("columns_to_add").unwrap();
+        assert_eq!(added.len(), Some(1));
+        let first = added.get_item(&Value::from(0)).unwrap();
+        assert_eq!(first.get_attr("name").unwrap().as_str(), Some("age"));
+
+        // any change with fail -> Python's schema_change_fail_error, list-repr'd
+        let err = column_changes_value("fail", source.clone(), target.clone(), "incremental")
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains(
+                "The source and target schemas on this incremental model are out of sync."
+            )
+        );
+        assert!(err.contains("set the `on_schema_change` config"));
+        assert!(err.contains("Source columns not in target: []"));
+        assert!(err.contains("Target columns not in source: ['age UInt8']"));
+        assert!(err.contains("New column types: []"));
+
+        // dropped column requires sync_all_columns; append_new_columns conflicts
+        let narrowed = vec![ch_column("id", "UInt64")];
+        let err = column_changes_value(
+            "append_new_columns",
+            source.clone(),
+            narrowed.clone(),
+            "incremental",
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("Source columns not in target: ['name String']"));
+        let synced =
+            column_changes_value("sync_all_columns", source.clone(), narrowed, "incremental")
+                .unwrap();
+        assert_eq!(synced.get_attr("columns_to_drop").unwrap().len(), Some(1));
+
+        // table materialization names the MV config key instead
+        let err = column_changes_value("fail", source, target, "table")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("set the `mv_on_schema_change` config"));
+        assert!(err.contains("this table model"));
     }
 
     /// A ClickHouse metadata adapter backed by a mock engine (no live

--- a/crates/dbt-adapter/src/metadata/clickhouse/mod.rs
+++ b/crates/dbt-adapter/src/metadata/clickhouse/mod.rs
@@ -475,11 +475,6 @@ pub struct ClickHouseCapabilities {
     /// `has_lw_deletes` gated by the profile `use_lw_deletes` flag; picks the
     /// default incremental strategy.
     pub use_lw_deletes: bool,
-    /// Settings sent as query-level `SETTINGS` on the statements of models
-    /// resolved to a lightweight-delete strategy — Fusion's replacement for
-    /// Python's per-session/per-connection settings, which don't persist
-    /// across the connection pool.
-    pub lw_deletes_query_settings: Vec<(String, Value)>,
 }
 
 impl ClickHouseCapabilities {
@@ -618,8 +613,7 @@ pub fn server_capabilities(
     token: CancellationToken,
 ) -> &'static ClickHouseCapabilities {
     CLICKHOUSE_CAPABILITIES.get_or_init(|| {
-        let (has_lw_deletes, lw_deletes_query_settings) =
-            probe_lightweight_deletes(adapter, state, token.clone());
+        let has_lw_deletes = probe_lightweight_deletes(adapter, state, token.clone());
         let use_lw_deletes_requested = adapter
             .get_db_config_value("use_lw_deletes")
             .and_then(|value| value.as_bool())
@@ -628,7 +622,6 @@ pub fn server_capabilities(
             server_version: probe_server_version(adapter, state, token).unwrap_or_default(),
             has_lw_deletes,
             use_lw_deletes: has_lw_deletes && use_lw_deletes_requested,
-            lw_deletes_query_settings,
         }
     })
 }
@@ -673,33 +666,34 @@ const ND_MUTATION_SETTING: &str = "allow_nondeterministic_mutations";
 
 /// Mirrors dbclient.py `_check_lightweight_deletes` (only
 /// `allow_nondeterministic_mutations` needs checking — lightweight deletes
-/// themselves are GA since ClickHouse 23.3). Divergence: Python raises a config
-/// error at connection time when the setting is readonly and the profile
-/// requested `use_lw_deletes`; here the probe just reports "unavailable" and
-/// `validate_incremental_strategy` errors when a lightweight-delete strategy is
-/// actually used.
+/// themselves are GA since ClickHouse 23.3). Divergences: Python raises a
+/// config error at connection time when the setting is readonly and the
+/// profile requested `use_lw_deletes` — here the probe just reports
+/// "unavailable" and `validate_incremental_strategy` errors when a
+/// lightweight-delete strategy is actually used; and Python enables the
+/// disabled-but-changeable case with a per-session `SET` — the v2 equivalent
+/// (a per-connection driver setting) arrives with the new adbc_clickhouse
+/// driver (issue #70).
 fn probe_lightweight_deletes(
     adapter: &AdapterImpl,
     state: &State,
     token: CancellationToken,
-) -> (bool, Vec<(String, Value)>) {
-    // dbclient.py defaults `lightweight_deletes_sync='3'` per connection.
-    let sync_setting = ("lightweight_deletes_sync".to_string(), Value::from(3));
+) -> bool {
     let sql = format!(
         "SELECT value, toString(readonly) AS readonly FROM system.settings \
          WHERE name = '{ND_MUTATION_SETTING}'"
     );
     let Some(batch) = probe_query(adapter, state, &sql, token.clone()) else {
-        return (false, Vec::new());
+        return false;
     };
     if batch.num_rows() == 0 {
-        return (false, Vec::new());
+        return false;
     }
     let (Ok(values), Ok(readonlys)) = (
         batch.column_values::<StringArray>("value"),
         batch.column_values::<StringArray>("readonly"),
     ) else {
-        return (false, Vec::new());
+        return false;
     };
     let enabled = values
         .value(0)
@@ -707,24 +701,15 @@ fn probe_lightweight_deletes(
         .map(|v| v > 0)
         .unwrap_or(false);
     if enabled {
-        return (true, vec![sync_setting]);
+        return true;
     }
     if readonlys.value(0) != "0" {
-        return (false, Vec::new());
+        return false;
     }
     // Python's `SET {setting} = 1` try/except: verify the user may override
-    // the setting per query.
+    // the setting.
     let probe = format!("SELECT 1 SETTINGS {ND_MUTATION_SETTING} = 1");
-    if probe_query(adapter, state, &probe, token).is_none() {
-        return (false, Vec::new());
-    }
-    (
-        true,
-        vec![
-            (ND_MUTATION_SETTING.to_string(), Value::from(1)),
-            sync_setting,
-        ],
-    )
+    probe_query(adapter, state, &probe, token).is_some()
 }
 
 /// Mirrors impl.py `calculate_incremental_strategy`.

--- a/crates/dbt-adapter/src/time_machine/semantic.rs
+++ b/crates/dbt-adapter/src/time_machine/semantic.rs
@@ -64,7 +64,8 @@ impl SemanticCategory {
             | "has_dbr_capability"
             | "get_missing_columns"
             | "is_replaceable"
-            | "location_exists" => SemanticCategory::MetadataRead,
+            | "location_exists"
+            | "check_incremental_schema_changes" => SemanticCategory::MetadataRead,
 
             // Mutate database state (DDL/DML)
             "execute"

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-clickhouse/macros/materializations/incremental/distributed_incremental.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-clickhouse/macros/materializations/incremental/distributed_incremental.sql
@@ -50,7 +50,7 @@
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
   {{ run_hooks(pre_hooks, inside_transaction=True) }}
   {% set to_drop = [] %}
-  {% set local_column_changes = none %}
+  {% set schema_changes = none %}
 
   {% call statement('main') %}
     {{ create_view_as(view_relation, sql) }}
@@ -80,17 +80,16 @@
       {% set existing_relation = target_relation %}
     {% endif %}
 
-    {#- See incremental.sql for divergence notes re: calculate/validate_incremental_strategy -#}
-    {% set incremental_strategy = config.get('incremental_strategy') or 'legacy' %}
-    {% set incremental_strategy = incremental_strategy | replace('+', '_') %}
-    {% set valid_incremental_strategies = ['legacy', 'append', 'delete_insert', 'insert_overwrite'] %}
-    {% if incremental_strategy not in valid_incremental_strategies %}
-      {% do exceptions.raise_compiler_error("Invalid ClickHouse distributed_incremental strategy '" ~ incremental_strategy ~ "'") %}
-    {% endif %}
+    {% set incremental_strategy = adapter.calculate_incremental_strategy(config.get('incremental_strategy'))  %}
     {% set incremental_predicates = config.get('predicates', []) or config.get('incremental_predicates', []) %}
     {% set partition_by = config.get('partition_by') %}
+    {% do adapter.validate_incremental_strategy(incremental_strategy, incremental_predicates, unique_key, partition_by) %}
     {%- if on_schema_change != 'ignore' %}
-      {% do exceptions.raise_compiler_error("ClickHouse on_schema_change != 'ignore' is not yet supported in Fusion") %}
+      {%- set local_column_changes = adapter.check_incremental_schema_changes(on_schema_change, existing_relation_local, sql, query_settings=config.get('query_settings', {})) -%}
+      {% if local_column_changes and incremental_strategy != 'legacy' %}
+        {% do clickhouse__apply_column_changes(local_column_changes, existing_relation, True) %}
+        {% set existing_relation = load_cached_relation(this) %}
+      {% endif %}
     {% endif %}
     {% if incremental_strategy == 'legacy' %}
       {% do clickhouse__incremental_legacy(existing_relation, intermediate_relation, local_column_changes, unique_key, True) %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-clickhouse/macros/materializations/incremental/incremental.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-clickhouse/macros/materializations/incremental/incremental.sql
@@ -56,26 +56,16 @@
 
   {% else %}
     {% set column_changes = none %}
-    {#-
-      Divergence from Python adapter: the upstream dbt-clickhouse Python adapter calls
-      adapter.calculate_incremental_strategy() (defaulting None→'legacy') and
-      adapter.validate_incremental_strategy() (ClickHouse-specific cross-config checks).
-      In Fusion those methods don't exist; instead we:
-        1. Apply the 'legacy' default directly in Jinja.
-        2. Validate the supported ClickHouse strategy names in Jinja.
-      Cross-config validation (e.g. insert_overwrite requires partition_by) is deferred to a
-      future Rust-layer validator; invalid combos will currently fail at SQL execution time.
-    -#}
-    {% set incremental_strategy = config.get('incremental_strategy') or 'legacy' %}
-    {% set incremental_strategy = incremental_strategy | replace('+', '_') %}
-    {% set valid_incremental_strategies = ['legacy', 'append', 'delete_insert', 'insert_overwrite', 'microbatch'] %}
-    {% if incremental_strategy not in valid_incremental_strategies %}
-      {% do exceptions.raise_compiler_error("Invalid ClickHouse incremental strategy '" ~ incremental_strategy ~ "'") %}
-    {% endif %}
+    {% set incremental_strategy = adapter.calculate_incremental_strategy(config.get('incremental_strategy'))  %}
     {% set incremental_predicates = config.get('predicates', []) or config.get('incremental_predicates', []) %}
     {% set partition_by = config.get('partition_by') %}
+    {% do adapter.validate_incremental_strategy(incremental_strategy, incremental_predicates, unique_key, partition_by) %}
     {%- if on_schema_change != 'ignore' %}
-      {% do exceptions.raise_compiler_error("ClickHouse on_schema_change != 'ignore' is not yet supported in Fusion") %}
+      {%- set column_changes = adapter.check_incremental_schema_changes(on_schema_change, existing_relation, sql, query_settings=config.get('query_settings', {})) -%}
+      {% if column_changes and incremental_strategy != 'legacy' %}
+        {% do clickhouse__apply_column_changes(column_changes, existing_relation) %}
+        {% set existing_relation = load_cached_relation(this) %}
+      {% endif %}
     {% endif %}
     {% if incremental_strategy == 'legacy' %}
       {% do clickhouse__incremental_legacy(existing_relation, intermediate_relation, column_changes, unique_key) %}


### PR DESCRIPTION
Related to #14585
## Incremental strategies with Python-exact resolution and validation

`incremental_strategy` now resolves and validates like the Python adapter: `delete+insert` normalizes to `delete_insert`, invalid strategies and invalid config combinations fail at compile time with the same messages, and lightweight-delete availability is probed from the server once per run (`allow_nondeterministic_mutations` enabled, or overridable by the user — mirroring the Python client's connection-time check). When the profile sets `use_lw_deletes: true` the default strategy becomes `delete_insert` instead of `legacy`.

```yaml
# profiles.yml
use_lw_deletes: true
```
```sql
{{ config(materialized='incremental', unique_key='key1', incremental_strategy='delete+insert') }}
```
Before: strategy defaulted in Jinja, invalid combos surfaced as raw SQL errors mid-run. Now: a model with `insert_overwrite` and no `partition_by` fails immediately with `'insert_overwrite' strategy requires non-empty 'partition_by'. Current partition_by is None.`, a lightweight-delete strategy on a server where it can't be enabled fails with the Python adapter's exact error, and with no strategy set plus `use_lw_deletes: true` the model runs delete+insert automatically.

Note: the connection-level settings the Python client pins per session (`lightweight_deletes_sync`, `allow_nondeterministic_mutations` when disabled-but-changeable) are intentionally NOT emitted into SQL text here — they arrive as driver connection settings once adbc_clickhouse supports arbitrary settings options (ClickHouse/adbc_clickhouse#70).

## `on_schema_change` on incremental models

`fail`, `append_new_columns`, and `sync_all_columns` now work on incremental models, with codec-aware column additions:

```sql
{{ config(materialized='incremental', unique_key='id', incremental_strategy='delete_insert',
          on_schema_change='append_new_columns') }}
select id, name, age from ...   -- `age` is new; its yml entry can carry codec: ZSTD
```
Before: any `on_schema_change != 'ignore'` aborted with "not yet supported in Fusion". Now: `append_new_columns` ALTERs the new column in (with its `codec`), `sync_all_columns` also drops/modifies, and `fail` raises Python's exact "schemas … out of sync" error. Supporting fix: introspected `String` columns no longer re-render as `FixedString(256)`, so the ALTERs and type comparisons are correct.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
