### PR TITLE
fix(parser): don't reassign a disabled package resource's schema.yml patch to an unrelated same-named node

### DIFF
--- a/.changes/unreleased/Fixes-20260904-120000.yaml
+++ b/.changes/unreleased/Fixes-20260904-120000.yaml
@@ -1,0 +1,8 @@
+kind: Fixes
+body: Fix a disabled package resource's own schema.yml patch being silently
+    reassigned to an unrelated, same-named resource in a different package
+    instead of the disabled resource itself
+time: 2026-09-04T12:00:00.000000+00:00
+custom:
+    Author: Kunal8954
+    Issue: "15562"

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -839,7 +839,28 @@ class NodePatchParser(PatchParser[NodeTarget, ParsedNodePatch], Generic[NodeTarg
         if patch.yaml_key in ["models", "seeds", "snapshots"]:
             unique_id = self.manifest.ref_lookup.get_unique_id(
                 patch.name, self.project.project_name, None
-            ) or self.manifest.ref_lookup.get_unique_id(patch.name, None, None)
+            )
+            if unique_id is None:
+                # A schema.yml entry describes a resource that lives in its
+                # own package. Before falling back to an unscoped,
+                # cross-package lookup (which can bind this patch to an
+                # unrelated resource in a different package that merely
+                # shares the same name), check whether *this* package has a
+                # disabled resource with this name -- if so, this patch
+                # describes that disabled resource and is handled by the
+                # "handle disabled nodes" branch below. See #15562: a
+                # package's own seed being disabled via `+enabled: false`
+                # in a dependent project must not cause its schema.yml
+                # patch to be silently reassigned to a same-named, already
+                # patched resource belonging to a different package.
+                resource_type = schema_file_keys_to_resource_types[patch.yaml_key]
+                has_disabled_in_own_package = bool(
+                    self.manifest.disabled_lookup.find(
+                        patch.name, patch.package_name, resource_types=[resource_type]
+                    )
+                )
+                if not has_disabled_in_own_package:
+                    unique_id = self.manifest.ref_lookup.get_unique_id(patch.name, None, None)
 
             if unique_id:
                 resource_type = NodeType(unique_id.split(".")[0])

--- a/tests/functional/dependencies/test_disabled_dependency_seed_schema_patch.py
+++ b/tests/functional/dependencies/test_disabled_dependency_seed_schema_patch.py
@@ -1,0 +1,113 @@
+import os
+
+import pytest
+
+from dbt.tests.util import get_manifest, run_dbt, write_file
+
+common_dbt_project_yml = """
+name: common_pkg
+version: '1.0'
+config-version: 2
+"""
+
+common_seed_csv = """id,name
+1,Alice
+2,Bob
+"""
+
+common_seed_schema_yml = """
+version: 2
+seeds:
+  - name: shared_seed
+    description: "The common package's version of the seed."
+"""
+
+root_seed_csv = """id,name
+1,Charlie
+2,Dana
+3,Erin
+"""
+
+root_seed_schema_yml = """
+version: 2
+seeds:
+  - name: shared_seed
+    description: "This project's own override of the seed."
+"""
+
+
+class TestDisabledDependencySeedSchemaPatch:
+    """
+    Regression test for https://github.com/dbt-labs/dbt-core/issues/15562
+
+    A common pattern for projects built on top of a shared package: disable
+    the package's seed via `+enabled: false` in the root project's
+    dbt_project.yml, and define a same-named seed directly in the root
+    project instead. Both the package and the root project describe the
+    seed (with the same name) in their own schema.yml.
+
+    Parsing used to fail with "dbt found two schema.yml entries for the
+    same resource named shared_seed" even though only one schema.yml
+    entry actually describes an *enabled* resource. The disabled package's
+    own schema.yml patch was resolving, via a cross-package name lookup,
+    to the root project's unrelated (and already-patched) node instead of
+    being recognized as describing the package's own disabled seed.
+    """
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "shared_seed.csv": root_seed_csv,
+            "schema.yml": root_seed_schema_yml,
+        }
+
+    @pytest.fixture(scope="class")
+    def packages(self):
+        return {"packages": [{"local": "common_pkg"}]}
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"seeds": {"common_pkg": {"+enabled": False}}}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def prepare_dependencies(self, project):
+        pkg_root = os.path.join(project.project_root, "common_pkg")
+        os.makedirs(os.path.join(pkg_root, "seeds"), exist_ok=True)
+        write_file(common_dbt_project_yml, pkg_root, "dbt_project.yml")
+        write_file(common_seed_csv, pkg_root, "seeds", "shared_seed.csv")
+        write_file(common_seed_schema_yml, pkg_root, "seeds", "schema.yml")
+
+    def test_parses_without_duplicate_patch_error(self, project):
+        run_dbt(["deps"])
+        # Before the fix, this raised DuplicatePatchPathError: "dbt found
+        # two schema.yml entries for the same resource named shared_seed."
+        run_dbt(["parse"])
+
+        manifest = get_manifest(project.project_root)
+
+        # The root project's own (enabled) seed is the one that gets
+        # patched with the root project's schema.yml description.
+        root_seed_id = "seed.test.shared_seed"
+        assert root_seed_id in manifest.nodes
+        assert manifest.nodes[root_seed_id].patch_path is not None
+        assert (
+            manifest.nodes[root_seed_id].description
+            == "This project's own override of the seed."
+        )
+
+        # The common package's seed is disabled, as configured, and is
+        # patched with its own package's schema.yml description rather
+        # than being conflated with the root project's seed.
+        disabled_seeds = [
+            node
+            for nodes in manifest.disabled.values()
+            for node in nodes
+            if node.name == "shared_seed"
+        ]
+        assert len(disabled_seeds) == 1
+        assert disabled_seeds[0].unique_id.startswith("seed.common_pkg.")
+        assert disabled_seeds[0].patch_path is not None
+        assert (
+            disabled_seeds[0].description
+            == "The common package's version of the seed."
+        )


### PR DESCRIPTION
NodePatchParser.parse_patch() resolves a models/seeds/snapshots schema.yml patch by first looking it up scoped to its own package, then falling back to an unscoped, cross-package lookup if that fails. When a package's own resource is disabled (e.g. via +enabled: false in a dependent project), the scoped lookup correctly returns nothing — but the unscoped fallback can then find and bind the patch to an unrelated same-named resource in a different package. If that other resource already has its own patch, this raises DuplicatePatchPathError even though only one schema.yml entry actually describes an enabled resource.

This is a common pattern: disable a shared package's seed and define a same-named seed in the root project to override it. Both describe the seed in their own schema.yml.

Fix: before falling back to the unscoped lookup, check whether the resource's own package has a disabled node with this name — if so, let the patch flow into the existing disabled-node handling instead.

Added a regression test using a local package dependency (tests/functional/dependencies/test_disabled_dependency_seed_schema_patch.py) — confirmed it reproduces the exact reported error before the fix and passes after, run against a real Postgres instance.

Fixes #15562