### PR TITLE
Allow account_id filter for OAuthPassiveResolver / AuthChain

### DIFF
--- a/.changes/unreleased/Fixes-20260907-111547.yaml
+++ b/.changes/unreleased/Fixes-20260907-111547.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Allow account id for OauthResolver for filtering oauth sessions
+time: 2026-09-07T11:15:47.911186+05:30
+custom:
+    Author: ash2shukla
+    Issue: N/A

--- a/core/dbt/auth/chain.py
+++ b/core/dbt/auth/chain.py
@@ -26,23 +26,23 @@ class AuthChain:
         self._resolvers = resolvers
 
     @classmethod
-    def default(cls) -> AuthChain:
+    def default(cls, account_id: Optional[str] = None) -> AuthChain:
         """Non-interactive chain: EnvVar -> OAuthPassive -> CloudYaml."""
         return cls(
             resolvers=[
                 EnvVarResolver(),
-                OAuthPassiveResolver(),
+                OAuthPassiveResolver(account_id=account_id),
                 CloudYamlResolver(),
             ]
         )
 
     @classmethod
-    def interactive(cls) -> AuthChain:
+    def interactive(cls, account_id: Optional[str] = None) -> AuthChain:
         """Interactive chain: EnvVar -> OAuthPassive -> CloudYaml -> OAuthInteractive."""
         return cls(
             resolvers=[
                 EnvVarResolver(),
-                OAuthPassiveResolver(),
+                OAuthPassiveResolver(account_id=account_id),
                 CloudYamlResolver(),
                 OAuthInteractiveResolver(),
             ]

--- a/core/dbt/auth/resolvers.py
+++ b/core/dbt/auth/resolvers.py
@@ -81,8 +81,9 @@ class OAuthPassiveResolver:
     """Resolves credentials from a cached OAuth session — no user interaction.
 
     Checks ~/.dbt/oauth_sessions.json for a non-expired session matching
-    client_id. If the access token is expired but a refresh token is present,
-    attempts a token refresh.
+    client_id (and account_id, if set — compared as a string against the
+    session's numeric account id). If the access token is expired but a
+    refresh token is present, attempts a token refresh.
     """
 
     kind = ResolverKind.OAUTH_PASSIVE
@@ -92,14 +93,21 @@ class OAuthPassiveResolver:
         client_id: str = OAUTH_CLIENT_ID,
         cache_path: Optional[Path] = None,
         token_endpoint_override: Optional[str] = None,
+        account_id: Optional[str] = None,
     ) -> None:
         self.client_id = client_id
         self.cache_path = cache_path or DEFAULT_CACHE_PATH
         self.token_endpoint_override = token_endpoint_override
+        self.account_id = account_id
 
     def resolve(self) -> Credential:
         cache = read_session_cache(self.cache_path)
-        matching = [s for s in cache.sessions if s.client_id == self.client_id]
+        matching = [
+            s
+            for s in cache.sessions
+            if s.client_id == self.client_id
+            and (self.account_id is None or str(s.account_id) == self.account_id)
+        ]
 
         if not matching:
             raise NotAuthenticated()

--- a/tests/unit/auth/test_chain.py
+++ b/tests/unit/auth/test_chain.py
@@ -4,7 +4,7 @@ from unittest import mock
 import pytest
 
 from dbt.auth.chain import AuthChain
-from dbt.auth.resolvers import CloudYamlResolver, EnvVarResolver
+from dbt.auth.resolvers import CloudYamlResolver, EnvVarResolver, OAuthPassiveResolver
 from dbt.exceptions import MalformedAuthConfig, NotAuthenticated
 
 
@@ -101,3 +101,25 @@ projects:
         chain = AuthChain([])
         with pytest.raises(NotAuthenticated):
             chain.resolve()
+
+
+class TestAuthChainDefaultAndInteractive:
+    @staticmethod
+    def _passive_resolver(chain: AuthChain) -> OAuthPassiveResolver:
+        return next(r for r in chain._resolvers if isinstance(r, OAuthPassiveResolver))
+
+    def test_default_account_id_is_applied_to_passive_resolver(self):
+        chain = AuthChain.default(account_id="7")
+        assert self._passive_resolver(chain).account_id == "7"
+
+    def test_default_without_account_id_leaves_passive_resolver_unrestricted(self):
+        chain = AuthChain.default()
+        assert self._passive_resolver(chain).account_id is None
+
+    def test_interactive_account_id_is_applied_to_passive_resolver(self):
+        chain = AuthChain.interactive(account_id="7")
+        assert self._passive_resolver(chain).account_id == "7"
+
+    def test_interactive_without_account_id_leaves_passive_resolver_unrestricted(self):
+        chain = AuthChain.interactive()
+        assert self._passive_resolver(chain).account_id is None

--- a/tests/unit/auth/test_resolvers.py
+++ b/tests/unit/auth/test_resolvers.py
@@ -228,6 +228,39 @@ class TestOAuthPassiveResolver:
             with pytest.raises(RefreshFailed):
                 OAuthPassiveResolver("test_client", cache_path=p).resolve()
 
+    def test_configured_account_id_selects_matching_session(self, tmp_path):
+        p = tmp_path / "oauth_sessions.json"
+        upsert_session(_make_session(account_id=1, access_token="tok_a"), p)
+        upsert_session(_make_session(account_id=2, access_token="tok_b"), p)
+
+        cred = OAuthPassiveResolver("test_client", cache_path=p, account_id="2").resolve()
+        assert cred.token == "tok_b"
+        assert cred.account_id == 2
+
+    def test_configured_account_id_without_session_raises_not_authenticated(self, tmp_path):
+        p = tmp_path / "oauth_sessions.json"
+        upsert_session(_make_session(account_id=1), p)
+
+        with pytest.raises(NotAuthenticated):
+            OAuthPassiveResolver("test_client", cache_path=p, account_id="999").resolve()
+
+    def test_configured_account_id_ignores_refresh_token_of_other_account(self, tmp_path):
+        # The other account's session is expired but refreshable; without an
+        # account filter it would be refreshed and returned.
+        p = tmp_path / "oauth_sessions.json"
+        upsert_session(
+            _make_session(
+                account_id=1,
+                expires_at=time.time() - 3600,
+                refresh_token="refresh_tok",
+            ),
+            p,
+        )
+        upsert_session(_make_session(account_id=2, access_token="tok_wanted"), p)
+
+        cred = OAuthPassiveResolver("test_client", cache_path=p, account_id="2").resolve()
+        assert cred.token == "tok_wanted"
+
 
 class TestCloudYamlResolver:
     def test_happy_path_service_token(self, tmp_path):


### PR DESCRIPTION
## Summary
- Port of [dbt-labs/fs#14108](https://github.com/dbt-labs/fs/pull/14108)'s account-aware OAuth session selection into dbt-core's Python auth module.
- `OAuthPassiveResolver` now accepts an optional `account_id` filter; cached sessions are matched on it (compared as a string against the session's numeric account id) before considering expiry/refresh, so a session cache holding sessions for several dbt platform accounts resolves the configured one instead of whichever session happens to come first. No match raises `NotAuthenticated` so the chain falls through to another resolver.
- `AuthChain.default()` / `AuthChain.interactive()` accept an optional `account_id` and thread it into the `OAuthPassiveResolver`.
- Scoped per discussion in #dev-experience Slack thread with Iaroslav Zeigerman: only the shared resolver/chain API gets the `account_id` filter here — it isn't wired up to `dbt_project.yml`'s `dbt-cloud.account_id` yet, since that will be consumed by the dbt State plugin as a follow-up.

## Test plan
- [x] Added unit tests mirroring the fs PR's Rust tests: selecting the matching account, no match raising `NotAuthenticated`, and not refreshing an expired session belonging to a different account.
- [x] `pytest tests/unit/auth` passes (91 passed).