### PR TITLE
ci: follow the `dbt-sa-cli` → `dbt` binary rename

### DIFF
--- a/.github/workflows/publish-homebrew.yml
+++ b/.github/workflows/publish-homebrew.yml
@@ -65,7 +65,7 @@ on:
           tarball by the build job).
         type: string
         required: false
-        default: "dbt-sa-cli"
+        default: "dbt"
       tarball_prefix:
         description: |
           Tarball filename prefix. Filenames are
@@ -107,10 +107,10 @@ on:
         type: boolean
         default: true
       binary_name:
-        description: "Name of the binary inside each tarball (default: dbt-sa-cli)."
+        description: "Name of the binary inside each tarball (default: dbt)."
         required: false
         type: string
-        default: "dbt-sa-cli"
+        default: "dbt"
       tarball_prefix:
         description: "Tarball filename prefix (default: dbt-core-)."
         required: false

--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -1,5 +1,5 @@
 # **what?**
-# Cut a `dbt-sa-cli` release: bump version on a release branch, build the
+# Cut a `dbt` release: bump version on a release branch, build the
 # binary matrix via `cargo build`, pack each binary into a wheel via
 # `cargo ci pypi pack`, tag the build commit, publish to PyPI, create a
 # GitHub Release with the platform tarballs, and push a Homebrew formula
@@ -191,7 +191,7 @@ jobs:
       CARGO_INCREMENTAL: 0
       RUST_BACKTRACE: 1
       RUSTC_WRAPPER: sccache
-      BINARY_NAME: dbt-sa-cli
+      BINARY_NAME: dbt
       PACKAGE_NAME: dbt-core
     strategy:
       fail-fast: false
@@ -1008,7 +1008,7 @@ jobs:
       # `ARCHIVE_BASE` template's `${PACKAGE_NAME}-` prefix. Hardcoded
       # because reusable-workflow `with:` blocks don't accept the `env`
       # context — keep these in lockstep with the build job manually.
-      binary_name: dbt-sa-cli
+      binary_name: dbt
       tarball_prefix: dbt-core-
     permissions:
       contents: read

--- a/crates/dbt-ci/src/homebrew/render.rs
+++ b/crates/dbt-ci/src/homebrew/render.rs
@@ -793,16 +793,17 @@ mod tests {
 
     #[test]
     fn render_formula_renames_when_install_as_differs_from_binary() {
-        // dbt-core's formula: tarball ships `dbt-sa-cli`, brew installs it
-        // as `dbt`, formula filename is `dbt-core.rb`. All three names
-        // distinct.
+        // Tarball ships `dbt-legacy-name`, brew installs it as `dbt`,
+        // formula filename is `dbt-core.rb`. All three names distinct.
+        // dbt-core's own formula no longer needs this (its tarball ships
+        // `dbt`), but the rename-on-install path is still supported.
         let mut ctx = fixture_ctx_dbt();
         ctx.class_name = "DbtCore".into();
-        ctx.binary_name = "dbt-sa-cli".into();
+        ctx.binary_name = "dbt-legacy-name".into();
         ctx.install_as = "dbt".into();
         let out = render_formula(&ctx);
         assert!(out.contains("class DbtCore < Formula\n"));
-        assert!(out.contains("bin.install \"dbt-sa-cli\" => \"dbt\"\n"));
+        assert!(out.contains("bin.install \"dbt-legacy-name\" => \"dbt\"\n"));
         // Test invocation uses the installed name, not the formula name.
         assert!(out.contains("shell_output(\"#{bin}/dbt --version\")"));
     }
@@ -811,7 +812,7 @@ mod tests {
     fn render_formula_emits_conflicts_with_clauses_referencing_installed_name() {
         let mut ctx = fixture_ctx_dbt();
         ctx.class_name = "DbtCore".into();
-        ctx.binary_name = "dbt-sa-cli".into();
+        ctx.binary_name = "dbt-legacy-name".into();
         ctx.install_as = "dbt".into();
         ctx.conflicts_with = vec!["dbt".into()];
         let out = render_formula(&ctx);

--- a/crates/dbt-docs-server/Dockerfile
+++ b/crates/dbt-docs-server/Dockerfile
@@ -43,7 +43,8 @@ WORKDIR /tmp
 
 # Resolve the version, download the tarball for the target architecture, check
 # it against the release's published SHA256SUMS, then install the single binary
-# it contains (named dbt-sa-cli in the archive) as `dbt`.
+# it contains as `dbt`. Releases through 2.0.0-beta.2 shipped that binary named
+# `dbt-sa-cli`; later ones name it `dbt`, so accept either.
 #
 # Why the release list and not /releases/latest: this repository also publishes
 # the dbt Core Python package, and those are the releases marked "latest", so
@@ -101,7 +102,15 @@ awk -v want="${base}.tar.gz" '$2 == want { print; found = 1 } END { exit !found 
 sha256sum -c wanted.sha256
 
 tar -xzf "${base}.tar.gz"
-install -Dm755 "${base}/dbt-sa-cli" /out/dbt
+if [ -f "${base}/dbt" ]; then
+  install -Dm755 "${base}/dbt" /out/dbt
+elif [ -f "${base}/dbt-sa-cli" ]; then
+  install -Dm755 "${base}/dbt-sa-cli" /out/dbt
+else
+  echo "no dbt binary found in ${base}.tar.gz" >&2
+  ls -la "${base}" >&2
+  exit 1
+fi
 EOF
 
 


### PR DESCRIPTION
ada598dd3 renamed the `[[bin]]` to `dbt`, but the release pipeline and the docs-server image still looked for `dbt-sa-cli` on disk — the next release would have failed at `strip`/`cp`.

- **release-v2.yml** — `BINARY_NAME`, plus the `binary_name` passed to publish-homebrew (hardcoded, since `with:` can't read `env`).
- **publish-homebrew.yml** — both `binary_name` input defaults. Now equal to `--install-as`, so the formula renders plain `bin.install "dbt"`.
- **dbt-docs-server Dockerfile** — installs from published release tarballs and `DBT_VERSION` can pin an older one, so it prefers `dbt` and falls back to `dbt-sa-cli` instead of breaking pinned builds.
- **homebrew render tests** — rename-on-install fixtures no longer claim to be dbt-core's real formula; the branch is still covered.

Crate/package name `dbt-sa-cli` is unchanged. Changelog already covered by ada598dd3's unreleased entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)