### PR TITLE
fix(databricks): stringify non-string tags and tblproperties

### DIFF
--- a/.changes/unreleased/Fixes-20260905-062000.yaml
+++ b/.changes/unreleased/Fixes-20260905-062000.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Stringify non-string Databricks tag and tblproperty YAML values
+time: 2026-09-05T06:20:00.00000+05:30
+custom:
+    author: sd-db
+    issue: ""
+    project: dbt-core

--- a/crates/dbt-adapter/src/relation/databricks/config/components/column_tags.rs
+++ b/crates/dbt-adapter/src/relation/databricks/config/components/column_tags.rs
@@ -9,7 +9,6 @@ use crate::relation::databricks::config::{
 };
 use dbt_schemas::schemas::DbtModel;
 use dbt_schemas::schemas::InternalDbtNodeAttributes;
-use dbt_yaml::Value as YmlValue;
 use indexmap::IndexMap;
 use minijinja::value::{Value, ValueMap};
 
@@ -93,9 +92,8 @@ fn from_local_config(relation_config: &dyn InternalDbtNodeAttributes) -> Adapter
             if let Some(column_databricks_tags) = &column.databricks_tags {
                 let mut column_tag_map = IndexMap::new();
                 for (tag_name, tag_value) in column_databricks_tags {
-                    if let YmlValue::String(value_str, _) = tag_value {
-                        column_tag_map.insert(tag_name.clone(), value_str.clone());
-                    }
+                    column_tag_map
+                        .insert(tag_name.clone(), super::relation_tags::stringify_tag_value(tag_value));
                 }
                 if !column_tag_map.is_empty() {
                     column_tags.insert(column.name.clone(), column_tag_map);

--- a/crates/dbt-adapter/src/relation/databricks/config/components/relation_tags.rs
+++ b/crates/dbt-adapter/src/relation/databricks/config/components/relation_tags.rs
@@ -34,6 +34,20 @@ fn set_only_diff(
     }
 }
 
+pub(crate) fn stringify_tag_value(value: &YmlValue) -> String {
+    match value {
+        YmlValue::Null(_) => String::new(),
+        YmlValue::Bool(value, _) => if *value { "True" } else { "False" }.to_string(),
+        YmlValue::Number(value, _) => value.to_string(),
+        YmlValue::String(value, _) => value.clone(),
+        YmlValue::Tagged(value, _) => stringify_tag_value(&value.value),
+        value => dbt_yaml::to_string(value)
+            .unwrap_or_default()
+            .trim()
+            .to_string(),
+    }
+}
+
 fn to_jinja(v: &IndexMap<String, String>) -> Value {
     Value::from(ValueMap::from([(
         Value::from("set_tags"),
@@ -61,10 +75,12 @@ fn from_remote_state(results: &DatabricksRelationMetadata) -> AdapterResult<Rela
     for row in remote_tags.rows() {
         if let (Ok(tag_name_val), Ok(tag_value_val)) =
             (row.get_item(&Value::from(0)), row.get_item(&Value::from(1)))
-            && let (Some(tag_name), Some(tag_value)) =
-                (tag_name_val.as_str(), tag_value_val.as_str())
+            && let Some(tag_name) = tag_name_val.as_str()
         {
-            tags.insert(tag_name.to_string(), tag_value.to_string());
+            tags.insert(
+                tag_name.to_string(),
+                tag_value_val.as_str().unwrap_or_default().to_string(),
+            );
         }
     }
 
@@ -84,9 +100,7 @@ fn from_local_config(
         && let Some(tags_map) = &databricks_attr.databricks_tags
     {
         for (key, value) in tags_map {
-            if let YmlValue::String(value_str, _) = value {
-                tags.insert(key.clone(), value_str.clone());
-            }
+            tags.insert(key.clone(), stringify_tag_value(value));
         }
     }
 
@@ -113,6 +127,17 @@ impl RelationTagsLoader {
 mod tests {
     use super::*;
     use crate::relation::config_v2::ComponentConfig;
+
+    #[test]
+    fn test_scalar_values_use_python_stringification() {
+        let integer = dbt_yaml::from_str("1").unwrap();
+        let null = dbt_yaml::from_str("null").unwrap();
+        let boolean = dbt_yaml::from_str("false").unwrap();
+
+        assert_eq!(stringify_tag_value(&integer), "1");
+        assert_eq!(stringify_tag_value(&null), "");
+        assert_eq!(stringify_tag_value(&boolean), "False");
+    }
 
     #[test]
     fn test_get_diff_add_or_update() {

--- a/crates/dbt-adapter/src/relation/databricks/config/components/tbl_properties.rs
+++ b/crates/dbt-adapter/src/relation/databricks/config/components/tbl_properties.rs
@@ -20,6 +20,20 @@ pub(crate) const PIPELINE_ID_KEY: &str = "pipelines.pipelineId";
 /// Component for Databricks table properties.
 pub type TblProperties = SimpleComponentConfigImpl<IndexMap<String, String>>;
 
+fn stringify_property_value(value: &YmlValue) -> String {
+    match value {
+        YmlValue::Null(_) => "None".to_string(),
+        YmlValue::Bool(value, _) => if *value { "True" } else { "False" }.to_string(),
+        YmlValue::Number(value, _) => value.to_string(),
+        YmlValue::String(value, _) => value.clone(),
+        YmlValue::Tagged(value, _) => stringify_property_value(&value.value),
+        value => dbt_yaml::to_string(value)
+            .unwrap_or_default()
+            .trim()
+            .to_string(),
+    }
+}
+
 fn to_jinja(v: &IndexMap<String, String>) -> Value {
     // FIXME: is there a way to ignore a key and serialize into Value without an extra allocation?
     let ignore_pipeline = v
@@ -110,9 +124,7 @@ fn from_local_config(
         && let Some(props_map) = &databricks_attr.tblproperties
     {
         for (key, value) in &props_map.0 {
-            if let YmlValue::String(value_str, _) = value {
-                tblproperties.insert(key.clone(), value_str.clone());
-            }
+            tblproperties.insert(key.clone(), stringify_property_value(value));
         }
     }
 
@@ -154,6 +166,17 @@ mod tests {
     use dbt_schemas::schemas::DbtModel;
     use indexmap::IndexMap;
     use std::sync::Arc;
+
+    #[test]
+    fn test_scalar_values_use_python_stringification() {
+        let integer = dbt_yaml::from_str("1").unwrap();
+        let null = dbt_yaml::from_str("null").unwrap();
+        let boolean = dbt_yaml::from_str("false").unwrap();
+
+        assert_eq!(stringify_property_value(&integer), "1");
+        assert_eq!(stringify_property_value(&null), "None");
+        assert_eq!(stringify_property_value(&boolean), "False");
+    }
 
     fn create_mock_show_tblproperties_table(properties: Vec<(&str, &str)>) -> AgateTable {
         use arrow::csv::ReaderBuilder;


### PR DESCRIPTION
## Summary
- Stringify boolean, numeric, and null YAML values when loading Databricks `databricks_tags`, column tags, and `tblproperties`.
- Match dbt-databricks Python `str(v)` / empty-null tag behavior so those configs are no longer silently dropped.

## Test plan
- [x] `cargo test --offline -p dbt-adapter relation_tags`
- [x] `cargo test --offline -p dbt-adapter tbl_properties`
- [x] `cargo test --offline -p dbt-adapter column_tags`