### PR TITLE
fix: keep column metadata local

### DIFF
--- a/.changes/unreleased/Fixes-20260827-013744.yaml
+++ b/.changes/unreleased/Fixes-20260827-013744.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Keep column metadata local to each column instead of inheriting parent resource metadata.
+time: 2026-08-27T01:37:44.848185+05:30
+custom:
+    author: sd-db
+    issue: "16097"
+    project: dbt-core

--- a/crates/dbt-parser/src/resolve/resolve_analyses.rs
+++ b/crates/dbt-parser/src/resolve/resolve_analyses.rs
@@ -198,7 +198,6 @@ pub async fn resolve_analyses(
         }
         let columns = process_columns(
             properties.columns.as_ref(),
-            analysis_config.meta.clone(),
             analysis_config.tags.inner().clone().map(|tags| tags.into()),
         )?;
 

--- a/crates/dbt-parser/src/resolve/resolve_models.rs
+++ b/crates/dbt-parser/src/resolve/resolve_models.rs
@@ -509,7 +509,6 @@ pub async fn resolve_models(
 
         let mut columns = process_columns(
             properties.columns.as_ref(),
-            model_config.meta.clone(),
             model_config.tags.inner().clone().map(|tags| tags.into()),
         )?;
         let materialized = model_config.materialized.clone();
@@ -1214,7 +1213,6 @@ fn process_versioned_columns(
                 .collect();
             let version_columns = process_columns(
                 Some(&version_column_props),
-                model_config.meta.clone(),
                 model_config.tags.inner().clone().map(|tags| tags.into()),
             )?;
 

--- a/crates/dbt-parser/src/resolve/resolve_seeds.rs
+++ b/crates/dbt-parser/src/resolve/resolve_seeds.rs
@@ -302,7 +302,6 @@ pub async fn resolve_seeds(
 
         let columns = process_columns(
             seed.columns.as_ref(),
-            properties_config.meta.clone(),
             properties_config
                 .tags
                 .inner()

--- a/crates/dbt-parser/src/resolve/resolve_snapshots.rs
+++ b/crates/dbt-parser/src/resolve/resolve_snapshots.rs
@@ -402,7 +402,6 @@ pub async fn resolve_snapshots(
 
             let columns = process_columns(
                 properties.columns.as_ref(),
-                snapshot_config.meta.clone(),
                 snapshot_config.tags.inner().clone().map(|tags| tags.into()),
             )?;
 

--- a/crates/dbt-parser/src/resolve/resolve_sources.rs
+++ b/crates/dbt-parser/src/resolve/resolve_sources.rs
@@ -368,7 +368,6 @@ pub async fn resolve_sources(
         let columns = if let Some(ref cols) = table.columns {
             process_columns(
                 Some(cols),
-                source_config.meta.clone(),
                 source_config.tags.inner().clone().map(|tags| tags.into()),
             )?
         } else {

--- a/crates/dbt-schemas/src/schemas/dbt_column.rs
+++ b/crates/dbt-schemas/src/schemas/dbt_column.rs
@@ -332,11 +332,10 @@ fn normalize_entity(
     }
 }
 
-/// Process columns by merging parent config with each column's config.
+/// Process column metadata locally and inherit resource tags when column tags are unset.
 /// Returns a Vec of DbtColumn references.
 pub fn process_columns(
     columns: Option<&Vec<ColumnProperties>>,
-    meta: Option<IndexMap<String, YmlValue>>,
     tags: Option<Vec<String>>,
 ) -> FsResult<Vec<DbtColumnRef>> {
     Ok(columns
@@ -351,13 +350,14 @@ pub fn process_columns(
                     .clone()
                     .map(|c| (c.meta, c.tags, c.databricks_tags, c.policy_tags))
                     .unwrap_or_default();
+                let column_meta = cp_meta.unwrap_or_default();
 
                 let col = Arc::new(DbtColumn {
                     name: cp.name.clone(),
                     data_type: cp.data_type.clone(),
                     description: cp.description.clone(),
                     constraints: cp.constraints.clone().unwrap_or_default(),
-                    meta: cp_meta.or_else(|| meta.clone()).unwrap_or_default(),
+                    meta: column_meta,
                     tags: cp_tags
                         .map(|t| t.into())
                         .or_else(|| tags.clone())
@@ -427,7 +427,7 @@ mod tests {
             make_col("id", "Second definition (last wins)."),
         ];
 
-        let result = process_columns(Some(&cols), None, None).unwrap();
+        let result = process_columns(Some(&cols), None).unwrap();
 
         assert_eq!(result.len(), 2, "duplicate 'id' should be collapsed to one");
 
@@ -458,7 +458,7 @@ mod tests {
             },
         ));
 
-        let result = process_columns(Some(&vec![col]), None, None).unwrap();
+        let result = process_columns(Some(&vec![col]), None).unwrap();
         let dimension = result[0].dimension.as_ref().expect("dimension preserved");
         match dimension {
             ColumnPropertiesDimension::DimensionConfig(c) => {
@@ -477,7 +477,7 @@ mod tests {
         let mut col = make_col("col_3", "Compressed column.");
         col.codec = Some("ZSTD".to_string());
 
-        let result = process_columns(Some(&vec![col]), None, None).unwrap();
+        let result = process_columns(Some(&vec![col]), None).unwrap();
         assert_eq!(result[0].codec.as_deref(), Some("ZSTD"));
     }
 
@@ -490,7 +490,7 @@ mod tests {
             ColumnPropertiesDimensionType::time,
         ));
 
-        let result = process_columns(Some(&vec![col]), None, None).unwrap();
+        let result = process_columns(Some(&vec![col]), None).unwrap();
         assert!(matches!(
             result[0].dimension,
             Some(ColumnPropertiesDimension::DimensionType(
@@ -530,6 +530,40 @@ policy_tags:
             }
             StringOrMap::StringValue(_) => panic!("expected MapValue for second entry"),
         }
+    }
+
+    #[test]
+    fn test_process_columns_keeps_config_meta_local() {
+        let yaml = r#"
+name: id
+config:
+  meta:
+    constraint: local
+    local_only: retained
+"#;
+        let column: ColumnProperties = dbt_yaml::from_str(yaml).unwrap();
+        let unconfigured = make_col("name", "No column metadata.");
+
+        let result = process_columns(Some(&vec![column, unconfigured]), None).unwrap();
+        let meta = &result[0].meta;
+        assert_eq!(
+            meta.get("constraint").and_then(|value| value.as_str()),
+            Some("local")
+        );
+        assert_eq!(
+            meta.get("local_only").and_then(|value| value.as_str()),
+            Some("retained")
+        );
+        assert_eq!(
+            result[0].deprecated_config.meta.as_ref(),
+            Some(meta),
+            "column.meta must expose its own config.meta"
+        );
+        assert!(
+            result[1].meta.is_empty(),
+            "a column without local metadata must not inherit model metadata"
+        );
+        assert!(result[1].deprecated_config.meta.is_none());
     }
 
     /// Regression for fs#13343: a scalar (non-list) `policy_tags` value must deserialize


### PR DESCRIPTION
Resolves #16097

### Problem

Fusion copies parent resource `meta` onto columns that do not define their own. That does not match dbt-core: column metadata is local and comes from that column's `config.meta`.

This behavior was introduced by [Type support for Node Level Configurations (#3922)](https://github.com/dbt-labs/dbt-core/commit/8d11838c0858acd61fd711798ece18b605d49d92), which stopped applying the full parent column config and began copying selected fields, including the parent metadata fallback.

### Solution

- Stop passing parent resource metadata into `process_columns`.
- Source `column.meta` only from that column's `config.meta`.
- Leave the column's config shape unchanged instead of manufacturing empty metadata.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes or has already received the necessary approval.

## Test plan

- [x] `cargo test -p dbt-schemas test_process_columns_keeps_config_meta_local`
- [x] `cargo test -p dbt-schemas --lib`
- [x] `cargo check -p dbt-parser`