### PR TITLE
Fix Windows absolute path selector parsing

### DIFF
--- a/.changes/unreleased/Fixes-20260827-070000.yaml
+++ b/.changes/unreleased/Fixes-20260827-070000.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fixed Windows absolute path node selectors being parsed as selector methods.
+time: 2026-08-27T07:00:00.000+05:30
+custom:
+  Author: arpansahu
+  Issue: "16094"

--- a/core/dbt/graph/selector_spec.py
+++ b/core/dbt/graph/selector_spec.py
@@ -53,6 +53,23 @@ def _match_to_int(match: Dict[str, str], key: str) -> Optional[int]:
         raise DbtRuntimeError(f"Invalid node spec - could not handle parent depth {raw}") from exc
 
 
+def _looks_like_windows_drive_path(method: Optional[str], value: str) -> bool:
+    return (
+        method is not None
+        and len(method) == 1
+        and method.isalpha()
+        and value.startswith(("\\", "/"))
+    )
+
+
+def _fix_windows_drive_path(dct: Dict[str, Any]) -> None:
+    method = dct.get("method")
+    value = dct.get("value", "")
+    if _looks_like_windows_drive_path(method, value):
+        dct["method"] = MethodName.Path
+        dct["value"] = f"{method}:{value}"
+
+
 SelectionSpec = Union[
     "SelectionCriteria",
     "SelectionIntersection",
@@ -112,8 +129,10 @@ class SelectionCriteria:
         raw: Any,
         dct: Dict[str, Any],
     ) -> "SelectionCriteria":
+        dct = dict(dct)
         if "value" not in dct:
             raise DbtRuntimeError(f'Invalid node spec "{raw}" - no search value!')
+        _fix_windows_drive_path(dct)
         method_name, method_arguments = cls.parse_method(dct)
 
         parents_depth = _match_to_int(dct, "parents_depth")
@@ -143,6 +162,7 @@ class SelectionCriteria:
         if result is None:
             return {"error": "Invalid selector spec"}
         dct: Dict[str, Any] = result.groupdict()
+        _fix_windows_drive_path(dct)
         method_name, method_arguments = cls.parse_method(dct)
         meth_name = str(method_name)
         if method_arguments:

--- a/tests/unit/graph/test_selector_spec.py
+++ b/tests/unit/graph/test_selector_spec.py
@@ -86,6 +86,20 @@ def test_raw_parse_simple_infer_path():
     assert result.children_depth is None
 
 
+def test_raw_parse_windows_drive_path():
+    raw = r"C:\dbt\models\orders.sql"
+    result = SelectionCriteria.from_single_spec(raw)
+    assert result.raw == raw
+    assert result.method == MethodName.Path
+    assert result.method_arguments == []
+    assert result.value == raw
+    assert not result.childrens_parents
+    assert not result.children
+    assert not result.parents
+    assert result.parents_depth is None
+    assert result.children_depth is None
+
+
 def test_raw_parse_simple_infer_path_modified():
     raw = "@" + os.path.join("asdf", "*")
     result = SelectionCriteria.from_single_spec(raw)
@@ -112,6 +126,13 @@ def test_raw_parse_simple_infer_fqn_parents():
     assert result.parents
     assert result.parents_depth is None
     assert result.children_depth is None
+
+
+def test_raw_parse_windows_drive_path_to_dict():
+    raw = r"C:\dbt\models\orders.sql"
+    result = SelectionCriteria.dict_from_single_spec(raw)
+    assert result["method"] == "path"
+    assert result["value"] == raw
 
 
 def test_raw_parse_simple_infer_fqn_children():


### PR DESCRIPTION
﻿Resolves #16094

### Problem

On Windows, raw node selectors parse `method:value` before inferring path selectors. An absolute path such as `C:\dbt\models\orders.sql` is split as method `C` and value `\dbt\models\orders.sql`, causing `InvalidSelectorError` instead of selecting by path.

### Reproducer

```py
from dbt.graph.selector_spec import SelectionCriteria
SelectionCriteria.from_single_spec(r"C:\dbt\models\orders.sql")
# before: InvalidSelectorError: 'C' is not a valid method name
# after: SelectionCriteria(method=MethodName.Path, value=r"C:\dbt\models\orders.sql", ...)
```

### Fix

When the raw selector parser sees a single-letter method followed by a slash or backslash value, reinterpret it as a Windows drive-letter path. This preserves explicit selector methods while letting drive-letter absolute paths use the existing path selector flow.

### Testing

- Added `tests/unit/graph/test_selector_spec.py::test_raw_parse_windows_drive_path` and `test_raw_parse_windows_drive_path_to_dict`.
- Before the fix: `pytest tests\unit\graph\test_selector_spec.py::test_raw_parse_windows_drive_path` failed with `InvalidSelectorError: 'C' is not a valid method name`.
- After the fix: `pytest tests\unit\graph\test_selector_spec.py tests\unit\graph\test_selector.py tests\unit\graph\test_selector_methods.py tests\unit\graph\test_cli.py` -> 145 passed, 1 skipped.
- Baseline `pytest tests\unit` before changes: 1451 passed, 9 skipped, 23 failed, 2 errors on Windows from existing unrelated failures.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
