### PR TITLE
fix(databricks): normalize tag metadata lookup identifiers

### DIFF
--- a/crates/dbt-adapter/src/metadata/databricks/mod.rs
+++ b/crates/dbt-adapter/src/metadata/databricks/mod.rs
@@ -1033,9 +1033,12 @@ impl DatabricksMetadataAdapter {
         let sql = format!(
             "SELECT tag_name, tag_value
             FROM `system`.`information_schema`.`table_tags`
-            WHERE catalog_name = '{database}'
-                AND schema_name = '{schema}'
-                AND table_name = '{identifier}'"
+            WHERE catalog_name = '{}'
+                AND schema_name = '{}'
+                AND table_name = '{}'",
+            database.to_lowercase(),
+            schema.to_lowercase(),
+            identifier.to_lowercase(),
         );
         let (_, result) = self.execute_sql_with_context(&sql, state, "Fetch tags", conn, token)?;
         Ok(result)
@@ -1053,9 +1056,12 @@ impl DatabricksMetadataAdapter {
         let sql = format!(
             "SELECT column_name, tag_name, tag_value
             FROM `system`.`information_schema`.`column_tags`
-            WHERE catalog_name = '{database}'
-                AND schema_name = '{schema}'
-                AND table_name = '{identifier}'"
+            WHERE catalog_name = '{}'
+                AND schema_name = '{}'
+                AND table_name = '{}'",
+            database.to_lowercase(),
+            schema.to_lowercase(),
+            identifier.to_lowercase(),
         );
         let (_, result) =
             self.execute_sql_with_context(&sql, state, "Fetch column tags", conn, token)?;

--- a/crates/dbt-adapter/src/metadata/databricks/mod.rs
+++ b/crates/dbt-adapter/src/metadata/databricks/mod.rs
@@ -1021,6 +1021,8 @@ impl DatabricksMetadataAdapter {
     }
 
     // https://github.com/databricks/dbt-databricks/blob/9e2566fdb56318cb7a59a4492f96c7aaa7af73b0/dbt/include/databricks/macros/relations/tags.sql#L11
+    // Databricks information_schema stores catalog, schema, and table identifiers in lowercase.
+    // https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-information-schema
     fn fetch_tags(
         &self,
         database: &str,


### PR DESCRIPTION
## Summary
- lowercase catalog, schema, and relation identifiers in Unity Catalog table-tag lookups
- apply the same normalization to column-tag lookups, matching dbt-databricks v1 behavior
- avoid treating existing tags as missing when relation identifiers contain uppercase characters

## Why lowercase?
Databricks documents that `information_schema` stores all identifiers except column and tag names as lowercase strings, and recommends comparing those identifier columns directly with lowercase values instead of applying `LOWER()` or `UPPER()` to the metadata columns. These predicates filter only `catalog_name`, `schema_name`, and `table_name`; returned `column_name`, `tag_name`, and `tag_value` values are not normalized. This also matches the existing dbt-databricks v1 tag lookup macros.

Documentation: https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-information-schema

Follow-up to #16140, which landed before this final lookup normalization.

## Test plan
- `cargo test --offline -p dbt-adapter metadata::databricks` (140 passed)
- `cargo fmt -p dbt-adapter -- --check`
- `cargo clippy --offline -p dbt-adapter --lib -- -D warnings`