### PR TITLE
feat: allow pinning the passive OAuth resolver to an account

### DIFF
--- a/.changes/unreleased/Under the Hood-20260903-120000.yaml
+++ b/.changes/unreleased/Under the Hood-20260903-120000.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Allow pinning the passive OAuth resolver to a dbt platform account so a session
+  cache holding several accounts resolves the configured one
+time: 2026-09-03T12:00:00.000000-07:00
+custom:
+    Author: izeigerman
+    Issue: ""

--- a/core/dbt/auth/chain.py
+++ b/core/dbt/auth/chain.py
@@ -26,23 +26,28 @@ class AuthChain:
         self._resolvers = resolvers
 
     @classmethod
-    def default(cls) -> AuthChain:
-        """Non-interactive chain: EnvVar -> OAuthPassive -> CloudYaml."""
+    def default(cls, configured_account_id: Optional[int] = None) -> AuthChain:
+        """Non-interactive chain: EnvVar -> OAuthPassive -> CloudYaml.
+
+        configured_account_id restricts cached OAuth session lookup to the given
+        dbt platform account. Without it, a session cache holding sessions for
+        several accounts resolves whichever session comes first.
+        """
         return cls(
             resolvers=[
                 EnvVarResolver(),
-                OAuthPassiveResolver(),
+                OAuthPassiveResolver(account_id=configured_account_id),
                 CloudYamlResolver(),
             ]
         )
 
     @classmethod
-    def interactive(cls) -> AuthChain:
+    def interactive(cls, configured_account_id: Optional[int] = None) -> AuthChain:
         """Interactive chain: EnvVar -> OAuthPassive -> CloudYaml -> OAuthInteractive."""
         return cls(
             resolvers=[
                 EnvVarResolver(),
-                OAuthPassiveResolver(),
+                OAuthPassiveResolver(account_id=configured_account_id),
                 CloudYamlResolver(),
                 OAuthInteractiveResolver(),
             ]

--- a/core/dbt/auth/resolvers.py
+++ b/core/dbt/auth/resolvers.py
@@ -81,16 +81,8 @@ class OAuthPassiveResolver:
     """Resolves credentials from a cached OAuth session — no user interaction.
 
     Checks ~/.dbt/oauth_sessions.json for a non-expired session matching
-    client_id. If the access token is expired but a refresh token is present,
-    attempts a token refresh.
-
-    Client ID and account matching:
-    Only sessions for the given client_id are considered. When account_id is set,
-    only sessions for that dbt platform account are considered — a cache holding
-    sessions for several accounts then resolves the configured one instead of
-    whichever session happens to come first. If no session matches the requested
-    account, NotAuthenticated is raised so the caller's chain can fall through to
-    another resolver rather than silently authenticating against the wrong account.
+    client_id and, when specified, account_id. If the access token is expired
+    but a refresh token is present, attempts a token refresh.
     """
 
     kind = ResolverKind.OAUTH_PASSIVE

--- a/core/dbt/auth/resolvers.py
+++ b/core/dbt/auth/resolvers.py
@@ -107,14 +107,14 @@ class OAuthPassiveResolver:
         self.token_endpoint_override = token_endpoint_override
         self.account_id = account_id
 
+    def _matches(self, session: OAuthSession) -> bool:
+        if session.client_id != self.client_id:
+            return False
+        return self.account_id is None or session.account_id == self.account_id
+
     def resolve(self) -> Credential:
         cache = read_session_cache(self.cache_path)
-        matching = [
-            s
-            for s in cache.sessions
-            if s.client_id == self.client_id
-            and (self.account_id is None or s.account_id == self.account_id)
-        ]
+        matching = [s for s in cache.sessions if self._matches(s)]
 
         if not matching:
             raise NotAuthenticated()

--- a/core/dbt/auth/resolvers.py
+++ b/core/dbt/auth/resolvers.py
@@ -107,11 +107,6 @@ class OAuthPassiveResolver:
         self.token_endpoint_override = token_endpoint_override
         self.account_id = account_id
 
-    def _matches(self, session: OAuthSession) -> bool:
-        if session.client_id != self.client_id:
-            return False
-        return self.account_id is None or session.account_id == self.account_id
-
     def resolve(self) -> Credential:
         cache = read_session_cache(self.cache_path)
         matching = [s for s in cache.sessions if self._matches(s)]
@@ -184,6 +179,11 @@ class OAuthPassiveResolver:
         upsert_session(new_session, self.cache_path)
 
         return PlatformCredential.from_oauth(new_session)
+
+    def _matches(self, session: OAuthSession) -> bool:
+        if session.client_id != self.client_id:
+            return False
+        return self.account_id is None or session.account_id == self.account_id
 
 
 class CloudYamlResolver:

--- a/core/dbt/auth/resolvers.py
+++ b/core/dbt/auth/resolvers.py
@@ -83,6 +83,14 @@ class OAuthPassiveResolver:
     Checks ~/.dbt/oauth_sessions.json for a non-expired session matching
     client_id. If the access token is expired but a refresh token is present,
     attempts a token refresh.
+
+    Client ID and account matching:
+    Only sessions for the given client_id are considered. When account_id is set,
+    only sessions for that dbt platform account are considered — a cache holding
+    sessions for several accounts then resolves the configured one instead of
+    whichever session happens to come first. If no session matches the requested
+    account, NotAuthenticated is raised so the caller's chain can fall through to
+    another resolver rather than silently authenticating against the wrong account.
     """
 
     kind = ResolverKind.OAUTH_PASSIVE
@@ -92,14 +100,21 @@ class OAuthPassiveResolver:
         client_id: str = OAUTH_CLIENT_ID,
         cache_path: Optional[Path] = None,
         token_endpoint_override: Optional[str] = None,
+        account_id: Optional[int] = None,
     ) -> None:
         self.client_id = client_id
         self.cache_path = cache_path or DEFAULT_CACHE_PATH
         self.token_endpoint_override = token_endpoint_override
+        self.account_id = account_id
 
     def resolve(self) -> Credential:
         cache = read_session_cache(self.cache_path)
-        matching = [s for s in cache.sessions if s.client_id == self.client_id]
+        matching = [
+            s
+            for s in cache.sessions
+            if s.client_id == self.client_id
+            and (self.account_id is None or s.account_id == self.account_id)
+        ]
 
         if not matching:
             raise NotAuthenticated()

--- a/tests/unit/auth/test_resolvers.py
+++ b/tests/unit/auth/test_resolvers.py
@@ -228,6 +228,57 @@ class TestOAuthPassiveResolver:
             with pytest.raises(RefreshFailed):
                 OAuthPassiveResolver("test_client", cache_path=p).resolve()
 
+    def test_account_id_selects_matching_session(self, tmp_path):
+        p = tmp_path / "oauth_sessions.json"
+        upsert_session(_make_session(account_id=1), p)
+        upsert_session(_make_session(account_id=2, access_token="tok_b"), p)
+
+        cred = OAuthPassiveResolver("test_client", cache_path=p, account_id=2).resolve()
+        assert cred.token == "tok_b"
+        assert cred.account_id == 2
+
+    def test_account_id_without_matching_session_raises_not_authenticated(self, tmp_path):
+        p = tmp_path / "oauth_sessions.json"
+        upsert_session(_make_session(), p)
+
+        with pytest.raises(NotAuthenticated):
+            OAuthPassiveResolver("test_client", cache_path=p, account_id=999).resolve()
+
+    def test_account_id_refreshes_only_the_matching_accounts_session(self, tmp_path):
+        # Both sessions are expired and refreshable. Unpinned, the first one wins
+        # and the other account's one-time-use refresh token gets spent.
+        p = tmp_path / "oauth_sessions.json"
+        upsert_session(
+            _make_session(
+                account_id=1, expires_at=time.time() - 3600, refresh_token="other_refresh"
+            ),
+            p,
+        )
+        upsert_session(
+            _make_session(
+                account_id=2, expires_at=time.time() - 3600, refresh_token="wanted_refresh"
+            ),
+            p,
+        )
+
+        new_jwt = _make_fake_jwt(account_id=2)
+        mock_response = mock.Mock()
+        mock_response.status_code = 200
+        mock_response.ok = True
+        mock_response.json.return_value = {
+            "access_token": new_jwt,
+            "scope": "account:read",
+            "expires_in": 3600,
+        }
+
+        with mock.patch(
+            "dbt.auth.resolvers.requests.post", return_value=mock_response
+        ) as mock_post:
+            cred = OAuthPassiveResolver("test_client", cache_path=p, account_id=2).resolve()
+
+        assert cred.account_id == 2
+        assert mock_post.call_args[1]["data"]["refresh_token"] == "wanted_refresh"
+
 
 class TestCloudYamlResolver:
     def test_happy_path_service_token(self, tmp_path):


### PR DESCRIPTION
TL;DR: this is needed for the dbt State integration to pick a correct session based on the configured `dbt-cloud.account_id` value. Instead of rewriting this class in the plugin, we extend the shared API here.

## AI Summary

`OAuthPassiveResolver` filters cached sessions in `~/.dbt/oauth_sessions.json` by `client_id` only and returns the first non-expired match, so a cache holding sessions for several accounts resolves whichever one comes first. The cache is keyed on `(client_id, account_id)`, so multi-account state is expected — but nothing could constrain the lookup to a particular account. The same gap was fixed in the Rust resolver, where it caused dbt State to exchange tokens against the wrong account.

- `OAuthPassiveResolver` gains an optional `account_id` filter. Both the non-expired pick and the refresh candidate derive from the filtered list, so a pinned resolver also will not spend another account's one-time-use refresh token.
- No match yields `NotAuthenticated`, so the chain falls through to the next resolver rather than silently authenticating against the wrong account.
- `AuthChain.default` / `.interactive` accept `configured_account_id` and propagate the pin.

No caller pins an account yet, so behavior is unchanged. Wiring a pin source is a follow-up: `dbt login` loads no project (`@requires.preflight` only), so `dbt-cloud: account_id` from `dbt_project.yml` is not in scope without further plumbing.