### PR TITLE
Rename dbt-core to dbt-oss in repo-facing docs

### DIFF
--- a/.changes/header.tpl.md
+++ b/.changes/header.tpl.md
@@ -1,8 +1,8 @@
-# dbt Core changelog
+# dbt OSS changelog
 All notable changes to this project will be documented in this file.
 
-- This file covers dbt Core v2.0. For changelogs for other dbt Engines, refer to:
-  - dbt Core v1 (Python) changelog, see [the `1.latest` branch's `CHANGELOG.md`](https://github.com/dbt-labs/dbt-core/blob/1.latest/CHANGELOG.md).
+- This file covers dbt OSS v2.0. For changelogs for other dbt Engines, refer to:
+  - dbt Core v1 (Python) changelog, see [the `1.latest` branch's `CHANGELOG.md`](https://github.com/dbt-labs/dbt-oss/blob/1.latest/CHANGELOG.md).
   - the [dbt Fusion CHANGELOG for beta and preview release notes](/CHANGELOG-fusion.md)
 - Changes are listed under the (pre)release in which they first appear. Subsequent releases include changes from previous releases.
 - "Breaking changes" listed under a version may require action from end users or external maintainers when upgrading to that version.

--- a/.changie.yaml
+++ b/.changie.yaml
@@ -13,7 +13,7 @@ kindFormat: "### {{.Kind}}"
 
 custom:
   - key: issue
-    label: "[Optional] dbt-core issue number (separated by a single space if multiple)"
+    label: "[Optional] dbt-oss issue number (separated by a single space if multiple)"
     type: string
     required: false
   - key: author
@@ -21,15 +21,16 @@ custom:
     type: string
     required: false
 
-# Change format: optional issue links only. The project field is retained in the
-# change files (for the internal changelog) but not rendered here. Issue links
-# are only rendered for dbt-core changes and only when an issue number is present.
+# Change format: optional issue links only, rendered for dbt-core/dbt-oss
+# changes with an issue number present (dbt-fusion changes are excluded).
+# Both project values are accepted since existing unreleased entries still
+# carry the legacy `dbt-core` discriminator.
 changeFormat: |-
   {{- $IssueList := list }}
-  {{- if eq $.Custom.project "dbt-core" }}
+  {{- if or (eq $.Custom.project "dbt-core") (eq $.Custom.project "dbt-oss") }}
   {{- range $issueNbr := splitList " " $.Custom.issue }}
     {{- if $issueNbr }}
-      {{- $changeLink := "[#nbr](https://github.com/dbt-labs/dbt-core/issues/nbr)" | replace "nbr" $issueNbr }}
+      {{- $changeLink := "[#nbr](https://github.com/dbt-labs/dbt-oss/issues/nbr)" | replace "nbr" $issueNbr }}
       {{- $IssueList = append $IssueList $changeLink  }}
     {{- end -}}
   {{- end -}}
@@ -44,10 +45,11 @@ kinds:
   - label: Dependencies
   - label: Security
 
-# these changelogs are always for dbt-core
+# new entries are tagged dbt-oss; see the changeFormat note above for why
+# both dbt-core and dbt-oss are still accepted.
 post:
   - key: project
-    value: dbt-core
+    value: dbt-oss
 
 newlines:
   afterChangelogHeader: 1
@@ -58,7 +60,7 @@ newlines:
 
 # Contributors section (mirrors fs). Set FUSION_TEAM (space-separated handles)
 # to exclude maintainers; otherwise all non-bot authors are listed. Issue links
-# resolve to the dbt-core repo, matching changeFormat above.
+# resolve to the dbt-oss repo, matching changeFormat above.
 footerFormat: |
   {{- $contributorDict := dict }}
   {{- $fusion_team_env := default "" .Env.FUSION_TEAM }}
@@ -72,10 +74,10 @@ footerFormat: |
     {{- range $author := $authorList }}
       {{- if and $author (not (has (lower $author) $maintainers)) }}
         {{- $IssueList := list }}
-        {{- if eq $change.Custom.project "dbt-core" }}
+        {{- if or (eq $change.Custom.project "dbt-core") (eq $change.Custom.project "dbt-oss") }}
         {{- range $issueNbr := splitList " " $change.Custom.issue }}
           {{- if $issueNbr }}
-            {{- $changeLink := "[#nbr](https://github.com/dbt-labs/dbt-core/issues/nbr)" | replace "nbr" $issueNbr }}
+            {{- $changeLink := "[#nbr](https://github.com/dbt-labs/dbt-oss/issues/nbr)" | replace "nbr" $issueNbr }}
             {{- $IssueList = append $IssueList $changeLink }}
           {{- end }}
         {{- end }}

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-# This file contains the code owners for the dbt-core repo.
+# This file contains the code owners for the dbt-oss repo.
 # PRs will be automatically assigned for review to the associated
 # team(s) or person(s) that touches any files that are mapped to them.
 #

--- a/.github/ISSUE_TEMPLATE/bug-report-v2.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report-v2.yml
@@ -1,5 +1,5 @@
 name: 🐞 Bug (dbt v2.x)
-description: Report a bug or issue you've found in dbt v2.x (Core or Fusion distributions)
+description: Report a bug or issue you've found in dbt v2.x (OSS or Fusion distributions)
 title: "[v2 Bug] <title>"
 labels: ["bug", "triage", "v2", "type:bug", "status:triage", "engine:v2"]
 body:
@@ -8,7 +8,7 @@ body:
       value: |
         Thanks for taking the time to fill out this bug report!
 
-        This template is for bugs in dbt v2.x (either the Core or Fusion distribution). For bugs in dbt Core 1.x, use the "🐞 Bug" template instead.
+        This template is for bugs in dbt v2.x (either the OSS or Fusion distribution). For bugs in dbt Core 1.x, use the "🐞 Bug" template instead.
   - type: checkboxes
     attributes:
       label: Is this a new bug in dbt v2.x compared to the latest version of dbt 1.x?

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -13,7 +13,7 @@ contact_links:
     url: mailto:support@getdbt.com
     about: Are you using dbt Cloud? Contact our support team for help!
   - name: Participate in Discussions
-    url: https://github.com/dbt-labs/dbt-core/discussions
+    url: https://github.com/dbt-labs/dbt-oss/discussions
     about: Do you have a Big Idea for dbt? Read open discussions, or start a new one
   - name: Create an issue for v1.x adapters
     url: https://github.com/dbt-labs/dbt-adapters/issues/new/choose

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -16,7 +16,7 @@ body:
 
         Issues are the right place to request straightforward extensions of existing dbt functionality.
         For "big ideas" about future capabilities of dbt, we ask that you open a
-        [discussion](https://github.com/dbt-labs/dbt-core/discussions) in the "Ideas" category instead.
+        [discussion](https://github.com/dbt-labs/dbt-oss/discussions) in the "Ideas" category instead.
       options:
         - label: I have read the [expectations for open source contributors](https://docs.getdbt.com/docs/contributing/oss-expectations)
           required: true

--- a/.github/ISSUE_TEMPLATE/implementation-ticket.yml
+++ b/.github/ISSUE_TEMPLATE/implementation-ticket.yml
@@ -1,11 +1,11 @@
 name: 🛠️ Implementation
-description: This is an implementation ticket intended for use by the maintainers of dbt-core
+description: This is an implementation ticket intended for use by the maintainers of dbt OSS
 title: "[<project>] <title>"
 labels: ["action:needs-docs"]
 body:
   - type: markdown
     attributes:
-      value: This is an implementation ticket intended for use by the maintainers of dbt-core
+      value: This is an implementation ticket intended for use by the maintainers of dbt OSS
   - type: checkboxes
     attributes:
       label: Housekeeping
@@ -14,7 +14,7 @@ body:
           1. Remove the `action:needs-docs` label if the scope of this work does not require changes to https://docs.getdbt.com/docs: no end-user interface (e.g. yml spec, CLI, error messages, etc) or functional changes
           2. Link any blocking issues in the "Blocked on" field under the "Core devs & maintainers" project.
       options:
-        - label: I am a maintainer of dbt-core
+        - label: I am a maintainer of dbt OSS
           required: true
   - type: textarea
     attributes:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,7 +26,7 @@ Resolves #
 
 ### Checklist
 
-- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
+- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-oss/blob/main/CONTRIBUTING.md) and understand what's expected of me.
 - [ ] I have run this code in development, and it appears to resolve the stated issue.
 - [ ] This PR includes tests, or tests are not required or relevant for this PR.
 - [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.

--- a/.github/workflows/changelog-existence.yml
+++ b/.github/workflows/changelog-existence.yml
@@ -35,6 +35,6 @@ jobs:
   changelog:
     uses: dbt-labs/actions/.github/workflows/changelog-existence.yml@main
     with:
-      changelog_comment: 'Thank you for your pull request! We could not find a changelog entry for this change. For details on how to document a change, see [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-changelog-entry).'
+      changelog_comment: 'Thank you for your pull request! We could not find a changelog entry for this change. For details on how to document a change, see [the contributing guide](https://github.com/dbt-labs/dbt-oss/blob/main/CONTRIBUTING.md#adding-a-changelog-entry).'
       skip_label: 'Skip Changelog'
     secrets: inherit

--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -364,8 +364,8 @@ jobs:
           echo "::notice title="New branch created": $title::$message"
 
       - name: "Bump dependencies via script"
-        # This bumps the dependency on dbt-core in the adapters
-        if: ${{ !contains(github.repository, 'dbt-core') }}
+        # This bumps the dependency on dbt-oss in the adapters
+        if: ${{ !contains(github.repository, 'dbt-oss') }}
         run: |
           echo ${{ github.repository }}
           echo "running update_dependencies script"
@@ -378,7 +378,7 @@ jobs:
 
       - name: "Bump env variable via script"
         # bumps the RELEASE_BRANCH variable in nightly-release.yml in adapters
-        if: ${{ !contains(github.repository, 'dbt-core') }}
+        if: ${{ !contains(github.repository, 'dbt-oss') }}
         run: |
           file="./.github/scripts/update_release_branch.sh"
           if test -f "$file"; then

--- a/.github/workflows/docs-issue.yml
+++ b/.github/workflows/docs-issue.yml
@@ -149,5 +149,5 @@ jobs:
     with:
         issue_repository: "dbt-labs/docs.getdbt.com"
         issue_title: "[Core] Docs changes needed from ${{ github.event.repository.name }} issue #${{ github.event.issue.number }}"
-        issue_body: "Originating from this issue: https://github.com/dbt-labs/dbt-core/issues/${{ github.event.issue.number }}\nRelated PR: ${{ needs.get_pr_info.outputs.pr_url }}\nPR title: ${{ needs.get_pr_info.outputs.pr_title }}\n\n---\n${{ needs.generate_ai_summary.outputs.summary }}\n\n---\nAt a minimum, update body to include a link to the page on docs.getdbt.com requiring updates and what part(s) of the page you would like to see updated."
+        issue_body: "Originating from this issue: https://github.com/dbt-labs/dbt-oss/issues/${{ github.event.issue.number }}\nRelated PR: ${{ needs.get_pr_info.outputs.pr_url }}\nPR title: ${{ needs.get_pr_info.outputs.pr_title }}\n\n---\n${{ needs.generate_ai_summary.outputs.summary }}\n\n---\nAt a minimum, update body to include a link to the page on docs.getdbt.com requiring updates and what part(s) of the page you would like to see updated."
     secrets: inherit

--- a/.github/workflows/release-awaiting.yml
+++ b/.github/workflows/release-awaiting.yml
@@ -8,7 +8,7 @@
 # a different release cadence and is not tracked by this automation.
 
 # **when?**
-# Whenever a v2 issue in dbt-labs/dbt-core is closed as completed.
+# Whenever a v2 issue in dbt-labs/dbt-oss is closed as completed.
 
 name: "Release Tracker: Awaiting Release"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-# dbt Core changelog
+# dbt OSS changelog
 All notable changes to this project will be documented in this file.
 
-- This file covers dbt Core v2.0. For changelogs for other dbt Engines, refer to:
-  - dbt Core v1 (Python) changelog, see [the `1.latest` branch's `CHANGELOG.md`](https://github.com/dbt-labs/dbt-core/blob/1.latest/CHANGELOG.md).
+- This file covers dbt OSS v2.0. For changelogs for other dbt Engines, refer to:
+  - dbt Core v1 (Python) changelog, see [the `1.latest` branch's `CHANGELOG.md`](https://github.com/dbt-labs/dbt-oss/blob/1.latest/CHANGELOG.md).
   - the [dbt Fusion CHANGELOG for beta and preview release notes](/CHANGELOG-fusion.md)
 - Changes are listed under the (pre)release in which they first appear. Subsequent releases include changes from previous releases.
 - "Breaking changes" listed under a version may require action from end users or external maintainers when upgrading to that version.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,45 +1,45 @@
-# Contributing to dbt Core
+# Contributing to dbt OSS
 
-There are many ways to contribute to the ongoing development of dbt Core, including code, discussions, and issues. We encourage you to first read our higher-level document: "[Expectations for Open Source Contributors](https://docs.getdbt.com/community/resources/oss-expectations)".
+There are many ways to contribute to the ongoing development of dbt OSS, including code, discussions, and issues. We encourage you to first read our higher-level document: "[Expectations for Open Source Contributors](https://docs.getdbt.com/community/resources/oss-expectations)".
 
 ### Notes
 * **Adapters** - All adapter jinja logic is maintained in this repository. Please open up an issue here.
-* **Database Drivers** - dbt Core uses the next generation ADBC protocol to submit queries. 
+* **Database Drivers** - dbt OSS uses the next generation ADBC protocol to submit queries. 
   * **For Snowflake** - please see the [Go Arrow Snowflake Driver](https://github.com/apache/arrow-adbc/tree/main/go/adbc/driver/snowflake)
   * **For BigQuery** - please see the [Go Arrow BigQuery Driver](https://github.com/apache/arrow-adbc/tree/main/go/adbc/driver/bigquery)
   * **For Postgres** - please see the [C Arrow Postgres Driver](https://github.com/dbt-labs/arrow-adbc/tree/main/c/driver/postgresql)
   
 * **Branches** - All pull requests from community contributors should target the main branch (default). If the change is needed as a patch for a minor version of dbt that has already been released (or is already a release candidate), a maintainer will backport the changes in your PR to the release branch.
-* **Releases** - While dbt Core v2.0 is in beta, new releases will include fixes and new features. Versions will be labelled `2.0.0-beta.1`, `2.0.0-beta.2`, etc. Before filing a bug, please ensure that you have the latest release installed. 
+* **Releases** - While dbt OSS v2.0 is in beta, new releases will include fixes and new features. Versions will be labelled `2.0.0-beta.1`, `2.0.0-beta.2`, etc. Before filing a bug, please ensure that you have the latest release installed. 
 
 ### Setting up an environment
 
 #### Tools
-dbt Core is written in Rust. Please make sure that you have the [rust toolchain installed](https://www.rust-lang.org/tools/install), along with the preferred testing utility [Nextest](https://nexte.st/). 
+dbt OSS is written in Rust. Please make sure that you have the [rust toolchain installed](https://www.rust-lang.org/tools/install), along with the preferred testing utility [Nextest](https://nexte.st/). 
 
 1. [Install Rust](https://www.rust-lang.org/tools/install)
 2. Install the testing framework used for all tests & testbench configuration [Nextest](https://nexte.st/docs/installation/pre-built-binaries/)
-3. Clone the repository `git clone https://github.com/dbt-labs/dbt-core.git`
-4. `cd dbt-core`
+3. Clone the repository `git clone https://github.com/dbt-labs/dbt-oss.git`
+4. `cd dbt-oss`
 5. `cargo build` for a debug build. `cargo build --release` for a release build
 
 *There are no virtual environments needed!*
 
 
-## Making a Change to dbt Core
+## Making a Change to dbt OSS
 After you're done making your code change, make sure:
 - your code is formatted: `cargo fmt`
 - all tests pass: `cargo nextest run`
 - all lints pass: `cargo clippy --all-targets --all-features`.
 - you have manually verified it works with a local build of dbt against a real project
 
-Then, open a pull request against the current development branch, `main`. A dbt Core maintainer will triage the PR and, once it's on the right track, assign a reviewer. They may suggest code revisions for style or clarity, or request that you add test(s).
+Then, open a pull request against the current development branch, `main`. A dbt OSS maintainer will triage the PR and, once it's on the right track, assign a reviewer. They may suggest code revisions for style or clarity, or request that you add test(s).
 
-Once your PR has been approved, a maintainer will take it from there and shepherd your changes into dbt Core. And that's it! Happy developing 🎉
+Once your PR has been approved, a maintainer will take it from there and shepherd your changes into dbt OSS. And that's it! Happy developing 🎉
 
 ## What happens after you open a pull request
 
-dbt Core is developed through dbt Labs' internal build and review process, and this repository is kept in sync with it automatically. You don't need to do anything special for this — but it's worth knowing, because it explains the labels, comments, and status checks you'll see on your PR.
+dbt OSS is developed through dbt Labs' internal build and review process, and this repository is kept in sync with it automatically. You don't need to do anything special for this — but it's worth knowing, because it explains the labels, comments, and status checks you'll see on your PR.
 
 1. **Your PR is triaged.** PRs opened by community members are automatically labeled `community`, and during triage they're marked `source:community` to note the change came from an external contributor. A maintainer reviews the change and, once it's on the right track, assigns a reviewer.
 
@@ -72,4 +72,4 @@ changie new
 
 Commit the file that's created and your changelog entry is complete!
 
-You don't need to worry about which `dbt-core` version your change will go into. Just create the changelog entry with `changie`, and open your PR against the `main` branch. All merged changes will be included in the next release of `dbt-core`.  If a changelog is not required, a maintainer can add the label `Skip Changelog` to bypass this requirement.
+You don't need to worry about which `dbt-oss` version your change will go into. Just create the changelog entry with `changie`, and open your PR against the `main` branch. All merged changes will be included in the next release of `dbt-oss`.  If a changelog is not required, a maintainer can add the label `Skip Changelog` to bypass this requirement.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,12 +105,12 @@ resolver = "2"
 
 [workspace.package]
 authors = ["dbt Labs <info@getdbt.com>"]
-description = "Fusion: A fast dbt engine, SQL compiler, local development framework, and in-memory analytical database"
+description = "dbt OSS: A fast dbt engine, SQL compiler, local development framework, and in-memory analytical database"
 edition = "2024"
 homepage = "https://getdbt.com"
 keywords = ["sql", "parquet", "json", "csv", "dbt"]
 license = "Apache-2.0"
-repository = "https://github.com/dbt-labs/dbt-core"
+repository = "https://github.com/dbt-labs/dbt-oss"
 version = "2.0.0-rc.1"
 
 [patch.crates-io]

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-<p align="center">
+<!-- <p align="center">
   <img src="https://raw.githubusercontent.com/dbt-labs/dbt-core/fa1ea14ddfb1d5ae319d5141844910dd53ab2834/etc/dbt-core.svg" alt="dbt logo" width="750"/>
-</p>
+</p> -->
 
 > [!WARNING]
-> **dbt Core v1 development has moved to the [`1.latest`](https://github.com/dbt-labs/dbt-core/tree/1.latest) branch.**
-> The `main` branch now hosts dbt Core v2.0 (beta) — a ground-up rewrite in Rust that is the foundation of the Fusion engine. If you're looking for the Python implementation of dbt Core, switch to [`1.latest`](https://github.com/dbt-labs/dbt-core/tree/1.latest).
+> **dbt Core v1 development has moved to the [`1.latest`](https://github.com/dbt-labs/dbt-oss/tree/1.latest) branch.**
+> The `main` branch now hosts dbt OSS v2.0 (beta) — a ground-up rewrite in Rust that is the foundation of the Fusion engine. If you're looking for the Python implementation of dbt Core, switch to [`1.latest`](https://github.com/dbt-labs/dbt-oss/tree/1.latest).
 
 **[dbt](https://www.getdbt.com/)** enables data analysts and engineers to transform their data using the same practices that software engineers use to build applications.
 
 ![architecture](https://raw.githubusercontent.com/dbt-labs/dbt-core/202cb7e51e218c7b29eb3b11ad058bd56b7739de/etc/dbt-transform.png)
 
-## About dbt Core v2.0
+## About dbt OSS v2.0
 
-> 🚧 dbt Core v2.0 is in beta. Behavior, APIs, and on-disk formats may change before the stable release.
+> 🚧 dbt OSS v2.0 is in beta. Behavior, APIs, and on-disk formats may change before the stable release.
 
-dbt Core v2.0 is engineered for performance at scale — parsing, compiling, and running projects in a fraction of the time compared to v1. It's released under the Apache 2.0 license and is the foundation of the [Fusion engine](https://docs.getdbt.com/docs/fusion/about-fusion).
+dbt OSS v2.0 is engineered for performance at scale — parsing, compiling, and running projects in a fraction of the time compared to v1. It's released under the Apache 2.0 license and is the foundation of the [Fusion engine](https://docs.getdbt.com/docs/fusion/about-fusion).
 
 The big shifts from v1:
 
@@ -26,7 +26,7 @@ The big shifts from v1:
 
 ### Supported operating systems and architectures
 
-dbt Core v2.0 and its drivers are compiled per operating system and architecture.
+dbt OSS v2.0 and its drivers are compiled per operating system and architecture.
 
 Legend:
 * 🟢 — Supported today
@@ -48,10 +48,10 @@ These select statements, or "models", form a dbt project. Models frequently buil
 
 ## Getting started
 
-Start by choosing a distribution. dbt Core is the baseline distribution of dbt. Fusion extends dbt Core with additional SQL comprehension abilities. Both distributions are free to install and can run locally.
+Start by choosing a distribution. dbt OSS is the baseline distribution of dbt. Fusion extends dbt OSS with additional SQL comprehension abilities. Both distributions are free to install and can run locally.
 
-- **If you need an Apache 2.0 licensed tool** and the ability to review every line of code inside of it, [install dbt Core](https://docs.getdbt.com/docs/local/install-dbt-core-v2?version=2.0).
-- **If you need a free CLI you can use locally**, [install Fusion](https://docs.getdbt.com/docs/local/install-dbt?version=2.0). It can do more than dbt Core out of the box and you can seamlessly enable other advanced features over time if you choose to.
+- **If you need an Apache 2.0 licensed tool** and the ability to review every line of code inside of it, [install dbt OSS](https://docs.getdbt.com/docs/local/install-dbt-core-v2?version=2.0).
+- **If you need a free CLI you can use locally**, [install Fusion](https://docs.getdbt.com/docs/local/install-dbt?version=2.0). It can do more than dbt OSS out of the box and you can seamlessly enable other advanced features over time if you choose to.
 
 Regardless of the distribution you choose, each is part of a single framework with a single language specification, meaning your business logic is portable in both directions.
 
@@ -65,8 +65,8 @@ Read the [introduction](https://docs.getdbt.com/docs/introduction/) and [viewpoi
 
 ## Reporting bugs and contributing code
 
-- Want to report a bug or request a feature? Let us know and open [an issue](https://github.com/dbt-labs/dbt-core/issues/new/choose)
-- Want to help us build dbt? Check out the [Contributing Guide](https://github.com/dbt-labs/dbt-core/blob/HEAD/CONTRIBUTING.md)
+- Want to report a bug or request a feature? Let us know and open [an issue](https://github.com/dbt-labs/dbt-oss/issues/new/choose)
+- Want to help us build dbt? Check out the [Contributing Guide](https://github.com/dbt-labs/dbt-oss/blob/HEAD/CONTRIBUTING.md)
 
 ## Code of Conduct
 
@@ -74,4 +74,4 @@ Everyone interacting in the dbt project's codebases, issue trackers, chat rooms,
 
 ## License
 
-dbt Core is licensed under the [Apache License 2.0](LICENSE).
+dbt OSS is licensed under the [Apache License 2.0](LICENSE).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "dbt-core"
+name = "dbt-oss"
 dynamic = ["version"]
 description = "Build analytics the way engineers build applications"
 authors = [{ name = "dbt Labs", email = "info@dbtlabs.com" }]
@@ -18,6 +18,6 @@ classifiers = [
 
 [project.urls]
 Homepage = "https://getdbt.com"
-Repository = "https://github.com/dbt-labs/dbt-core"
-Issues = "https://github.com/dbt-labs/dbt-core/issues"
+Repository = "https://github.com/dbt-labs/dbt-oss"
+Issues = "https://github.com/dbt-labs/dbt-oss/issues"
 Documentation = "https://docs.getdbt.com"


### PR DESCRIPTION
## Summary
- Rebrands repo-facing docs, GitHub templates, workflow copy, and package metadata from dbt-core/dbt Core to dbt-oss/dbt OSS.
- Code and release-pipeline changes are handled in separate PRs.

## Test plan
- [ ] N/A — docs/config only