### PR TITLE
fix(databricks): drop tblproperties ignore list to match dbt-databricks

### DIFF
--- a/.changes/unreleased/Fixes-20260823-174712.yaml
+++ b/.changes/unreleased/Fixes-20260823-174712.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Match dbt-databricks table-property comparison by retaining all remote properties and detecting changes to configured properties.
+time: 2026-08-23T17:47:12.374464+05:30
+custom:
+    author: sd-db
+    issue: "16051"
+    project: dbt-core

--- a/crates/dbt-adapter/src/relation/databricks/config/components/tbl_properties.rs
+++ b/crates/dbt-adapter/src/relation/databricks/config/components/tbl_properties.rs
@@ -17,36 +17,6 @@ pub(crate) const TYPE_NAME: &str = "tblproperties";
 
 pub(crate) const PIPELINE_ID_KEY: &str = "pipelines.pipelineId";
 
-/// All of the following keys are ignoring by the diffing function
-///
-/// These are generally set by databricks and cannot be modified by the user
-const EQ_IGNORE_LIST: [&str; 24] = [
-    PIPELINE_ID_KEY,
-    "delta.enableChangeDataFeed",
-    "delta.minReaderVersion",
-    "delta.minWriterVersion",
-    "pipeline_internal.catalogType",
-    "pipelines.metastore.tableName",
-    "pipeline_internal.enzymeMode",
-    "clusterByAuto",
-    "clusteringColumns",
-    "delta.enableRowTracking",
-    "delta.feature.appendOnly",
-    "delta.feature.changeDataFeed",
-    "delta.feature.checkConstraints",
-    "delta.feature.domainMetadata",
-    "delta.feature.generatedColumns",
-    "delta.feature.invariants",
-    "delta.feature.rowTracking",
-    "delta.rowTracking.materializedRowCommitVersionColumnName",
-    "delta.rowTracking.materializedRowIdColumnName",
-    "spark.internal.pipelines.top_level_entry.user_specified_name",
-    "delta.columnMapping.maxColumnId",
-    "spark.sql.internal.pipelines.parentTableId",
-    "delta.enableDeletionVectors",
-    "delta.feature.deletionVectors",
-];
-
 /// Component for Databricks table properties.
 pub type TblProperties = SimpleComponentConfigImpl<IndexMap<String, String>>;
 
@@ -89,19 +59,18 @@ fn new_component(properties: IndexMap<String, String>) -> TblProperties {
 /// ```
 ///
 /// This is an asymmetric, one-directional comparison: a diff is reported only when the
-/// *desired* state has a non-ignored key/value pair that is missing or different in the
-/// *current* state. Keys present only in the current state (e.g. server-managed properties
-/// Databricks sets automatically) are ignored — a model that declares no opinion on
-/// `tblproperties` never produces a diff, regardless of what's already on the relation.
-/// The returned value is the full desired state (matching Python's `get_diff` returning `self`).
+/// *desired* state has a non-pipeline key/value pair that is missing or different in the
+/// *current* state. Fusion retains the pipeline ID for rendering but excludes it from comparison
+/// because dbt-databricks stores it separately from `tblproperties`. Keys present only in the
+/// current state are ignored, and the returned value is the full desired state (matching Python's
+/// `get_diff` returning `self`).
 fn diff(
     desired_state: &IndexMap<String, String>,
     current_state: &IndexMap<String, String>,
 ) -> Option<IndexMap<String, String>> {
-    let has_diff = desired_state.iter().any(|(k, v)| {
-        !EQ_IGNORE_LIST.contains(&k.as_str())
-            && current_state.get(k).map(|cv| cv != v).unwrap_or(true)
-    });
+    let has_diff = desired_state
+        .iter()
+        .any(|(k, v)| k.as_str() != PIPELINE_ID_KEY && current_state.get(k) != Some(v));
 
     if has_diff {
         Some(desired_state.clone())
@@ -121,9 +90,7 @@ fn from_remote_state(results: &DatabricksRelationMetadata) -> AdapterResult<TblP
             (row.get_item(&Value::from(0)), row.get_item(&Value::from(1)))
             && let (Some(key_str), Some(value_str)) = (key_val.as_str(), value_val.as_str())
         {
-            if key_str == PIPELINE_ID_KEY || !EQ_IGNORE_LIST.contains(&key_str) {
-                tblproperties.insert(key_str.to_string(), value_str.to_string());
-            }
+            tblproperties.insert(key_str.to_string(), value_str.to_string());
         }
     }
 
@@ -228,167 +195,130 @@ mod tests {
     }
 
     #[test]
-    fn test_diff_changed_databricks_keys() {
-        let prev = IndexMap::from_iter([
+    fn test_diff_ignores_pipeline_id_changes() {
+        let current = IndexMap::from_iter([
             (
                 "pipelines.pipelineId".to_string(),
                 "pipeline123".to_string(),
             ),
-            ("delta.enableChangeDataFeed".to_string(), "true".to_string()),
+            ("custom.property".to_string(), "value".to_string()),
         ]);
-        let next = IndexMap::from_iter([
-            (
-                "pipelines.pipelineId".to_string(),
-                "pipeline123456".to_string(),
-            ),
-            (
-                "delta.enableChangeDataFeed".to_string(),
-                "false".to_string(),
-            ),
-        ]);
-
-        let diff = diff(&next, &prev);
-        assert!(diff.is_none());
-    }
-
-    #[test]
-    fn test_diff_changed_custom_keys() {
-        let prev = IndexMap::from_iter([
-            (
-                "pipelines.pipelineId".to_string(),
-                "pipeline123".to_string(),
-            ),
-            ("custom.change".to_string(), "old".to_string()),
-            ("custom.drop".to_string(), "old".to_string()),
-        ]);
-        let next = IndexMap::from_iter([
-            (
-                "pipelines.pipelineId".to_string(),
-                "pipeline123456".to_string(),
-            ),
-            ("custom.change".to_string(), "new".to_string()),
-            ("custom.add".to_string(), "new".to_string()),
-        ]);
-
-        let diff = diff(&next, &prev).unwrap();
-
-        // diff returns the full desired state (matching Python's get_diff returning self)
-        assert_eq!(diff.len(), 3);
-        assert_eq!(
-            diff.get("pipelines.pipelineId").unwrap().as_str(),
-            "pipeline123456"
-        );
-        assert_eq!(diff.get("custom.change").unwrap().as_str(), "new");
-        assert_eq!(diff.get("custom.add").unwrap().as_str(), "new");
-    }
-
-    /// The model config has tblproperties:
-    ///   {"delta.enableChangeDataFeed": "true", "delta.columnMapping.mode": "name"}
-    ///
-    /// The existing table (SHOW TBLPROPERTIES) has those plus a few other properties
-    /// like delta.checkpoint.*, delta.parquet.*, etc.
-    ///
-    /// Python dbt-databricks's `get_diff` is a one-directional set difference
-    /// (`self.tblproperties.items() - other.tblproperties.items()`): it only reports a
-    /// diff when the *desired* state has a non-ignored key/value pair missing or different
-    /// in current. Extra keys present only in current (server-managed properties the model
-    /// never declared an opinion on) must be ignored. Here every non-ignored desired key
-    /// (`delta.columnMapping.mode`) matches current, so there is no diff even though current
-    /// has additional keys.
-    #[test]
-    fn test_diff_extra_current_keys_are_ignored() {
-        // Desired state: what from_local_config produces from the model config.
-        // Note: delta.enableChangeDataFeed is in the model config but will be
-        // filtered by EQ_IGNORE_LIST in the diff function.
         let desired = IndexMap::from_iter([
-            ("delta.enableChangeDataFeed".to_string(), "true".to_string()),
-            ("delta.columnMapping.mode".to_string(), "name".to_string()),
-        ]);
-
-        // Current state: what from_remote_state produces from SHOW TBLPROPERTIES.
-        // from_remote_state already filters EQ_IGNORE_LIST, so delta.enableChangeDataFeed
-        // is NOT here. But extra system properties (not in ignore list) ARE here.
-        let current = IndexMap::from_iter([
             (
-                "delta.checkpoint.writeStatsAsJson".to_string(),
-                "false".to_string(),
+                "pipelines.pipelineId".to_string(),
+                "pipeline123456".to_string(),
             ),
-            (
-                "delta.checkpoint.writeStatsAsStruct".to_string(),
-                "true".to_string(),
-            ),
-            ("delta.columnMapping.mode".to_string(), "name".to_string()),
-            (
-                "delta.parquet.compression.codec".to_string(),
-                "zstd".to_string(),
-            ),
-        ]);
-
-        // No diff: the only non-ignored desired key/value pair (delta.columnMapping.mode =
-        // "name") is present and identical in current. Extra current-only keys don't count.
-        let result = diff(&desired, &current);
-        assert!(
-            result.is_none(),
-            "Extra non-ignored keys present only in current state must not trigger a diff"
-        );
-    }
-
-    /// A model that declares no tblproperties opinion at all must never report a diff,
-    /// even when the existing relation already has server-managed properties set
-    /// (regression test for the bug that triggered spurious `apply_tblproperties` calls,
-    /// e.g. unnecessary `adapter.is_uniform` checks, for models that never configured
-    /// tblproperties).
-    #[test]
-    fn test_diff_empty_desired_never_reports_change() {
-        let desired = IndexMap::new();
-
-        let current = IndexMap::from_iter([
-            (
-                "delta.checkpoint.writeStatsAsJson".to_string(),
-                "false".to_string(),
-            ),
-            (
-                "delta.checkpoint.writeStatsAsStruct".to_string(),
-                "true".to_string(),
-            ),
-            ("delta.minReaderVersion".to_string(), "1".to_string()),
-            ("delta.minWriterVersion".to_string(), "2".to_string()),
+            ("custom.property".to_string(), "value".to_string()),
         ]);
 
         assert!(diff(&desired, &current).is_none());
     }
 
     #[test]
-    fn test_from_remote_state() {
+    fn test_diff_empty_and_some_exist() {
+        let desired = IndexMap::new();
+        let current = IndexMap::from_iter([("prop".to_string(), "1".to_string())]);
+
+        assert!(diff(&desired, &current).is_none());
+    }
+
+    #[test]
+    fn test_diff_some_new_and_empty_existing() {
+        let desired = IndexMap::from_iter([("prop".to_string(), "1".to_string())]);
+        let current = IndexMap::new();
+
+        assert_eq!(diff(&desired, &current), Some(desired));
+    }
+
+    #[test]
+    fn test_diff_mixed_case() {
+        let desired = IndexMap::from_iter([
+            ("prop".to_string(), "1".to_string()),
+            ("other".to_string(), "other".to_string()),
+        ]);
+        let current = IndexMap::from_iter([
+            ("prop".to_string(), "2".to_string()),
+            ("c".to_string(), "value".to_string()),
+        ]);
+
+        assert_eq!(diff(&desired, &current), Some(desired));
+    }
+
+    #[test]
+    fn test_diff_retains_already_applied_properties() {
+        let desired = IndexMap::from_iter([
+            ("a".to_string(), "1".to_string()),
+            ("c".to_string(), "1".to_string()),
+        ]);
+        let current = IndexMap::from_iter([("a".to_string(), "1".to_string())]);
+
+        assert_eq!(diff(&desired, &current), Some(desired));
+    }
+
+    #[test]
+    fn test_diff_no_changes() {
+        let desired = IndexMap::from_iter([("prop".to_string(), "1".to_string())]);
+        let current = desired.clone();
+
+        assert!(diff(&desired, &current).is_none());
+    }
+
+    #[test]
+    fn test_diff_ignores_server_set_properties() {
+        let desired = IndexMap::from_iter([("prop".to_string(), "1".to_string())]);
+        let current = IndexMap::from_iter([
+            ("prop".to_string(), "1".to_string()),
+            ("server.property".to_string(), "value".to_string()),
+        ]);
+
+        assert!(diff(&desired, &current).is_none());
+    }
+
+    #[test]
+    fn test_from_remote_state_retains_server_set_properties() {
         let table = create_mock_show_tblproperties_table(vec![
-            ("streaming.checkpointLocation", "/tmp/checkpoint"),
-            ("streaming.outputMode", "append"),
-            ("custom.property", "test_value"),
-            ("pipelines.pipelineId", "pipeline123"),
-            ("delta.enableChangeDataFeed", "true"), // Should be ignored
+            ("prop", "1"),
+            ("delta.enableChangeDataFeed", "true"),
         ]);
 
         let results = IndexMap::from([(DatabricksRelationMetadataKey::ShowTblProperties, table)]);
         let config = from_remote_state(&results).unwrap();
 
-        assert_eq!(config.value.len(), 4); // Ignores delta properties
+        let expected = IndexMap::<String, String>::from_iter([
+            ("prop".to_string(), "1".to_string()),
+            ("delta.enableChangeDataFeed".to_string(), "true".to_string()),
+        ]);
+
+        assert_eq!(config.value, expected);
+    }
+
+    #[test]
+    fn test_to_jinja_separates_pipeline_id_from_tblproperties() {
+        let properties = IndexMap::from_iter([
+            (PIPELINE_ID_KEY.to_string(), "pipeline123".to_string()),
+            ("prop".to_string(), "1".to_string()),
+        ]);
+
+        let value = to_jinja(&properties);
+        let tblproperties = value.get_attr("tblproperties").unwrap();
+
         assert_eq!(
-            config.value.get("streaming.checkpointLocation"),
-            Some(&"/tmp/checkpoint".to_string())
+            value.get_attr("pipeline_id").unwrap().as_str(),
+            Some("pipeline123")
         );
         assert_eq!(
-            config.value.get("streaming.outputMode"),
-            Some(&"append".to_string())
+            tblproperties
+                .get_item(&Value::from("prop"))
+                .unwrap()
+                .as_str(),
+            Some("1")
         );
-        assert_eq!(
-            config.value.get("custom.property"),
-            Some(&"test_value".to_string())
+        assert!(
+            tblproperties
+                .get_item(&Value::from(PIPELINE_ID_KEY))
+                .unwrap()
+                .is_undefined()
         );
-        assert_eq!(
-            config.value.get(PIPELINE_ID_KEY),
-            Some(&"pipeline123".to_string())
-        );
-        assert!(!config.value.contains_key("delta.enableChangeDataFeed"));
     }
 
     #[test]

--- a/crates/dbt-adapter/src/relation/databricks/config/relation_types/incremental_table.rs
+++ b/crates/dbt-adapter/src/relation/databricks/config/relation_types/incremental_table.rs
@@ -1,9 +1,9 @@
 //! https://github.com/databricks/dbt-databricks/blob/main/dbt/adapters/databricks/relation_configs/incremental.py
 
-use crate::AdapterType;
 use crate::relation::config_v2::ComponentConfigChange;
 use crate::relation::config_v2::{ComponentConfigLoader, RelationConfigLoader};
-use crate::relation::databricks::config::{DatabricksRelationMetadata, components};
+use crate::relation::databricks::config::{components, DatabricksRelationMetadata};
+use crate::AdapterType;
 use indexmap::IndexMap;
 
 fn requires_full_refresh(components: &IndexMap<&'static str, ComponentConfigChange>) -> bool {
@@ -31,22 +31,24 @@ pub(crate) fn new_loader() -> RelationConfigLoader<'static, DatabricksRelationMe
 #[cfg(test)]
 mod tests {
     use super::{new_loader, requires_full_refresh};
-    use crate::AdapterType;
     use crate::relation::config_v2::{
         ComponentConfigChange, ComponentConfigLoader, RelationComponentConfigChangeSet,
     };
     use crate::relation::databricks::config::{
-        DatabricksRelationMetadata, components,
-        test_helpers::{TestModelColumn, TestModelConfig, run_test_cases},
+        components,
+        test_helpers::{run_test_cases, TestModelColumn, TestModelConfig},
+        DatabricksRelationMetadata,
     };
     use crate::relation::test_helpers::TestCase;
+    use crate::AdapterType;
     use dbt_schemas::schemas::common::{Constraint, ConstraintType};
     use dbt_schemas::schemas::dbt_column::ColumnMask;
     use indexmap::{IndexMap, IndexSet};
 
     fn create_test_cases() -> Vec<TestCase<DatabricksRelationMetadata, TestModelConfig>> {
         vec![TestCase {
-            description: "changing any incremental table components should not trigger a full refresh",
+            description:
+                "changing any incremental table components should not trigger a full refresh",
             relation_loader: new_loader(),
             current_state: TestModelConfig {
                 persist_relation_comments: true,
@@ -79,14 +81,10 @@ mod tests {
                     ("a_tag".to_string(), "old".to_string()),
                     ("b_tag".to_string(), "old".to_string()),
                 ]),
-                tbl_properties: IndexMap::from_iter([
-                    ("delta.enableRowTracking".to_string(), "false".to_string()),
-                    (
-                        "pipelines.pipelineId".to_string(),
-                        "my_old_pipeline".to_string(),
-                    ),
-                    ("customKey".to_string(), "old".to_string()),
-                ]),
+                tbl_properties: IndexMap::from_iter([(
+                    "delta.enableChangeDataFeed".to_string(),
+                    "false".to_string(),
+                )]),
                 ..Default::default()
             },
             desired_state: TestModelConfig {
@@ -123,16 +121,11 @@ mod tests {
                     ("b_tag".to_string(), "old".to_string()),
                 ]),
                 tbl_properties: IndexMap::from_iter([
-                    // changing these key should not result in anything as these should be ignored
-                    ("delta.enableRowTracking".to_string(), "true".to_string()),
+                    ("delta.enableChangeDataFeed".to_string(), "true".to_string()),
                     (
-                        "pipelines.pipelineId".to_string(),
-                        "my_new_pipeline".to_string(),
+                        "data.owner".to_string(),
+                        "analytics-engineering".to_string(),
                     ),
-                    // changing a key not in the ignore list should cause a changeset entry
-                    ("customKey".to_string(), "new".to_string()),
-                    // introducing a new key should also add it to the changeset
-                    ("customKey2".to_string(), "value".to_string()),
                 ]),
                 ..Default::default()
             },
@@ -219,8 +212,11 @@ mod tests {
                         ComponentConfigChange::Some(
                             components::TblPropertiesLoader::new_component_type_erased(
                                 IndexMap::from_iter([
-                                    ("customKey".to_string(), "new".to_string()),
-                                    ("customKey2".to_string(), "value".to_string()),
+                                    ("delta.enableChangeDataFeed".to_string(), "true".to_string()),
+                                    (
+                                        "data.owner".to_string(),
+                                        "analytics-engineering".to_string(),
+                                    ),
                                 ]),
                             ),
                         ),
@@ -318,18 +314,15 @@ mod tests {
 </row_filter>
 <tblproperties>
     <tblproperties>
-        <delta.enableRowTracking>
+        <data.owner>
+            analytics-engineering
+        </data.owner>
+        <delta.enableChangeDataFeed>
             true
-        </delta.enableRowTracking>
-        <customKey>
-            new
-        </customKey>
-        <customKey2>
-            value
-        </customKey2>
+        </delta.enableChangeDataFeed>
     </tblproperties>
     <pipeline_id>
-        my_new_pipeline
+        None
     </pipeline_id>
 </tblproperties>
 <column_masks>

--- a/crates/dbt-adapter/src/relation/databricks/config/relation_types/materialized_view.rs
+++ b/crates/dbt-adapter/src/relation/databricks/config/relation_types/materialized_view.rs
@@ -1,9 +1,9 @@
 //! https://github.com/databricks/dbt-databricks/blob/main/dbt/adapters/databricks/relation_configs/materialized_view.py
 
-use crate::AdapterType;
 use crate::relation::config_v2::ComponentConfigChange;
 use crate::relation::config_v2::{ComponentConfigLoader, RelationConfigLoader};
-use crate::relation::databricks::config::{DatabricksRelationMetadata, components};
+use crate::relation::databricks::config::{components, DatabricksRelationMetadata};
+use crate::AdapterType;
 use indexmap::IndexMap;
 
 fn requires_full_refresh(components: &IndexMap<&'static str, ComponentConfigChange>) -> bool {
@@ -33,15 +33,16 @@ pub(crate) fn new_loader() -> RelationConfigLoader<'static, DatabricksRelationMe
 #[cfg(test)]
 mod tests {
     use super::{new_loader, requires_full_refresh};
-    use crate::AdapterType;
     use crate::relation::config_v2::{
         ComponentConfigChange, ComponentConfigLoader, RelationComponentConfigChangeSet,
     };
     use crate::relation::databricks::config::{
-        DatabricksRelationMetadata, components,
-        test_helpers::{TestModelConfig, run_test_cases},
+        components,
+        test_helpers::{run_test_cases, TestModelConfig},
+        DatabricksRelationMetadata,
     };
     use crate::relation::test_helpers::TestCase;
+    use crate::AdapterType;
     use indexmap::IndexMap;
 
     fn create_test_cases() -> Vec<TestCase<DatabricksRelationMetadata, TestModelConfig>> {
@@ -53,12 +54,12 @@ mod tests {
                     persist_relation_comments: true,
                     query: Some("SELECT 1".to_string()),
                     tbl_properties: IndexMap::from_iter([
-                        ("delta.enableRowTracking".to_string(), "false".to_string()),
                         (
                             "pipelines.pipelineId".to_string(),
-                            "my_old_pipeline".to_string(),
+                            "dlt-pipeline-1".to_string(),
                         ),
-                        ("custom.key".to_string(), "old".to_string()),
+                        ("data.quality".to_string(), "silver".to_string()),
+                        ("reporting.audience".to_string(), "internal".to_string()),
                     ]),
                     partition_by: vec!["partition_column_old".to_string()],
                     ..Default::default()
@@ -67,12 +68,12 @@ mod tests {
                     persist_relation_comments: true,
                     query: Some("SELECT 1000".to_string()),
                     tbl_properties: IndexMap::from_iter([
-                        ("delta.enableRowTracking".to_string(), "true".to_string()),
                         (
                             "pipelines.pipelineId".to_string(),
-                            "my_old_pipeline".to_string(),
+                            "dlt-pipeline-1".to_string(),
                         ),
-                        ("custom.key".to_string(), "new".to_string()),
+                        ("data.quality".to_string(), "gold".to_string()),
+                        ("reporting.audience".to_string(), "company-wide".to_string()),
                     ]),
                     partition_by: vec!["partition_column_new".to_string()],
                     ..Default::default()
@@ -84,10 +85,17 @@ mod tests {
                             components::TblPropertiesLoader.type_name(),
                             ComponentConfigChange::Some(
                                 components::TblPropertiesLoader::new_component_type_erased(
-                                    IndexMap::from_iter([(
-                                        "custom.key".to_string(),
-                                        "new".to_string(),
-                                    )]),
+                                    IndexMap::from_iter([
+                                        (
+                                            "pipelines.pipelineId".to_string(),
+                                            "dlt-pipeline-1".to_string(),
+                                        ),
+                                        ("data.quality".to_string(), "gold".to_string()),
+                                        (
+                                            "reporting.audience".to_string(),
+                                            "company-wide".to_string(),
+                                        ),
+                                    ]),
                                 ),
                             ),
                         ),
@@ -110,15 +118,15 @@ mod tests {
 </partitioned_by>
 <tblproperties>
     <tblproperties>
-        <delta.enableRowTracking>
-            true
-        </delta.enableRowTracking>
-        <custom.key>
-            new
-        </custom.key>
+        <data.quality>
+            gold
+        </data.quality>
+        <reporting.audience>
+            company-wide
+        </reporting.audience>
     </tblproperties>
     <pipeline_id>
-        my_old_pipeline
+        dlt-pipeline-1
     </pipeline_id>
 </tblproperties>
                     ",

--- a/crates/dbt-adapter/src/relation/databricks/config/relation_types/streaming_table.rs
+++ b/crates/dbt-adapter/src/relation/databricks/config/relation_types/streaming_table.rs
@@ -1,9 +1,9 @@
 //! https://github.com/databricks/dbt-databricks/blob/main/dbt/adapters/databricks/relation_configs/streaming_table.py
 
-use crate::AdapterType;
 use crate::relation::config_v2::ComponentConfigChange;
 use crate::relation::config_v2::{ComponentConfigLoader, RelationConfigLoader};
-use crate::relation::databricks::config::{DatabricksRelationMetadata, components};
+use crate::relation::databricks::config::{components, DatabricksRelationMetadata};
+use crate::AdapterType;
 use indexmap::IndexMap;
 
 fn requires_full_refresh(components: &IndexMap<&'static str, ComponentConfigChange>) -> bool {
@@ -31,15 +31,16 @@ pub(crate) fn new_loader() -> RelationConfigLoader<'static, DatabricksRelationMe
 #[cfg(test)]
 mod tests {
     use super::{new_loader, requires_full_refresh};
-    use crate::AdapterType;
     use crate::relation::config_v2::{
         ComponentConfigChange, ComponentConfigLoader, RelationComponentConfigChangeSet,
     };
     use crate::relation::databricks::config::{
-        DatabricksRelationMetadata, components,
-        test_helpers::{TestModelConfig, run_test_cases},
+        components,
+        test_helpers::{run_test_cases, TestModelConfig},
+        DatabricksRelationMetadata,
     };
     use crate::relation::test_helpers::TestCase;
+    use crate::AdapterType;
     use indexmap::IndexMap;
 
     fn create_test_cases() -> Vec<TestCase<DatabricksRelationMetadata, TestModelConfig>> {
@@ -60,12 +61,12 @@ mod tests {
                         ("b_tag".to_string(), "old".to_string()),
                     ]),
                     tbl_properties: IndexMap::from_iter([
-                        ("delta.enableRowTracking".to_string(), "false".to_string()),
                         (
                             "pipelines.pipelineId".to_string(),
-                            "my_old_pipeline".to_string(),
+                            "dlt-pipeline-1".to_string(),
                         ),
-                        ("customKey".to_string(), "old".to_string()),
+                        ("data.quality".to_string(), "bronze".to_string()),
+                        ("source.system".to_string(), "events-v1".to_string()),
                     ]),
                     ..Default::default()
                 },
@@ -82,16 +83,12 @@ mod tests {
                     row_filter_function: None,
                     row_filter_columns: vec![],
                     tbl_properties: IndexMap::from_iter([
-                        // changing these key should not result in anything as these should be ignored
-                        ("delta.enableRowTracking".to_string(), "true".to_string()),
                         (
                             "pipelines.pipelineId".to_string(),
-                            "my_new_pipeline".to_string(),
+                            "dlt-pipeline-1".to_string(),
                         ),
-                        // changing a key not in the ignore list should cause a changeset entry
-                        ("customKey".to_string(), "new".to_string()),
-                        // introducing a new key should also add it to the changeset
-                        ("customKey2".to_string(), "value".to_string()),
+                        ("data.quality".to_string(), "silver".to_string()),
+                        ("source.system".to_string(), "events-v2".to_string()),
                     ]),
                     ..Default::default()
                 },
@@ -148,8 +145,12 @@ mod tests {
                             ComponentConfigChange::Some(
                                 components::TblPropertiesLoader::new_component_type_erased(
                                     IndexMap::from_iter([
-                                        ("customKey".to_string(), "new".to_string()),
-                                        ("customKey2".to_string(), "value".to_string()),
+                                        (
+                                            "pipelines.pipelineId".to_string(),
+                                            "dlt-pipeline-1".to_string(),
+                                        ),
+                                        ("data.quality".to_string(), "silver".to_string()),
+                                        ("source.system".to_string(), "events-v2".to_string()),
                                     ]),
                                 ),
                             ),
@@ -176,18 +177,15 @@ mod tests {
 </comment>
 <tblproperties>
     <tblproperties>
-        <delta.enableRowTracking>
-            true
-        </delta.enableRowTracking>
-        <customKey>
-            new
-        </customKey>
-        <customKey2>
-            value
-        </customKey2>
+        <data.quality>
+            silver
+        </data.quality>
+        <source.system>
+            events-v2
+        </source.system>
     </tblproperties>
     <pipeline_id>
-        my_new_pipeline
+        dlt-pipeline-1
     </pipeline_id>
 </tblproperties>
 <refresh>

--- a/crates/dbt-adapter/src/relation/databricks/config/relation_types/view.rs
+++ b/crates/dbt-adapter/src/relation/databricks/config/relation_types/view.rs
@@ -1,9 +1,9 @@
 //! https://github.com/databricks/dbt-databricks/blob/main/dbt/adapters/databricks/relation_configs/view.py
 
-use crate::AdapterType;
 use crate::relation::config_v2::ComponentConfigChange;
 use crate::relation::config_v2::{ComponentConfigLoader, RelationConfigLoader};
-use crate::relation::databricks::config::{DatabricksRelationMetadata, components};
+use crate::relation::databricks::config::{components, DatabricksRelationMetadata};
+use crate::AdapterType;
 use indexmap::IndexMap;
 
 fn requires_full_refresh(components: &IndexMap<&'static str, ComponentConfigChange>) -> bool {
@@ -26,15 +26,16 @@ pub(crate) fn new_loader() -> RelationConfigLoader<'static, DatabricksRelationMe
 #[cfg(test)]
 mod tests {
     use super::{new_loader, requires_full_refresh};
-    use crate::AdapterType;
     use crate::relation::config_v2::{
         ComponentConfigChange, ComponentConfigLoader, RelationComponentConfigChangeSet,
     };
     use crate::relation::databricks::config::{
-        DatabricksRelationMetadata, components,
-        test_helpers::{TestModelColumn, TestModelConfig, run_test_cases},
+        components,
+        test_helpers::{run_test_cases, TestModelColumn, TestModelConfig},
+        DatabricksRelationMetadata,
     };
     use crate::relation::test_helpers::TestCase;
+    use crate::AdapterType;
     use indexmap::IndexMap;
 
     fn create_test_cases() -> Vec<TestCase<DatabricksRelationMetadata, TestModelConfig>> {
@@ -63,12 +64,8 @@ mod tests {
                         ("b_tag".to_string(), "old".to_string()),
                     ]),
                     tbl_properties: IndexMap::from_iter([
-                        ("delta.enableRowTracking".to_string(), "false".to_string()),
-                        (
-                            "pipelines.pipelineId".to_string(),
-                            "my_old_pipeline".to_string(),
-                        ),
-                        ("customKey".to_string(), "old".to_string()),
+                        ("data.owner".to_string(), "data-engineering".to_string()),
+                        ("data.quality".to_string(), "bronze".to_string()),
                     ]),
                     ..Default::default()
                 },
@@ -93,16 +90,11 @@ mod tests {
                         ("b_tag".to_string(), "old".to_string()),
                     ]),
                     tbl_properties: IndexMap::from_iter([
-                        // changing these key should not result in anything as these should be ignored
-                        ("delta.enableRowTracking".to_string(), "true".to_string()),
                         (
-                            "pipelines.pipelineId".to_string(),
-                            "my_new_pipeline".to_string(),
+                            "data.owner".to_string(),
+                            "analytics-engineering".to_string(),
                         ),
-                        // changing a key not in the ignore list should cause a changeset entry
-                        ("customKey".to_string(), "new".to_string()),
-                        // introducing a new key should also add it to the changeset
-                        ("customKey2".to_string(), "value".to_string()),
+                        ("data.quality".to_string(), "silver".to_string()),
                     ]),
                     ..Default::default()
                 },
@@ -142,8 +134,11 @@ mod tests {
                             ComponentConfigChange::Some(
                                 components::TblPropertiesLoader::new_component_type_erased(
                                     IndexMap::from_iter([
-                                        ("customKey".to_string(), "new".to_string()),
-                                        ("customKey2".to_string(), "value".to_string()),
+                                        (
+                                            "data.owner".to_string(),
+                                            "analytics-engineering".to_string(),
+                                        ),
+                                        ("data.quality".to_string(), "silver".to_string()),
                                     ]),
                                 ),
                             ),
@@ -179,18 +174,15 @@ mod tests {
 </tags>
 <tblproperties>
     <tblproperties>
-        <delta.enableRowTracking>
-            true
-        </delta.enableRowTracking>
-        <customKey>
-            new
-        </customKey>
-        <customKey2>
-            value
-        </customKey2>
+        <data.owner>
+            analytics-engineering
+        </data.owner>
+        <data.quality>
+            silver
+        </data.quality>
     </tblproperties>
     <pipeline_id>
-        my_new_pipeline
+        None
     </pipeline_id>
 </tblproperties>
                     ",


### PR DESCRIPTION
Resolves #16051

### Problem

Fusion compared Databricks `tblproperties` with a hardcoded ignore list of server-looking keys (`delta.enableChangeDataFeed`, `delta.enableRowTracking`, protocol internals, etc.). One-directional `desired - current` already ignores keys that exist only on the table, so that list was leftover from an older bidirectional comparison. It also blocked a real case: if a model *declares* a formerly ignored key (especially change data feed), Fusion would not treat a mismatch as a change and would never `SET TBLPROPERTIES`, while dbt-databricks does.

### Solution

Match current dbt-databricks `TblPropertiesConfig.get_diff` (`self.tblproperties.items() - other.tblproperties.items()`):

- Keep every `SHOW TBLPROPERTIES` row in remote state.
- Compare only non-pipeline keys on the desired side; extras on the table stay ignored (set-only; no unset).
- Still peel `pipelines.pipelineId` out of comparison and Jinja `tblproperties`, because Python stores it separately.

This restores the genuine apply path for user-declared Delta settings (CDF, and other `delta.*` knobs the model actually names). Databricks may still reject ALTER of protocol internals if someone puts those in config; dbt does not pretend the user did not set them.

Relation-config fixtures were normalized to the new comparison: incremental uses a CDF update plus a user-defined property; views use user metadata; MV/ST keep a stable server-assigned pipeline id that is not treated as a user change.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.