### PR TITLE
fix(bigquery): skip draining Arrow results for DML

### DIFF
--- a/.changes/unreleased/Fixes-20260824-103000.yaml
+++ b/.changes/unreleased/Fixes-20260824-103000.yaml
@@ -2,6 +2,6 @@ kind: Fixes
 body: Skip materializing BigQuery DML/DDL Arrow results so run_query(INSERT) cannot Storage-Read the destination table and OOM
 time: 2026-08-24T10:30:00.000000-10:00
 custom:
-    author: ""
+    author: Kayrnt
     issue: ""
     project: dbt-core

--- a/.changes/unreleased/Fixes-20260824-103000.yaml
+++ b/.changes/unreleased/Fixes-20260824-103000.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Skip materializing BigQuery DML/DDL Arrow results so run_query(INSERT) cannot Storage-Read the destination table and OOM
+time: 2026-08-24T10:30:00.000000-10:00
+custom:
+    author: ""
+    issue: ""
+    project: dbt-core

--- a/.changes/unreleased/Fixes-20260901-133917.yaml
+++ b/.changes/unreleased/Fixes-20260901-133917.yaml
@@ -1,7 +1,7 @@
 kind: Fixes
 body: Skip materializing BigQuery DML/DDL Arrow results so run_query(INSERT) cannot Storage-Read the destination table and OOM
-time: 2026-08-24T10:30:00.000000-10:00
+time: 2026-09-01T13:39:17.210144-10:00
 custom:
     author: Kayrnt
-    issue: ""
+    issue: "16064"
     project: dbt-core

--- a/crates/dbt-adapter-sql/src/statements.rs
+++ b/crates/dbt-adapter-sql/src/statements.rs
@@ -32,6 +32,46 @@ pub fn is_update_statement(sql: &str, adapter_type: AdapterType) -> bool {
     }
 }
 
+/// Whether `sql` is expected to produce a result set worth materializing.
+///
+/// BigQuery's ADBC driver Storage-Reads the destination table for DML when
+/// `fetch=true` (e.g. `dbt.run_query` on `INSERT`). Callers must not drain
+/// those readers. Leading comments are stripped so Elementary's
+/// `/* --ELEMENTARY-METADATA-- */` prefix does not hide `INSERT`.
+pub fn statement_returns_result_rows(sql: &str, adapter_type: AdapterType) -> bool {
+    match adapter_type {
+        AdapterType::Bigquery => {
+            let sql = trim_leading_sql_comments(sql);
+            let mut tokenizer = Tokenizer::new(sql);
+            matches!(
+                tokenizer.next(),
+                Some(Token::Word(token)) if is_bigquery_result_statement_token(token)
+            )
+        }
+        AdapterType::ClickHouse => !is_update_statement(sql, adapter_type),
+        _ => true,
+    }
+}
+
+/// BigQuery job `statistics.query.statementType` values that return rows.
+pub fn bigquery_statement_type_returns_rows(statement_type: &str) -> bool {
+    statement_type.eq_ignore_ascii_case("SELECT")
+        || statement_type.eq_ignore_ascii_case("CALL")
+        || statement_type.eq_ignore_ascii_case("SCRIPT")
+}
+
+fn is_bigquery_result_statement_token(token: &str) -> bool {
+    // Conservative: only skip fetch when the first keyword cannot be a result
+    // set. WITH starts CTEs that may SELECT; CALL/SCRIPT can return rows.
+    token.eq_ignore_ascii_case("SELECT")
+        || token.eq_ignore_ascii_case("WITH")
+        || token.eq_ignore_ascii_case("SHOW")
+        || token.eq_ignore_ascii_case("DESCRIBE")
+        || token.eq_ignore_ascii_case("DESC")
+        || token.eq_ignore_ascii_case("EXPLAIN")
+        || token.eq_ignore_ascii_case("CALL")
+}
+
 fn trim_leading_sql_comments(mut sql: &str) -> &str {
     loop {
         let trimmed = sql.trim_start_matches(char::is_whitespace);
@@ -78,7 +118,9 @@ fn is_clickhouse_read_statement_token(token: &str) -> bool {
 mod tests {
     use dbt_adapter_core::AdapterType;
 
-    use super::is_update_statement;
+    use super::{
+        bigquery_statement_type_returns_rows, is_update_statement, statement_returns_result_rows,
+    };
 
     #[test]
     fn clickhouse_update_statement_classification_uses_sql_tokenizer() {
@@ -114,6 +156,79 @@ mod tests {
         assert!(!is_update_statement(
             "CREATE TABLE foo (id int)",
             AdapterType::DuckDB,
+        ));
+    }
+
+    #[test]
+    fn bigquery_insert_does_not_return_result_rows() {
+        assert!(!statement_returns_result_rows(
+            "INSERT INTO `proj`.`ds`.`dbt_run_results` (id) VALUES (1)",
+            AdapterType::Bigquery,
+        ));
+    }
+
+    #[test]
+    fn bigquery_insert_with_elementary_leading_comment_does_not_return_result_rows() {
+        let sql = "/* --ELEMENTARY-METADATA-- {\"command\": \"build\"} --END-ELEMENTARY-METADATA-- */\ninsert into `proj`.`ds`.`dbt_run_results` values (1)";
+        assert!(!statement_returns_result_rows(sql, AdapterType::Bigquery));
+    }
+
+    #[test]
+    fn bigquery_dml_and_ddl_do_not_return_result_rows() {
+        for sql in [
+            "UPDATE t SET x = 1 WHERE true",
+            "DELETE FROM t WHERE true",
+            "MERGE t USING s ON t.id = s.id WHEN MATCHED THEN UPDATE SET x = 1",
+            "ALTER TABLE t SET OPTIONS (labels = [('a','b')])",
+            "CREATE TABLE t AS SELECT 1 AS x",
+            "DROP TABLE t",
+            "TRUNCATE TABLE t",
+        ] {
+            assert!(
+                !statement_returns_result_rows(sql, AdapterType::Bigquery),
+                "expected no result rows for {sql}"
+            );
+        }
+    }
+
+    #[test]
+    fn bigquery_select_and_with_return_result_rows() {
+        assert!(statement_returns_result_rows(
+            "SELECT 1",
+            AdapterType::Bigquery,
+        ));
+        assert!(statement_returns_result_rows(
+            "/* comment */\nSELECT table_name FROM `proj`.`ds`.INFORMATION_SCHEMA.TABLES",
+            AdapterType::Bigquery,
+        ));
+        assert!(statement_returns_result_rows(
+            "WITH cte AS (SELECT 1 AS x) SELECT * FROM cte",
+            AdapterType::Bigquery,
+        ));
+        assert!(statement_returns_result_rows(
+            "SHOW SCHEMAS",
+            AdapterType::Bigquery,
+        ));
+    }
+
+    #[test]
+    fn statement_returns_result_rows_defaults_true_for_other_adapters() {
+        assert!(statement_returns_result_rows(
+            "INSERT INTO t VALUES (1)",
+            AdapterType::Snowflake,
+        ));
+    }
+
+    #[test]
+    fn bigquery_statement_type_returns_rows_matches_job_statistics() {
+        assert!(bigquery_statement_type_returns_rows("SELECT"));
+        assert!(bigquery_statement_type_returns_rows("CALL"));
+        assert!(bigquery_statement_type_returns_rows("SCRIPT"));
+        assert!(!bigquery_statement_type_returns_rows("INSERT"));
+        assert!(!bigquery_statement_type_returns_rows("MERGE"));
+        assert!(!bigquery_statement_type_returns_rows("ALTER_TABLE"));
+        assert!(!bigquery_statement_type_returns_rows(
+            "CREATE_TABLE_AS_SELECT"
         ));
     }
 }

--- a/crates/dbt-adapter-sql/src/statements.rs
+++ b/crates/dbt-adapter-sql/src/statements.rs
@@ -55,24 +55,20 @@ pub fn statement_returns_result_rows(sql: &str, adapter_type: AdapterType) -> bo
 
 /// BigQuery job `statistics.query.statementType` values that return rows.
 pub fn bigquery_statement_type_returns_rows(statement_type: &str) -> bool {
-    statement_type.eq_ignore_ascii_case("SELECT")
-        || statement_type.eq_ignore_ascii_case("CALL")
-        || statement_type.eq_ignore_ascii_case("SCRIPT")
+    ["SELECT", "CALL", "SCRIPT"]
+        .iter()
+        .any(|token| statement_type.eq_ignore_ascii_case(token))
 }
 
 fn is_bigquery_result_statement_token(token: &str) -> bool {
     // Conservative: only skip fetch when the first keyword cannot be a result
     // set. WITH starts CTEs that may SELECT; FROM/TABLE are GoogleSQL query
     // forms (pipe syntax and TABLE <table>); CALL/SCRIPT can return rows.
-    token.eq_ignore_ascii_case("SELECT")
-        || token.eq_ignore_ascii_case("WITH")
-        || token.eq_ignore_ascii_case("FROM")
-        || token.eq_ignore_ascii_case("TABLE")
-        || token.eq_ignore_ascii_case("SHOW")
-        || token.eq_ignore_ascii_case("DESCRIBE")
-        || token.eq_ignore_ascii_case("DESC")
-        || token.eq_ignore_ascii_case("EXPLAIN")
-        || token.eq_ignore_ascii_case("CALL")
+    [
+        "SELECT", "WITH", "FROM", "TABLE", "SHOW", "DESCRIBE", "DESC", "EXPLAIN", "CALL",
+    ]
+    .iter()
+    .any(|keyword| token.eq_ignore_ascii_case(keyword))
 }
 
 fn trim_leading_sql_comments(mut sql: &str) -> &str {

--- a/crates/dbt-adapter-sql/src/statements.rs
+++ b/crates/dbt-adapter-sql/src/statements.rs
@@ -36,8 +36,8 @@ pub fn is_update_statement(sql: &str, adapter_type: AdapterType) -> bool {
 ///
 /// BigQuery's ADBC driver Storage-Reads the destination table for DML when
 /// `fetch=true` (e.g. `dbt.run_query` on `INSERT`). Callers must not drain
-/// those readers. Leading comments are stripped so Elementary's
-/// `/* --ELEMENTARY-METADATA-- */` prefix does not hide `INSERT`.
+/// those readers. Leading comments are stripped so a comment prefix cannot
+/// hide the statement keyword.
 pub fn statement_returns_result_rows(sql: &str, adapter_type: AdapterType) -> bool {
     match adapter_type {
         AdapterType::Bigquery => {
@@ -162,14 +162,14 @@ mod tests {
     #[test]
     fn bigquery_insert_does_not_return_result_rows() {
         assert!(!statement_returns_result_rows(
-            "INSERT INTO `proj`.`ds`.`dbt_run_results` (id) VALUES (1)",
+            "INSERT INTO `proj`.`ds`.`target` (id) VALUES (1)",
             AdapterType::Bigquery,
         ));
     }
 
     #[test]
-    fn bigquery_insert_with_elementary_leading_comment_does_not_return_result_rows() {
-        let sql = "/* --ELEMENTARY-METADATA-- {\"command\": \"build\"} --END-ELEMENTARY-METADATA-- */\ninsert into `proj`.`ds`.`dbt_run_results` values (1)";
+    fn bigquery_insert_with_leading_comment_does_not_return_result_rows() {
+        let sql = "/* metadata */\ninsert into `proj`.`ds`.`target` values (1)";
         assert!(!statement_returns_result_rows(sql, AdapterType::Bigquery));
     }
 

--- a/crates/dbt-adapter-sql/src/statements.rs
+++ b/crates/dbt-adapter-sql/src/statements.rs
@@ -62,9 +62,12 @@ pub fn bigquery_statement_type_returns_rows(statement_type: &str) -> bool {
 
 fn is_bigquery_result_statement_token(token: &str) -> bool {
     // Conservative: only skip fetch when the first keyword cannot be a result
-    // set. WITH starts CTEs that may SELECT; CALL/SCRIPT can return rows.
+    // set. WITH starts CTEs that may SELECT; FROM/TABLE are GoogleSQL query
+    // forms (pipe syntax and TABLE <table>); CALL/SCRIPT can return rows.
     token.eq_ignore_ascii_case("SELECT")
         || token.eq_ignore_ascii_case("WITH")
+        || token.eq_ignore_ascii_case("FROM")
+        || token.eq_ignore_ascii_case("TABLE")
         || token.eq_ignore_ascii_case("SHOW")
         || token.eq_ignore_ascii_case("DESCRIBE")
         || token.eq_ignore_ascii_case("DESC")
@@ -207,6 +210,14 @@ mod tests {
         ));
         assert!(statement_returns_result_rows(
             "SHOW SCHEMAS",
+            AdapterType::Bigquery,
+        ));
+        assert!(statement_returns_result_rows(
+            "TABLE `proj`.`ds`.`target`",
+            AdapterType::Bigquery,
+        ));
+        assert!(statement_returns_result_rows(
+            "FROM `proj`.`ds`.`target` |> SELECT id",
             AdapterType::Bigquery,
         ));
     }

--- a/crates/dbt-adapter/src/adapter/mod.rs
+++ b/crates/dbt-adapter/src/adapter/mod.rs
@@ -3879,13 +3879,12 @@ impl Adapter {
                 };
                 // TODO(harry): add iter.finish() and fix the tests
 
-                // NOTE(serramatutu): this is a hacky fix for: https://github.com/dbt-labs/dbt-fusion/issues/1332
-                // It is possible this still fails for other things that return large result sets
-                // unnecessarily. Without users explicitly running with `fetch=False`, we'd need full SQL
-                // parsing to determine whether to fetch or not.
-                if self.adapter_type() == AdapterType::Bigquery
-                    && sql.trim().to_lowercase().starts_with("alter table")
-                {
+                // dbt.run_query always passes fetch=true. BigQuery DML/DDL
+                // readers Storage-Read the destination table (dbt-fusion#1332).
+                if !dbt_adapter_sql::statements::statement_returns_result_rows(
+                    sql,
+                    self.adapter_type(),
+                ) {
                     fetch = false;
                 }
 

--- a/crates/dbt-adapter/src/engine/adapter_engine.rs
+++ b/crates/dbt-adapter/src/engine/adapter_engine.rs
@@ -5,8 +5,11 @@ use std::sync::Arc;
 use adbc_core::options::{OptionStatement, OptionValue};
 use arrow_array::RecordBatch;
 use arrow_schema::Schema;
-use dbt_adapter_sql::statements::is_update_statement;
+use dbt_adapter_sql::statements::{
+    bigquery_statement_type_returns_rows, is_update_statement, statement_returns_result_rows,
+};
 use dbt_adbc::bigquery::QUERY_LABELS;
+use dbt_adbc::bigquery::schema_metadata as bq_schema_metadata;
 use dbt_adbc::{Backend, Connection, QueryCtx, Statement};
 use dbt_auth::AdapterConfig;
 use dbt_common::behavior_flags::Behavior;
@@ -239,6 +242,34 @@ fn log_step_duration(label: &str, elapsed: std::time::Duration) {
     tracing::debug!("{label} took {elapsed:?}");
 }
 
+/// Skip draining the Arrow reader. BigQuery DML/DDL readers can Storage-Read
+/// the destination table (`dbt.run_query` on `INSERT` into a large
+/// `dbt_run_results` table OOMs). Snowflake DML still needs the metadata row.
+pub(crate) fn skip_result_batch_consume(
+    adapter_type: AdapterType,
+    sql: &str,
+    schema: &Schema,
+    fetch: bool,
+) -> bool {
+    if schema.has_dml_columns(adapter_type) {
+        return false;
+    }
+    if !fetch {
+        return true;
+    }
+    match adapter_type {
+        AdapterType::Bigquery => {
+            if let Some(statement_type) = schema.metadata().get(bq_schema_metadata::STATEMENT_TYPE)
+            {
+                !bigquery_statement_type_returns_rows(statement_type)
+            } else {
+                !statement_returns_result_rows(sql, adapter_type)
+            }
+        }
+        _ => false,
+    }
+}
+
 /// Default ADBC-based execute_with_options implementation.
 ///
 /// Used by engines whose connections implement the full ADBC protocol
@@ -459,7 +490,9 @@ pub(crate) fn adbc_execute_with_options(
         // Snowflake DML (MERGE/INSERT/UPDATE/DELETE) returns a one-row metadata batch
         // with columns like "number of rows inserted". AdapterResponse needs that batch
         // to compute rows_affected correctly, so we must drain even when fetch=false.
-        if !fetch && !schema.has_dml_columns(engine.adapter_type()) {
+        // BigQuery DML/DDL readers can Storage-Read the destination table; skip that
+        // drain even when fetch=true (dbt.run_query / Elementary INSERT).
+        if skip_result_batch_consume(engine.adapter_type(), sql.as_ref(), &schema, fetch) {
             drop(reader);
             let schema = attach_alt_warnings(&stmt, schema);
             return Ok((schema, batches, None));
@@ -738,5 +771,71 @@ mod tests {
             uppercase_constraint_batch(),
         );
         assert_eq!(batch.schema().field(0).name(), "COLUMN_NAME");
+    }
+
+    fn schema_with_bq_statement_type(statement_type: &str) -> Schema {
+        Schema::new_with_metadata(
+            vec![Field::new("compiled_code", DataType::Utf8, true)],
+            std::collections::HashMap::from([(
+                bq_schema_metadata::STATEMENT_TYPE.to_string(),
+                statement_type.to_string(),
+            )]),
+        )
+    }
+
+    #[test]
+    fn skip_result_batch_consume_skips_bigquery_insert_even_when_fetch_true() {
+        let schema = Schema::empty();
+        let sql = "/* --ELEMENTARY-METADATA-- {} --END-ELEMENTARY-METADATA-- */\nINSERT INTO t VALUES (1)";
+        assert!(skip_result_batch_consume(
+            AdapterType::Bigquery,
+            sql,
+            &schema,
+            true,
+        ));
+    }
+
+    #[test]
+    fn skip_result_batch_consume_uses_bigquery_statement_type_metadata() {
+        let insert_schema = schema_with_bq_statement_type("INSERT");
+        assert!(skip_result_batch_consume(
+            AdapterType::Bigquery,
+            "SELECT 1",
+            &insert_schema,
+            true,
+        ));
+        let select_schema = schema_with_bq_statement_type("SELECT");
+        assert!(!skip_result_batch_consume(
+            AdapterType::Bigquery,
+            "INSERT INTO t VALUES (1)",
+            &select_schema,
+            true,
+        ));
+    }
+
+    #[test]
+    fn skip_result_batch_consume_still_fetches_bigquery_select() {
+        let schema = Schema::empty();
+        assert!(!skip_result_batch_consume(
+            AdapterType::Bigquery,
+            "SELECT 1",
+            &schema,
+            true,
+        ));
+    }
+
+    #[test]
+    fn skip_result_batch_consume_does_not_skip_snowflake_dml_metadata() {
+        let schema = Schema::new(vec![Field::new(
+            "number of rows inserted",
+            DataType::Int64,
+            false,
+        )]);
+        assert!(!skip_result_batch_consume(
+            AdapterType::Snowflake,
+            "INSERT INTO t VALUES (1)",
+            &schema,
+            false,
+        ));
     }
 }

--- a/crates/dbt-adapter/src/engine/adapter_engine.rs
+++ b/crates/dbt-adapter/src/engine/adapter_engine.rs
@@ -243,8 +243,8 @@ fn log_step_duration(label: &str, elapsed: std::time::Duration) {
 }
 
 /// Skip draining the Arrow reader. BigQuery DML/DDL readers can Storage-Read
-/// the destination table (`dbt.run_query` on `INSERT` into a large
-/// `dbt_run_results` table OOMs). Snowflake DML still needs the metadata row.
+/// the destination table (`dbt.run_query` on `INSERT` into a large table).
+/// Snowflake DML still needs the metadata row.
 pub(crate) fn skip_result_batch_consume(
     adapter_type: AdapterType,
     sql: &str,
@@ -491,7 +491,7 @@ pub(crate) fn adbc_execute_with_options(
         // with columns like "number of rows inserted". AdapterResponse needs that batch
         // to compute rows_affected correctly, so we must drain even when fetch=false.
         // BigQuery DML/DDL readers can Storage-Read the destination table; skip that
-        // drain even when fetch=true (dbt.run_query / Elementary INSERT).
+        // drain even when fetch=true (e.g. `dbt.run_query` on `INSERT`).
         if skip_result_batch_consume(engine.adapter_type(), sql.as_ref(), &schema, fetch) {
             drop(reader);
             let schema = attach_alt_warnings(&stmt, schema);
@@ -786,7 +786,7 @@ mod tests {
     #[test]
     fn skip_result_batch_consume_skips_bigquery_insert_even_when_fetch_true() {
         let schema = Schema::empty();
-        let sql = "/* --ELEMENTARY-METADATA-- {} --END-ELEMENTARY-METADATA-- */\nINSERT INTO t VALUES (1)";
+        let sql = "/* metadata */\nINSERT INTO t VALUES (1)";
         assert!(skip_result_batch_consume(
             AdapterType::Bigquery,
             sql,


### PR DESCRIPTION
Resolves #16064

### Problem

`dbt.run_query()` always fetches. On BigQuery, Fusion then drains the ADBC Arrow reader. For `INSERT`/`UPDATE`/`DELETE`/`MERGE`/DDL the job destination is the **mutated table**, so Storage Read + concat can OOM (SIGKILL / exit 137) after the DML job itself succeeded.

`adapter.execute` only special-cased SQL that starts with `alter table` (#14280). A leading comment, or any other DML keyword, missed that guard.

### Solution

- Classify SQL in `dbt-adapter-sql` (`statement_returns_result_rows`), stripping leading comments so the first keyword is visible.
- After `reader.schema()`, do not drain BigQuery DML/DDL readers even when `fetch=true`.
- Force `fetch=false` in `adapter.execute` for those statements (replaces the `ALTER TABLE` prefix hack).
- Prefer BigQuery job `STATEMENT_TYPE` metadata when present.

This stops Fusion concatenating the destination table. It does **not** stop the ADBC driver from opening Storage Read during `Execute()`; that is a separate driver change.

### Checklist

- [x] I have read the contributing guide and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.

### Test plan

- [x] `cargo test -p dbt-adapter-sql --lib statements`
- [x] `cargo test -p dbt-adapter --lib engine::adapter_engine`