### PR TITLE
fix(databricks): detect materialized view query changesets

### DIFF
--- a/.changes/unreleased/Fixes-20260829-034542.yaml
+++ b/.changes/unreleased/Fixes-20260829-034542.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Detect Databricks materialized view query changes and require full refresh when compiled SQL changes
+time: 2026-08-29T03:45:42.626006+05:30
+custom:
+    author: sd-db
+    issue: "16123"
+    project: dbt-core

--- a/crates/dbt-adapter/src/metadata/databricks/mod.rs
+++ b/crates/dbt-adapter/src/metadata/databricks/mod.rs
@@ -302,7 +302,7 @@ impl DatabricksMetadataAdapter {
         match relation_type {
             RelationType::MaterializedView => {
                 metadata.insert(
-                    DatabricksRelationMetadataKey::DescribeExtended,
+                    DatabricksRelationMetadataKey::InfoSchemaViews,
                     self.get_view_description(
                         &database,
                         &schema,

--- a/crates/dbt-adapter/src/relation/databricks/config/relation_types/materialized_view.rs
+++ b/crates/dbt-adapter/src/relation/databricks/config/relation_types/materialized_view.rs
@@ -14,12 +14,11 @@ fn requires_full_refresh(components: &IndexMap<&'static str, ComponentConfigChan
 pub(crate) fn new_loader() -> RelationConfigLoader<'static, DatabricksRelationMetadata> {
     // TODO: missing from Python dbt-databricks:
     // - relation tags
-    // - query
-    let loaders: [Box<dyn ComponentConfigLoader<DatabricksRelationMetadata>>; 7] = [
+    let loaders: [Box<dyn ComponentConfigLoader<DatabricksRelationMetadata>>; 8] = [
         Box::new(components::LiquidClusteringLoader),
         Box::new(components::RelationCommentLoader),
         Box::new(components::PartitionByLoader),
-        // Box::new(components::QueryLoader),
+        Box::new(components::QueryLoader),
         Box::new(components::RefreshLoader),
         // Box::new(components::RelationTagsLoader),
         Box::new(components::RowFilterLoader),
@@ -99,6 +98,12 @@ mod tests {
                                 ]),
                             ),
                         ),
+                        (
+                            components::QueryLoader.type_name(),
+                            ComponentConfigChange::Some(
+                                components::QueryLoader::new_component_type_erased("SELECT 1000"),
+                            ),
+                        ),
                     ],
                     requires_full_refresh,
                 ),
@@ -108,6 +113,11 @@ mod tests {
         partition_column_new
     </partition_by>
 </partitioned_by>
+<query>
+    <query>
+        SELECT 1000
+    </query>
+</query>
 <tblproperties>
     <tblproperties>
         <delta.enableRowTracking>
@@ -125,9 +135,40 @@ mod tests {
                 requires_full_refresh: true,
             },
             TestCase {
+                description: "changing only a materialized view's compiled SQL should require a full refresh",
+                relation_loader: new_loader(),
+                current_state: TestModelConfig {
+                    query: Some("SELECT 1".to_string()),
+                    ..Default::default()
+                },
+                desired_state: TestModelConfig {
+                    query: Some("SELECT 1000".to_string()),
+                    ..Default::default()
+                },
+                expected_changeset: RelationComponentConfigChangeSet::new(
+                    AdapterType::Databricks,
+                    [(
+                        components::QueryLoader.type_name(),
+                        ComponentConfigChange::Some(
+                            components::QueryLoader::new_component_type_erased("SELECT 1000"),
+                        ),
+                    )],
+                    requires_full_refresh,
+                ),
+                changeset_jinja: "
+<query>
+    <query>
+        SELECT 1000
+    </query>
+</query>
+                    ",
+                requires_full_refresh: true,
+            },
+            TestCase {
                 description: "changing a materialized view's refresh cron or tags should not trigger a full refresh",
                 relation_loader: new_loader(),
                 current_state: TestModelConfig {
+                    query: Some("SELECT 1".to_string()),
                     cron: Some("* * * * *".to_string()),
                     time_zone: Some("UTC".to_string()),
                     tags: IndexMap::from_iter([
@@ -137,6 +178,7 @@ mod tests {
                     ..Default::default()
                 },
                 desired_state: TestModelConfig {
+                    query: Some("SELECT 1".to_string()),
                     cron: Some("*/60 * * * *".to_string()),
                     time_zone: Some("UTC".to_string()),
                     tags: IndexMap::from_iter([("a_tag".to_string(), "new".to_string())]),


### PR DESCRIPTION
## Summary
- Enable `QueryLoader` on Databricks materialized views so compiled-SQL changes appear in the relation-config changeset and force full refresh/replace, matching `dbt-databricks`.
- Store MV view definitions under `InfoSchemaViews` instead of overwriting the non-table `DescribeExtended` prefix result, so remote applied SQL can be compared.
- Add a focused regression for SQL-only MV changes requiring full refresh.

Fixes #16123

## Test plan
- [x] `cargo test -p dbt-adapter relation::databricks::config::relation_types::materialized_view`
- [x] `cargo test -p dbt-adapter relation::databricks::config::components::query`
- [x] `cargo check -p dbt-adapter`
- [ ] CI green on this PR