### PR TITLE
fix: validate resolved package installation path stays within packages-install-path

### DIFF
--- a/.changes/unreleased/Fixes-20260907-120000.yaml
+++ b/.changes/unreleased/Fixes-20260907-120000.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Validate that a resolved package installation path stays within the configured
+  packages-install-path
+time: 2026-09-07T12:00:00.000000+00:00
+custom:
+    Author: ash2shukla

--- a/core/dbt/deps/base.py
+++ b/core/dbt/deps/base.py
@@ -121,6 +121,9 @@ class PinnedPackage(BasePackage):
     def _install(self, project, renderer):
         metadata = self.fetch_metadata(project, renderer)
 
+        # Raises DependencyError if package_name resolves outside packages_install_path
+        self.get_installation_path(project, renderer)
+
         tar_name = f"{self.package}.{self.version}.tar.gz"
         tar_path = (Path(get_downloads_path()) / tar_name).resolve(strict=False)
         system.make_directory(str(tar_path.parent))

--- a/core/dbt/deps/base.py
+++ b/core/dbt/deps/base.py
@@ -8,6 +8,7 @@ from typing import Dict, Generic, List, Optional, TypeVar
 
 from dbt.contracts.project import ProjectPackageMetadata
 from dbt.events.types import DepsSetDownloadDirectory
+from dbt.exceptions import DependencyError
 from dbt_common.clients import system
 from dbt_common.events.functions import fire_event
 from dbt_common.utils.connection import connection_exception_retry
@@ -99,7 +100,20 @@ class PinnedPackage(BasePackage):
 
     def get_installation_path(self, project, renderer):
         dest_dirname = self.get_project_name(project, renderer)
-        return os.path.join(project.packages_install_path, dest_dirname)
+        install_path = os.path.join(project.packages_install_path, dest_dirname)
+
+        packages_install_path = os.path.realpath(project.packages_install_path)
+        resolved_install_path = os.path.realpath(install_path)
+        if (
+            os.path.commonpath([packages_install_path, resolved_install_path])
+            != packages_install_path
+        ):
+            raise DependencyError(
+                f"Invalid package name '{dest_dirname}': resolves outside of the "
+                f"packages-install-path ('{project.packages_install_path}')"
+            )
+
+        return install_path
 
     def get_subdirectory(self):
         return None

--- a/tests/unit/deps/test_deps.py
+++ b/tests/unit/deps/test_deps.py
@@ -2,6 +2,7 @@ import os
 import unittest
 from argparse import Namespace
 from copy import deepcopy
+from types import SimpleNamespace
 from unittest import mock
 
 import dbt.deps
@@ -16,6 +17,7 @@ from dbt.contracts.project import (
     RegistryPackage,
     TarballPackage,
 )
+from dbt.deps.base import PinnedPackage
 from dbt.deps.git import GitUnpinnedPackage
 from dbt.deps.local import LocalPinnedPackage, LocalUnpinnedPackage
 from dbt.deps.registry import RegistryUnpinnedPackage
@@ -1241,3 +1243,69 @@ class TestCheckForDuplicatePackagesWithBooleans(unittest.TestCase):
         self.assertIsNotNone(result)
         self.assertEqual(len(result["packages"]), 1)
         self.assertIn("dbt-utils-extra", result["packages"][0]["git"])
+
+
+class TestGetInstallationPathTraversal(unittest.TestCase):
+    """Regression: a malicious tarball/git package can set its `name` (parsed
+    unsanitized from the dependency's own dbt_project.yml or packages.yml) to
+    an absolute path or a path containing `..`. Since os.path.join discards
+    the first argument when the second is absolute, get_installation_path
+    must reject any resolved name that escapes packages_install_path instead
+    of silently returning an attacker-controlled destination."""
+
+    class FakePinnedPackage(PinnedPackage):
+        def __init__(self, project_name):
+            super().__init__()
+            self._project_name = project_name
+
+        @property
+        def name(self):
+            return self._project_name
+
+        def source_type(self):
+            return "fake"
+
+        def get_version(self):
+            return None
+
+        def _fetch_metadata(self, project, renderer):
+            return SimpleNamespace(name=self._project_name)
+
+        def install(self, project, renderer):
+            raise NotImplementedError
+
+        def nice_version_name(self):
+            return "1.0"
+
+        def to_dict(self):
+            return {}
+
+    def _project(self):
+        project = mock.Mock()
+        project.packages_install_path = "/tmp/proj/dbt_packages"
+        return project
+
+    def test_normal_package_name_resolves_inside_install_path(self):
+        pkg = self.FakePinnedPackage("my_package")
+        path = pkg.get_installation_path(self._project(), None)
+        self.assertEqual(path, "/tmp/proj/dbt_packages/my_package")
+
+    def test_absolute_path_name_is_rejected(self):
+        pkg = self.FakePinnedPackage("/etc/cron.d/evil")
+        with self.assertRaises(dbt.exceptions.DependencyError):
+            pkg.get_installation_path(self._project(), None)
+
+    def test_parent_traversal_name_is_rejected(self):
+        pkg = self.FakePinnedPackage("../../../../etc/cron.d/evil")
+        with self.assertRaises(dbt.exceptions.DependencyError):
+            pkg.get_installation_path(self._project(), None)
+
+    def test_relative_traversal_within_bounds_is_allowed(self):
+        # "./my_package" still resolves inside packages_install_path and
+        # should not be rejected.
+        pkg = self.FakePinnedPackage("./my_package")
+        path = pkg.get_installation_path(self._project(), None)
+        self.assertEqual(
+            os.path.realpath(path),
+            os.path.realpath("/tmp/proj/dbt_packages/my_package"),
+        )

--- a/tests/unit/deps/test_deps.py
+++ b/tests/unit/deps/test_deps.py
@@ -1309,3 +1309,61 @@ class TestGetInstallationPathTraversal(unittest.TestCase):
             os.path.realpath(path),
             os.path.realpath("/tmp/proj/dbt_packages/my_package"),
         )
+
+
+class TestInstallPathTraversalHubPackage(unittest.TestCase):
+    """Regression: hub packages install via PinnedPackage._install, which builds
+    its untar destination from get_project_name directly instead of going
+    through get_installation_path. Assert _install also rejects a package
+    name that resolves outside packages_install_path, before it ever
+    downloads or untars anything."""
+
+    class FakeRegistryPinnedPackage(PinnedPackage):
+        def __init__(self, project_name):
+            super().__init__()
+            self._project_name = project_name
+            self.package = project_name
+            self.version = "1.0.0"
+
+        @property
+        def name(self):
+            return self._project_name
+
+        def source_type(self):
+            return "hub"
+
+        def get_version(self):
+            return self.version
+
+        def _fetch_metadata(self, project, renderer):
+            return SimpleNamespace(
+                name=self._project_name,
+                downloads=SimpleNamespace(tarball="http://example.com/package.tar.gz"),
+            )
+
+        def install(self, project, renderer):
+            self._install(project, renderer)
+
+        def nice_version_name(self):
+            return "1.0.0"
+
+        def to_dict(self):
+            return {}
+
+    def _project(self):
+        project = mock.Mock()
+        project.packages_install_path = "/tmp/proj/dbt_packages"
+        return project
+
+    @mock.patch("dbt.deps.base.get_downloads_path", return_value="/tmp/downloads")
+    @mock.patch("dbt_common.clients.system.make_directory")
+    @mock.patch("dbt_common.clients.system.download")
+    @mock.patch("dbt_common.clients.system.untar_package")
+    def test_traversal_name_is_rejected_before_download(
+        self, untar_package, download, make_directory, get_downloads_path
+    ):
+        pkg = self.FakeRegistryPinnedPackage("../../../../etc/cron.d/evil")
+        with self.assertRaises(dbt.exceptions.DependencyError):
+            pkg.install(self._project(), None)
+        download.assert_not_called()
+        untar_package.assert_not_called()


### PR DESCRIPTION
## Summary
- `PinnedPackage.get_installation_path` joins `packages_install_path` with a package-derived name without checking whether the resolved path escapes the intended install directory.
- This adds a containment check (via `os.path.realpath` + `os.path.commonpath`) that raises `DependencyError` if the resolved install path would fall outside of `packages_install_path`.

## Test plan
- [x] Added `TestGetInstallationPathTraversal` in `tests/unit/deps/test_deps.py` covering: a normal package name, an absolute-path name, a `../`-traversal name, and a benign relative name.
- [x] `python -m pytest tests/unit/deps/test_deps.py` passes (46/46).

🤖 Generated with [Claude Code](https://claude.com/claude-code)