### PR TITLE
fix(databricks): apply constraints only when contract is enforced

### DIFF
--- a/.changes/unreleased/Fixes-20260827-195451.yaml
+++ b/.changes/unreleased/Fixes-20260827-195451.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Apply Databricks model and column constraints only when contract.enforced is true
+time: 2026-08-27T19:54:51.612629+05:30
+custom:
+    author: sd-db
+    issue: ""
+    project: dbt-core

--- a/.changes/unreleased/Fixes-20260827-195451.yaml
+++ b/.changes/unreleased/Fixes-20260827-195451.yaml
@@ -3,5 +3,5 @@ body: Apply Databricks model and column constraints only when contract.enforced 
 time: 2026-08-27T19:54:51.612629+05:30
 custom:
     author: sd-db
-    issue: ""
+    issue: "16056"
     project: dbt-core

--- a/crates/dbt-adapter/src/adapter/adapter_impl.rs
+++ b/crates/dbt-adapter/src/adapter/adapter_impl.rs
@@ -58,7 +58,7 @@ use dbt_adbc::{Connection, QueryCtx};
 use dbt_agate::AgateTable;
 use dbt_common::behavior_flags::{Behavior, BehaviorFlag};
 use dbt_common::cancellation::CancellationToken;
-use dbt_common::tracing::dbt_emit::emit_warn_log_message;
+use dbt_common::tracing::dbt_emit::{emit_info_log_message, emit_warn_log_message};
 use dbt_common::{ErrorCode, FsResult, unexpected_fs_err};
 use dbt_schema_store::SchemaStoreTrait;
 use dbt_schemas::dbt_types::RelationType;
@@ -4965,16 +4965,18 @@ impl AdapterImpl {
     /// Returns [enriched_columns, typed_constraints] for use with get_column_and_constraints_sql
     /// and relation.enrich().
     ///
-    /// DatabricksAdapter https://github.com/databricks/dbt-databricks/blob/2f11abb306a400cde32b27891b766bf41a11fb1f/dbt/adapters/databricks/impl.py#L899
+    /// DatabricksAdapter https://github.com/databricks/dbt-databricks/blob/45351e11517d3f37c5ac7a736b5fcba453d3f368/dbt/adapters/databricks/impl.py#L1038
     pub fn parse_columns_and_constraints(
         &self,
         _state: &State,
         existing_columns: &Value,
         model_columns: &Value,
         model_constraints: &Value,
+        contract_enforced: bool,
+        model_name: &str,
     ) -> Result<Value, minijinja::Error> {
         use crate::relation::databricks::typed_constraint;
-        use std::collections::BTreeMap;
+        use std::collections::{BTreeMap, BTreeSet};
 
         if self.adapter_type() != Databricks && self.adapter_type() != Spark {
             return Err(minijinja::Error::new(
@@ -5022,7 +5024,7 @@ impl AdapterImpl {
             .map(|c| Arc::new(c.clone()))
             .collect();
 
-        let (not_nulls, typed_constraints) =
+        let (not_nulls, typed_constraints) = if contract_enforced {
             typed_constraint::parse_constraints(&column_refs, &model_constraints_vec).map_err(
                 |e| {
                     minijinja::Error::new(
@@ -5030,18 +5032,37 @@ impl AdapterImpl {
                         format!("parse_constraints: {e}"),
                     )
                 },
-            )?;
+            )?
+        } else {
+            if model_columns_map
+                .values()
+                .any(|column| !column.constraints.is_empty())
+            {
+                let model_ref = if model_name.is_empty() {
+                    String::new()
+                } else {
+                    format!(" on '{model_name}'")
+                };
+                emit_info_log_message(format!(
+                    "Skipping column-level constraints{model_ref}: set `contract.enforced: true` \
+                     to apply NOT NULL / primary key / foreign key / check constraints."
+                ));
+            }
+            (BTreeSet::new(), Vec::new())
+        };
 
         let model_columns_lower: BTreeMap<String, &DbtColumn> = model_columns_map
             .iter()
             .map(|(k, v)| (k.to_lowercase(), v))
             .collect();
+        let not_nulls_lower: BTreeSet<String> =
+            not_nulls.iter().map(|name| name.to_lowercase()).collect();
 
         let enriched_columns: Vec<Column> = columns
             .iter()
             .map(|col| {
                 let model_col = model_columns_lower.get(&col.name().to_lowercase()).copied();
-                let not_null = not_nulls.contains(col.name());
+                let not_null = not_nulls_lower.contains(&col.name().to_lowercase());
                 col.enrich_for_create(model_col, not_null)
             })
             .collect();
@@ -6590,6 +6611,140 @@ mod tests {
         assert!(
             v.is_undefined(),
             "Expected column NOT to be selected when existing comment is already empty, got: {selected:?}"
+        );
+    }
+
+    #[test]
+    fn test_parse_columns_and_constraints_matches_not_null_case_insensitively() {
+        let adapter = AdapterImpl::new_mock(
+            Databricks,
+            BTreeMap::new(),
+            DEFAULT_RESOLVED_QUOTING,
+            Arc::new(DefaultTypeOps::new(Databricks)),
+            Arc::new(DefaultStmtSplitter),
+        );
+        let env = Environment::new();
+        let state = State::new_for_env(&env);
+        let existing_columns = Value::from(vec![Value::from_object(Column::new(
+            Databricks,
+            "id".to_string(),
+            "int".to_string(),
+            None,
+            None,
+            None,
+        ))]);
+        let model_columns = Value::from_serialize(BTreeMap::from([(
+            "ID".to_string(),
+            DbtColumn {
+                name: "ID".to_string(),
+                data_type: Some("int".to_string()),
+                constraints: vec![Constraint {
+                    type_: ConstraintType::NotNull,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+        )]));
+        let model_constraints = Value::from_serialize(Vec::<ModelConstraint>::new());
+
+        let result = adapter
+            .parse_columns_and_constraints(
+                &state,
+                &existing_columns,
+                &model_columns,
+                &model_constraints,
+                true,
+                "case_mismatch_model",
+            )
+            .expect("constraint parsing should succeed");
+        let mut result_parts = result.try_iter().expect("result should be iterable");
+        let enriched_columns = result_parts.next().expect("enriched columns should exist");
+        let enriched_column = enriched_columns
+            .try_iter()
+            .expect("enriched columns should be iterable")
+            .next()
+            .expect("one enriched column should exist");
+        let rendered = enriched_column
+            .downcast_object_ref::<Column>()
+            .expect("enriched value should be a Column")
+            .render_for_create();
+
+        assert!(
+            rendered.contains("NOT NULL"),
+            "expected NOT NULL when YAML column ID matches warehouse id, got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn test_parse_columns_and_constraints_defaults_to_unenforced() {
+        use crate::adapter::Adapter;
+
+        let adapter = Adapter::new(
+            Arc::new(AdapterImpl::new_mock(
+                Databricks,
+                BTreeMap::new(),
+                DEFAULT_RESOLVED_QUOTING,
+                Arc::new(DefaultTypeOps::new(Databricks)),
+                Arc::new(DefaultStmtSplitter),
+            )),
+            None,
+            dbt_common::cancellation::never_cancels(),
+        );
+        let env = Environment::new();
+        let state = State::new_for_env(&env);
+        let existing_columns = Value::from(vec![Value::from_object(Column::new(
+            Databricks,
+            "id".to_string(),
+            "int".to_string(),
+            None,
+            None,
+            None,
+        ))]);
+        let model_columns = Value::from_serialize(BTreeMap::from([(
+            "id".to_string(),
+            DbtColumn {
+                name: "id".to_string(),
+                data_type: Some("int".to_string()),
+                constraints: vec![Constraint {
+                    type_: ConstraintType::NotNull,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+        )]));
+        let model_constraints = Value::from_serialize(vec![ModelConstraint {
+            type_: ConstraintType::PrimaryKey,
+            name: Some("pk_contract_model".to_string()),
+            columns: Some(vec!["id".to_string()]),
+            ..Default::default()
+        }]);
+
+        let result = adapter
+            .parse_columns_and_constraints(
+                &state,
+                &[existing_columns, model_columns, model_constraints],
+            )
+            .expect("constraint parsing should succeed");
+        let mut result_parts = result.try_iter().expect("result should be iterable");
+        let enriched_columns = result_parts.next().expect("enriched columns should exist");
+        let parsed_constraints = result_parts.next().expect("constraints should exist");
+        let enriched_column = enriched_columns
+            .try_iter()
+            .expect("enriched columns should be iterable")
+            .next()
+            .expect("one enriched column should exist");
+        let rendered = enriched_column
+            .downcast_object_ref::<Column>()
+            .expect("enriched value should be a Column")
+            .render_for_create();
+
+        assert!(!rendered.contains("NOT NULL"));
+        assert_eq!(
+            parsed_constraints
+                .try_iter()
+                .expect("parsed constraints should be iterable")
+                .count(),
+            0
         );
     }
 

--- a/crates/dbt-adapter/src/adapter/mod.rs
+++ b/crates/dbt-adapter/src/adapter/mod.rs
@@ -3238,12 +3238,20 @@ impl Adapter {
             Typed { adapter, .. } => {
                 let iter = ArgsIter::new(
                     "parse_columns_and_constraints",
-                    &["existing_columns", "model_columns", "model_constraints"],
+                    &[
+                        "existing_columns",
+                        "model_columns",
+                        "model_constraints",
+                        "contract_enforced",
+                        "model_name",
+                    ],
                     args,
                 );
                 let existing_columns = iter.next_arg::<&Value>()?;
                 let model_columns = iter.next_arg::<&Value>()?;
                 let model_constraints = iter.next_arg::<&Value>()?;
+                let contract_enforced = iter.next_arg::<Option<bool>>()?.unwrap_or(false);
+                let model_name = iter.next_arg::<Option<&str>>()?.unwrap_or("");
                 iter.finish()?;
 
                 adapter.parse_columns_and_constraints(
@@ -3251,6 +3259,8 @@ impl Adapter {
                     existing_columns,
                     model_columns,
                     model_constraints,
+                    contract_enforced,
+                    model_name,
                 )
             }
             Parse(_) => Ok(Value::from(vec![

--- a/crates/dbt-adapter/src/relation/databricks/config/components/constraints.rs
+++ b/crates/dbt-adapter/src/relation/databricks/config/components/constraints.rs
@@ -318,6 +318,15 @@ impl Constraints {
     }
 
     fn from_local_config(relation_config: &dyn InternalDbtNodeAttributes) -> Self {
+        let contract_enforced = relation_config
+            .as_any()
+            .downcast_ref::<dbt_schemas::schemas::nodes::DbtModel>()
+            .and_then(|model| model.deprecated_config.contract.as_ref())
+            .is_some_and(|contract| contract.enforced);
+        if !contract_enforced {
+            return Self::default();
+        }
+
         let columns = &relation_config.base().columns;
 
         let model_constraints = if let Some(model) = relation_config
@@ -505,6 +514,7 @@ mod tests {
     use dbt_schemas::schemas::{
         common::{Constraint, ConstraintType},
         nodes::DbtModel,
+        properties::ModelConstraint,
     };
     use dbt_test_primitives::assert_contains;
     use indexmap::{IndexMap, IndexSet};
@@ -593,6 +603,24 @@ fk_composite,parent_type,main,default,parents,type
                     ..Default::default()
                 })
                 .collect(),
+            ..Default::default()
+        };
+        test_helpers::create_mock_dbt_model(cfg)
+    }
+
+    fn create_mock_unenforced_dbt_model_with_constraints(
+        constraints: IndexMap<&str, Vec<Constraint>>,
+    ) -> DbtModel {
+        let cfg = test_helpers::TestModelConfig {
+            columns: constraints
+                .into_iter()
+                .map(|(name, constraints)| test_helpers::TestModelColumn {
+                    name: name.to_string(),
+                    constraints,
+                    ..Default::default()
+                })
+                .collect(),
+            contract_enforced: Some(false),
             ..Default::default()
         };
         test_helpers::create_mock_dbt_model(cfg)
@@ -817,6 +845,28 @@ fk_composite,parent_type,main,default,parents,type
         assert_contains!(config.set_non_nulls, "id");
         assert_contains!(config.set_non_nulls, "name");
         // Only not-null constraints from columns (model constraints would also be processed here)
+        assert!(config.set_constraints.is_empty());
+    }
+
+    #[test]
+    fn test_from_local_config_ignores_declared_constraints_when_contract_is_unenforced() {
+        let columns = IndexMap::from_iter([(
+            "id",
+            vec![Constraint {
+                type_: ConstraintType::NotNull,
+                ..Default::default()
+            }],
+        )]);
+        let mut mock_node = create_mock_unenforced_dbt_model_with_constraints(columns);
+        mock_node.__model_attr__.constraints = vec![ModelConstraint {
+            type_: ConstraintType::PrimaryKey,
+            columns: Some(vec!["id".to_string()]),
+            ..Default::default()
+        }];
+
+        let config = Constraints::from_local_config(&mock_node);
+
+        assert!(config.set_non_nulls.is_empty());
         assert!(config.set_constraints.is_empty());
     }
 

--- a/crates/dbt-adapter/src/relation/databricks/config/test_helpers.rs
+++ b/crates/dbt-adapter/src/relation/databricks/config/test_helpers.rs
@@ -33,6 +33,9 @@ pub(crate) struct TestModelConfig {
     #[expect(dead_code)]
     pub cluster_by: Vec<String>,
     pub columns: Vec<TestModelColumn>,
+    /// Defaults to enforced for legacy component tests; set explicitly to `Some(false)` when a
+    /// test exercises the contract ownership boundary.
+    pub contract_enforced: Option<bool>,
     pub cron: Option<String>,
     pub partition_by: Vec<String>,
     pub persist_column_comments: bool,
@@ -128,6 +131,10 @@ pub(crate) fn create_mock_dbt_model(cfg: TestModelConfig) -> DbtModel {
 
     DbtModel {
         deprecated_config: ModelConfig {
+            contract: Some(DbtContract {
+                enforced: cfg.contract_enforced.unwrap_or(true),
+                ..Default::default()
+            }),
             table_format: cfg.table_format,
             __warehouse_specific_config__: wh_config,
             ..Default::default()

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-databricks/macros/materializations/incremental/incremental.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-databricks/macros/materializations/incremental/incremental.sql
@@ -213,7 +213,8 @@
           {{ apply_row_filter(target_relation, row_filter) }}
         {% endif %}
         {#- Incremental constraint application requires information_schema access (see fetch_*_constraints macros) -#}
-        {% if constraints and not target_relation.is_hive_metastore() %}
+        {% set contract_config = config.get('contract') %}
+        {% if constraints and contract_config and contract_config.enforced and not target_relation.is_hive_metastore() %}
           {{ apply_constraints(target_relation, constraints) }}
         {% endif %}
       {%- endif -%}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-databricks/macros/relations/materialized_view/create.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-databricks/macros/relations/materialized_view/create.sql
@@ -26,8 +26,17 @@
 
   {%- set columns = adapter.get_columns_in_relation(temp_relation) -%}
   {%- set model_columns = model.get('columns', {}) -%}
-  {%- set model_constraints = model.get('constraints', []) -%}
-  {%- set columns_and_constraints = adapter.parse_columns_and_constraints(columns, model_columns, model_constraints) -%}
+  {%- set contract_config = config.get('contract') -%}
+  {%- set contract_enforced = contract_config and contract_config.enforced -%}
+  {%- if contract_enforced -%}
+    {%- do exceptions.warn(
+         "contract.enforced=true on materialized_view '" ~ model.name ~ "': not supported by dbt (https://docs.getdbt.com/docs/mesh/govern/model-contracts). dbt-databricks provides best-effort support that may change without notice."
+       ) -%}
+    {%- set model_constraints = model.get('constraints', []) -%}
+  {%- else -%}
+    {%- set model_constraints = [] -%}
+  {%- endif -%}
+  {%- set columns_and_constraints = adapter.parse_columns_and_constraints(columns, model_columns, model_constraints, contract_enforced, model.name) -%}
   {%- set target_relation = relation.enrich(columns_and_constraints[1]) -%}
 
   create or replace materialized view {{ target_relation.render() }}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-databricks/macros/relations/streaming_table/create.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-databricks/macros/relations/streaming_table/create.sql
@@ -29,7 +29,9 @@
 
   {%- set columns = adapter.get_columns_in_relation(temp_relation) -%}
   {%- set model_columns = model.get('columns', {}) -%}
-  {%- set columns_and_constraints = adapter.parse_columns_and_constraints(columns, model_columns, []) -%}
+  {%- set contract_config = config.get('contract') -%}
+  {%- set contract_enforced = contract_config and contract_config.enforced -%}
+  {%- set columns_and_constraints = adapter.parse_columns_and_constraints(columns, model_columns, [], contract_enforced, model.name) -%}
 
   {#-- We don't enrich the relation with model constraints because they are not supported for streaming tables --#}
   CREATE STREAMING TABLE {{ relation.render() }}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-databricks/macros/relations/table/alter.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-databricks/macros/relations/table/alter.sql
@@ -28,7 +28,9 @@
       {% if column_tags %}
         {{ apply_column_tags(target_relation, column_tags) }}
       {% endif %}
-      {% if constraints %}
+      {#-- Reconcile constraints only when the contract is enforced. --#}
+      {% set contract_config = config.get('contract') %}
+      {% if constraints and contract_config and contract_config.enforced %}
         {{ apply_constraints(target_relation, constraints) }}
       {% endif %}
       {% if column_masks %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-databricks/macros/relations/table/create.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-databricks/macros/relations/table/create.sql
@@ -2,8 +2,14 @@
   {% set tags = config.get('databricks_tags') %}
   {% set model_columns = model.get('columns', []) %}
   {% set existing_columns = adapter.get_columns_in_relation(intermediate_relation) %}
-  {% set model_constraints = model.get('constraints', []) %}
-  {% set columns_and_constraints = adapter.parse_columns_and_constraints(existing_columns, model_columns, model_constraints) %}
+  {% set contract_config = config.get('contract') %}
+  {% set contract_enforced = contract_config and contract_config.enforced %}
+  {% if contract_enforced %}
+    {% set model_constraints = model.get('constraints', []) %}
+  {% else %}
+    {% set model_constraints = [] %}
+  {% endif %}
+  {% set columns_and_constraints = adapter.parse_columns_and_constraints(existing_columns, model_columns, model_constraints, contract_enforced, model.name) %}
   {% set target_relation = relation.enrich(columns_and_constraints[1]) %}
 
   {% call statement('main') %}

--- a/crates/dbt-loader/tests/macros/relations.rs
+++ b/crates/dbt-loader/tests/macros/relations.rs
@@ -7,7 +7,7 @@ use dbt_schemas::schemas::dbt_catalogs_v2::CatalogType;
 use dbt_schemas::schemas::relations::base::TableFormat;
 use minijinja::Value;
 
-use crate::macro_test_harness::MacroTestHarness;
+use crate::macro_test_harness::{MacroTestHarness, default_mock_config};
 
 mod databricks {
     use super::*;
@@ -358,6 +358,74 @@ mod databricks {
         assert!(
             lower.contains("using iceberg") && !lower.contains("using delta"),
             "table_format=iceberg with use_catalogs_v2=true but no catalogs.yml must still default to managed Iceberg (`using iceberg`), got:\n{rendered}"
+        );
+    }
+
+    fn render_constraint_changeset(contract_enforced: bool) -> String {
+        let alter_sql = include_str!(
+            "../../src/dbt_macro_assets/dbt-databricks/macros/relations/table/alter.sql"
+        );
+        let harness = MacroTestHarness::for_adapter(AdapterType::Databricks)
+            .with_macro_at_path(
+                "dbt_databricks",
+                "apply_config_changeset",
+                alter_sql,
+                "dbt-databricks/macros/relations/table/alter.sql",
+            )
+            .with_macro(
+                "test_project",
+                "apply_constraints",
+                "{% macro apply_constraints(relation, constraints) %}APPLY_CONSTRAINTS_SENTINEL{% endmacro %}",
+            )
+            .with_stub_functions()
+            .build()
+            .expect("constraint changeset harness should build");
+        let config = default_mock_config();
+        config.on("get", move |args| {
+            let key = args.first().and_then(Value::as_str);
+            let default = args.get(1).cloned().unwrap_or(Value::UNDEFINED);
+            match key {
+                Some("contract") => Ok(Value::from_serialize(BTreeMap::from([(
+                    "enforced",
+                    contract_enforced,
+                )]))),
+                _ => Ok(default),
+            }
+        });
+        let changes = Value::from_serialize(BTreeMap::from([(
+            "changes",
+            BTreeMap::from([("constraints", Value::from(true))]),
+        )]));
+        let ctx = harness
+            .materialization_context("constraint_table", "select 1")
+            .relation_type(RelationType::Table)
+            .config(Value::from_dyn_object(config))
+            .with("configuration_changes", changes)
+            .build();
+
+        harness
+            .render(
+                "{{ apply_config_changeset(this, model, configuration_changes) }}",
+                ctx,
+            )
+            .expect("constraint changeset should render")
+    }
+
+    #[test]
+    fn table_alter_skips_constraint_reconciliation_when_contract_is_unenforced() {
+        let rendered = render_constraint_changeset(false);
+        assert!(
+            !rendered.contains("APPLY_CONSTRAINTS_SENTINEL"),
+            "unenforced contract must not apply constraints, got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn table_alter_reconciles_constraints_when_contract_is_enforced() {
+        let rendered = render_constraint_changeset(true);
+        assert!(
+            rendered.contains("APPLY_CONSTRAINTS_SENTINEL"),
+            "enforced contract must apply constraints, got: {rendered}"
         );
     }
 }

--- a/crates/dbt-loader/tests/materializations/incremental.rs
+++ b/crates/dbt-loader/tests/materializations/incremental.rs
@@ -29,6 +29,7 @@ fn render_incremental(
 
 fn incremental_model(alias: &str, sql: &str) -> Value {
     Value::from_serialize(BTreeMap::from([
+        ("name", Value::from(alias)),
         ("alias", Value::from(alias)),
         (
             "unique_id",
@@ -48,6 +49,14 @@ fn incremental_model(alias: &str, sql: &str) -> Value {
 }
 
 fn incremental_config_with(strategy: Option<&str>, full_refresh: bool) -> Arc<MockJinjaObject> {
+    incremental_config_with_contract(strategy, full_refresh, false)
+}
+
+fn incremental_config_with_contract(
+    strategy: Option<&str>,
+    full_refresh: bool,
+    contract_enforced: bool,
+) -> Arc<MockJinjaObject> {
     let mock = default_mock_config();
     mock.set_attr("materialized", Value::from("incremental"));
     let strategy = strategy.map(str::to_owned);
@@ -57,7 +66,7 @@ fn incremental_config_with(strategy: Option<&str>, full_refresh: bool) -> Arc<Mo
         match key {
             Some("contract") => Ok(Value::from_serialize(BTreeMap::from([(
                 "enforced".to_string(),
-                Value::from(false),
+                Value::from(contract_enforced),
             )]))),
             Some("full_refresh") => Ok(Value::from(full_refresh)),
             Some("incremental_strategy") => Ok(strategy
@@ -106,6 +115,11 @@ mod databricks {
         let mut harness = MacroTestHarness::for_adapter(ADAPTER)
             .load_all_macros()
             .with_stub_functions()
+            .with_macro(
+                "test_project",
+                "apply_constraints",
+                "{% macro apply_constraints(relation, constraints) %}{% do adapter.execute('APPLY_CONSTRAINTS_SENTINEL') %}{% endmacro %}",
+            )
             .with_behavior_flag("use_materialization_v2", enabled)
             .with_behavior_flag("use_catalogs_v2", false)
             .with_behavior_flag("use_managed_iceberg", false)
@@ -233,6 +247,65 @@ mod databricks {
             sqls.len() >= 2,
             "Expected at least 2 SQL statements (temp table + merge), got: {sqls:?}",
         );
+    }
+
+    fn render_incremental_constraint_changeset(contract_enforced: bool) -> MacroTestHarness {
+        let harness = build_harness();
+        let existing = harness.relation(
+            "TEST_DB",
+            "TEST_SCHEMA",
+            "my_incr",
+            Some(RelationType::Table),
+        );
+        harness.mock().on("get_relation", move |_| {
+            Ok(RelationObject::new(Arc::clone(&existing)).into_value())
+        });
+        harness
+            .mock()
+            .on("get_relation_config", |_| Ok(Value::UNDEFINED));
+
+        let changeset = Value::from_serialize(BTreeMap::from([(
+            "changes",
+            BTreeMap::from([("constraints", Value::from(true))]),
+        )]));
+        let model_config = Arc::new(MockJinjaObject::new());
+        model_config.on("get_changeset", move |_| Ok(changeset.clone()));
+        let model_config = Value::from_dyn_object(model_config);
+        harness
+            .mock()
+            .on("get_config_from_model", move |_| Ok(model_config.clone()));
+        harness.mock().on("get_incremental_strategy_macro", |_| {
+            Ok(Value::from_function(
+                |_args: &[Value]| -> Result<Value, minijinja::Error> {
+                    Ok(Value::from("SELECT 1 /* incremental merge */"))
+                },
+            ))
+        });
+
+        let ctx = incremental_ctx_with_config(
+            &harness,
+            incremental_config_with_contract(None, false, contract_enforced),
+        );
+        render_incremental(&harness, ADAPTER, ctx)
+            .unwrap_or_else(|e| panic!("constraint reconciliation render failed: {e:?}"));
+        harness
+    }
+
+    #[test]
+    fn incremental_skips_constraint_reconciliation_when_contract_is_unenforced() {
+        let harness = render_incremental_constraint_changeset(false);
+        let sqls = executed_sql(harness.mock());
+        assert!(
+            sqls.iter()
+                .all(|sql| !sql.contains("APPLY_CONSTRAINTS_SENTINEL")),
+            "unenforced contract must not apply constraints, got: {sqls:?}"
+        );
+    }
+
+    #[test]
+    fn incremental_reconciles_constraints_when_contract_is_enforced() {
+        let harness = render_incremental_constraint_changeset(true);
+        assert_executed_contains(harness.mock(), "APPLY_CONSTRAINTS_SENTINEL");
     }
 
     mod append;


### PR DESCRIPTION
Resolves #16056

## Problem

Fusion did not consistently honor Databricks constraint ownership. Model and column constraints could be parsed or reconciled when `contract.enforced` was false, and an incremental run that disabled enforcement could attempt to change constraints that should remain untouched.

## Fix

Port the current dbt-databricks contract-enforcement behavior to Fusion:

- Pass `contract_enforced` and `model_name` through `parse_columns_and_constraints`.
- Parse and create model- and column-level constraints only when the contract is enforced.
- Gate local constraint state and table/incremental reconciliation on the same condition, so unenforced incremental reruns leave existing warehouse constraints unchanged.
- Apply the behavior consistently across table, incremental, materialized-view, and streaming-table paths.
- Preserve the materialized-view best-effort warning for enforced contracts.
- Add focused coverage for enforced and unenforced create/config-change paths.

#### Case Insensitive match for NOT NULL column names (match v1)

Additionally I have also updated the CREATE path with v1 by matching NOT NULL column names case-insensitively. For example, a YAML column named `ID` and a warehouse column returned as `id` both receive `NOT NULL`. This is a small preexisting parity gap found during the port, separate from the ownership change.

## Tests

- Added adapter unit coverage for contract gating, default unenforced behavior, and case-insensitive NOT NULL matching.
- Added relation-config, table-alter, and incremental-materialization coverage for enforced and unenforced reconciliation.
- `cargo test -p dbt-adapter --lib adapter::adapter_impl::tests::test_parse_columns_and_constraints` — 3 passed.