### PR TITLE
fix(snowflake): resolve catalog-linked relation casing

### DIFF
--- a/.changes/unreleased/Fixes-20260902-102525.yaml
+++ b/.changes/unreleased/Fixes-20260902-102525.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: 'Snowflake: resolve catalog-linked relations using catalog-stored database, schema, and identifier casing.'
+time: 2026-09-02T10:25:25.363866158-07:00
+custom:
+    author: dataders
+    issue: ""
+    project: dbt-core

--- a/crates/dbt-adapter/src/adapter/mod.rs
+++ b/crates/dbt-adapter/src/adapter/mod.rs
@@ -1,4 +1,4 @@
-use crate::cache::RelationCache;
+use crate::cache::{RelationCache, RelationCacheResolution};
 use crate::cast_util::downcast_value_to_dyn_base_relation;
 use crate::catalog_relation::CatalogRelation;
 use crate::engine::{AdbcEngine, Options};
@@ -25,7 +25,8 @@ use dbt_agate::AgateTable;
 use dbt_auth::{AdapterConfig, Auth, auth_for_backend};
 use dbt_common::behavior_flags::Behavior;
 use dbt_common::cancellation::{CancellationToken, never_cancels};
-use dbt_common::{AdapterError, AdapterErrorKind, FsResult};
+use dbt_common::tracing::dbt_emit::emit_warn_log_message;
+use dbt_common::{AdapterError, AdapterErrorKind, ErrorCode, FsResult};
 use dbt_schemas::schemas::InternalDbtNodeWrapper;
 use dbt_schemas::schemas::common::{ClusterConfig, DbtQuoting, PartitionConfig};
 use dbt_schemas::schemas::dbt_catalogs::DbtCatalogs;
@@ -1413,27 +1414,31 @@ impl Adapter {
         schema: &str,
         identifier: &str,
         needs_information: bool,
+        requested_relation: Option<Arc<dyn BaseRelation>>,
     ) -> Result<Value, minijinja::Error> {
         match &self.inner {
             Typed { adapter, .. } => {
                 // Skip cache in replay mode
                 let is_replay = adapter.as_replay().is_some();
 
-                let temp_relation = crate::relation::do_create_relation(
-                    adapter.adapter_type(),
-                    database.to_string(),
-                    schema.to_string(),
-                    Some(identifier.to_string()),
-                    None,
-                    adapter.quoting(),
-                )?;
+                let temp_relation = match requested_relation {
+                    Some(relation) => relation,
+                    None => Arc::from(crate::relation::do_create_relation(
+                        adapter.adapter_type(),
+                        database.to_string(),
+                        schema.to_string(),
+                        Some(identifier.to_string()),
+                        None,
+                        adapter.quoting(),
+                    )?),
+                };
 
                 let maybe_cache_result = if is_replay {
                     None
                 } else {
                     // Cache hit
                     if let Some(cache_result) =
-                        self.get_relation_value_from_cache(temp_relation.as_ref())
+                        self.get_relation_value_from_cache(temp_relation.as_ref())?
                     {
                         Some(cache_result)
                     } else {
@@ -1494,8 +1499,8 @@ impl Adapter {
                                     ),
                                 }
 
-                                self.get_relation_value_from_cache(temp_relation.as_ref())
-                                    .or(Some(none_value()))
+                                self.get_relation_value_from_cache(temp_relation.as_ref())?
+                                    .or(Some((none_value(), None)))
                             } else {
                                 None
                             }
@@ -1508,12 +1513,8 @@ impl Adapter {
                 // Return early when cache is sufficient:
                 // - Relation doesn't exist (contains_full_schema): return none_value
                 // - Cache hit with relation: return cached value unless needs_information && !has_information
-                if let Some(cache_result) = maybe_cache_result {
-                    if let Some(cached_entry) = adapter
-                        .engine()
-                        .relation_cache()
-                        .get_relation(temp_relation.as_ref())
-                    {
+                if let Some((cache_result, cached_entry)) = maybe_cache_result {
+                    if let Some(cached_entry) = cached_entry {
                         let can_use_cache =
                             !needs_information || cached_entry.relation().has_information();
                         if can_use_cache {
@@ -3900,9 +3901,20 @@ impl Adapter {
                 let needs_information = iter
                     .next_kwarg::<Option<bool>>("needs_information")?
                     .unwrap_or(false);
+                let requested_relation = iter
+                    .next_kwarg::<Option<&Value>>("relation")?
+                    .map(downcast_value_to_dyn_base_relation)
+                    .transpose()?;
                 iter.finish()?;
 
-                self.get_relation(state, database, schema, identifier, needs_information)
+                self.get_relation(
+                    state,
+                    database,
+                    schema,
+                    identifier,
+                    needs_information,
+                    requested_relation,
+                )
             }
             "get_columns_in_relation" => {
                 let iter = ArgsIter::new(name, &["relation"], args);
@@ -4581,17 +4593,83 @@ impl Object for Adapter {
 }
 
 impl Adapter {
-    fn get_relation_value_from_cache(&self, temp_relation: &dyn BaseRelation) -> Option<Value> {
-        let relation_cache = self.engine().relation_cache();
-        if let Some(cached_entry) = relation_cache.get_relation(temp_relation) {
-            Some(RelationObject::new(cached_entry.relation()).into_value())
+    pub fn physicalize_relation_value(&self, relation: &Value) -> Result<Value, minijinja::Error> {
+        let Some(relation_object) = relation.downcast_object_ref::<RelationObject>() else {
+            return Ok(relation.clone());
+        };
+        let requested = relation_object.inner();
+        match self.resolve_cached_relation(requested.as_ref())? {
+            Some(entry) => Ok(relation_object.with_relation(entry.relation()).into_value()),
+            None => Ok(relation.clone()),
         }
-        // If we have captured the entire schema previously, we can check for non-existence
-        // In these cases, return early with a None value
-        else if relation_cache.contains_full_schema_for_relation(temp_relation) {
-            Some(none_value())
+    }
+
+    fn resolve_cached_relation(
+        &self,
+        requested: &dyn BaseRelation,
+    ) -> Result<Option<crate::cache::RelationCacheEntry>, minijinja::Error> {
+        let allow_approximate = CatalogRelation::uses_catalog_stored_relation_casing(
+            self.adapter_type(),
+            requested.database().unwrap_or_default(),
+        )?;
+        match self
+            .engine()
+            .relation_cache()
+            .resolve_relation(requested, allow_approximate)
+        {
+            RelationCacheResolution::Exact(entry) => Ok(Some(entry)),
+            RelationCacheResolution::Approximate(entry) => {
+                let relation = entry.relation();
+                if self
+                    .engine()
+                    .relation_cache()
+                    .mark_approximate_resolution_warned(relation.as_ref())
+                {
+                    emit_warn_log_message(
+                        ErrorCode::Generic,
+                        format!(
+                            "dbt resolved '{}' to {}, which is stored under a different case in the catalog-linked database. dbt will manage that object. If it is not meant to be managed by dbt, rename one of them or set an explicit `alias` on the model.",
+                            requested.identifier().unwrap_or_default(),
+                            relation.render_self_as_str(),
+                        ),
+                    );
+                }
+                Ok(Some(entry))
+            }
+            RelationCacheResolution::Missing => Ok(None),
+            RelationCacheResolution::Ambiguous(entries) => {
+                let mut candidates = entries
+                    .iter()
+                    .map(|entry| entry.relation().render_self_as_str())
+                    .collect::<Vec<_>>();
+                candidates.sort();
+                Err(minijinja::Error::new(
+                    minijinja::ErrorKind::InvalidOperation,
+                    format!(
+                        "Cannot resolve '{}' in catalog-linked database '{}': the catalog holds more than one relation whose database, schema, and identifier differ only by case: {}. dbt cannot tell which one you mean, and choosing either could read or overwrite the wrong object. Rename or remove one of them, or set an explicit `alias` and enable `quoting` for the identifier.",
+                        requested.identifier().unwrap_or_default(),
+                        requested.database().unwrap_or_default(),
+                        candidates.join(", ")
+                    ),
+                ))
+            }
+        }
+    }
+
+    fn get_relation_value_from_cache(
+        &self,
+        temp_relation: &dyn BaseRelation,
+    ) -> Result<Option<(Value, Option<crate::cache::RelationCacheEntry>)>, minijinja::Error> {
+        let relation_cache = self.engine().relation_cache();
+        if let Some(entry) = self.resolve_cached_relation(temp_relation)? {
+            Ok(Some((
+                RelationObject::new(entry.relation()).into_value(),
+                Some(entry),
+            )))
+        } else if relation_cache.contains_full_schema_for_relation(temp_relation) {
+            Ok(Some((none_value(), None)))
         } else {
-            None
+            Ok(None)
         }
     }
 

--- a/crates/dbt-adapter/src/cache.rs
+++ b/crates/dbt-adapter/src/cache.rs
@@ -27,6 +27,15 @@ pub struct RelationCacheEntry {
     relation_config: Option<Arc<dyn BaseRelationConfig>>,
 }
 
+#[derive(Debug, Clone)]
+/// Outcome of resolving a requested relation against cached warehouse identity.
+pub enum RelationCacheResolution {
+    Missing,
+    Exact(RelationCacheEntry),
+    Approximate(RelationCacheEntry),
+    Ambiguous(Vec<RelationCacheEntry>),
+}
+
 impl RelationCacheEntry {
     pub fn new(
         relation: Arc<dyn BaseRelation>,
@@ -81,6 +90,10 @@ pub struct RelationCache {
     // The inner key is a unique key generated from a relation's fully qualified name
     // We also differentiate using [SchemaEntry] to see what information we actually know about that schema
     schemas_and_relations: DashMap<String, SchemaEntry>,
+    /// Folded database/schema path -> the small set of cache buckets populated
+    /// for that warehouse schema. This lets catalog-linked resolution cross a
+    /// configured-case bucket without scanning unrelated schemas.
+    folded_schema_buckets: Arc<DashMap<String, BTreeSet<String>>>,
     /// Per-node set of dependents: `parent_to_children[k]` is the set of relations
     /// that would be cascade-dropped if `k` were dropped. Lifted out of
     /// `RelationCacheEntry` so the cache entry stays Clone-via-derive and
@@ -89,6 +102,7 @@ pub struct RelationCache {
     /// Whether the project defines any function (UDF) nodes. Set once, before
     /// the run starts.
     project_has_functions: Arc<AtomicBool>,
+    warned_approximate_resolutions: Arc<DashMap<String, ()>>,
 }
 
 #[derive(Debug, Default)]
@@ -118,6 +132,65 @@ impl RelationCache {
         }
     }
 
+    /// Resolves `relation` against catalog-stored path components.
+    ///
+    /// The ordinary cache key remains authoritative unless `allow_approximate`
+    /// is enabled. In that mode all case-insensitive candidates are collected
+    /// before an exact entry can be selected, so a case collision is never
+    /// hidden by an exact spelling.
+    pub fn resolve_relation(
+        &self,
+        relation: &dyn BaseRelation,
+        allow_approximate: bool,
+    ) -> RelationCacheResolution {
+        if !allow_approximate {
+            return self
+                .get_relation(relation)
+                .map(RelationCacheResolution::Exact)
+                .unwrap_or(RelationCacheResolution::Missing);
+        }
+
+        let mut candidates = HashMap::new();
+        let schema_key = Self::get_schema_cache_key_from_relation(relation);
+        let schema_keys = self
+            .folded_schema_buckets
+            .get(&Self::folded_schema_path_from_relation(relation))
+            .map(|keys| keys.clone())
+            .unwrap_or_else(|| BTreeSet::from([schema_key]));
+        for schema_key in schema_keys {
+            if let Some(schema) = self.schemas_and_relations.get(&schema_key) {
+                for entry in &schema.relations {
+                    let cached = entry.value();
+                    if relation_paths_match(cached.relation.as_ref(), relation) {
+                        candidates
+                            .entry(cached.relation.semantic_fqn())
+                            .or_insert_with(|| cached.clone());
+                    }
+                }
+            }
+        }
+
+        if candidates.len() > 1 {
+            return RelationCacheResolution::Ambiguous(candidates.into_values().collect());
+        }
+
+        let Some(candidate) = candidates.into_values().next() else {
+            return RelationCacheResolution::Missing;
+        };
+        if candidate.relation.semantic_fqn() == relation.semantic_fqn() {
+            RelationCacheResolution::Exact(candidate)
+        } else {
+            RelationCacheResolution::Approximate(candidate)
+        }
+    }
+
+    /// Returns true once per cached relation until the cache is cleared.
+    pub fn mark_approximate_resolution_warned(&self, relation: &dyn BaseRelation) -> bool {
+        self.warned_approximate_resolutions
+            .insert(relation.semantic_fqn(), ())
+            .is_none()
+    }
+
     /// Inserts a relation of [Arc<dyn BaseRelation] along with an optional <Arc<dyn BaseRelationConfig>> if applicable
     pub fn insert_relation(
         &self,
@@ -125,6 +198,7 @@ impl RelationCache {
         relation_config: Option<Arc<dyn BaseRelationConfig>>,
     ) -> Option<RelationCacheEntry> {
         let (schema_key, relation_key) = Self::get_relation_cache_keys(relation.as_ref());
+        self.index_schema_bucket(relation.as_ref(), &schema_key);
         let entry = RelationCacheEntry::new(relation, relation_config);
         self.schemas_and_relations
             .entry(schema_key)
@@ -157,6 +231,14 @@ impl RelationCache {
     /// Inserts a schema and its relations into the cache
     pub fn insert_schema(&self, schema: CatalogAndSchema, relations: RelationVec) {
         let schema_key = schema.to_string();
+        self.index_schema_path(
+            &schema.resolved_catalog,
+            &schema.resolved_schema,
+            &schema_key,
+        );
+        for relation in &relations {
+            self.index_schema_bucket(relation.as_ref(), &schema_key);
+        }
         let cached_relations: DashMap<_, _> = relations
             .iter()
             .map(|r| {
@@ -198,6 +280,7 @@ impl RelationCache {
     pub fn evict_schema_for_relation(&self, relation: &dyn BaseRelation) {
         let schema_key = Self::get_schema_cache_key_from_relation(relation);
         self.schemas_and_relations.remove(&schema_key);
+        self.remove_schema_bucket_index(&schema_key);
     }
 
     /// Checks if the entire schema was cached
@@ -250,6 +333,7 @@ impl RelationCache {
 
         let original_entry = self.evict(&old_schema_key, &old_relation_key)?;
         let new_entry = RelationCacheEntry::new(new, original_entry.relation_config.clone());
+        self.index_schema_bucket(new_entry.relation.as_ref(), &new_dep_key.0);
 
         // Move the renamed node's incoming-edge set to its new key.
         if let Some(refs) = graph.parent_to_children.remove(&old_dep_key) {
@@ -347,6 +431,8 @@ impl RelationCache {
     /// Removes all entries from the cache
     pub fn clear(&self) {
         self.schemas_and_relations.clear();
+        self.folded_schema_buckets.clear();
+        self.warned_approximate_resolutions.clear();
     }
 
     /// Number of total relations cached
@@ -383,6 +469,36 @@ impl RelationCache {
         CatalogAndSchema::from(relation).to_string()
     }
 
+    fn folded_schema_path_from_relation(relation: &dyn BaseRelation) -> String {
+        let database = relation.database_as_resolved_str().unwrap_or_default();
+        let schema = relation.schema_as_resolved_str().unwrap_or_default();
+        Self::folded_schema_path(&database, &schema)
+    }
+
+    fn folded_schema_path(database: &str, schema: &str) -> String {
+        format!("{}\0{}", database.to_lowercase(), schema.to_lowercase())
+    }
+
+    fn index_schema_bucket(&self, relation: &dyn BaseRelation, schema_key: &str) {
+        let database = relation.database_as_resolved_str().unwrap_or_default();
+        let schema = relation.schema_as_resolved_str().unwrap_or_default();
+        self.index_schema_path(&database, &schema, schema_key);
+    }
+
+    fn index_schema_path(&self, database: &str, schema: &str, schema_key: &str) {
+        self.folded_schema_buckets
+            .entry(Self::folded_schema_path(database, schema))
+            .or_default()
+            .insert(schema_key.to_string());
+    }
+
+    fn remove_schema_bucket_index(&self, schema_key: &str) {
+        self.folded_schema_buckets.retain(|_, schema_keys| {
+            schema_keys.remove(schema_key);
+            !schema_keys.is_empty()
+        });
+    }
+
     /// Helper: Generates a normalized relation key by substituting the relation's own schema
     /// prefix with the provided `schema_key`.
     ///
@@ -404,6 +520,28 @@ impl RelationCache {
             relation_fqn
         }
     }
+}
+
+fn relation_paths_match(candidate: &dyn BaseRelation, requested: &dyn BaseRelation) -> bool {
+    fn component_matches(candidate: Option<&str>, requested: Option<&str>, quoted: bool) -> bool {
+        match (candidate, requested) {
+            (_, None) => true,
+            (Some(candidate), Some(requested)) if quoted => candidate == requested,
+            (Some(candidate), Some(requested)) => {
+                candidate.to_lowercase() == requested.to_lowercase()
+            }
+            (None, Some(_)) => false,
+        }
+    }
+
+    let quoting = requested.quote_policy();
+    component_matches(candidate.database(), requested.database(), quoting.database)
+        && component_matches(candidate.schema(), requested.schema(), quoting.schema)
+        && component_matches(
+            candidate.identifier(),
+            requested.identifier(),
+            quoting.identifier,
+        )
 }
 
 /// Hydrates the relation cache of the given [Adapter]
@@ -640,6 +778,173 @@ mod tests {
 
         let found_unquoted_entry = cache.get_relation(search_relation_unquoted.as_ref());
         assert!(found_unquoted_entry.is_some());
+    }
+
+    fn snowflake_relation(
+        database: &str,
+        schema: &str,
+        identifier: &str,
+        quoting: ResolvedQuoting,
+    ) -> Arc<dyn BaseRelation> {
+        crate::relation::do_create_relation(
+            AdapterType::Snowflake,
+            database.to_string(),
+            schema.to_string(),
+            Some(identifier.to_string()),
+            None,
+            quoting,
+        )
+        .map(Arc::from)
+        .unwrap()
+    }
+
+    #[test]
+    fn catalog_stored_resolution_adopts_identifier_and_schema_case() {
+        let cache = RelationCache::default();
+        let requested =
+            snowflake_relation("CLD", "SCHEMA_A", "T_ORDERS", ResolvedQuoting::falses());
+        let stored = snowflake_relation("CLD", "schema_a", "t_orders", ResolvedQuoting::trues());
+        cache.insert_schema(CatalogAndSchema::from(requested.as_ref()), vec![stored]);
+
+        let RelationCacheResolution::Approximate(entry) =
+            cache.resolve_relation(requested.as_ref(), true)
+        else {
+            panic!("expected an approximate stored-case match");
+        };
+        assert_eq!(entry.relation().schema(), Some("schema_a"));
+        assert_eq!(entry.relation().identifier(), Some("t_orders"));
+
+        assert!(matches!(
+            cache.resolve_relation(entry.relation().as_ref(), true),
+            RelationCacheResolution::Exact(_)
+        ));
+    }
+
+    #[test]
+    fn same_spelling_with_different_identifier_semantics_is_approximate() {
+        let cache = RelationCache::default();
+        let requested = snowflake_relation(
+            "CLD",
+            "SCHEMA_A",
+            "t_orders",
+            ResolvedQuoting {
+                database: true,
+                schema: true,
+                identifier: false,
+            },
+        );
+        let stored = snowflake_relation("CLD", "SCHEMA_A", "t_orders", ResolvedQuoting::trues());
+        cache.insert_schema(CatalogAndSchema::from(requested.as_ref()), vec![stored]);
+
+        assert!(matches!(
+            cache.resolve_relation(requested.as_ref(), true),
+            RelationCacheResolution::Approximate(_)
+        ));
+    }
+
+    #[test]
+    fn folded_schema_index_tracks_rename_and_schema_eviction() {
+        let cache = RelationCache::default();
+        let old = snowflake_relation("CLD", "SCHEMA_A", "T_ORDERS", ResolvedQuoting::falses());
+        let new = snowflake_relation("CLD", "schema_b", "t_orders", ResolvedQuoting::trues());
+        cache.insert_relation(old.clone(), None);
+
+        cache
+            .rename_relation(old.as_ref(), new.clone())
+            .expect("old relation should be cached");
+        assert!(matches!(
+            cache.resolve_relation(new.as_ref(), true),
+            RelationCacheResolution::Exact(_)
+        ));
+
+        cache.evict_schema_for_relation(new.as_ref());
+        assert!(matches!(
+            cache.resolve_relation(new.as_ref(), true),
+            RelationCacheResolution::Missing
+        ));
+        assert!(
+            cache
+                .folded_schema_buckets
+                .get(&RelationCache::folded_schema_path_from_relation(
+                    new.as_ref()
+                ))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn catalog_stored_resolution_rejects_case_variants_before_exact_match() {
+        let cache = RelationCache::default();
+        let requested =
+            snowflake_relation("CLD", "SCHEMA_A", "T_ORDERS", ResolvedQuoting::falses());
+        let exact = snowflake_relation("CLD", "SCHEMA_A", "T_ORDERS", ResolvedQuoting::trues());
+        let variant = snowflake_relation("CLD", "SCHEMA_A", "t_orders", ResolvedQuoting::trues());
+        cache.insert_schema(
+            CatalogAndSchema::from(requested.as_ref()),
+            vec![exact, variant],
+        );
+
+        let RelationCacheResolution::Ambiguous(entries) =
+            cache.resolve_relation(requested.as_ref(), true)
+        else {
+            panic!("case variants must be rejected before selecting the exact spelling");
+        };
+        assert_eq!(entries.len(), 2);
+    }
+
+    #[test]
+    fn explicit_identifier_quoting_selects_only_the_exact_identity() {
+        let cache = RelationCache::default();
+        let requested = snowflake_relation(
+            "CLD",
+            "SCHEMA_A",
+            "T_ORDERS",
+            ResolvedQuoting {
+                database: false,
+                schema: false,
+                identifier: true,
+            },
+        );
+        let exact = snowflake_relation("CLD", "SCHEMA_A", "T_ORDERS", ResolvedQuoting::trues());
+        let variant = snowflake_relation("CLD", "SCHEMA_A", "t_orders", ResolvedQuoting::trues());
+        cache.insert_schema(
+            CatalogAndSchema::from(requested.as_ref()),
+            vec![exact, variant],
+        );
+
+        assert!(matches!(
+            cache.resolve_relation(requested.as_ref(), true),
+            RelationCacheResolution::Exact(_)
+        ));
+    }
+
+    #[test]
+    fn quoted_identity_does_not_strip_literal_quote_characters() {
+        let cache = RelationCache::default();
+        let requested =
+            snowflake_relation("CLD", "SCHEMA_A", "\"t_orders\"", ResolvedQuoting::trues());
+        let stored = snowflake_relation("CLD", "SCHEMA_A", "t_orders", ResolvedQuoting::trues());
+        cache.insert_schema(CatalogAndSchema::from(requested.as_ref()), vec![stored]);
+
+        assert!(matches!(
+            cache.resolve_relation(requested.as_ref(), true),
+            RelationCacheResolution::Missing
+        ));
+    }
+
+    #[test]
+    fn approximate_matching_is_disabled_for_regular_databases() {
+        let cache = RelationCache::default();
+        let requested =
+            snowflake_relation("REGULAR", "SCHEMA_A", "T_ORDERS", ResolvedQuoting::falses());
+        let stored =
+            snowflake_relation("REGULAR", "SCHEMA_A", "t_orders", ResolvedQuoting::trues());
+        cache.insert_schema(CatalogAndSchema::from(requested.as_ref()), vec![stored]);
+
+        assert!(matches!(
+            cache.resolve_relation(requested.as_ref(), false),
+            RelationCacheResolution::Missing
+        ));
     }
 
     #[test]

--- a/crates/dbt-adapter/src/catalog_relation.rs
+++ b/crates/dbt-adapter/src/catalog_relation.rs
@@ -154,6 +154,53 @@ impl PhysicalFormatResolver for CatalogRelation {
 }
 
 impl CatalogRelation {
+    /// Whether relations in `database` must adopt identity stored by an external catalog.
+    pub fn uses_catalog_stored_relation_casing(
+        adapter_type: AdapterType,
+        database: &str,
+    ) -> AdapterResult<bool> {
+        match adapter_type {
+            AdapterType::Snowflake => {
+                let Some(catalogs) = load_catalogs::fetch_catalogs() else {
+                    return Ok(false);
+                };
+                Self::snowflake_database_uses_catalog_stored_relation_casing(
+                    catalogs.as_ref(),
+                    database,
+                    load_catalogs::fetch_use_catalogs_v2(),
+                )
+            }
+            _ => Ok(false),
+        }
+    }
+
+    fn snowflake_database_uses_catalog_stored_relation_casing(
+        catalogs: &DbtCatalogs,
+        database: &str,
+        use_catalogs_v2: bool,
+    ) -> AdapterResult<bool> {
+        if use_catalogs_v2 {
+            let view = catalogs.view_v2().map_err(|error| {
+                AdapterError::new(AdapterErrorKind::Configuration, error.to_string())
+            })?;
+            Ok(view.catalogs.iter().any(|catalog| {
+                matches!(
+                    catalog.catalog_type,
+                    CatalogType::Glue | CatalogType::IcebergRest | CatalogType::Unity
+                ) && catalog
+                    .config_block("snowflake")
+                    .and_then(|config| config.get(YmlValue::from("catalog_database")))
+                    .and_then(YmlValue::as_str)
+                    .is_some_and(|linked| linked.trim().eq_ignore_ascii_case(database))
+            }))
+        } else {
+            Ok(Self::cld_exists_in_iceberg_rest(
+                catalogs.mapping(),
+                database,
+            ))
+        }
+    }
+
     // Builder pattern setters - prefer these over introducing a new named
     // `default_catalog_relation_<adapter>_<variant>()` constructor
     pub fn with_table_format(mut self, table_format: TableFormat) -> Self {
@@ -3810,5 +3857,79 @@ mod tests {
                 Some("cool_connection")
             );
         }
+    }
+
+    fn catalogs_from_yaml(yaml: &str) -> DbtCatalogs {
+        let parsed: YmlValue = dbt_yaml::from_str(yaml).unwrap();
+        let YmlValue::Mapping(mapping, span) = parsed else {
+            panic!("expected catalogs mapping");
+        };
+        DbtCatalogs::new(mapping, span)
+    }
+
+    #[test]
+    fn legacy_catalog_linked_database_uses_stored_relation_casing() {
+        let catalogs = catalogs_from_yaml(
+            r#"
+catalogs:
+  - name: external
+    active_write_integration: rest
+    write_integrations:
+      - name: rest
+        catalog_type: iceberg_rest
+        table_format: iceberg
+        adapter_properties:
+          catalog_linked_database: mixed_db
+"#,
+        );
+
+        assert!(
+            CatalogRelation::snowflake_database_uses_catalog_stored_relation_casing(
+                &catalogs, "MIXED_DB", false,
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn v2_linked_catalog_types_use_stored_relation_casing_but_horizon_does_not() {
+        let linked = catalogs_from_yaml(
+            r#"
+catalogs:
+  - name: external
+    type: unity
+    table_format: iceberg
+    config:
+      snowflake:
+        catalog_database: mixed_db
+"#,
+        );
+        let managed = catalogs_from_yaml(
+            r#"
+catalogs:
+  - name: managed
+    type: horizon
+    table_format: iceberg
+    config:
+      snowflake:
+        external_volume: volume
+        catalog_database: managed_db
+"#,
+        );
+
+        assert!(
+            CatalogRelation::snowflake_database_uses_catalog_stored_relation_casing(
+                &linked, "MIXED_DB", true,
+            )
+            .unwrap()
+        );
+        assert!(
+            !CatalogRelation::snowflake_database_uses_catalog_stored_relation_casing(
+                &managed,
+                "MANAGED_DB",
+                true,
+            )
+            .unwrap()
+        );
     }
 }

--- a/crates/dbt-adapter/src/load_catalogs.rs
+++ b/crates/dbt-adapter/src/load_catalogs.rs
@@ -22,6 +22,14 @@ pub fn fetch_catalogs() -> Option<Arc<DbtCatalogs>> {
     }
 }
 
+/// Clear project-scoped catalog definitions before loading another project.
+pub fn clear_catalogs() {
+    *match CATALOGS.write() {
+        Ok(g) => g,
+        Err(p) => p.into_inner(),
+    } = None;
+}
+
 pub fn fetch_use_catalogs_v2() -> bool {
     match USE_CATALOGS_V2.read() {
         Ok(g) => *g,

--- a/crates/dbt-adapter/src/relation/relation_impl.rs
+++ b/crates/dbt-adapter/src/relation/relation_impl.rs
@@ -704,6 +704,7 @@ impl BaseRelation for Relation {
         .with_metadata(self.metadata.clone())
         .with_is_delta(self.is_delta)
         .with_temporary(self.temporary)
+        .with_table_format(self.table_format)
         // FIXME: no need to validate here since the parent relation is already valid.
         .validate()?;
 
@@ -711,6 +712,8 @@ impl BaseRelation for Relation {
         relation.create_constraints = self.create_constraints.clone();
         relation.alter_constraints = self.alter_constraints.clone();
         relation.external = self.external.clone();
+        relation.location = self.location.clone();
+        relation.native_schema = self.native_schema.clone();
         relation.is_parse_time = self.is_parse_time;
 
         Ok(Arc::new(relation))
@@ -729,10 +732,14 @@ impl BaseRelation for Relation {
         .with_metadata(self.metadata.clone())
         .with_is_delta(self.is_delta)
         .with_temporary(self.temporary)
+        .with_table_format(self.table_format)
         // FIXME: no need to validate here since the parent relation is already valid.
         .validate()?;
         relation.create_constraints = self.create_constraints.clone();
         relation.alter_constraints = self.alter_constraints.clone();
+        relation.external = self.external.clone();
+        relation.location = self.location.clone();
+        relation.native_schema = self.native_schema.clone();
         relation.is_parse_time = self.is_parse_time;
         Ok(Arc::new(relation))
     }
@@ -1200,6 +1207,7 @@ impl BaseRelation for Relation {
             .with_metadata(self.metadata.clone())
             .with_is_delta(self.is_delta)
             .with_temporary(self.temporary)
+            .with_table_format(self.table_format)
             .validate()?;
         Ok(Arc::new(relation))
     }

--- a/crates/dbt-adapter/src/relation/relation_object.rs
+++ b/crates/dbt-adapter/src/relation/relation_object.rs
@@ -59,6 +59,15 @@ impl RelationObject {
         self.relation.clone()
     }
 
+    /// Replace the base relation while preserving runtime filtering metadata.
+    pub fn with_relation(&self, relation: Arc<dyn BaseRelation>) -> Self {
+        Self {
+            relation,
+            run_filter: self.run_filter.clone(),
+            event_time: self.event_time.clone(),
+        }
+    }
+
     /// Whether this relation is the placeholder returned during parsing.
     pub fn is_parse_time(&self) -> bool {
         self.relation

--- a/crates/dbt-freshness/src/freshness.rs
+++ b/crates/dbt-freshness/src/freshness.rs
@@ -381,6 +381,7 @@ async fn calculate_freshness_common(
     dependencies: BTreeSet<String>,
     error_message: &str,
 ) -> FsResult<FreshnessResult> {
+    let context_adapter = jinja_env.get_adapter();
     let context = build_run_node_ctx(
         node,
         &node.serialized_config(),
@@ -391,7 +392,8 @@ async fn calculate_freshness_common(
         ExecutionPhase::Run,
         None,
         dependencies,
-    );
+        context_adapter.as_deref(),
+    )?;
 
     let expr = jinja_env.compile_expression(macro_expr)?;
     let table = expr

--- a/crates/dbt-jinja-utils/src/phases/compile/compile_node_context.rs
+++ b/crates/dbt-jinja-utils/src/phases/compile/compile_node_context.rs
@@ -2,10 +2,10 @@
 
 use chrono::TimeZone;
 use chrono_tz::{Europe::London, Tz};
-use dbt_adapter::{AdapterType, load_store::ResultStore};
+use dbt_adapter::{Adapter, AdapterType, load_store::ResultStore};
 use dbt_common::io_args::StaticAnalysisKind;
 use dbt_common::serde_utils::convert_yml_to_dash_map;
-use dbt_common::{FsResult, dashmap::DashMap, serde_utils::convert_yml_to_value_map};
+use dbt_common::{FsError, FsResult, dashmap::DashMap, serde_utils::convert_yml_to_value_map};
 use dbt_schemas::schemas::InternalDbtNode;
 use dbt_schemas::{
     schemas::{InternalDbtNodeAttributes, common::DbtMaterialization, telemetry::NodeType},
@@ -23,7 +23,9 @@ use dbt_jinja_ctx::{
     CompileNodeCtx, JinjaObject, MacroLookupContext, to_jinja_btreemap, to_model_context_map,
 };
 
-use crate::phases::compile_and_run_context::{FunctionFunction, SourceFunction};
+use crate::phases::compile_and_run_context::{
+    FunctionFunction, SourceFunction, physicalize_relation_value,
+};
 use dbt_schemas::schemas::project::ConfigKeys;
 
 use super::super::compile_and_run_context::RefFunction;
@@ -178,6 +180,9 @@ where
         BTreeMap::new()
     };
     let mut ctx = base_context.clone();
+    let adapter = base_context
+        .get("adapter")
+        .and_then(|value| value.downcast_object::<Adapter>());
 
     let this_relation = match model.resource_type() {
         NodeType::UnitTest => {
@@ -268,6 +273,8 @@ where
         ))
         .into_value(),
     };
+    let this_relation = physicalize_relation_value(adapter.as_deref(), this_relation)
+        .map_err(|error| FsError::from_jinja_err(error, "Failed to resolve `this` relation"))?;
     let config_map = Arc::new(convert_yml_to_dash_map(model.serialized_config()));
 
     // Get valid config keys based on resource type
@@ -305,7 +312,8 @@ where
         runtime_config.clone(),
         validation_config_with_depends_on.clone(),
         model.common().unique_id.clone(),
-    );
+    )
+    .with_adapter(adapter.clone());
     let ref_value = MinijinjaValue::from_object(ref_function);
     base_builtins.insert("ref".to_string(), ref_value.clone());
 
@@ -324,7 +332,8 @@ where
         node_resolver.clone(),
         model.common().package_name.clone(),
         validation_config_with_depends_on,
-    );
+    )
+    .with_adapter(adapter);
     let source_value = MinijinjaValue::from_object(source_function);
     base_builtins.insert("source".to_string(), source_value.clone());
 

--- a/crates/dbt-jinja-utils/src/phases/compile_and_run_context.rs
+++ b/crates/dbt-jinja-utils/src/phases/compile_and_run_context.rs
@@ -35,6 +35,17 @@ pub fn configure_compile_and_run_jinja_environment(env: &mut JinjaEnv, adapter: 
     env.set_undefined_behavior(UndefinedBehavior::Lenient);
 }
 
+/// Replace a configured relation value with its cached warehouse identity when available.
+pub fn physicalize_relation_value(
+    adapter: Option<&Adapter>,
+    relation: MinijinjaValue,
+) -> Result<MinijinjaValue, MinijinjaError> {
+    match adapter {
+        Some(adapter) => adapter.physicalize_relation_value(&relation),
+        None => Ok(relation),
+    }
+}
+
 /// Build the truly-shared compile/run base ctx — values that are identical
 /// across REPL, `run-operation`, per-node compile, and per-node run renders.
 /// Leaf ctxs ([`OperationCtx`], `CompileNodeCtx`, `RunNodeCtx`) hold this via
@@ -49,6 +60,27 @@ pub fn build_compile_base_ctx(
     defer_nodes: Option<&Nodes>,
     runtime_config: Arc<DbtRuntimeConfig>,
     namespace_keys: Vec<String>,
+) -> CompileBaseCtx {
+    build_compile_base_ctx_with_adapter(
+        node_resolver,
+        package_name,
+        nodes,
+        defer_nodes,
+        runtime_config,
+        namespace_keys,
+        None,
+    )
+}
+
+/// Build the shared compile/run base with cache-backed relation resolution enabled.
+pub fn build_compile_base_ctx_with_adapter(
+    node_resolver: Arc<dyn NodeResolverTracker>,
+    package_name: &str,
+    nodes: &Nodes,
+    defer_nodes: Option<&Nodes>,
+    runtime_config: Arc<DbtRuntimeConfig>,
+    namespace_keys: Vec<String>,
+    adapter: Option<Arc<Adapter>>,
 ) -> CompileBaseCtx {
     // Wrap each per-namespace search order as `Value::from(Vec<String>)` —
     // dispatch lookup downcasts to `Vec<String>` so the underlying Object
@@ -75,13 +107,15 @@ pub fn build_compile_base_ctx(
         node_resolver.clone(),
         package_name.to_owned(),
         runtime_config.clone(),
-    );
+    )
+    .with_adapter(adapter.clone());
     let ref_value = MinijinjaValue::from_object(ref_function);
     builtins.insert("ref".to_string(), ref_value.clone());
 
     // Create source function
     let source_function =
-        SourceFunction::new_unvalidated(node_resolver.clone(), package_name.to_owned());
+        SourceFunction::new_unvalidated(node_resolver.clone(), package_name.to_owned())
+            .with_adapter(adapter);
     let source_value = MinijinjaValue::from_object(source_function);
     builtins.insert("source".to_string(), source_value.clone());
 
@@ -265,6 +299,7 @@ pub struct RefFunction {
     /// The unique_id of the node that owns this ref context.
     /// Used for O(1) defer decisions via `NodeResolver::prefers_deferred`.
     current_node_unique_id: String,
+    adapter: Option<Arc<Adapter>>,
 }
 
 impl RefFunction {
@@ -282,6 +317,7 @@ impl RefFunction {
             validation_config: DependencyValidationConfig::default(),
             microbatch_context: None,
             current_node_unique_id: String::new(),
+            adapter: None,
         }
     }
 
@@ -300,6 +336,7 @@ impl RefFunction {
             validation_config,
             microbatch_context: None,
             current_node_unique_id,
+            adapter: None,
         }
     }
 
@@ -323,6 +360,7 @@ impl RefFunction {
             validation_config,
             microbatch_context: Some(microbatch_context),
             current_node_unique_id,
+            adapter: None,
         }
     }
 
@@ -334,6 +372,11 @@ impl RefFunction {
             microbatch_context: Some(microbatch_context),
             ..self
         }
+    }
+
+    /// Use the adapter's hydrated relation cache when returning a resolved ref.
+    pub fn with_adapter(self, adapter: Option<Arc<Adapter>>) -> Self {
+        Self { adapter, ..self }
     }
 
     fn resolve_args(
@@ -454,6 +497,8 @@ impl Object for RefFunction {
                     (true, Some(deferred)) => deferred,
                     _ => relation,
                 };
+                let resolved_relation =
+                    physicalize_relation_value(self.adapter.as_deref(), resolved_relation)?;
 
                 for listener in listeners {
                     listener.on_ref_or_source_resolved(&unique_id);
@@ -544,6 +589,7 @@ pub struct SourceFunction {
     package_name: String,
     microbatch_context: Option<MicrobatchRefContext>,
     validation_config: DependencyValidationConfig,
+    adapter: Option<Arc<Adapter>>,
 }
 
 impl SourceFunction {
@@ -561,6 +607,7 @@ impl SourceFunction {
             package_name,
             microbatch_context: Some(microbatch_context),
             validation_config: DependencyValidationConfig::default(),
+            adapter: None,
         }
     }
 }
@@ -577,6 +624,7 @@ impl SourceFunction {
             package_name,
             microbatch_context: None,
             validation_config: DependencyValidationConfig::default(),
+            adapter: None,
         }
     }
 
@@ -591,7 +639,13 @@ impl SourceFunction {
             package_name,
             microbatch_context: None,
             validation_config,
+            adapter: None,
         }
+    }
+
+    /// Use the adapter's hydrated relation cache when returning a resolved source.
+    pub fn with_adapter(self, adapter: Option<Arc<Adapter>>) -> Self {
+        Self { adapter, ..self }
     }
 
     /// Validate that the referenced source is in the allowed dependencies.
@@ -683,6 +737,7 @@ impl Object for SourceFunction {
                 }
 
                 self.validate_dependency(&unique_id, &source_name, &table_name)?;
+                let relation = physicalize_relation_value(self.adapter.as_deref(), relation)?;
 
                 // Apply microbatch filtering if we have a microbatch context and
                 // the referenced source has event_time configured

--- a/crates/dbt-jinja-utils/src/phases/mod.rs
+++ b/crates/dbt-jinja-utils/src/phases/mod.rs
@@ -7,6 +7,6 @@ mod utils;
 
 pub use compile_and_run_context::{
     MacroLookupContext, MicrobatchRefContext, RefFunction, SourceFunction, build_compile_base_ctx,
-    build_operation_context, build_operation_context_btreemap,
+    build_compile_base_ctx_with_adapter, build_operation_context, build_operation_context_btreemap,
     configure_compile_and_run_jinja_environment,
 };

--- a/crates/dbt-jinja-utils/src/phases/run/run_node_context.rs
+++ b/crates/dbt-jinja-utils/src/phases/run/run_node_context.rs
@@ -7,11 +7,11 @@ use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::sync::Arc;
 
-use dbt_adapter_core::AdapterType;
+use dbt_adapter::{Adapter, AdapterType};
 use dbt_agate::AgateTable;
-use dbt_common::ErrorCode;
 use dbt_common::io_args::IoArgs;
 use dbt_common::serde_utils::convert_yml_to_value_map;
+use dbt_common::{ErrorCode, FsError, FsResult};
 
 use dbt_adapter::column::ColumnStatic;
 use dbt_adapter::load_store::ResultStore;
@@ -33,6 +33,7 @@ use dbt_jinja_ctx::{
 };
 
 use super::run_config::RunConfig;
+use crate::phases::compile_and_run_context::physicalize_relation_value;
 use dbt_schemas::schemas::project::ConfigKeys;
 
 type YmlValue = dbt_yaml::Value;
@@ -469,11 +470,11 @@ pub fn build_run_node_context<S: Serialize>(
     phase: ExecutionPhase,
     sql_header: Option<MinijinjaValue>,
     packages: BTreeSet<String>,
-) -> (BTreeMap<String, MinijinjaValue>, ResultStore) {
+) -> FsResult<(BTreeMap<String, MinijinjaValue>, ResultStore)> {
     // Downcast the base `builtins` Object to its concrete map here so the
     // shared overlay builder receives a typed map (no downcast on its side).
     let base_builtins = base_context.get("builtins").map(downcast_builtins_map);
-    let (overlay, result_store) = build_run_node_overlay(
+    let (mut overlay, result_store) = build_run_node_overlay(
         node,
         deprecated_config,
         adapter_type,
@@ -484,10 +485,15 @@ pub fn build_run_node_context<S: Serialize>(
         sql_header,
         packages,
     );
+    let adapter = base_context
+        .get("adapter")
+        .and_then(|value| value.downcast_object::<Adapter>());
+    overlay.this = physicalize_relation_value(adapter.as_deref(), overlay.this)
+        .map_err(|error| FsError::from_jinja_err(error, "Failed to resolve run relation"))?;
 
     let mut context = base_context.clone();
     context.extend(to_jinja_btreemap(&overlay));
-    (context, result_store)
+    Ok((context, result_store))
 }
 
 /// Build a run context as a typed [`RunNodeCtx`] composed onto `base` via the
@@ -509,7 +515,8 @@ pub fn build_run_node_ctx<S: Serialize>(
     phase: ExecutionPhase,
     sql_header: Option<MinijinjaValue>,
     packages: BTreeSet<String>,
-) -> RunNodeCtx {
+    adapter: Option<&Adapter>,
+) -> FsResult<RunNodeCtx> {
     // `CompileBaseCtx::builtins` is a `MinijinjaValue` (Jinja-facing Object
     // slot), so downcast it to the concrete map for the shared overlay builder.
     let base_builtins = downcast_builtins_map(&base.builtins);
@@ -524,8 +531,10 @@ pub fn build_run_node_ctx<S: Serialize>(
         sql_header,
         packages,
     );
+    overlay.this = physicalize_relation_value(adapter, overlay.this)
+        .map_err(|error| FsError::from_jinja_err(error, "Failed to resolve run relation"))?;
     overlay.base = Some(base.clone());
-    overlay
+    Ok(overlay)
 }
 
 #[cfg(test)]

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-adapters/macros/adapters/relation.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-adapters/macros/adapters/relation.sql
@@ -86,7 +86,8 @@
   {% do return(adapter.get_relation(
     database=relation.database,
     schema=relation.schema,
-    identifier=relation.identifier
+    identifier=relation.identifier,
+    relation=relation
   )) -%}
 {% endmacro %}
 

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-snowflake/macros/materializations/incremental.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-snowflake/macros/materializations/incremental.sql
@@ -130,6 +130,13 @@
 
   {% set existing_relation = load_relation(this) %}
 
+  {%- if is_catalog_linked_db and existing_relation is not none -%}
+    {%- set target_relation = target_relation.incorporate(path={
+          "schema": existing_relation.schema,
+          "identifier": existing_relation.identifier,
+        }).quote(schema=true, identifier=true) -%}
+  {%- endif -%}
+
   {#-- The temp relation will be a view, temp table, or transient table, depending on strategy and config --#}
   {%- set unique_key = config.get('unique_key') -%}
   {% set incremental_strategy = config.get('incremental_strategy') or 'default' %}

--- a/crates/dbt-loader/src/loader.rs
+++ b/crates/dbt-loader/src/loader.rs
@@ -659,6 +659,10 @@ pub async fn load_catalogs(
     env: &JinjaEnv,
     project_flags: Option<&dbt_yaml::Value>,
 ) -> FsResult<()> {
+    // Catalog definitions are project-scoped. Clear the process-global holder
+    // even when this project has no catalogs.yml so a prior invocation cannot
+    // enable catalog-linked behavior in the next project.
+    load_catalogs::clear_catalogs();
     let ctx: BTreeMap<String, minijinja::Value> = BTreeMap::from([
         (
             "env_var".to_owned(),

--- a/crates/dbt-loader/tests/macros/snowflake.rs
+++ b/crates/dbt-loader/tests/macros/snowflake.rs
@@ -1,8 +1,11 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
+use dbt_adapter::relation::{Relation, RelationObject, do_create_relation};
 use dbt_adapter_core::AdapterType;
 use dbt_jinja_utils::mock_object::MockJinjaObject;
+use dbt_schemas::schemas::common::ResolvedQuoting;
+use dbt_schemas::schemas::relations::base::TableFormat;
 use minijinja::Value;
 
 use crate::macro_test_harness::{MacroTestHarness, default_mock_config};
@@ -85,4 +88,95 @@ fn python_table_preserves_transient_config() {
         "Python table models should preserve transient configuration, got:\n{rendered}"
     );
     assert!(!rendered.contains("table_type='temporary'"));
+}
+
+#[test]
+fn incremental_catalog_linked_target_adopts_and_quotes_existing_identity() {
+    let incremental = include_str!(
+        "../../src/dbt_macro_assets/dbt-snowflake/macros/materializations/incremental.sql"
+    );
+    assert!(incremental.contains("is_catalog_linked_db and existing_relation is not none"));
+    assert!(incremental.contains("\"schema\": existing_relation.schema"));
+    assert!(incremental.contains("\"identifier\": existing_relation.identifier"));
+    assert!(incremental.contains(".quote(schema=true, identifier=true)"));
+
+    let harness = MacroTestHarness::for_adapter(AdapterType::Snowflake)
+        .load_all_macros()
+        .build()
+        .expect("incremental macro should parse");
+    let target = RelationObject::new(Arc::new(
+        Relation::new(
+            AdapterType::Snowflake,
+            "cld".to_string(),
+            "SCHEMA_A".to_string(),
+            "T_ORDERS".to_string(),
+        )
+        .with_quoting(ResolvedQuoting::falses())
+        .with_table_format(TableFormat::Iceberg),
+    ));
+    let existing = RelationObject::new(Arc::from(
+        do_create_relation(
+            AdapterType::Snowflake,
+            "CLD".to_string(),
+            "schema_a".to_string(),
+            Some("t_orders".to_string()),
+            None,
+            ResolvedQuoting::trues(),
+        )
+        .unwrap(),
+    ));
+    let rendered = harness
+        .render(
+            r#"{% set adopted = target.incorporate(path={"schema": existing.schema, "identifier": existing.identifier}).quote(schema=true, identifier=true) %}{{ adopted }}|{{ adopted.is_iceberg_format }}"#,
+            BTreeMap::from([
+                ("target".to_string(), target.into_value()),
+                ("existing".to_string(), existing.into_value()),
+            ]),
+        )
+        .unwrap();
+
+    assert_eq!(rendered, "cld.\"schema_a\".\"t_orders\"|True");
+}
+
+#[test]
+fn load_cached_relation_passes_node_specific_quote_policy() {
+    let harness = MacroTestHarness::for_adapter(AdapterType::Snowflake)
+        .load_all_macros()
+        .build()
+        .expect("relation macros should parse");
+    harness.mock().on("get_relation", |args| {
+        let kwargs = args.last().and_then(Value::as_object).expect("kwargs");
+        let relation_value = kwargs
+            .get_value(&Value::from("relation"))
+            .expect("relation-aware lookup argument");
+        let relation = relation_value
+            .downcast_object_ref::<RelationObject>()
+            .expect("RelationObject");
+        assert!(relation.inner().quote_policy().identifier);
+        Ok(relation_value)
+    });
+    let requested = RelationObject::new(Arc::from(
+        do_create_relation(
+            AdapterType::Snowflake,
+            "CLD".to_string(),
+            "SCHEMA_A".to_string(),
+            Some("t_orders".to_string()),
+            None,
+            ResolvedQuoting {
+                database: false,
+                schema: false,
+                identifier: true,
+            },
+        )
+        .unwrap(),
+    ));
+
+    let rendered = harness
+        .render(
+            "{{ load_cached_relation(requested) }}",
+            BTreeMap::from([("requested".to_string(), requested.into_value())]),
+        )
+        .expect("load_cached_relation should preserve the relation object");
+
+    assert_eq!(rendered, "CLD.SCHEMA_A.\"t_orders\"");
 }

--- a/crates/dbt-schemas/src/schemas/relations/base.rs
+++ b/crates/dbt-schemas/src/schemas/relations/base.rs
@@ -645,7 +645,7 @@ pub trait BaseRelation: BaseRelationProperties + Any + Send + Sync + fmt::Debug 
         schema: Option<bool>,
         identifier: Option<bool>,
     ) -> Result<Arc<dyn BaseRelation>, MinijinjaError> {
-        let defaults = self.include_policy();
+        let defaults = self.quote_policy();
         let quote_policy = Policy {
             database: database.unwrap_or(defaults.database),
             schema: schema.unwrap_or(defaults.schema),

--- a/crates/dbt-tasks-sa/src/base_context.rs
+++ b/crates/dbt-tasks-sa/src/base_context.rs
@@ -1,6 +1,9 @@
 use std::collections::BTreeMap;
 
-use dbt_jinja_utils::{jinja_environment::JinjaEnv, phases::build_operation_context_btreemap};
+use dbt_jinja_utils::{
+    jinja_environment::JinjaEnv,
+    phases::{build_compile_base_ctx_with_adapter, build_operation_context_btreemap},
+};
 use dbt_schemas::state::ResolverState;
 
 pub fn build_base_context(
@@ -12,13 +15,27 @@ pub fn build_base_context(
         .get_macro_namespace_registry()
         .map(|r| r.keys().map(|k| k.to_string()).collect())
         .unwrap_or_default();
-    build_operation_context_btreemap(
+    let adapter = env.get_adapter();
+    let compile_base = build_compile_base_ctx_with_adapter(
         resolver_state.node_resolver.clone(),
         &resolver_state.root_project_name,
         &resolver_state.nodes,
         resolver_state.defer_nodes.as_ref(),
         resolver_state.runtime_config.clone(),
         namespace_keys,
-        None,
-    )
+        adapter.clone(),
+    );
+    let mut context = build_operation_context_btreemap(
+        resolver_state.node_resolver.clone(),
+        &resolver_state.root_project_name,
+        &resolver_state.nodes,
+        resolver_state.defer_nodes.as_ref(),
+        resolver_state.runtime_config.clone(),
+        Vec::new(),
+        Some(compile_base),
+    );
+    if let Some(adapter) = adapter {
+        context.insert("adapter".to_string(), adapter.as_value());
+    }
+    context
 }

--- a/crates/dbt-tasks-sa/src/materialize.rs
+++ b/crates/dbt-tasks-sa/src/materialize.rs
@@ -312,7 +312,7 @@ pub fn execute_node_hooks<S: serde::Serialize>(
         ExecutionPhase::Run,
         None,
         runtime_config.dependencies.keys().cloned().collect(),
-    );
+    )?;
 
     if let Some(sql) = sql {
         context.insert("sql".to_string(), Value::from(sql));
@@ -501,7 +501,7 @@ pub fn materialize_clone<S: serde::Serialize>(
         ExecutionPhase::Run,
         None,
         runtime_config.dependencies.keys().cloned().collect(),
-    );
+    )?;
 
     // `dbt clone` takes the target default: this path is typed `&dyn InternalDbtNode`,
     // which does not expose the node's `+adapter`. Cloning a node on a non-default
@@ -592,7 +592,7 @@ pub fn materialize_seed(
         ExecutionPhase::Run,
         None,
         runtime_config.dependencies.keys().cloned().collect(),
-    );
+    )?;
 
     // Runtime-phase errors report the run/Executable path per the path-requirements matrix.
     let run_path = seed
@@ -658,7 +658,7 @@ pub fn materialize_model(
         ExecutionPhase::Run,
         sql_header,
         runtime_config.dependencies.keys().cloned().collect(),
-    );
+    )?;
     let materialization = model.__base_attr__.materialized.clone();
 
     let macro_name = materialization_resolver
@@ -829,7 +829,7 @@ pub fn materialize_latest_version_pointer(
         ExecutionPhase::Run,
         None,
         runtime_config.dependencies.keys().cloned().collect(),
-    );
+    )?;
 
     let pointer_identifier =
         latest_version_pointer_identifier(model, &jinja_env, &mut resolve_context)?;
@@ -964,7 +964,7 @@ pub fn materialize_latest_version_pointer(
         ExecutionPhase::Run,
         None,
         runtime_config.dependencies.keys().cloned().collect(),
-    );
+    )?;
 
     let macro_name = materialization_resolver
         .find_materialization_macro_by_name("view", model.node_adapter())?;
@@ -1124,7 +1124,7 @@ pub fn materialize_snapshot(
         ExecutionPhase::Run,
         None,
         runtime_config.dependencies.keys().cloned().collect(),
-    );
+    )?;
 
     context.insert("sql".to_string(), Value::from(sql));
     context.insert("compiled_code".to_string(), Value::from(sql));
@@ -1203,7 +1203,7 @@ pub fn materialize_unit_test(
             .keys()
             .cloned()
             .collect(),
-    );
+    )?;
     let materialization = DbtMaterialization::Unit;
     let macro_name = materialization_resolver.find_materialization_macro_by_name(
         &materialization.to_string(),
@@ -1287,7 +1287,7 @@ pub fn materialize_unit_test_fast_pass(
         ExecutionPhase::Run,
         None,
         runtime_config.dependencies.keys().cloned().collect(),
-    );
+    )?;
 
     context.insert("sql".to_string(), Value::from(sql));
 
@@ -1509,7 +1509,7 @@ pub fn materialize_test(
         ExecutionPhase::Run,
         None,
         packages,
-    );
+    )?;
 
     let is_aggregated = relationships.unique_ids.contains_key(&test.common().name);
     let materialization_name = if is_aggregated {
@@ -2012,7 +2012,7 @@ pub fn materialize_function(
         ExecutionPhase::Run,
         None,
         runtime_config.dependencies.keys().cloned().collect(),
-    );
+    )?;
 
     // Find the function materialization macro
     let macro_name = materialization_resolver

--- a/crates/dbt-tasks-sa/src/renderable/renderable/unit_test.rs
+++ b/crates/dbt-tasks-sa/src/renderable/renderable/unit_test.rs
@@ -423,7 +423,7 @@ fn populate_schema_from_empty_relation(
         TelemetryExecutionPhase::Render,
         None,
         ctx.runtime_config().dependencies.keys().cloned().collect(),
-    );
+    )?;
 
     // Ensure schema inference macro evaluation is node-scoped for replay and any other
     // context-dependent adapter behavior.

--- a/crates/dbt-tasks-sa/src/runnable/microbatch.rs
+++ b/crates/dbt-tasks-sa/src/runnable/microbatch.rs
@@ -341,13 +341,17 @@ pub fn is_incremental(
         }
     };
 
+    let database = relation.database().unwrap_or_default().to_string();
+    let schema = relation.schema().unwrap_or_default().to_string();
+    let identifier = relation.identifier().unwrap_or_default().to_string();
     adapter
         .get_relation(
             &state,
-            relation.database().unwrap_or_default(),
-            relation.schema().unwrap_or_default(),
-            relation.identifier().unwrap_or_default(),
+            &database,
+            &schema,
+            &identifier,
             false,
+            Some(Arc::from(relation)),
         )
         .ok()
         .filter(|v| !v.is_none())

--- a/crates/dbt-tasks-sa/src/runnable/model.rs
+++ b/crates/dbt-tasks-sa/src/runnable/model.rs
@@ -121,7 +121,7 @@ pub fn prepare_microbatch_batches(
             ExecutionPhase::Run,
             sql_header,
             ctx.runtime_config().dependencies.keys().cloned().collect(),
-        )
+        )?
         .0,
     );
 


### PR DESCRIPTION
## Summary

- add quote-aware, cache-instance relation identity resolution for Snowflake catalog-linked databases
- preserve explicit identifier quoting and fail safely when case variants are ambiguous
- pass the requested relation and its quote policy through `load_relation` and task compile/run contexts
- adopt and quote catalog-stored schema and identifier casing for Snowflake incremental targets
- keep catalog and relation-cache lifecycle state scoped and preserve relation metadata across transforms

This is the dbt Core 2.0 counterpart to the behavior explored in https://github.com/dbt-labs/dbt-adapters/pull/2155, with the adversarial review findings addressed in the resolver design.

## Draft status and follow-ups

Additional follow-up validation should cover a live Snowflake catalog-linked database, a source-only schema, an unselected deferred ref, and cache-disabled behavior.

## Scope provenance

- no code was transferred from private `crates/dbt-tasks`, `crates/dbt-schema-hydration`, or `crates/dbt-lsp`
- task-layer adaptations use the public `dbt-tasks-sa` and shared `dbt-tasks-core` interfaces
- all transferred behavior maps to files under `fs/sa`; the only new repository metadata is the generated changelog entry

