### PR TITLE
Declare the referenced wheel's runtime metadata in the sdist

### DIFF
--- a/.changes/unreleased/Fixes-20260827-134012.yaml
+++ b/.changes/unreleased/Fixes-20260827-134012.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: The download-at-install sdist now declares the runtime dependencies and `requires-python` of the wheel it installs, so `uv pip install dbt-core`/`dbt-oss` no longer produces an unimportable package
+time: 2026-08-27T13:40:12.815018+05:30
+custom:
+    author: "tauhid621"
+    issue: ""
+    project: dbt-core

--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -844,6 +844,9 @@ jobs:
       # the binary CLI wheel (py3-none) `cargo ci pypi pack` produces — pass
       # the matching python/abi tags so the sdist manifest's filenames match
       # what's actually sitting at BASE_URL.
+      # `--runtime-metadata-from` points at the same crate for requires-python
+      # and dependencies, since the root pyproject describes the binary CLI
+      # wheel instead and understates both.
       - name: Publish (dbt-core)
         if: inputs.release_target == 'all' || inputs.release_target == 'core'
         run: |
@@ -853,6 +856,7 @@ jobs:
             --download-base-url "$BASE_URL" \
             --python-tag cp311 \
             --abi-tag abi3 \
+            --runtime-metadata-from crates/dbt-python \
             --target x86_64-unknown-linux-gnu \
             --target aarch64-unknown-linux-gnu \
             --target x86_64-apple-darwin \
@@ -902,6 +906,7 @@ jobs:
             --download-base-url "$BASE_URL" \
             --python-tag cp311 \
             --abi-tag abi3 \
+            --runtime-metadata-from crates/dbt-python \
             --target x86_64-unknown-linux-gnu \
             --target aarch64-unknown-linux-gnu \
             --target x86_64-apple-darwin \

--- a/crates/dbt-ci/README.md
+++ b/crates/dbt-ci/README.md
@@ -12,6 +12,16 @@ workspace `.cargo/config.toml` alias.
 - `cargo ci homebrew render --tarballs-dir DIR --version X.Y.Z --url-template URL [--out PATH] [--formula-name NAME] [--binary-name NAME] [--conflicts-with NAME]…` — writes a `Formula/<name>.rb` from release tarballs (`fs-v{version}-{target}.tar.gz`). Reads name/license/homepage from pyproject. Linux + macOS only — Windows tarballs are skipped.
 - `cargo ci homebrew publish --formula PATH --tap-repo URL --version X.Y.Z [--tap-branch B] [--token-env VAR] [--dry-run]` — clones the tap, copies the formula into `Formula/`, commits, and pushes. Idempotent: no-op if the formula is byte-identical. `--token-env` defaults to `HOMEBREW_TAP_REPO_TOKEN`.
 
+### sdist runtime metadata
+
+An sdist must declare the same `requires-python` and dependencies as the wheel it
+hands back: pip re-reads the built wheel's metadata, but uv trusts the sdist and
+installs exactly what it declares. `dbt-core` / `dbt-oss` reference the maturin
+extension wheels, so they pass `--runtime-metadata-from crates/dbt-python` to
+take those two fields from there while keeping the root pyproject's descriptive
+metadata. `dbt-core-experimental-parser` ships the `py3-none` binary CLI wheel,
+which has no Python dependencies, and needs no flag.
+
 ## Version shapes
 
 | SemVer            | PEP 440 |
@@ -42,7 +52,9 @@ cargo ci pypi publish --environment staging --version X.Y.Z   # uploads wheels
 cargo ci pypi publish --environment prod --version X.Y.Z      # uploads wheels
 
 # Publish the download-at-install sdist pointing at the release's wheel host
-# (one --target per published wheel):
+# (one --target per published wheel). For dbt-core / dbt-oss add
+# `--python-tag cp311 --abi-tag abi3 --runtime-metadata-from crates/dbt-python`,
+# since those reference the maturin extension wheels:
 cargo ci pypi publish --environment prod --version X.Y.Z \
   --download-base-url https://github.com/dbt-labs/dbt-core/releases/download/vX.Y.Z \
   --target x86_64-unknown-linux-gnu \

--- a/crates/dbt-ci/src/args.rs
+++ b/crates/dbt-ci/src/args.rs
@@ -32,6 +32,12 @@ pub struct PypiPublishArgs {
     #[arg(long, value_name = "DIR")]
     pub project_dir: Option<PathBuf>,
 
+    /// Dir whose `pyproject.toml` supplies the sdist's `requires-python` and
+    /// `dependencies` — the one describing the referenced wheels. Point at
+    /// `crates/dbt-python` for the maturin extension build.
+    #[arg(long, value_name = "DIR", requires = "download_base_url")]
+    pub runtime_metadata_from: Option<PathBuf>,
+
     /// Interpreter tag of the referenced wheels (sdist mode). `py3` for the binary
     /// CLI wheel, `cp310` for the maturin abi3 extension wheel.
     #[arg(long, default_value = "py3", requires = "download_base_url")]

--- a/crates/dbt-ci/src/pack.rs
+++ b/crates/dbt-ci/src/pack.rs
@@ -203,6 +203,9 @@ pub(crate) fn render_metadata(spec: &Spec, version_pep440: &str) -> String {
     if let Some(rp) = &spec.requires_python {
         let _ = writeln!(out, "Requires-Python: {rp}");
     }
+    for dep in &spec.dependencies {
+        let _ = writeln!(out, "Requires-Dist: {dep}");
+    }
     if let Some(l) = &spec.license {
         let _ = writeln!(out, "License: {}", flatten_for_header(l));
     }
@@ -386,6 +389,7 @@ mod tests {
             pyproject_dir: dir.to_path_buf(),
             summary: Some("dbt fusion standalone analyzer CLI".to_string()),
             requires_python: Some(">=3.9".to_string()),
+            dependencies: vec![],
             classifiers: vec!["Programming Language :: Rust".to_string()],
             urls: vec![("Homepage".to_string(), "https://getdbt.com".to_string())],
             authors: vec![Author {
@@ -472,6 +476,7 @@ mod tests {
             pyproject_dir: dir.to_path_buf(),
             summary: None,
             requires_python: None,
+            dependencies: vec![],
             classifiers: vec![],
             urls: vec![],
             authors: vec![],

--- a/crates/dbt-ci/src/publish.rs
+++ b/crates/dbt-ci/src/publish.rs
@@ -119,13 +119,19 @@ pub fn execute(args: PypiPublishArgs) -> ExitCode {
         Some(dir) => pyproject::discover_at(dir),
         None => pyproject::discover(),
     };
-    let spec = match spec {
+    let mut spec = match spec {
         Ok(s) => s,
         Err(e) => {
             eprintln!("error: {e:#}");
             return ExitCode::from(2);
         }
     };
+    if let Some(dir) = &args.runtime_metadata_from {
+        if let Err(e) = spec.overlay_runtime_metadata(dir) {
+            eprintln!("error: --runtime-metadata-from: {e:#}");
+            return ExitCode::from(2);
+        }
+    }
     if let Some(v) = &args.version {
         if let Err(e) = validate_release_version(v) {
             eprintln!("error: --version {e:#}");

--- a/crates/dbt-ci/src/pyproject.rs
+++ b/crates/dbt-ci/src/pyproject.rs
@@ -14,6 +14,7 @@ pub(crate) struct Spec {
     pub(crate) pyproject_dir: PathBuf,
     pub(crate) summary: Option<String>,
     pub(crate) requires_python: Option<String>,
+    pub(crate) dependencies: Vec<String>,
     pub(crate) classifiers: Vec<String>,
     pub(crate) urls: Vec<(String, String)>,
     pub(crate) authors: Vec<Author>,
@@ -27,6 +28,18 @@ pub(crate) struct Spec {
 pub(crate) struct Author {
     pub(crate) name: Option<String>,
     pub(crate) email: Option<String>,
+}
+
+impl Spec {
+    /// Takes `requires-python` and `dependencies` from the `pyproject.toml` under
+    /// `dir`, leaving descriptive metadata alone — for the sdist, whose rich
+    /// metadata is the workspace root's but whose wheel maturin builds elsewhere.
+    pub(crate) fn overlay_runtime_metadata(&mut self, dir: &Path) -> Result<()> {
+        let wheel_spec = discover_at(dir)?;
+        self.requires_python = wheel_spec.requires_python;
+        self.dependencies = wheel_spec.dependencies;
+        Ok(())
+    }
 }
 
 pub(crate) fn discover() -> Result<Spec> {
@@ -72,15 +85,8 @@ fn parse(pyproject_dir: PathBuf) -> Result<Spec> {
         .and_then(|v| v.as_str())
         .map(str::to_string);
 
-    let classifiers = project
-        .get("classifiers")
-        .and_then(|v| v.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|i| i.as_str().map(str::to_string))
-                .collect()
-        })
-        .unwrap_or_default();
+    let dependencies = string_array(project, "dependencies");
+    let classifiers = string_array(project, "classifiers");
 
     let urls = project
         .get("urls")
@@ -116,6 +122,7 @@ fn parse(pyproject_dir: PathBuf) -> Result<Spec> {
         pyproject_dir,
         summary,
         requires_python,
+        dependencies,
         classifiers,
         urls,
         authors,
@@ -123,6 +130,19 @@ fn parse(pyproject_dir: PathBuf) -> Result<Spec> {
         description,
         description_content_type,
     })
+}
+
+/// A PEP 621 array-of-strings field; absent or non-string entries are skipped.
+fn string_array(project: &Item, key: &str) -> Vec<String> {
+    project
+        .get(key)
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|i| i.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 /// Accepts both `authors = [{ name = "x" }, ...]` (inline-table array) and
@@ -235,6 +255,46 @@ name = "my-thing"
         assert!(spec.authors.is_empty());
         assert!(spec.license.is_none());
         assert!(spec.description.is_none());
+    }
+
+    #[test]
+    fn overlay_runtime_metadata_takes_only_runtime_fields() {
+        let root = tempfile::tempdir().unwrap();
+        fs::write(
+            root.path().join("pyproject.toml"),
+            r#"
+[project]
+name = "dbt-oss"
+description = "Build analytics the way engineers build applications"
+requires-python = ">=3.9"
+classifiers = ["Programming Language :: Rust"]
+"#,
+        )
+        .unwrap();
+
+        let wheel = tempfile::tempdir().unwrap();
+        fs::write(
+            wheel.path().join("pyproject.toml"),
+            r#"
+[project]
+name = "dbt-core"
+requires-python = ">=3.11"
+dependencies = ["mashumaro[msgpack]>=3.14"]
+"#,
+        )
+        .unwrap();
+
+        let mut spec = parse(root.path().to_path_buf()).unwrap();
+        spec.overlay_runtime_metadata(wheel.path()).unwrap();
+
+        assert_eq!(spec.requires_python.as_deref(), Some(">=3.11"));
+        assert_eq!(spec.dependencies, vec!["mashumaro[msgpack]>=3.14"]);
+        assert_eq!(spec.wheel_name, "dbt-oss");
+        assert_eq!(
+            spec.summary.as_deref(),
+            Some("Build analytics the way engineers build applications")
+        );
+        assert_eq!(spec.classifiers.len(), 1);
     }
 
     #[test]

--- a/crates/dbt-ci/src/sdist.rs
+++ b/crates/dbt-ci/src/sdist.rs
@@ -176,6 +176,15 @@ fn render_sdist_pyproject(spec: &Spec, version_pep440: &str) -> String {
     if let Some(rp) = &spec.requires_python {
         let _ = writeln!(out, "requires-python = {rp:?}");
     }
+    // Must mirror the downloaded wheel's deps: uv trusts sdist metadata rather
+    // than rebuilding to read the wheel's, so omitting these installs broken.
+    if !spec.dependencies.is_empty() {
+        out.push_str("dependencies = [\n");
+        for dep in &spec.dependencies {
+            let _ = writeln!(out, "  {dep:?},");
+        }
+        out.push_str("]\n");
+    }
     out
 }
 
@@ -243,6 +252,7 @@ mod tests {
             pyproject_dir: dir.to_path_buf(),
             summary: Some("dbt fusion standalone analyzer CLI".to_string()),
             requires_python: Some(">=3.9".to_string()),
+            dependencies: vec![],
             classifiers: vec![],
             urls: vec![],
             authors: vec![],
@@ -307,6 +317,8 @@ mod tests {
         assert!(pyproject.contains("name = \"dbt-sa-cli\""));
         assert!(pyproject.contains("version = \"2.0.0a1\""));
         assert!(pyproject.contains("requires-python = \">=3.9\""));
+        // The binary CLI wheel has no Python deps; don't emit an empty key.
+        assert!(!pyproject.contains("dependencies"));
 
         let backend = &files["dbt_sa_cli-2.0.0a1/_dbt_sa_build/__init__.py"];
         assert!(backend.contains("def build_wheel("));
@@ -324,6 +336,35 @@ mod tests {
             assets["wheels"]["macosx_11_0_arm64"]["sha256"],
             "bb".repeat(32)
         );
+    }
+
+    #[test]
+    fn build_sdist_declares_wheel_dependencies() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        let mut spec = sample_spec(dir);
+        spec.wheel_name = "dbt-oss".to_string();
+        spec.requires_python = Some(">=3.11".to_string());
+        spec.dependencies = vec!["mashumaro[msgpack]>=3.14".to_string()];
+        let wheels = vec![WheelAsset {
+            platform_tag: "macosx_11_0_arm64".to_string(),
+            filename: "dbt_oss-2.0.0a1-cp311-abi3-macosx_11_0_arm64.whl".to_string(),
+            sha256_hex: "cc".repeat(32),
+        }];
+
+        let path = build_sdist(&spec, "2.0.0a1", &wheels, "https://example.com/dl/", dir).unwrap();
+        let files = read_targz(&path);
+
+        let pyproject = &files["dbt_oss-2.0.0a1/pyproject.toml"];
+        assert!(pyproject.contains("requires-python = \">=3.11\""));
+        assert!(
+            pyproject.contains("dependencies = [\n  \"mashumaro[msgpack]>=3.14\",\n]"),
+            "sdist pyproject must declare the wheel's deps, got:\n{pyproject}"
+        );
+
+        let pkg_info = &files["dbt_oss-2.0.0a1/PKG-INFO"];
+        assert!(pkg_info.contains("Requires-Dist: mashumaro[msgpack]>=3.14"));
+        assert!(pkg_info.contains("Requires-Python: >=3.11"));
     }
 
     #[test]


### PR DESCRIPTION
The download-at-install sdist declared no `dependencies` and inherited the root pyproject's `requires-python = ">=3.9"`, but the wheel it hands back for `dbt-core` / `dbt-oss` is the maturin extension wheel from `crates/dbt-python` — `>=3.11`, and it needs `mashumaro`. pip re-reads the built wheel's metadata so it was fine; uv trusts the sdist and installed the package without `mashumaro`, leaving it unimportable.

Adds `--runtime-metadata-from DIR`, which takes `requires-python` and `dependencies` from that crate's pyproject while keeping the root's descriptive metadata, and wires it into the `dbt-core` and `dbt-oss` publish steps. `dbt-core-experimental-parser` ships the dep-free binary CLI wheel and is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)