### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/.changes/unreleased/Under the Hood-20260827-173336.yaml
+++ b/.changes/unreleased/Under the Hood-20260827-173336.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: sync JSON schemas from dbt-fusion
+time: 2026-08-27T17:33:36.292220368Z
+custom:
+    Author: fa-assistant
+    Issue: N/A

--- a/core/dbt/jsonschemas/project/latest.json
+++ b/core/dbt/jsonschemas/project/latest.json
@@ -2347,6 +2347,12 @@
             }
           ]
         },
+        "+query_tags": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "+quoting": {
           "anyOf": [
             {
@@ -4265,6 +4271,12 @@
             }
           ]
         },
+        "+query_tags": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "+quoting": {
           "anyOf": [
             {
@@ -5460,6 +5472,12 @@
             }
           ]
         },
+        "+query_tags": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "+quote_columns": {
           "anyOf": [
             {
@@ -6411,6 +6429,12 @@
             {
               "type": "null"
             }
+          ]
+        },
+        "+query_tags": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "+quote_columns": {
@@ -7875,6 +7899,12 @@
             {
               "type": "null"
             }
+          ]
+        },
+        "+query_tags": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "+refresh_interval_minutes": {

--- a/core/dbt/jsonschemas/resources/latest.json
+++ b/core/dbt/jsonschemas/resources/latest.json
@@ -1885,6 +1885,12 @@
             }
           ]
         },
+        "query_tags": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "quoting": {
           "anyOf": [
             {
@@ -4269,6 +4275,12 @@
             {
               "type": "null"
             }
+          ]
+        },
+        "query_tags": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "quoting": {
@@ -6886,6 +6898,12 @@
             }
           ]
         },
+        "query_tags": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "quoting": {
           "anyOf": [
             {
@@ -9308,6 +9326,12 @@
             }
           ]
         },
+        "query_tags": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "quote_columns": {
           "anyOf": [
             {
@@ -10779,6 +10803,12 @@
             }
           ]
         },
+        "query_tags": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "quote_columns": {
           "anyOf": [
             {
@@ -12219,6 +12249,12 @@
             {
               "type": "null"
             }
+          ]
+        },
+        "query_tags": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "range": {
@@ -13860,6 +13896,12 @@
             {
               "type": "null"
             }
+          ]
+        },
+        "query_tags": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "range": {


### PR DESCRIPTION
## Summary

This PR syncs the JSON schemas from the dbt-fusion repository.

### Files Updated
- `core/dbt/jsonschemas/project/latest.json`
- `core/dbt/jsonschemas/resources/latest.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Commit**: [`4eef7cd803c54835b7ae724befcbf7c78f56a629`](https://github.com/dbt-labs/fs/commit/4eef7cd803c54835b7ae724befcbf7c78f56a629)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/33096261886)