### PR TITLE
[ClickHouse] Add remaining v1 features for `table` and `materialized_view`

### DIFF
--- a/.changes/unreleased/Features-20260903-184138.yaml
+++ b/.changes/unreleased/Features-20260903-184138.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: '[ClickHouse] `table` now compatible with MVs (mv_on_schema_change defaults to fail, repopulate_from_mvs_on_full_refresh replays the MV queries), `materialized_view` supports on_schema_change, in-place refresh-schedule updates (MODIFY REFRESH) with safe transition errors, multi-MV update/rename flows and refreshable: false, and projections accept the index form with up-front validation.'
+time: 2026-09-03T18:41:38.291916+02:00
+custom:
+    author: koletzilla
+    issue: "14585"
+    project: dbt-core

--- a/crates/dbt-adapter/src/metadata/clickhouse/mod.rs
+++ b/crates/dbt-adapter/src/metadata/clickhouse/mod.rs
@@ -4,7 +4,7 @@ use crate::column::Column;
 use crate::connection::AdapterConnectionFactory;
 use crate::query_ctx::{node_id_from_state, query_ctx_from_state};
 use crate::record_batch::RecordBatchExt;
-use crate::relation::do_create_relation;
+use crate::relation::Relation;
 use crate::sql_types::{TypeOps, make_arrow_field_v2};
 use crate::{AdapterResult, errors::AsyncAdapterResult, metadata::*};
 use arrow_schema::Schema;
@@ -39,15 +39,89 @@ pub(crate) fn escape_clickhouse_string_literal(value: &str) -> String {
     value.replace('\\', "\\\\").replace('\'', "\\'")
 }
 
+/// Mirrors dbt-clickhouse util.py `engine_can_atomic_exchange`.
+pub(crate) fn engine_can_atomic_exchange(engine: &str) -> bool {
+    matches!(engine, "Atomic" | "Replicated" | "Shared")
+}
+
+/// MV target `db.table` regex from the upstream `clickhouse__list_relations_without_caching`
+/// macro. The `?` quantifiers are `\x3F` hex escapes: the ADBC driver treats a literal `?`
+/// anywhere in the SQL, even inside string literals, as a bind parameter.
+const MV_TARGET_FQN_REGEX_SQL: &str =
+    r"'.*TO\\s+`\x3F([^`\\s(]+)`\x3F\\.`\x3F([^`\\s(]+)`\x3F.*', '\\1.\\2'";
+
+/// The `is_refreshable`/`refreshable_append` columns of the upstream
+/// `clickhouse__list_relations_without_caching` macro: the REFRESH clause sits between
+/// the view name and TO (`CREATE MATERIALIZED VIEW db.mv REFRESH EVERY 2 MINUTE [APPEND] TO …`).
+fn refreshable_marker_columns(col: &str, agg: &str) -> String {
+    let clause = |marker: &str| {
+        format!("{agg}(position(substring({col}, 1, position({col}, ' TO ')), '{marker}')) > 0")
+    };
+    format!(
+        "if({}, 'true', 'false') AS is_refreshable, \
+         if({}, 'true', 'false') AS refreshable_append",
+        clause(" REFRESH "),
+        clause(" APPEND")
+    )
+}
+
 pub(crate) fn build_get_relation_sql(schema: &str, identifier: &str) -> String {
     let escaped_database = escape_clickhouse_string_literal(schema);
     let escaped_identifier = escape_clickhouse_string_literal(identifier);
+    let refreshable_columns = refreshable_marker_columns("create_table_query", "");
     format!(
-        "SELECT engine, name \
+        "SELECT engine, name, \
+                (SELECT engine FROM system.databases WHERE name = '{escaped_database}') AS database_engine, \
+                (SELECT toJSONString(groupArray(map('schema', database, 'name', name, 'sql', as_select))) \
+                 FROM system.tables \
+                 WHERE engine = 'MaterializedView' AND create_table_query LIKE '%TO %' \
+                   AND replaceRegexpOne(create_table_query, {MV_TARGET_FQN_REGEX_SQL}) = '{escaped_database}.{escaped_identifier}') AS mvs_pointing_to_it, \
+                {refreshable_columns} \
          FROM system.tables \
          WHERE database = '{escaped_database}' \
            AND name = '{escaped_identifier}'",
     )
+}
+
+/// impl.py `list_relations_without_caching`:
+/// `can_exchange = conn_supports_exchange and rel_type == Table and engine_can_atomic_exchange(db_engine)`.
+pub(crate) fn relation_can_exchange(
+    caps: &ClickHouseCapabilities,
+    relation_type: RelationType,
+    database_engine: &str,
+) -> bool {
+    caps.atomic_exchange
+        && relation_type == RelationType::Table
+        && engine_can_atomic_exchange(database_engine)
+}
+
+/// Mirrors impl.py `json.loads(mvs_pointing_to_it) or []`.
+pub(crate) fn parse_mvs_pointing_to_it(json: &str) -> Vec<BTreeMap<String, String>> {
+    serde_json::from_str::<Vec<BTreeMap<String, String>>>(json).unwrap_or_default()
+}
+
+/// Stamps the state columns shared by [`build_get_relation_sql`] and [`list_relations`]
+/// (impl.py `list_relations_without_caching`).
+pub(crate) fn with_catalog_state(
+    relation: Relation,
+    caps: &ClickHouseCapabilities,
+    batch: &RecordBatch,
+    row: usize,
+) -> AdapterResult<Relation> {
+    let column = |name: &str| batch.column_values::<StringArray>(name);
+    let database_engines = column("database_engine")?;
+    let can_exchange = relation.relation_type.is_some_and(|relation_type| {
+        relation_can_exchange(caps, relation_type, database_engines.value(row))
+    });
+    relation
+        .with_can_exchange(can_exchange)
+        .with_mvs_pointing_to_it(parse_mvs_pointing_to_it(
+            column("mvs_pointing_to_it")?.value(row),
+        ))
+        .with_is_refreshable(column("is_refreshable")?.value(row) == "true")
+        .with_refreshable_append(column("refreshable_append")?.value(row) == "true")
+        .validate()
+        .map_err(|e| AdapterError::new(AdapterErrorKind::Internal, e.to_string()))
 }
 
 pub struct ClickHouseMetadataAdapter {
@@ -350,13 +424,34 @@ pub fn list_relations(
 ) -> AdapterResult<Vec<Arc<dyn BaseRelation>>> {
     // ClickHouse only has databases, no schemas — we map dbt `schema` to CH `database`.
     let escaped_database = escape_clickhouse_string_literal(&db_schema.resolved_schema);
+    let refreshable_columns = refreshable_marker_columns("t.create_table_query", "max");
     let sql = format!(
-        "SELECT database AS table_database, \
-                name AS table_name, \
-                engine AS table_type \
-         FROM system.tables \
-         WHERE database = '{escaped_database}'"
+        "WITH mv_sources AS ( \
+            SELECT name AS mv_name, \
+                   database AS mv_database, \
+                   any(as_select) AS mv_sql, \
+                   any(replaceRegexpOne(create_table_query, {MV_TARGET_FQN_REGEX_SQL})) AS target_fqn \
+            FROM system.tables \
+            WHERE engine = 'MaterializedView' AND create_table_query LIKE '%TO %' \
+            GROUP BY mv_name, mv_database \
+         ) \
+         SELECT t.database AS table_database, \
+                t.name AS table_name, \
+                t.engine AS table_type, \
+                db.engine AS database_engine, \
+                toJSONString(groupArrayIf( \
+                    map('schema', mv_sources.mv_database, 'name', mv_sources.mv_name, 'sql', mv_sources.mv_sql), \
+                    mv_sources.mv_name != '' \
+                )) AS mvs_pointing_to_it, \
+                {refreshable_columns} \
+         FROM system.tables AS t \
+         JOIN system.databases AS db ON t.database = db.name \
+         LEFT JOIN mv_sources ON mv_sources.target_fqn = concat(t.database, '.', t.name) \
+         WHERE t.database = '{escaped_database}' \
+         GROUP BY table_database, table_name, table_type, database_engine"
     );
+
+    let caps = server_capabilities_over_connection(engine, ctx, conn, token.clone());
 
     let batch = engine.execute(None, conn, ctx, &sql, token)?;
 
@@ -370,22 +465,17 @@ pub fn list_relations(
 
     let mut relations = Vec::with_capacity(batch.num_rows());
     for i in 0..batch.num_rows() {
-        let database = table_databases.value(i);
-        let name = table_names.value(i);
-        let engine_name = table_types.value(i);
-        let relation_type = relation_type_from_engine(engine_name);
-
-        let relation = do_create_relation(
+        let relation = Relation::new(
             engine.adapter_type(),
-            db_schema.resolved_catalog.clone(),
-            database.to_string(),
-            Some(name.to_string()),
-            Some(relation_type),
-            engine.quoting(),
+            Some(db_schema.resolved_catalog.clone()),
+            Some(table_databases.value(i).to_string()),
+            Some(table_names.value(i).to_string()),
         )
-        .map_err(|e| AdapterError::new(AdapterErrorKind::Internal, e.to_string()))?;
+        .with_relation_type(relation_type_from_engine(table_types.value(i)))
+        .with_quoting(engine.quoting());
+        let relation = with_catalog_state(relation, caps, &batch, i)?;
 
-        relations.push(Arc::from(relation));
+        relations.push(Arc::new(relation) as Arc<dyn BaseRelation>);
     }
 
     Ok(relations)
@@ -464,13 +554,16 @@ fn build_schema_from_clickhouse_describe(
 }
 
 /// ClickHouse server capabilities, probed once per process and reused for every
-/// model/thread afterwards (as the Python client does at connection init).
-/// Later capability probes (atomic exchange) extend this struct.
+/// model/thread afterwards (as the Python client does at connection init, and
+/// for `atomic_exchange` behind a process-global lock).
 #[derive(Debug, Clone)]
 pub struct ClickHouseCapabilities {
     /// `SELECT version()` result; empty when the probe failed (callers treat
     /// unknown as "modern server").
     pub server_version: String,
+    /// Whether atomic `EXCHANGE TABLES` works on this server/database
+    /// (dbclient.py `_check_atomic_exchange`).
+    pub atomic_exchange: bool,
     /// Whether lightweight deletes are usable. Mirrors dbclient.py
     /// `_check_lightweight_deletes`.
     pub has_lw_deletes: bool,
@@ -766,17 +859,45 @@ pub fn server_capabilities(
     token: CancellationToken,
 ) -> &'static ClickHouseCapabilities {
     CLICKHOUSE_CAPABILITIES.get_or_init(|| {
-        let has_lw_deletes = probe_lightweight_deletes(adapter, state, token.clone());
-        let use_lw_deletes_requested = adapter
-            .get_db_config_value("use_lw_deletes")
-            .and_then(|value| value.as_bool())
-            .unwrap_or(false);
-        ClickHouseCapabilities {
-            server_version: probe_server_version(adapter, state, token).unwrap_or_default(),
-            has_lw_deletes,
-            use_lw_deletes: has_lw_deletes && use_lw_deletes_requested,
-        }
+        probe_capabilities(adapter.engine().as_ref(), |sql| {
+            probe_query(adapter, state, sql, token.clone())
+        })
     })
+}
+
+/// [`server_capabilities`] for the catalog paths, which already hold a connection and
+/// have no Jinja `State`.
+pub fn server_capabilities_over_connection(
+    engine: &dyn AdapterEngine,
+    ctx: &QueryCtx,
+    conn: &mut dyn Connection,
+    token: CancellationToken,
+) -> &'static ClickHouseCapabilities {
+    CLICKHOUSE_CAPABILITIES.get_or_init(|| {
+        probe_capabilities(engine, |sql| {
+            engine.execute(None, conn, ctx, sql, token.clone()).ok()
+        })
+    })
+}
+
+fn probe_capabilities(
+    engine: &dyn AdapterEngine,
+    mut run: impl FnMut(&str) -> Option<RecordBatch>,
+) -> ClickHouseCapabilities {
+    let flag = |key: &str| {
+        engine
+            .get_config()
+            .get(key)
+            .and_then(|value| value.as_bool())
+    };
+    let has_lw_deletes = probe_lightweight_deletes(&mut run);
+    ClickHouseCapabilities {
+        server_version: probe_server_version(&mut run).unwrap_or_default(),
+        // dbclient.py: `not check_exchange or _check_atomic_exchange()`
+        atomic_exchange: !flag("check_exchange").unwrap_or(true) || probe_atomic_exchange(&mut run),
+        has_lw_deletes,
+        use_lw_deletes: has_lw_deletes && flag("use_lw_deletes").unwrap_or(false),
+    }
 }
 
 /// Run a capability-probe query; None when the probe cannot run (replay has no
@@ -800,18 +921,63 @@ fn probe_query(
     engine.execute(None, conn.as_mut(), &ctx, sql, token).ok()
 }
 
-/// `SELECT version()`; None leaves the version unknown -> "assume modern server".
-fn probe_server_version(
-    adapter: &AdapterImpl,
-    state: &State,
-    token: CancellationToken,
-) -> Option<String> {
-    let batch = probe_query(adapter, state, "SELECT version() AS v", token)?;
+fn scalar_probe(run: &mut impl FnMut(&str) -> Option<RecordBatch>, sql: &str) -> Option<String> {
+    let batch = run(sql)?;
     if batch.num_rows() == 0 {
         return None;
     }
     let values = batch.column_values::<StringArray>("v").ok()?;
     Some(values.value(0).to_string())
+}
+
+/// `SELECT version()`; None leaves the version unknown -> "assume modern server".
+fn probe_server_version(run: &mut impl FnMut(&str) -> Option<RecordBatch>) -> Option<String> {
+    scalar_probe(run, "SELECT version() AS v")
+}
+
+/// Mirrors dbclient.py `_run_exchange_test` (`Shared` = ClickHouse Cloud, exchange
+/// guaranteed without probing).
+fn probe_atomic_exchange(run: &mut impl FnMut(&str) -> Option<RecordBatch>) -> bool {
+    let db_engine = scalar_probe(
+        run,
+        "SELECT engine AS v FROM system.databases WHERE name = database()",
+    )
+    .unwrap_or_default();
+    if !engine_can_atomic_exchange(&db_engine) {
+        return false;
+    }
+    if db_engine == "Shared" {
+        return true;
+    }
+
+    let table_id = format!(
+        "{}_{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or_default()
+    );
+    let swap_tables = [
+        format!("__dbt_exchange_test_0_{table_id}"),
+        format!("__dbt_exchange_test_1_{table_id}"),
+    ];
+    let created = swap_tables.iter().all(|table| {
+        run(&format!(
+            "CREATE TABLE IF NOT EXISTS `{table}` (test String) ENGINE MergeTree() ORDER BY tuple()"
+        ))
+        .is_some()
+    });
+    let exchanged = created
+        && run(&format!(
+            "EXCHANGE TABLES `{}` AND `{}`",
+            swap_tables[0], swap_tables[1]
+        ))
+        .is_some();
+    for table in &swap_tables {
+        let _ = run(&format!("DROP TABLE IF EXISTS `{table}`"));
+    }
+    exchanged
 }
 
 /// dbclient.py `ND_MUTATION_SETTING`.
@@ -827,16 +993,12 @@ const ND_MUTATION_SETTING: &str = "allow_nondeterministic_mutations";
 /// disabled-but-changeable case with a per-session `SET` — the v2 equivalent
 /// (a per-connection driver setting) arrives with the new adbc_clickhouse
 /// driver (issue #70).
-fn probe_lightweight_deletes(
-    adapter: &AdapterImpl,
-    state: &State,
-    token: CancellationToken,
-) -> bool {
+fn probe_lightweight_deletes(run: &mut impl FnMut(&str) -> Option<RecordBatch>) -> bool {
     let sql = format!(
         "SELECT value, toString(readonly) AS readonly FROM system.settings \
          WHERE name = '{ND_MUTATION_SETTING}'"
     );
-    let Some(batch) = probe_query(adapter, state, &sql, token.clone()) else {
+    let Some(batch) = run(&sql) else {
         return false;
     };
     if batch.num_rows() == 0 {
@@ -862,7 +1024,7 @@ fn probe_lightweight_deletes(
     // Python's `SET {setting} = 1` try/except: verify the user may override
     // the setting.
     let probe = format!("SELECT 1 SETTINGS {ND_MUTATION_SETTING} = 1");
-    probe_query(adapter, state, &probe, token).is_some()
+    run(&probe).is_some()
 }
 
 /// Mirrors impl.py `calculate_incremental_strategy`.
@@ -1577,10 +1739,30 @@ mod tests {
     /// ClickHouse's `system.tables` is case-sensitive on `database` and `name`
     #[test]
     fn build_get_relation_sql_passes_names_through_verbatim() {
-        assert_eq!(
-            build_get_relation_sql("Mixed_Case", "Stg_Customers"),
-            "SELECT engine, name FROM system.tables \
-             WHERE database = 'Mixed_Case' AND name = 'Stg_Customers'",
+        let sql = build_get_relation_sql("Mixed_Case", "Stg_Customers");
+        assert!(
+            sql.ends_with(
+                "FROM system.tables WHERE database = 'Mixed_Case' AND name = 'Stg_Customers'"
+            ),
+            "got: {sql}"
+        );
+        assert!(
+            sql.contains(
+                "(SELECT engine FROM system.databases WHERE name = 'Mixed_Case') AS database_engine"
+            ),
+            "got: {sql}"
+        );
+        assert!(
+            sql.contains("= 'Mixed_Case.Stg_Customers') AS mvs_pointing_to_it"),
+            "got: {sql}"
+        );
+        assert!(
+            sql.contains("' REFRESH ')) > 0, 'true', 'false') AS is_refreshable"),
+            "got: {sql}"
+        );
+        assert!(
+            sql.contains("' APPEND')) > 0, 'true', 'false') AS refreshable_append"),
+            "got: {sql}"
         );
     }
 
@@ -1589,9 +1771,74 @@ mod tests {
     /// the literal terminates early or trails an unbalanced backslash.
     #[test]
     fn build_get_relation_sql_escapes_quotes_and_backslashes() {
-        assert_eq!(
-            build_get_relation_sql("a'b", r"c\d"),
-            r"SELECT engine, name FROM system.tables WHERE database = 'a\'b' AND name = 'c\\d'",
+        let sql = build_get_relation_sql("a'b", r"c\d");
+        assert!(
+            sql.ends_with(r"FROM system.tables WHERE database = 'a\'b' AND name = 'c\\d'"),
+            "got: {sql}"
         );
+        assert!(
+            sql.contains(r"= 'a\'b.c\\d') AS mvs_pointing_to_it"),
+            "got: {sql}"
+        );
+    }
+
+    #[test]
+    fn mv_target_regex_has_no_literal_question_mark() {
+        assert!(!MV_TARGET_FQN_REGEX_SQL.contains('?'));
+        assert!(!build_get_relation_sql("db", "t").contains('?'));
+    }
+
+    #[test]
+    fn can_exchange_mirrors_python() {
+        assert!(engine_can_atomic_exchange("Atomic"));
+        assert!(engine_can_atomic_exchange("Replicated"));
+        assert!(engine_can_atomic_exchange("Shared"));
+        assert!(!engine_can_atomic_exchange("Ordinary"));
+        assert!(!engine_can_atomic_exchange("Lazy"));
+
+        let caps = |atomic_exchange| ClickHouseCapabilities {
+            server_version: String::new(),
+            atomic_exchange,
+            has_lw_deletes: false,
+            use_lw_deletes: false,
+        };
+        assert!(relation_can_exchange(
+            &caps(true),
+            RelationType::Table,
+            "Atomic"
+        ));
+        assert!(!relation_can_exchange(
+            &caps(true),
+            RelationType::View,
+            "Atomic"
+        ));
+        assert!(!relation_can_exchange(
+            &caps(true),
+            RelationType::MaterializedView,
+            "Atomic"
+        ));
+        assert!(!relation_can_exchange(
+            &caps(false),
+            RelationType::Table,
+            "Atomic"
+        ));
+        assert!(!relation_can_exchange(
+            &caps(true),
+            RelationType::Table,
+            "Ordinary"
+        ));
+    }
+
+    #[test]
+    fn parse_mvs_pointing_to_it_handles_json_and_garbage() {
+        let parsed =
+            parse_mvs_pointing_to_it(r#"[{"schema":"db1","name":"mv1","sql":"select 1"}]"#);
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0]["schema"], "db1");
+        assert_eq!(parsed[0]["name"], "mv1");
+        assert_eq!(parsed[0]["sql"], "select 1");
+        assert!(parse_mvs_pointing_to_it("[]").is_empty());
+        assert!(parse_mvs_pointing_to_it("").is_empty());
+        assert!(parse_mvs_pointing_to_it("not json").is_empty());
     }
 }

--- a/crates/dbt-adapter/src/metadata/get_relation.rs
+++ b/crates/dbt-adapter/src/metadata/get_relation.rs
@@ -1067,12 +1067,20 @@ fn clickhouse_get_relation(
     identifier: &str,
     token: CancellationToken,
 ) -> AdapterResult<Option<Box<dyn BaseRelation>>> {
-    use crate::metadata::clickhouse::{build_get_relation_sql, relation_type_from_engine};
+    use crate::metadata::clickhouse::{
+        build_get_relation_sql, relation_type_from_engine, server_capabilities_over_connection,
+        with_catalog_state,
+    };
     use crate::record_batch::RecordBatchExt;
 
     // ClickHouse only has databases, not schemas — dbt `schema` maps to CH `database`.
     // dbt `database` is unused here.
     let sql = build_get_relation_sql(schema, identifier);
+
+    // Probe over the connection we already hold: the State-based entry would
+    // borrow a second thread-local connection and trip the nested-guard check.
+    let caps =
+        server_capabilities_over_connection(adapter.engine().as_ref(), ctx, conn, token.clone());
 
     let batch = adapter
         .engine()
@@ -1088,18 +1096,16 @@ fn clickhouse_get_relation(
             "Expected exactly one row for ClickHouse get_relation",
         ));
     }
-
-    let relation_type = Some(relation_type_from_engine(engines.value(0)));
-
-    let relation = do_create_relation(
+    let relation = Relation::new(
         adapter.adapter_type(),
-        database.to_string(),
-        schema.to_string(),
+        Some(database.to_string()),
+        Some(schema.to_string()),
         Some(identifier.to_string()),
-        relation_type,
-        adapter.quoting(),
-    )?;
-    Ok(Some(relation))
+    )
+    .with_relation_type(relation_type_from_engine(engines.value(0)))
+    .with_quoting(adapter.quoting());
+    let relation = with_catalog_state(relation, caps, &batch, 0)?;
+    Ok(Some(Box::new(relation) as Box<dyn BaseRelation>))
 }
 
 #[cfg(test)]

--- a/crates/dbt-adapter/src/relation/relation_impl.rs
+++ b/crates/dbt-adapter/src/relation/relation_impl.rs
@@ -201,6 +201,11 @@ pub struct Relation {
     pub alter_constraints: Vec<databricks::typed_constraint::TypedConstraint>,
     /// Whether the relation is a temporary view (session-scoped).
     pub temporary: bool,
+    /// ClickHouse catalog state; see [`BaseRelation::can_exchange`] and siblings.
+    pub can_exchange: bool,
+    pub mvs_pointing_to_it: Vec<BTreeMap<String, String>>,
+    pub is_refreshable: bool,
+    pub refreshable_append: bool,
     /// The location/region for this relation (BigQuery only, e.g., "US", "EU").
     pub location: Option<String>,
     /// DuckDB external source location, rendered in place of schema/table.
@@ -358,6 +363,10 @@ impl Relation {
             create_constraints: Vec::new(),
             alter_constraints: Vec::new(),
             temporary: false,
+            can_exchange: false,
+            mvs_pointing_to_it: Vec::new(),
+            is_refreshable: false,
+            refreshable_append: false,
             external: None,
             table_format: TableFormat::Default,
         }
@@ -395,6 +404,26 @@ impl Relation {
 
     pub fn with_temporary(mut self, temporary: bool) -> Self {
         self.temporary = temporary;
+        self
+    }
+
+    pub fn with_can_exchange(mut self, can_exchange: bool) -> Self {
+        self.can_exchange = can_exchange;
+        self
+    }
+
+    pub fn with_mvs_pointing_to_it(mut self, mvs: Vec<BTreeMap<String, String>>) -> Self {
+        self.mvs_pointing_to_it = mvs;
+        self
+    }
+
+    pub fn with_is_refreshable(mut self, is_refreshable: bool) -> Self {
+        self.is_refreshable = is_refreshable;
+        self
+    }
+
+    pub fn with_refreshable_append(mut self, refreshable_append: bool) -> Self {
+        self.refreshable_append = refreshable_append;
         self
     }
 
@@ -455,6 +484,10 @@ impl Relation {
             create_constraints: Vec::default(),
             alter_constraints: Vec::default(),
             temporary: false,
+            can_exchange: false,
+            mvs_pointing_to_it: Vec::new(),
+            is_refreshable: false,
+            refreshable_append: false,
             location: Some("".to_string()),
             external: None,
             table_format: TableFormat::Default,
@@ -704,6 +737,10 @@ impl BaseRelation for Relation {
         .with_metadata(self.metadata.clone())
         .with_is_delta(self.is_delta)
         .with_temporary(self.temporary)
+        .with_can_exchange(self.can_exchange)
+        .with_mvs_pointing_to_it(self.mvs_pointing_to_it.clone())
+        .with_is_refreshable(self.is_refreshable)
+        .with_refreshable_append(self.refreshable_append)
         // FIXME: no need to validate here since the parent relation is already valid.
         .validate()?;
 
@@ -729,6 +766,10 @@ impl BaseRelation for Relation {
         .with_metadata(self.metadata.clone())
         .with_is_delta(self.is_delta)
         .with_temporary(self.temporary)
+        .with_can_exchange(self.can_exchange)
+        .with_mvs_pointing_to_it(self.mvs_pointing_to_it.clone())
+        .with_is_refreshable(self.is_refreshable)
+        .with_refreshable_append(self.refreshable_append)
         // FIXME: no need to validate here since the parent relation is already valid.
         .validate()?;
         relation.create_constraints = self.create_constraints.clone();
@@ -769,6 +810,22 @@ impl BaseRelation for Relation {
 
     fn is_temporary(&self) -> bool {
         self.temporary
+    }
+
+    fn can_exchange(&self) -> bool {
+        self.can_exchange
+    }
+
+    fn mvs_pointing_to_it(&self) -> &[BTreeMap<String, String>] {
+        &self.mvs_pointing_to_it
+    }
+
+    fn is_refreshable(&self) -> bool {
+        self.is_refreshable
+    }
+
+    fn refreshable_append(&self) -> bool {
+        self.refreshable_append
     }
 
     fn is_delta(&self) -> bool {
@@ -1201,6 +1258,10 @@ impl BaseRelation for Relation {
             .with_is_delta(self.is_delta)
             .with_temporary(self.temporary)
             .with_table_format(self.table_format)
+            .with_can_exchange(self.can_exchange)
+            .with_mvs_pointing_to_it(self.mvs_pointing_to_it.clone())
+            .with_is_refreshable(self.is_refreshable)
+            .with_refreshable_append(self.refreshable_append)
             .validate()?;
         Ok(Arc::new(relation))
     }

--- a/crates/dbt-adapter/src/relation/relation_object.rs
+++ b/crates/dbt-adapter/src/relation/relation_object.rs
@@ -404,6 +404,12 @@ impl Object for RelationObject {
             Some("project") => Some(Value::from(self.database())),
             Some("dataset") => Some(Value::from(self.schema())),
 
+            // ClickHouse
+            Some("can_exchange") => Some(Value::from(self.can_exchange())),
+            Some("mvs_pointing_to_it") => Some(Value::from_serialize(self.mvs_pointing_to_it())),
+            Some("is_refreshable") => Some(Value::from(self.is_refreshable())),
+            Some("refreshable_append") => Some(Value::from(self.refreshable_append())),
+
             _ => None,
         }
     }
@@ -1311,6 +1317,82 @@ mod tests {
         assert_eq!(
             result_get_part.detail().unwrap(),
             "'bad' is not a valid argument"
+        );
+    }
+
+    #[test]
+    fn clickhouse_relation_exposes_catalog_state_attributes() {
+        let relation = Relation::new(
+            AdapterType::ClickHouse,
+            None,
+            Some("analytics".to_string()),
+            Some("events".to_string()),
+        )
+        .with_relation_type(RelationType::Table)
+        .with_quoting(DEFAULT_RESOLVED_QUOTING)
+        .with_mvs_pointing_to_it(vec![BTreeMap::from([
+            ("schema".to_string(), "analytics".to_string()),
+            ("name".to_string(), "events_mv".to_string()),
+            ("sql".to_string(), "select 1".to_string()),
+        ])])
+        .with_is_refreshable(true)
+        .with_can_exchange(true)
+        .validate()
+        .unwrap();
+        let obj = Arc::new(RelationObject::new(Arc::new(relation)));
+
+        assert!(
+            obj.get_value(&Value::from("can_exchange"))
+                .unwrap()
+                .is_true()
+        );
+        let mvs = obj.get_value(&Value::from("mvs_pointing_to_it")).unwrap();
+        assert_eq!(mvs.len(), Some(1));
+        assert_eq!(
+            mvs.get_item_by_index(0)
+                .unwrap()
+                .get_attr("name")
+                .unwrap()
+                .as_str(),
+            Some("events_mv")
+        );
+        assert!(
+            obj.get_value(&Value::from("is_refreshable"))
+                .unwrap()
+                .is_true()
+        );
+        assert!(
+            !obj.get_value(&Value::from("refreshable_append"))
+                .unwrap()
+                .is_true()
+        );
+
+        let bare = Relation::new(
+            AdapterType::ClickHouse,
+            None,
+            Some("analytics".to_string()),
+            Some("plain".to_string()),
+        )
+        .validate()
+        .unwrap();
+        let bare = Arc::new(RelationObject::new(Arc::new(bare)));
+        assert_eq!(
+            bare.get_value(&Value::from("mvs_pointing_to_it"))
+                .unwrap()
+                .len(),
+            Some(0)
+        );
+        assert!(
+            !bare
+                .get_value(&Value::from("is_refreshable"))
+                .unwrap()
+                .is_true()
+        );
+        assert!(
+            !bare
+                .get_value(&Value::from("can_exchange"))
+                .unwrap()
+                .is_true()
         );
     }
 }

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-clickhouse/macros/adapters.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-clickhouse/macros/adapters.sql
@@ -94,6 +94,10 @@
         map('schema', mv_sources.mv_database, 'name', mv_sources.mv_name, 'sql', mv_sources.mv_sql),
         mv_sources.mv_name != ''
       ) as mvs_pointing_to_it,
+      -- The refresh clause of a refreshable MV sits between the view name and the TO clause,
+      -- e.g. CREATE MATERIALIZED VIEW db.mv REFRESH EVERY 2 MINUTE [APPEND] TO db.target ...
+      max(position(substring(t.create_table_query, 1, position(t.create_table_query, ' TO ')), ' REFRESH ')) > 0 as is_refreshable,
+      max(position(substring(t.create_table_query, 1, position(t.create_table_query, ' TO ')), ' APPEND')) > 0 as refreshable_append,
       {%- if get_clickhouse_cluster_name() -%}
         count(distinct _shard_num) > 1  as  is_on_cluster
         from clusterAllReplicas({{ get_clickhouse_cluster_name() }}, system.tables) as t

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-clickhouse/macros/materializations/materialized_view.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-clickhouse/macros/materializations/materialized_view.sql
@@ -28,6 +28,33 @@
     {{ return(result) }}
 {%- endmaterialization -%}
 
+{#-
+  Split a model's sql into individual materialized view queries (if multiple exist).
+
+  Views are delimited by `--<name>:begin` / `--<name>:end` marker comments.
+  The returned mapping is keyed by marker name in the order the markers appear.
+  Each key becomes a suffix on the model's relation, so marker `mv1` creates the
+  view `<model>_mv1`. A model without any markers yields the single key `mv`
+  covering the whole sql, yielding one `<model>_mv` view.
+-#}
+{% macro clickhouse__extract_mv_views(sql) %}
+  {#- the name must be a single token. If the pattern permits a space in the name, an
+      unrelated `--` comment becomes a part of the marker, and the name is then wrong -#}
+  {% set view_names = modules.re.findall('--(?:\\s)?([^:\\s]+):begin', sql) %}
+
+  {% set views = {} %}
+  {% if view_names %}
+    {% for view_name in view_names %}
+      {% set view_sql = modules.re.findall('--(?:\\s)?' + view_name + ':begin(.*)--(?:\\s)?' + view_name + ':end', sql, modules.re.DOTALL)[0] %}
+      {%- set _ = views.update({view_name: view_sql}) -%}
+    {% endfor %}
+  {% else %}
+    {%- set _ = views.update({"mv": sql}) -%}
+  {% endif %}
+
+  {{ return(views) }}
+{% endmacro %}
+
 {% macro strip_identifier_quotes(ident) %}
   {%- set s = ident.strip() -%}
   {%- if (s.startswith('`') and s.endswith('`')) or
@@ -114,7 +141,7 @@
     {% endif %}
 
     {{ log('Updating query of existing MV ' ~ mv_relation.name ~ ' for recreation') }}
-    -- We should also update refreshable paramenters here https://github.com/ClickHouse/dbt-clickhouse/issues/611
+    {{ clickhouse__modify_mv_refresh(mv_relation, existing_relation, cluster_clause) }}
     {{ clickhouse__modify_mv(mv_relation, cluster_clause, sql, is_main_statement=True) }};
     {%- set view_created = False -%}
   {% endif %}
@@ -178,19 +205,8 @@
   -- `BEGIN` happens here:
   {{ run_hooks(pre_hooks, inside_transaction=True) }}
 
-  -- extract the names of the materialized views from the sql
-  {% set view_names = modules.re.findall('--(?:\s)?([^:]+):begin', sql) %}
-
-  -- extract the sql for each of the materialized view into a map
-  {% set views = {} %}
-  {% if view_names %}
-    {% for view_name in view_names %}
-      {% set view_sql = modules.re.findall('--(?:\s)?' + view_name + ':begin(.*)--(?:\s)?' + view_name + ':end', sql, modules.re.DOTALL)[0] %}
-      {%- set _ = views.update({view_name: view_sql}) -%}
-    {% endfor %}
-  {% else %}
-    {%- set _ = views.update({"mv": sql}) -%}
-  {% endif %}
+  -- extract the sql for each of the materialized views into a map
+  {% set views = clickhouse__extract_mv_views(sql) %}
 
   {% if backup_relation is none %}
     {{ log('Creating new materialized view ' + target_relation.name )}}
@@ -213,9 +229,7 @@
       {% endfor %}
     {% endif %}
     {% if should_full_refresh() %}
-      {% call statement('main') -%}
-        {{ clickhouse__create_target_table(backup_relation, sql, catchup_data) }}
-      {%- endcall %}
+      {% do clickhouse__create_target_table(backup_relation, sql, catchup_data) %}
 
       {# Drop MV just before exchange to minimize blind period while avoiding old MV writing to new table #}
       {{ clickhouse__drop_mvs_by_suffixes(target_relation, cluster_clause, views) }}
@@ -232,7 +246,11 @@
        {%- set on_schema_change = incremental_validate_on_schema_change(config.get('on_schema_change'), default='ignore') -%}
        {{ log('on_schema_change strategy for destination table of  MV: ' + on_schema_change, info=True) }}
        {%- if on_schema_change != 'ignore' -%}
-        {% do exceptions.raise_compiler_error("ClickHouse materialized_view on_schema_change != 'ignore' is not yet supported in Fusion") %}
+        {%- set column_changes = adapter.check_incremental_schema_changes(on_schema_change, existing_relation, sql, materialization='materialized view', query_settings=config.get('query_settings', {})) -%}
+        {% if column_changes %}
+          {% do clickhouse__apply_column_changes(column_changes, existing_relation) %}
+          {% set existing_relation = load_cached_relation(this) %}
+        {% endif %}
       {%- endif %}
       -- try to alter view first to replace sql, else drop and create
       {{ clickhouse__update_mvs(target_relation, cluster_clause, refreshable_clause, views) }}
@@ -272,12 +290,14 @@
   If catchup is False, creates an empty table without backfilling.
 #}
 {% macro clickhouse__create_target_table(relation, sql, catchup=True) -%}
-  {% if catchup == True %}
-    {{ get_create_table_as_sql(False, relation, sql) }}
+  {% if catchup %}
+    {% call statement('main') %}
+      {{ get_create_table_as_sql(False, relation, sql) }}
+    {% endcall %}
   {% else %}
     {{ log('Catchup config set to false, skipping table backfill for ' + relation.name) }}
     {% set has_contract = config.get('contract').enforced %}
-    {{ create_table_or_empty(False, relation, sql, has_contract) }}
+    {{ clickhouse__create_empty_table(False, relation, sql, has_contract, statement_name='main') }}
   {% endif %}
 {%- endmacro %}
 
@@ -289,9 +309,7 @@
   data into the table creating during step 1
 #}
 {% macro clickhouse__get_create_materialized_view_as_sql(relation, sql, views, catchup=True ) -%}
-  {% call statement('main') %}
-    {{ clickhouse__create_target_table(relation, sql, catchup) }}
-  {% endcall %}
+  {% do clickhouse__create_target_table(relation, sql, catchup) %}
   {%- set cluster_clause = on_cluster_clause(relation) -%}
   {%- set refreshable_clause = refreshable_mv_clause() -%}
   {%- set mv_relation = relation.derivative('_mv', 'materialized_view') -%}
@@ -323,7 +341,10 @@
 
 {% macro clickhouse__get_mv_current_target(mv_relation) %}
   {% set query %}
-    {#- '\x3F' is the ClickHouse string-literal escape for '?' (regex quantifier); the ADBC driver treats a literal '?' in query text as a bind parameter. To be fixed in https://github.com/ClickHouse/adbc_clickhouse/issues/53 -#}
+    {# 
+      '\x3F' is the ClickHouse string-literal escape for '?' (regex quantifier); some drivers treat a literal '?' in query text as a bind parameter.
+      Literal can be configured back to '?' after https://github.com/ClickHouse/adbc_clickhouse/issues/53 is fixed.
+    #}
     select replaceRegexpOne(create_table_query, '.*TO\\s+`\x3F([^`\\s(]+)`\x3F\\.`\x3F([^`\\s(]+)`\x3F.*', '\\1.\\2') as target_table
     from system.tables
     where database = '{{ mv_relation.schema }}'
@@ -337,9 +358,62 @@
   {{ return(none) }}
 {% endmacro %}
 
+{#-
+  Applies refresh parameter changes to an existing refreshable MV in place via
+  ALTER TABLE ... MODIFY REFRESH (https://github.com/ClickHouse/dbt-clickhouse/issues/611).
+  Like MODIFY QUERY, the statement is deliberately issued on every run without diffing
+  against the deployed schedule (simplicity over avoiding no-op DDL): it replaces the
+  whole schedule (interval, randomization and dependencies), so reissuing unchanged
+  parameters is a harmless no-op.
+  The deployed state comes from the cached relation (is_refreshable / refreshable_append),
+  so no extra round trip to ClickHouse is needed. Transitions that ClickHouse cannot apply
+  in place (regular <-> refreshable, APPEND <-> non-APPEND) raise an error pointing the
+  user to --full-refresh instead of being silently ignored.
+  mv_relation and existing_relation always refer to the same MV: both call sites resolve
+  existing_relation from mv_relation's own schema and identifier. The split exists because
+  mv_relation is the render target while existing_relation carries the cache-populated flags.
+-#}
+{% macro clickhouse__modify_mv_refresh(mv_relation, existing_relation, cluster_clause) %}
+  {%- set refreshable_config = config.get('refreshable') -%}
+  {%- if refreshable_config is none or refreshable_config == false -%}
+    {%- if existing_relation.is_refreshable -%}
+      {% do exceptions.raise_compiler_error(
+        'Materialized view "' ~ mv_relation.name ~ '" is refreshable, but the model does not define a "refreshable" config. '
+        ~ 'A refreshable MV cannot be converted to a regular MV in place. '
+        ~ 'If you want to change this MV to a regular MV, please run with --full-refresh.'
+      ) %}
+    {%- endif -%}
+  {%- else -%}
+    {%- if not existing_relation.is_refreshable -%}
+      {% do exceptions.raise_compiler_error(
+        'Materialized view "' ~ mv_relation.name ~ '" is not refreshable, but the model defines a "refreshable" config. '
+        ~ 'A regular MV cannot be converted to a refreshable MV in place. '
+        ~ 'If you want to change this MV to be refreshable, please run with --full-refresh.'
+      ) %}
+    {%- endif -%}
+    {%- set config_append = true if (refreshable_config is mapping and refreshable_config.get('append', false)) else false -%}
+    {%- if config_append != existing_relation.refreshable_append -%}
+      {% do exceptions.raise_compiler_error(
+        'The APPEND setting of materialized view "' ~ mv_relation.name ~ '" does not match the model config. '
+        ~ 'APPEND cannot be changed via ALTER TABLE ... MODIFY REFRESH. '
+        ~ 'If you want to change it, please run with --full-refresh.'
+      ) %}
+    {%- endif -%}
+    {{ log('Updating refresh parameters of existing MV ' ~ mv_relation.name) }}
+    {#- ClickHouse requires the APPEND keyword in MODIFY REFRESH to match the view's
+        creation-time APPEND mode ("Adding or removing APPEND is not supported"), so the
+        full clause is used here; the guard above guarantees config and deployed agree. -#}
+    {%- set modify_refresh_clause = refreshable_mv_clause() -%}
+    {% call statement('modify refresh of existing mv: ' ~ mv_relation.name) -%}
+      alter table {{ mv_relation }} {{ cluster_clause }} modify {{ modify_refresh_clause }}
+    {%- endcall %}
+  {%- endif -%}
+{% endmacro %}
+
 {% macro clickhouse__update_mv(mv_relation, target_relation, cluster_clause, refreshable_clause, view_sql)  -%}
   {% set existing_relation = adapter.get_relation(database=mv_relation.database, schema=mv_relation.schema, identifier=mv_relation.identifier) %}
   {% if existing_relation %}
+    {{ clickhouse__modify_mv_refresh(mv_relation, existing_relation, cluster_clause) }}
     {{ clickhouse__modify_mv(mv_relation, cluster_clause, view_sql) }};
   {% else %}
     {{ clickhouse__drop_mv(mv_relation, cluster_clause) }};
@@ -434,9 +508,7 @@
   {{ clickhouse__drop_mvs_by_suffixes(target_relation, cluster_clause, views) }}
 
   {# recreate the target table #}
-  {% call statement('main') -%}
-    {{ clickhouse__create_target_table(intermediate_relation, sql, catchup) }}
-  {%- endcall %}
+  {% do clickhouse__create_target_table(intermediate_relation, sql, catchup) %}
   {{ adapter.rename_relation(existing_relation, backup_relation) }}
   {{ adapter.rename_relation(intermediate_relation, target_relation) }}
 
@@ -444,8 +516,12 @@
   {{ clickhouse__create_mvs(target_relation, cluster_clause, refreshable_clause, views) }}
 {% endmacro %}
 
+{#-
+  Renders the refresh clause of a refreshable MV
+  (REFRESH ... [RANDOMIZE FOR ...] [DEPENDS ON ...] [APPEND]).
+-#}
 {% macro refreshable_mv_clause() %}
-  {%- if config.get('refreshable') is not none -%}
+  {%- if config.get('refreshable') is not none and config.get('refreshable') != false -%}
 
     {% set refreshable_config = config.get('refreshable') %}
     {% if refreshable_config is not mapping %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-clickhouse/macros/materializations/table.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-clickhouse/macros/materializations/table.sql
@@ -10,10 +10,10 @@
     {%- set backup_relation_type = existing_relation.type -%}
     {%- set backup_relation = make_backup_relation(target_relation, backup_relation_type) -%}
     {%- set preexisting_backup_relation = load_cached_relation(backup_relation) -%}
-    {# v2: no can_exchange/EXCHANGE TABLES support yet — every rebuild takes
-       upstream's intermediate+rename fallback. #}
-    {%- set intermediate_relation = make_intermediate_relation(target_relation) -%}
-    {%- set preexisting_intermediate_relation = load_cached_relation(intermediate_relation) -%}
+    {% if not existing_relation.can_exchange %}
+      {%- set intermediate_relation =  make_intermediate_relation(target_relation) -%}
+      {%- set preexisting_intermediate_relation = load_cached_relation(intermediate_relation) -%}
+    {% endif %}
   {% endif %}
 
   {% set grant_config = config.get('grants') %}
@@ -27,19 +27,112 @@
   -- `BEGIN` happens here:
   {{ run_hooks(pre_hooks, inside_transaction=True) }}
 
+  {%- set configured_mv_on_schema_change = none -%}
+  {%- set repopulate_from_mvs_on_full_refresh = config.get('repopulate_from_mvs_on_full_refresh', False) -%}
+  {%- set dbt_mvs_pointing_to_this_table = clickhouse__get_dbt_mvs_for_target(existing_relation) -%}
+
   {# If there is not existing relation, we can just create a new one #}
   {% if existing_relation is none %}
     {{ log('Creating new relation ' + target_relation.name )}}
     {% call statement('main') -%}
       {{ get_create_table_as_sql(False, target_relation, sql) }}
     {%- endcall %}
+
+  {# If regular run was executed: Apply mv_on_schema_change strategy #}
+  {% elif not should_full_refresh() %}
+    {# mv_on_schema_change defaults to 'ignore' in dbt, so we need unrendered_config to know if the user actually set it #}
+    {%- set user_has_configured_mv_on_schema_change = 'mv_on_schema_change' in config.model.unrendered_config -%}
+
+    {# `mv_on_schema_change` is only meaningful for tables targeted by dbt-managed MVs.
+      - For non-MV tables: always rebuild normally, ignoring any mv_on_schema_change
+      - For MV-target tables: default to `fail` if it's not configured by the user #}
+    {%- if dbt_mvs_pointing_to_this_table -%}
+      {%- if user_has_configured_mv_on_schema_change -%}
+        {%- set configured_mv_on_schema_change = config.get('mv_on_schema_change', 'ignore') -%}
+      {%- else -%}
+        {{ log('Table ' ~ target_relation.name ~ ' is used as a target by a dbt-managed materialized view. Defaulting mv_on_schema_change to "fail" to prevent data loss.', info=True) }}
+        {%- set configured_mv_on_schema_change = 'fail' -%}
+      {%- endif -%}
+    {%- endif -%}
+
+    {# If no mv_on_schema_change is set, we behave as usual (rebuild the table) #}
+    {% if configured_mv_on_schema_change is none %}
+      {% if existing_relation.can_exchange %}
+      {% call statement('main') -%}
+            {{ get_create_table_as_sql(False, backup_relation, sql) }}
+          {%- endcall %}
+      {% do exchange_tables_atomic(backup_relation, existing_relation) %}
+      {% else %}
+          -- We have to use an intermediate and rename accordingly
+          {% call statement('main') -%}
+            {{ get_create_table_as_sql(False, intermediate_relation, sql) }}
+          {%- endcall %}
+          {{ adapter.rename_relation(existing_relation, backup_relation) }}
+          {{ adapter.rename_relation(intermediate_relation, target_relation) }}
+      {% endif %}
+
+    {# If mv_on_schema_change is set, we apply the strategy #}
+    {% else %}
+      {%- set mv_on_schema_change = incremental_validate_on_schema_change(configured_mv_on_schema_change, default='ignore') -%}
+      {% call statement('main') -%}
+        Select 1
+      {%- endcall %}
+      {{ log('on_schema_change strategy for table: ' + mv_on_schema_change) }}
+      {%- if mv_on_schema_change != 'ignore' -%}
+        {%- set column_changes = adapter.check_incremental_schema_changes(mv_on_schema_change, existing_relation, sql, materialization='table', query_settings=config.get('query_settings', {})) -%}
+        {% if column_changes %}
+          {% do clickhouse__apply_column_changes(column_changes, existing_relation) %}
+          {% set existing_relation = load_cached_relation(this) %}
+        {% endif %}
+      {%- endif %}
+    {% endif %}
+
+  {# Behaviour under full_refresh operations #}
   {% else %}
-    -- We have to use an intermediate and rename accordingly
-    {% call statement('main') -%}
-      {{ get_create_table_as_sql(False, intermediate_relation, sql) }}
-    {%- endcall %}
-    {{ adapter.rename_relation(existing_relation, backup_relation) }}
-    {{ adapter.rename_relation(intermediate_relation, target_relation) }}
+    {# Atomic full refresh with MV repopulation: when table is target of dbt MVs and repopulate_from_mvs_on_full_refresh is enabled #}
+    {% if dbt_mvs_pointing_to_this_table and repopulate_from_mvs_on_full_refresh %}
+      {{ log('Performing atomic full refresh with MV repopulation for ' ~ target_relation.name, info=True) }}
+
+      {# Choose staging relation based on exchange support #}
+      {% set staging_relation = backup_relation if existing_relation.can_exchange else intermediate_relation %}
+
+      {# Create staging table with new schema (empty) #}
+      {% call statement('main') -%}
+        {{ get_create_table_as_sql(False, staging_relation, sql) }}
+      {%- endcall %}
+
+      {# Populate staging table from each MV's SELECT #}
+      {% for mv_info in dbt_mvs_pointing_to_this_table %}
+          {{ log('Repopulating from MV: ' ~ mv_info.name, info=True) }}
+          {% set wrapped_sql = 'SELECT * FROM (' ~ mv_info.sql ~ ')' %}
+          {% do run_query(clickhouse__insert_into(staging_relation, wrapped_sql, false, use_columns_from_sql=True)) %}
+      {% endfor %}
+
+      {# Swap tables #}
+      {% if existing_relation.can_exchange %}
+        {% do exchange_tables_atomic(backup_relation, existing_relation) %}
+      {% else %}
+        {{ adapter.rename_relation(existing_relation, backup_relation) }}
+        {{ adapter.rename_relation(intermediate_relation, target_relation) }}
+      {% endif %}
+
+    {# Normal full refresh: no MV repopulation, just create a new, empty table #}
+    {% else %}
+      {% if existing_relation.can_exchange %}
+        -- We can do an atomic exchange, so no need for an intermediate
+        {% call statement('main') -%}
+          {{ get_create_table_as_sql(False, backup_relation, sql) }}
+        {%- endcall %}
+        {% do exchange_tables_atomic(backup_relation, existing_relation) %}
+      {% else %}
+        -- We have to use an intermediate and rename accordingly
+        {% call statement('main') -%}
+          {{ get_create_table_as_sql(False, intermediate_relation, sql) }}
+        {%- endcall %}
+        {{ adapter.rename_relation(existing_relation, backup_relation) }}
+        {{ adapter.rename_relation(intermediate_relation, target_relation) }}
+      {% endif %}
+    {% endif %}
   {% endif %}
 
   -- cleanup
@@ -182,7 +275,7 @@
 {%- endmacro -%}
 
 {% macro on_cluster_clause(relation, force_sync) %}
-  {% set active_cluster = get_clickhouse_cluster_name() %}
+  {% set active_cluster = adapter.get_clickhouse_cluster_name() %}
   {%- if active_cluster is not none and relation.should_on_cluster %}
     {# Add trailing whitespace to avoid problems when this clause is not last #}
     ON CLUSTER {{ active_cluster + ' ' }}
@@ -212,6 +305,48 @@
     {%- endif %}
 {% endmacro %}
 
+{% macro validate_projection(projection) -%}
+    {%- set proj_name = projection.get('name') -%}
+    {%- set proj_query = projection.get('query') -%}
+    {%- set proj_index = projection.get('index') -%}
+    {%- if proj_query and proj_index -%}
+        {{ exceptions.raise_compiler_error("Projection '" ~ proj_name ~ "' cannot specify both 'query' and 'index'.") }}
+    {%- elif not proj_query and not proj_index -%}
+        {{ exceptions.raise_compiler_error("Projection '" ~ proj_name ~ "' must specify either 'query' or 'index'.") }}
+    {%- endif -%}
+{%- endmacro %}
+
+{# Validates every configured projection without emitting DDL, so materializations
+   can fail fast on bad configs before dropping or renaming any relation. #}
+{% macro validate_projections() -%}
+    {%- for projection in config.get('projections', default=[]) -%}
+        {%- do validate_projection(projection) -%}
+    {%- endfor -%}
+{%- endmacro %}
+
+{# Renders a projection declaration (PROJECTION <name> <body>), the unit shared by
+   CREATE TABLE and ALTER TABLE — ALTER call sites prepend ADD themselves. #}
+{% macro clickhouse_projection_ddl(projection) -%}
+    {%- do validate_projection(projection) -%}
+    {%- set proj_name = projection.get('name') -%}
+    {%- set proj_query = projection.get('query') -%}
+    {%- set proj_index = projection.get('index') -%}
+    {%- if proj_query -%}
+        PROJECTION {{ proj_name }} ({{ proj_query }})
+    {%- else -%}
+        {%- if proj_index is string -%}
+            {%- set proj_index = [proj_index] -%}
+        {%- endif -%}
+        {%- set cols_str = proj_index | join(', ') -%}
+        {%- set cols_index_expr = '(' ~ cols_str ~ ')' if proj_index | length > 1 else cols_str -%}
+        {%- if not adapter.is_before_version('26.1.1.1') -%}
+            PROJECTION {{ proj_name }} INDEX {{ cols_index_expr }} TYPE basic
+        {%- else -%}
+            PROJECTION {{ proj_name }} (SELECT _part_offset ORDER BY {{ cols_str }})
+        {%- endif -%}
+    {%- endif -%}
+{%- endmacro %}
+
 {#
     A macro that adds any configured projections or indexes at the same time.
     We optimise to reduce the number of ALTER TABLE statements that are run to avoid
@@ -229,7 +364,7 @@
             ALTER TABLE {{ relation }}
             {%- if projections %}
                 {%- for projection in projections %}
-                    ADD PROJECTION {{ projection.get('name') }} ({{ projection.get('query') }})
+                    ADD {{ clickhouse_projection_ddl(projection) }}
                     {%- if not loop.last or indexes | length > 0 -%}
                         ,
                     {% endif %}
@@ -284,7 +419,7 @@
 
 {%- endmacro %}
 
-{% macro clickhouse__insert_into(insert_relation, sql, has_contract, use_columns_from_sql=False) %}
+{% macro clickhouse__insert_into(target_relation, sql, has_contract, use_columns_from_sql=False) %}
   {% if use_columns_from_sql %}
     {% set dest_columns = clickhouse__get_columns_in_query(sql) %}
     {%- set ns = namespace(quoted_cols=[]) -%}
@@ -293,12 +428,12 @@
     {%- endfor -%}
     {%- set dest_cols_csv = ns.quoted_cols | join(', ') -%}
   {%- else %}
-    {%- set dest_columns = adapter.get_columns_in_relation(insert_relation) -%}
+    {%- set dest_columns = adapter.get_columns_in_relation(target_relation) -%}
     {%- set dest_cols_csv = dest_columns | map(attribute='quoted') | join(', ') -%}
   {%- endif %}
 
-  insert into {{ insert_relation }}
-        {% if dest_cols_csv %}({{ dest_cols_csv }}){% endif %}
+  insert into {{ target_relation }}
+        ({{ dest_cols_csv }})
   {%- if has_contract -%}
     -- Use a subquery to get columns in the right order
           SELECT {{ dest_cols_csv }}

--- a/crates/dbt-schemas/src/schemas/project/configs/common.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/common.rs
@@ -21,6 +21,7 @@ use crate::schemas::project::configs::model_config::DataLakeObjectCategory;
 use crate::schemas::project::dbt_project::{ResolvableConfig, ResolvedConfig};
 use crate::schemas::serde::PartitionsConfig;
 use crate::schemas::serde::QueryTag;
+use crate::schemas::serde::RefreshableConfig;
 use crate::schemas::serde::StringOrArrayOfStrings;
 use crate::schemas::serde::{
     IndexesConfig, OmissibleGrantConfig, PrimaryKeyConfig, StringOrInteger, bool_or_string_bool,
@@ -286,7 +287,7 @@ pub struct WarehouseSpecificNodeConfig {
     pub definer: Option<String>,
     pub sql_security: Option<String>,
     // materialized-view materialization
-    pub refreshable: Option<BTreeMap<String, YmlValue>>,
+    pub refreshable: Option<RefreshableConfig>,
     #[serde(default, deserialize_with = "bool_or_string_bool")]
     pub catchup: Option<bool>,
     pub mv_on_schema_change: Option<String>,

--- a/crates/dbt-schemas/src/schemas/project/configs/config_merge.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/config_merge.rs
@@ -383,6 +383,7 @@ impl ReplaceIfNone for dbt_adapter_core::AdapterType {}
 // list replaces the parent's rather than unioning with it -- matching `adapter`,
 // its single-valued sibling, not `Tags`.
 impl ReplaceIfNone for crate::schemas::serde::AdapterTypeOrArray {}
+impl ReplaceIfNone for crate::schemas::serde::RefreshableConfig {}
 impl ReplaceIfNone for crate::schemas::common::DbtBatchSize {}
 impl ReplaceIfNone for crate::schemas::common::DbtContract {}
 impl ReplaceIfNone for crate::schemas::common::DbtIncrementalStrategy {}

--- a/crates/dbt-schemas/src/schemas/project/configs/model_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/model_config.rs
@@ -43,8 +43,8 @@ use crate::schemas::properties::model_properties::ModelConstraint;
 use crate::schemas::properties::{ModelFreshness, ModelState};
 use crate::schemas::serde::StringOrArrayOfStrings;
 use crate::schemas::serde::{
-    IndexesConfig, PrimaryKeyConfig, StringOrInteger, bool_or_string_bool, column_types_map,
-    default_type, event_time_or_map_to_string, f64_or_string_f64,
+    IndexesConfig, PrimaryKeyConfig, RefreshableConfig, StringOrInteger, bool_or_string_bool,
+    column_types_map, default_type, event_time_or_map_to_string, f64_or_string_f64,
     hours_to_expiration_or_string_omissible, model_constraints_or_map, string_or_number_to_string,
     u64_or_string_u64,
 };
@@ -635,7 +635,7 @@ pub struct ProjectModelConfig {
     pub sql_security: Option<String>,
     // materialized-view materialization
     #[serde(rename = "+refreshable")]
-    pub refreshable: Option<BTreeMap<String, YmlValue>>,
+    pub refreshable: Option<RefreshableConfig>,
     #[serde(default, rename = "+catchup", deserialize_with = "bool_or_string_bool")]
     pub catchup: Option<bool>,
     #[serde(rename = "+mv_on_schema_change")]
@@ -2059,7 +2059,7 @@ mod tests {
     use crate::schemas::project::configs::model_config::ProjectModelConfig;
     use crate::schemas::project::dbt_project::ResolvableConfig;
     use crate::schemas::properties::StatePreClone;
-    use crate::schemas::serde::{AdapterTypeOrArray, StringOrArrayOfStrings};
+    use crate::schemas::serde::{AdapterTypeOrArray, RefreshableConfig, StringOrArrayOfStrings};
     use dbt_adapter_core::AdapterType;
 
     /// `+propagate` rides the same project -> node -> project path `+adapter`
@@ -2903,14 +2903,28 @@ __additional_properties__: {}
         )
         .unwrap();
 
-        let refreshable = config
-            .refreshable
-            .as_ref()
-            .expect("+refreshable should parse");
+        let Some(RefreshableConfig::Config(refreshable)) = config.refreshable.as_ref() else {
+            panic!("+refreshable map should parse as RefreshableConfig::Config");
+        };
         assert_eq!(
             refreshable.get("interval").and_then(|v| v.as_str()),
             Some("EVERY 1 MINUTE")
         );
+
+        for (yml, expected) in [
+            ("+refreshable: false", RefreshableConfig::Bool(false)),
+            ("+refreshable: true", RefreshableConfig::Bool(true)),
+        ] {
+            let config: ProjectModelConfig =
+                dbt_yaml::from_str(&format!("{yml}\n__additional_properties__: {{}}\n")).unwrap();
+            assert_eq!(config.refreshable, Some(expected));
+            let model_config: ModelConfig = config.into();
+            let serialized = dbt_yaml::to_string(&model_config).unwrap();
+            assert!(
+                serialized.contains(&format!("refreshable: {}", yml.rsplit(' ').next().unwrap())),
+                "bool refreshable must serialize as a bare bool for Jinja, got:\n{serialized}"
+            );
+        }
         assert_eq!(config.catchup, Some(false));
         assert_eq!(
             config.mv_on_schema_change.as_deref(),

--- a/crates/dbt-schemas/src/schemas/relations/base.rs
+++ b/crates/dbt-schemas/src/schemas/relations/base.rs
@@ -880,6 +880,28 @@ pub trait BaseRelation: BaseRelationProperties + Any + Send + Sync + fmt::Debug 
         false
     }
 
+    /// ClickHouse relation state, stamped from the catalog (dbt-clickhouse
+    /// `ClickHouseRelation.can_exchange`).
+    fn can_exchange(&self) -> bool {
+        false
+    }
+
+    /// dbt-managed MVs writing into this relation, `{schema, name, sql}` entries
+    /// (`ClickHouseRelation.mvs_pointing_to_it`).
+    fn mvs_pointing_to_it(&self) -> &[BTreeMap<String, String>] {
+        &[]
+    }
+
+    /// `ClickHouseRelation.is_refreshable`
+    fn is_refreshable(&self) -> bool {
+        false
+    }
+
+    /// `ClickHouseRelation.refreshable_append`
+    fn refreshable_append(&self) -> bool {
+        false
+    }
+
     /// materialized_view_config_changeset
     fn materialized_view_config_changeset(
         &self,

--- a/crates/dbt-schemas/src/schemas/serde.rs
+++ b/crates/dbt-schemas/src/schemas/serde.rs
@@ -1238,6 +1238,15 @@ pub enum IndexItem {
     ClickHouse(ClickHouseIndex),
 }
 
+/// ClickHouse `refreshable` MV config: the settings map or a bare bool, where `false`
+/// behaves like omitting the key (dbt-clickhouse parity).
+#[derive(Debug, Clone, PartialEq, UntaggedEnumDeserialize, Serialize, DbtSchema)]
+#[serde(untagged)]
+pub enum RefreshableConfig {
+    Bool(bool),
+    Config(BTreeMap<String, YmlValue>),
+}
+
 /// A wrapper type for the `indexes` config field that handles flexible deserialization.
 ///
 /// dbt-core accepts both list and dictionary formats for indexes. This type accepts


### PR DESCRIPTION
Related to #14585

### Tables targeted by dbt materialized views are protected
A `table` model that a dbt-managed MV writes into no longer gets silently rebuilt on a schema change. `mv_on_schema_change` defaults to `fail` for those tables; `append_new_columns` / `sync_all_columns` alter in place.

```sql
{{ config(materialized='table', mv_on_schema_change='append_new_columns') }}
select id, name, department from {{ source('raw', 'people') }}
```

### `--full-refresh` can repopulate the target from its MVs
```sql
{{ config(materialized='table', repopulate_from_mvs_on_full_refresh=True) }}
```
Each MV's stored `SELECT` is replayed into the new table before the swap, so the target keeps its data instead of coming back empty.

### Materialized views: `on_schema_change`, refresh-schedule updates, `refreshable: false`
```sql
{{ config(materialized='materialized_view', on_schema_change='append_new_columns',
          refreshable={'interval': 'EVERY 5 MINUTE', 'randomize': '30 SECOND'}) }}
```
- `on_schema_change` now works on the MV target (was a "not yet supported" error).
- Changing `refreshable` parameters issues `ALTER TABLE … MODIFY REFRESH` in place (was silently ignored). Regular↔refreshable and APPEND↔non-APPEND transitions raise a clear error pointing to `--full-refresh`.
- `refreshable: false` parses and behaves like omitting the key (was a config error).
- Multi-MV models (`--name:begin/end` markers) update and rename correctly; dbt-managed MVs are recognised through aliases.

### Index-type projections with validation
```yaml
projections:
  - name: by_dept_age
    index: [department, age]
```
Renders `PROJECTION … INDEX (department, age) TYPE basic` on 26.1+ (the `_part_offset` form before). A projection with both or neither of `query`/`index` fails before any DDL runs.

### Atomic rebuilds via `EXCHANGE TABLES`
Table and MV-target rebuilds swap atomically on Atomic/Replicated/Shared databases, as in dbt-clickhouse; other engines keep the rename fallback. Profile `check_exchange: false` skips the probe.

## Internals
- Relation state stamped from the catalog in both native paths: `can_exchange`, `mvs_pointing_to_it`, `is_refreshable`, `refreshable_append`.
- Once-per-process EXCHANGE probe added to `ClickHouseCapabilities`, with a connection-level entry for the catalog paths.
- `refreshable` config widened to `bool | map`.
- `table.sql` and `materialized_view.sql` synced byte-identical with dbt-clickhouse; `adapters.sql` only gains the two refresh-marker columns.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
