### PR TITLE
rename: dbt-core to dbt-oss CLI branding and remaining repo references

### DIFF
--- a/.changes/header.tpl.md
+++ b/.changes/header.tpl.md
@@ -1,8 +1,8 @@
-# dbt Core changelog
+# dbt OSS changelog
 All notable changes to this project will be documented in this file.
 
-- This file covers dbt Core v2.0. For changelogs for other dbt Engines, refer to:
-  - dbt Core v1 (Python) changelog, see [the `1.latest` branch's `CHANGELOG.md`](https://github.com/dbt-labs/dbt-core/blob/1.latest/CHANGELOG.md).
+- This file covers dbt OSS v2.0. For changelogs for other dbt Engines, refer to:
+  - dbt Core v1 (Python) changelog, see [the `1.latest` branch's `CHANGELOG.md`](https://github.com/dbt-labs/dbt-oss/blob/1.latest/CHANGELOG.md).
   - the [dbt Fusion CHANGELOG for beta and preview release notes](/CHANGELOG-fusion.md)
 - Changes are listed under the (pre)release in which they first appear. Subsequent releases include changes from previous releases.
 - "Breaking changes" listed under a version may require action from end users or external maintainers when upgrading to that version.

--- a/.changes/unreleased/Breaking Changes-20260907-164250.yaml
+++ b/.changes/unreleased/Breaking Changes-20260907-164250.yaml
@@ -1,0 +1,7 @@
+kind: Breaking Changes
+body: 'The OSS CLI now brands itself dbt-oss: ''dbt --version'' prints ''dbt-oss <version>'' instead of ''dbt-core <version>''. The machine-readable ''dbt --format json --version'' output now uses the ''oss'' key instead of ''core''.'
+time: 2026-09-07T16:42:50.605943+05:30
+custom:
+    author: ""
+    issue: ""
+    project: dbt-core

--- a/.changes/unreleased/Under the Hood-20260907-164250.yaml
+++ b/.changes/unreleased/Under the Hood-20260907-164250.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Renamed the repository to dbt-labs/dbt-oss and promoted dbt-oss to the primary PyPI distribution; dbt-core continues to be published as a legacy alias at the same version.
+time: 2026-09-07T16:42:50.630595+05:30
+custom:
+    author: ""
+    issue: ""
+    project: dbt-core

--- a/.changie.yaml
+++ b/.changie.yaml
@@ -13,7 +13,7 @@ kindFormat: "### {{.Kind}}"
 
 custom:
   - key: issue
-    label: "[Optional] dbt-core issue number (separated by a single space if multiple)"
+    label: "[Optional] dbt-oss issue number (separated by a single space if multiple)"
     type: string
     required: false
   - key: author
@@ -21,15 +21,16 @@ custom:
     type: string
     required: false
 
-# Change format: optional issue links only. The project field is retained in the
-# change files (for the internal changelog) but not rendered here. Issue links
-# are only rendered for dbt-core changes and only when an issue number is present.
+# Change format: optional issue links only, rendered for dbt-core/dbt-oss
+# changes with an issue number present (dbt-fusion changes are excluded).
+# Both project values are accepted since existing unreleased entries still
+# carry the legacy `dbt-core` discriminator.
 changeFormat: |-
   {{- $IssueList := list }}
-  {{- if eq $.Custom.project "dbt-core" }}
+  {{- if or (eq $.Custom.project "dbt-core") (eq $.Custom.project "dbt-oss") }}
   {{- range $issueNbr := splitList " " $.Custom.issue }}
     {{- if $issueNbr }}
-      {{- $changeLink := "[#nbr](https://github.com/dbt-labs/dbt-core/issues/nbr)" | replace "nbr" $issueNbr }}
+      {{- $changeLink := "[#nbr](https://github.com/dbt-labs/dbt-oss/issues/nbr)" | replace "nbr" $issueNbr }}
       {{- $IssueList = append $IssueList $changeLink  }}
     {{- end -}}
   {{- end -}}
@@ -44,10 +45,11 @@ kinds:
   - label: Dependencies
   - label: Security
 
-# these changelogs are always for dbt-core
+# new entries are tagged dbt-oss; see the changeFormat note above for why
+# both dbt-core and dbt-oss are still accepted.
 post:
   - key: project
-    value: dbt-core
+    value: dbt-oss
 
 newlines:
   afterChangelogHeader: 1
@@ -58,7 +60,7 @@ newlines:
 
 # Contributors section (mirrors fs). Set FUSION_TEAM (space-separated handles)
 # to exclude maintainers; otherwise all non-bot authors are listed. Issue links
-# resolve to the dbt-core repo, matching changeFormat above.
+# resolve to the dbt-oss repo, matching changeFormat above.
 footerFormat: |
   {{- $contributorDict := dict }}
   {{- $fusion_team_env := default "" .Env.FUSION_TEAM }}
@@ -72,10 +74,10 @@ footerFormat: |
     {{- range $author := $authorList }}
       {{- if and $author (not (has (lower $author) $maintainers)) }}
         {{- $IssueList := list }}
-        {{- if eq $change.Custom.project "dbt-core" }}
+        {{- if or (eq $change.Custom.project "dbt-core") (eq $change.Custom.project "dbt-oss") }}
         {{- range $issueNbr := splitList " " $change.Custom.issue }}
           {{- if $issueNbr }}
-            {{- $changeLink := "[#nbr](https://github.com/dbt-labs/dbt-core/issues/nbr)" | replace "nbr" $issueNbr }}
+            {{- $changeLink := "[#nbr](https://github.com/dbt-labs/dbt-oss/issues/nbr)" | replace "nbr" $issueNbr }}
             {{- $IssueList = append $IssueList $changeLink }}
           {{- end }}
         {{- end }}

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-# This file contains the code owners for the dbt-core repo.
+# This file contains the code owners for the dbt-oss repo.
 # PRs will be automatically assigned for review to the associated
 # team(s) or person(s) that touches any files that are mapped to them.
 #

--- a/.github/ISSUE_TEMPLATE/bug-report-v2.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report-v2.yml
@@ -1,5 +1,5 @@
 name: 🐞 Bug (dbt v2.x)
-description: Report a bug or issue you've found in dbt v2.x (Core or Fusion distributions)
+description: Report a bug or issue you've found in dbt v2.x (OSS or Fusion distributions)
 title: "[v2 Bug] <title>"
 labels: ["bug", "triage", "v2", "type:bug", "status:triage", "engine:v2"]
 body:
@@ -8,7 +8,7 @@ body:
       value: |
         Thanks for taking the time to fill out this bug report!
 
-        This template is for bugs in dbt v2.x (either the Core or Fusion distribution). For bugs in dbt Core 1.x, use the "🐞 Bug" template instead.
+        This template is for bugs in dbt v2.x (either the OSS or Fusion distribution). For bugs in dbt Core 1.x, use the "🐞 Bug" template instead.
   - type: checkboxes
     attributes:
       label: Is this a new bug in dbt v2.x compared to the latest version of dbt 1.x?

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -13,7 +13,7 @@ contact_links:
     url: mailto:support@getdbt.com
     about: Are you using dbt Cloud? Contact our support team for help!
   - name: Participate in Discussions
-    url: https://github.com/dbt-labs/dbt-core/discussions
+    url: https://github.com/dbt-labs/dbt-oss/discussions
     about: Do you have a Big Idea for dbt? Read open discussions, or start a new one
   - name: Create an issue for v1.x adapters
     url: https://github.com/dbt-labs/dbt-adapters/issues/new/choose

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -16,7 +16,7 @@ body:
 
         Issues are the right place to request straightforward extensions of existing dbt functionality.
         For "big ideas" about future capabilities of dbt, we ask that you open a
-        [discussion](https://github.com/dbt-labs/dbt-core/discussions) in the "Ideas" category instead.
+        [discussion](https://github.com/dbt-labs/dbt-oss/discussions) in the "Ideas" category instead.
       options:
         - label: I have read the [expectations for open source contributors](https://docs.getdbt.com/docs/contributing/oss-expectations)
           required: true

--- a/.github/ISSUE_TEMPLATE/implementation-ticket.yml
+++ b/.github/ISSUE_TEMPLATE/implementation-ticket.yml
@@ -1,11 +1,11 @@
 name: 🛠️ Implementation
-description: This is an implementation ticket intended for use by the maintainers of dbt-core
+description: This is an implementation ticket intended for use by the maintainers of dbt OSS
 title: "[<project>] <title>"
 labels: ["action:needs-docs"]
 body:
   - type: markdown
     attributes:
-      value: This is an implementation ticket intended for use by the maintainers of dbt-core
+      value: This is an implementation ticket intended for use by the maintainers of dbt OSS
   - type: checkboxes
     attributes:
       label: Housekeeping
@@ -14,7 +14,7 @@ body:
           1. Remove the `action:needs-docs` label if the scope of this work does not require changes to https://docs.getdbt.com/docs: no end-user interface (e.g. yml spec, CLI, error messages, etc) or functional changes
           2. Link any blocking issues in the "Blocked on" field under the "Core devs & maintainers" project.
       options:
-        - label: I am a maintainer of dbt-core
+        - label: I am a maintainer of dbt OSS
           required: true
   - type: textarea
     attributes:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,7 +26,7 @@ Resolves #
 
 ### Checklist
 
-- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
+- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-oss/blob/main/CONTRIBUTING.md) and understand what's expected of me.
 - [ ] I have run this code in development, and it appears to resolve the stated issue.
 - [ ] This PR includes tests, or tests are not required or relevant for this PR.
 - [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.

--- a/.github/workflows/changelog-existence.yml
+++ b/.github/workflows/changelog-existence.yml
@@ -35,6 +35,6 @@ jobs:
   changelog:
     uses: dbt-labs/actions/.github/workflows/changelog-existence.yml@main
     with:
-      changelog_comment: 'Thank you for your pull request! We could not find a changelog entry for this change. For details on how to document a change, see [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-changelog-entry).'
+      changelog_comment: 'Thank you for your pull request! We could not find a changelog entry for this change. For details on how to document a change, see [the contributing guide](https://github.com/dbt-labs/dbt-oss/blob/main/CONTRIBUTING.md#adding-a-changelog-entry).'
       skip_label: 'Skip Changelog'
     secrets: inherit

--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -364,8 +364,8 @@ jobs:
           echo "::notice title="New branch created": $title::$message"
 
       - name: "Bump dependencies via script"
-        # This bumps the dependency on dbt-core in the adapters
-        if: ${{ !contains(github.repository, 'dbt-core') }}
+        # This bumps the dependency on dbt-oss in the adapters
+        if: ${{ !contains(github.repository, 'dbt-oss') }}
         run: |
           echo ${{ github.repository }}
           echo "running update_dependencies script"
@@ -378,7 +378,7 @@ jobs:
 
       - name: "Bump env variable via script"
         # bumps the RELEASE_BRANCH variable in nightly-release.yml in adapters
-        if: ${{ !contains(github.repository, 'dbt-core') }}
+        if: ${{ !contains(github.repository, 'dbt-oss') }}
         run: |
           file="./.github/scripts/update_release_branch.sh"
           if test -f "$file"; then

--- a/.github/workflows/docs-issue.yml
+++ b/.github/workflows/docs-issue.yml
@@ -149,5 +149,5 @@ jobs:
     with:
         issue_repository: "dbt-labs/docs.getdbt.com"
         issue_title: "[Core] Docs changes needed from ${{ github.event.repository.name }} issue #${{ github.event.issue.number }}"
-        issue_body: "Originating from this issue: https://github.com/dbt-labs/dbt-core/issues/${{ github.event.issue.number }}\nRelated PR: ${{ needs.get_pr_info.outputs.pr_url }}\nPR title: ${{ needs.get_pr_info.outputs.pr_title }}\n\n---\n${{ needs.generate_ai_summary.outputs.summary }}\n\n---\nAt a minimum, update body to include a link to the page on docs.getdbt.com requiring updates and what part(s) of the page you would like to see updated."
+        issue_body: "Originating from this issue: https://github.com/dbt-labs/dbt-oss/issues/${{ github.event.issue.number }}\nRelated PR: ${{ needs.get_pr_info.outputs.pr_url }}\nPR title: ${{ needs.get_pr_info.outputs.pr_title }}\n\n---\n${{ needs.generate_ai_summary.outputs.summary }}\n\n---\nAt a minimum, update body to include a link to the page on docs.getdbt.com requiring updates and what part(s) of the page you would like to see updated."
     secrets: inherit

--- a/.github/workflows/release-awaiting.yml
+++ b/.github/workflows/release-awaiting.yml
@@ -8,7 +8,7 @@
 # a different release cadence and is not tracked by this automation.
 
 # **when?**
-# Whenever a v2 issue in dbt-labs/dbt-core is closed as completed.
+# Whenever a v2 issue in dbt-labs/dbt-oss is closed as completed.
 
 name: "Release Tracker: Awaiting Release"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-# dbt Core changelog
+# dbt OSS changelog
 All notable changes to this project will be documented in this file.
 
-- This file covers dbt Core v2.0. For changelogs for other dbt Engines, refer to:
-  - dbt Core v1 (Python) changelog, see [the `1.latest` branch's `CHANGELOG.md`](https://github.com/dbt-labs/dbt-core/blob/1.latest/CHANGELOG.md).
+- This file covers dbt OSS v2.0. For changelogs for other dbt Engines, refer to:
+  - dbt Core v1 (Python) changelog, see [the `1.latest` branch's `CHANGELOG.md`](https://github.com/dbt-labs/dbt-oss/blob/1.latest/CHANGELOG.md).
   - the [dbt Fusion CHANGELOG for beta and preview release notes](/CHANGELOG-fusion.md)
 - Changes are listed under the (pre)release in which they first appear. Subsequent releases include changes from previous releases.
 - "Breaking changes" listed under a version may require action from end users or external maintainers when upgrading to that version.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,45 +1,45 @@
-# Contributing to dbt Core
+# Contributing to dbt OSS
 
-There are many ways to contribute to the ongoing development of dbt Core, including code, discussions, and issues. We encourage you to first read our higher-level document: "[Expectations for Open Source Contributors](https://docs.getdbt.com/community/resources/oss-expectations)".
+There are many ways to contribute to the ongoing development of dbt OSS, including code, discussions, and issues. We encourage you to first read our higher-level document: "[Expectations for Open Source Contributors](https://docs.getdbt.com/community/resources/oss-expectations)".
 
 ### Notes
 * **Adapters** - All adapter jinja logic is maintained in this repository. Please open up an issue here.
-* **Database Drivers** - dbt Core uses the next generation ADBC protocol to submit queries. 
+* **Database Drivers** - dbt OSS uses the next generation ADBC protocol to submit queries. 
   * **For Snowflake** - please see the [Go Arrow Snowflake Driver](https://github.com/apache/arrow-adbc/tree/main/go/adbc/driver/snowflake)
   * **For BigQuery** - please see the [Go Arrow BigQuery Driver](https://github.com/apache/arrow-adbc/tree/main/go/adbc/driver/bigquery)
   * **For Postgres** - please see the [C Arrow Postgres Driver](https://github.com/dbt-labs/arrow-adbc/tree/main/c/driver/postgresql)
   
 * **Branches** - All pull requests from community contributors should target the main branch (default). If the change is needed as a patch for a minor version of dbt that has already been released (or is already a release candidate), a maintainer will backport the changes in your PR to the release branch.
-* **Releases** - While dbt Core v2.0 is in beta, new releases will include fixes and new features. Versions will be labelled `2.0.0-beta.1`, `2.0.0-beta.2`, etc. Before filing a bug, please ensure that you have the latest release installed. 
+* **Releases** - While dbt OSS v2.0 is in beta, new releases will include fixes and new features. Versions will be labelled `2.0.0-beta.1`, `2.0.0-beta.2`, etc. Before filing a bug, please ensure that you have the latest release installed. 
 
 ### Setting up an environment
 
 #### Tools
-dbt Core is written in Rust. Please make sure that you have the [rust toolchain installed](https://www.rust-lang.org/tools/install), along with the preferred testing utility [Nextest](https://nexte.st/). 
+dbt OSS is written in Rust. Please make sure that you have the [rust toolchain installed](https://www.rust-lang.org/tools/install), along with the preferred testing utility [Nextest](https://nexte.st/). 
 
 1. [Install Rust](https://www.rust-lang.org/tools/install)
 2. Install the testing framework used for all tests & testbench configuration [Nextest](https://nexte.st/docs/installation/pre-built-binaries/)
-3. Clone the repository `git clone https://github.com/dbt-labs/dbt-core.git`
-4. `cd dbt-core`
+3. Clone the repository `git clone https://github.com/dbt-labs/dbt-oss.git`
+4. `cd dbt-oss`
 5. `cargo build` for a debug build. `cargo build --release` for a release build
 
 *There are no virtual environments needed!*
 
 
-## Making a Change to dbt Core
+## Making a Change to dbt OSS
 After you're done making your code change, make sure:
 - your code is formatted: `cargo fmt`
 - all tests pass: `cargo nextest run`
 - all lints pass: `cargo clippy --all-targets --all-features`.
 - you have manually verified it works with a local build of dbt against a real project
 
-Then, open a pull request against the current development branch, `main`. A dbt Core maintainer will triage the PR and, once it's on the right track, assign a reviewer. They may suggest code revisions for style or clarity, or request that you add test(s).
+Then, open a pull request against the current development branch, `main`. A dbt OSS maintainer will triage the PR and, once it's on the right track, assign a reviewer. They may suggest code revisions for style or clarity, or request that you add test(s).
 
-Once your PR has been approved, a maintainer will take it from there and shepherd your changes into dbt Core. And that's it! Happy developing 🎉
+Once your PR has been approved, a maintainer will take it from there and shepherd your changes into dbt OSS. And that's it! Happy developing 🎉
 
 ## What happens after you open a pull request
 
-dbt Core is developed through dbt Labs' internal build and review process, and this repository is kept in sync with it automatically. You don't need to do anything special for this — but it's worth knowing, because it explains the labels, comments, and status checks you'll see on your PR.
+dbt OSS is developed through dbt Labs' internal build and review process, and this repository is kept in sync with it automatically. You don't need to do anything special for this — but it's worth knowing, because it explains the labels, comments, and status checks you'll see on your PR.
 
 1. **Your PR is triaged.** PRs opened by community members are automatically labeled `community`, and during triage they're marked `source:community` to note the change came from an external contributor. A maintainer reviews the change and, once it's on the right track, assigns a reviewer.
 
@@ -72,4 +72,4 @@ changie new
 
 Commit the file that's created and your changelog entry is complete!
 
-You don't need to worry about which `dbt-core` version your change will go into. Just create the changelog entry with `changie`, and open your PR against the `main` branch. All merged changes will be included in the next release of `dbt-core`.  If a changelog is not required, a maintainer can add the label `Skip Changelog` to bypass this requirement.
+You don't need to worry about which `dbt-oss` version your change will go into. Just create the changelog entry with `changie`, and open your PR against the `main` branch. All merged changes will be included in the next release of `dbt-oss`.  If a changelog is not required, a maintainer can add the label `Skip Changelog` to bypass this requirement.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,12 +105,12 @@ resolver = "2"
 
 [workspace.package]
 authors = ["dbt Labs <info@getdbt.com>"]
-description = "Fusion: A fast dbt engine, SQL compiler, local development framework, and in-memory analytical database"
+description = "dbt OSS: A fast dbt engine, SQL compiler, local development framework, and in-memory analytical database"
 edition = "2024"
 homepage = "https://getdbt.com"
 keywords = ["sql", "parquet", "json", "csv", "dbt"]
 license = "Apache-2.0"
-repository = "https://github.com/dbt-labs/dbt-core"
+repository = "https://github.com/dbt-labs/dbt-oss"
 version = "2.0.0-rc.1"
 
 [patch.crates-io]

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-<p align="center">
+<!-- <p align="center">
   <img src="https://raw.githubusercontent.com/dbt-labs/dbt-core/fa1ea14ddfb1d5ae319d5141844910dd53ab2834/etc/dbt-core.svg" alt="dbt logo" width="750"/>
-</p>
+</p> -->
 
 > [!WARNING]
-> **dbt Core v1 development has moved to the [`1.latest`](https://github.com/dbt-labs/dbt-core/tree/1.latest) branch.**
-> The `main` branch now hosts dbt Core v2.0 (beta) — a ground-up rewrite in Rust that is the foundation of the Fusion engine. If you're looking for the Python implementation of dbt Core, switch to [`1.latest`](https://github.com/dbt-labs/dbt-core/tree/1.latest).
+> **dbt Core v1 development has moved to the [`1.latest`](https://github.com/dbt-labs/dbt-oss/tree/1.latest) branch.**
+> The `main` branch now hosts dbt OSS v2.0 (beta) — a ground-up rewrite in Rust that is the foundation of the Fusion engine. If you're looking for the Python implementation of dbt Core, switch to [`1.latest`](https://github.com/dbt-labs/dbt-oss/tree/1.latest).
 
 **[dbt](https://www.getdbt.com/)** enables data analysts and engineers to transform their data using the same practices that software engineers use to build applications.
 
 ![architecture](https://raw.githubusercontent.com/dbt-labs/dbt-core/202cb7e51e218c7b29eb3b11ad058bd56b7739de/etc/dbt-transform.png)
 
-## About dbt Core v2.0
+## About dbt OSS v2.0
 
-> 🚧 dbt Core v2.0 is in beta. Behavior, APIs, and on-disk formats may change before the stable release.
+> 🚧 dbt OSS v2.0 is in beta. Behavior, APIs, and on-disk formats may change before the stable release.
 
-dbt Core v2.0 is engineered for performance at scale — parsing, compiling, and running projects in a fraction of the time compared to v1. It's released under the Apache 2.0 license and is the foundation of the [Fusion engine](https://docs.getdbt.com/docs/fusion/about-fusion).
+dbt OSS v2.0 is engineered for performance at scale — parsing, compiling, and running projects in a fraction of the time compared to v1. It's released under the Apache 2.0 license and is the foundation of the [Fusion engine](https://docs.getdbt.com/docs/fusion/about-fusion).
 
 The big shifts from v1:
 
@@ -26,7 +26,7 @@ The big shifts from v1:
 
 ### Supported operating systems and architectures
 
-dbt Core v2.0 and its drivers are compiled per operating system and architecture.
+dbt OSS v2.0 and its drivers are compiled per operating system and architecture.
 
 Legend:
 * 🟢 — Supported today
@@ -48,10 +48,10 @@ These select statements, or "models", form a dbt project. Models frequently buil
 
 ## Getting started
 
-Start by choosing a distribution. dbt Core is the baseline distribution of dbt. Fusion extends dbt Core with additional SQL comprehension abilities. Both distributions are free to install and can run locally.
+Start by choosing a distribution. dbt OSS is the baseline distribution of dbt. Fusion extends dbt OSS with additional SQL comprehension abilities. Both distributions are free to install and can run locally.
 
-- **If you need an Apache 2.0 licensed tool** and the ability to review every line of code inside of it, [install dbt Core](https://docs.getdbt.com/docs/local/install-dbt-core-v2?version=2.0).
-- **If you need a free CLI you can use locally**, [install Fusion](https://docs.getdbt.com/docs/local/install-dbt?version=2.0). It can do more than dbt Core out of the box and you can seamlessly enable other advanced features over time if you choose to.
+- **If you need an Apache 2.0 licensed tool** and the ability to review every line of code inside of it, [install dbt OSS](https://docs.getdbt.com/docs/local/install-dbt-core-v2?version=2.0).
+- **If you need a free CLI you can use locally**, [install Fusion](https://docs.getdbt.com/docs/local/install-dbt?version=2.0). It can do more than dbt OSS out of the box and you can seamlessly enable other advanced features over time if you choose to.
 
 Regardless of the distribution you choose, each is part of a single framework with a single language specification, meaning your business logic is portable in both directions.
 
@@ -65,8 +65,8 @@ Read the [introduction](https://docs.getdbt.com/docs/introduction/) and [viewpoi
 
 ## Reporting bugs and contributing code
 
-- Want to report a bug or request a feature? Let us know and open [an issue](https://github.com/dbt-labs/dbt-core/issues/new/choose)
-- Want to help us build dbt? Check out the [Contributing Guide](https://github.com/dbt-labs/dbt-core/blob/HEAD/CONTRIBUTING.md)
+- Want to report a bug or request a feature? Let us know and open [an issue](https://github.com/dbt-labs/dbt-oss/issues/new/choose)
+- Want to help us build dbt? Check out the [Contributing Guide](https://github.com/dbt-labs/dbt-oss/blob/HEAD/CONTRIBUTING.md)
 
 ## Code of Conduct
 
@@ -74,4 +74,4 @@ Everyone interacting in the dbt project's codebases, issue trackers, chat rooms,
 
 ## License
 
-dbt Core is licensed under the [Apache License 2.0](LICENSE).
+dbt OSS is licensed under the [Apache License 2.0](LICENSE).

--- a/crates/dbt-adapter/src/load_catalogs.rs
+++ b/crates/dbt-adapter/src/load_catalogs.rs
@@ -10,7 +10,7 @@ use dbt_yaml as yml;
 use std::path::Path;
 use std::sync::{Arc, RwLock};
 
-const CATALOGS_V2_DISCUSSION_URL: &str = "https://github.com/dbt-labs/dbt-core/discussions/12723";
+const CATALOGS_V2_DISCUSSION_URL: &str = "https://github.com/dbt-labs/dbt-oss/discussions/12723";
 
 static CATALOGS: RwLock<Option<Arc<DbtCatalogs>>> = RwLock::new(None);
 static USE_CATALOGS_V2: RwLock<bool> = RwLock::new(false);

--- a/crates/dbt-docs-server/Dockerfile
+++ b/crates/dbt-docs-server/Dockerfile
@@ -63,7 +63,7 @@ esac
 if [ "$DBT_VERSION" = latest ]; then
   version=$(
     curl -fsSL -H 'Accept: application/vnd.github+json' \
-      'https://api.github.com/repos/dbt-labs/dbt-core/releases?per_page=100' \
+      'https://api.github.com/repos/dbt-labs/dbt-oss/releases?per_page=100' \
       | jq -r --arg triple "$triple" '
           [ .[]
             | select(.draft == false)
@@ -84,12 +84,12 @@ else
 fi
 
 base="dbt-core-${version}-${triple}"
-url="https://github.com/dbt-labs/dbt-core/releases/download/v${version}"
+url="https://github.com/dbt-labs/dbt-oss/releases/download/v${version}"
 
 if ! curl -fsSL -o "${base}.tar.gz" "${url}/${base}.tar.gz"; then
   echo "could not download ${base}.tar.gz from ${url}" >&2
   echo "check that this version exists and ships a ${triple} binary:" >&2
-  echo "  https://github.com/dbt-labs/dbt-core/releases" >&2
+  echo "  https://github.com/dbt-labs/dbt-oss/releases" >&2
   exit 1
 fi
 curl -fsSL -o SHA256SUMS "${url}/SHA256SUMS"
@@ -118,7 +118,7 @@ FROM debian:bookworm-slim AS runtime
 
 LABEL org.opencontainers.image.title="dbt-docs-server" \
       org.opencontainers.image.description="Self-hosted dbt docs v2 server (dbt docs serve)." \
-      org.opencontainers.image.source="https://github.com/dbt-labs/dbt-core" \
+      org.opencontainers.image.source="https://github.com/dbt-labs/dbt-oss" \
       org.opencontainers.image.licenses="Apache-2.0"
 
 # ca-certificates and libstdc++6 are both for the ADBC DuckDB driver: it is

--- a/crates/dbt-docs-server/README.md
+++ b/crates/dbt-docs-server/README.md
@@ -6,7 +6,7 @@
   </p>
   <p>
     <a href="./API-CONTRACTS.md">Contracts &amp; decisions</a> ·
-    <a href="https://github.com/dbt-labs/dbt-core">dbt Core repo</a> ·
+    <a href="https://github.com/dbt-labs/dbt-oss">dbt OSS repo</a> ·
     <a href="https://docs.getdbt.com/docs/fusion/about-fusion">About Fusion</a> ·
     <a href="https://docs.getdbt.com">Official dbt docs</a>
   </p>
@@ -154,7 +154,7 @@ DBT_VERSION=2.0.0-beta.2 DBT_TARGET_PATH=/abs/path/to/project/target docker comp
 
 ### 🐋 Option C: Docker
 
-A `Dockerfile` is included. It downloads a released dbt binary from this repo's [GitHub Releases](https://github.com/dbt-labs/dbt-core/releases) and verifies it against the release's published `SHA256SUMS`, so the build is quick and needs no cargo toolchain. It is a multi-stage BuildKit build, produces `linux/amd64` and `linux/arm64`, and runs as an unprivileged user.
+A `Dockerfile` is included. It downloads a released dbt binary from this repo's [GitHub Releases](https://github.com/dbt-labs/dbt-oss/releases) and verifies it against the release's published `SHA256SUMS`, so the build is quick and needs no cargo toolchain. It is a multi-stage BuildKit build, produces `linux/amd64` and `linux/arm64`, and runs as an unprivileged user.
 
 Nothing is copied out of the build context, so the context is this crate's directory and the command is the same whether you run it from the repo root or from `crates/dbt-docs-server/`:
 
@@ -243,7 +243,7 @@ side: `cargo build` uses the committed bundle and never invokes `pnpm`.
 
 ## 🤝 Contributing
 
-Development happens in the [`dbt-labs/dbt-core`](https://github.com/dbt-labs/dbt-core) monorepo, under `crates/dbt-docs-server`.
+Development happens in the [`dbt-labs/dbt-oss`](https://github.com/dbt-labs/dbt-oss) monorepo, under `crates/dbt-docs-server`.
 
 ## 📄 License
 

--- a/crates/dbt-features/src/cli.rs
+++ b/crates/dbt-features/src/cli.rs
@@ -663,7 +663,7 @@ mod tests {
     #[test]
     fn hidden_self_management_commands_are_absent_from_help_but_parseable() {
         let version = "2.x";
-        let parser = CliParser::new("dbt-core", version, Box::new(OSSExtensionCommandParser));
+        let parser = CliParser::new("dbt-oss", version, Box::new(OSSExtensionCommandParser));
 
         // Hidden from help, but unaffected commands remain.
         let help = system_help(&parser);
@@ -685,7 +685,7 @@ mod tests {
 
     #[test]
     fn system_is_not_a_project_command() {
-        let parser = CliParser::new("dbt-core", "2.x", Box::new(OSSExtensionCommandParser));
+        let parser = CliParser::new("dbt-oss", "2.x", Box::new(OSSExtensionCommandParser));
         let cli = parser.try_parse_from(["dbt", "system", "update"]).unwrap();
 
         let oss_ext_cmd = cli.extension_command::<OSSExtensionCommand>().unwrap();
@@ -704,7 +704,7 @@ mod tests {
 
     #[test]
     fn distribution_stub_commands_are_visible_in_help_and_parseable() {
-        let parser = CliParser::new("dbt-core", "2.x", Box::new(OSSExtensionCommandParser));
+        let parser = CliParser::new("dbt-oss", "2.x", Box::new(OSSExtensionCommandParser));
 
         let help = root_help(&parser);
         assert!(help.contains("lint"), "got:\n{help}");
@@ -721,7 +721,7 @@ mod tests {
 
     #[test]
     fn distribution_stub_commands_are_not_project_commands() {
-        let parser = CliParser::new("dbt-core", "2.x", Box::new(OSSExtensionCommandParser));
+        let parser = CliParser::new("dbt-oss", "2.x", Box::new(OSSExtensionCommandParser));
 
         let cli = parser.try_parse_from(["dbt", "lint"]).unwrap();
         assert!(

--- a/crates/dbt-features/src/feature_stack_builder.rs
+++ b/crates/dbt-features/src/feature_stack_builder.rs
@@ -85,7 +85,7 @@ pub struct FeatureStackBuilder {
 impl FeatureStackBuilder {
     pub fn new(tracing: TracingFeature) -> Self {
         Self {
-            name: "dbt-core",
+            name: "dbt-oss",
             distribution: "dbt-oss",
             tracing,
         }

--- a/crates/dbt-sa-cli/src/main.rs
+++ b/crates/dbt-sa-cli/src/main.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 fn main() -> ExitCode {
     let version = env!("CARGO_PKG_VERSION");
-    let cli_parser = DefaultCliParserFactory.create("dbt-core", version);
+    let cli_parser = DefaultCliParserFactory.create("dbt-oss", version);
     let cli = dbt_main::prepare_cli_or_exit(&cli_parser);
 
     let mut arg = from_main(&cli);

--- a/crates/dbt-sa-cli/tests/common.rs
+++ b/crates/dbt-sa-cli/tests/common.rs
@@ -23,7 +23,7 @@ fn make_fs_command_fn() -> Arc<CommandFn> {
     });
 
     let version = env!("CARGO_PKG_VERSION");
-    let parser = DefaultCliParserFactory.create("dbt-core", version);
+    let parser = DefaultCliParserFactory.create("dbt-oss", version);
     Arc::new(
         move |cmd_vec, project_dir, target_dir, stdout, stderr, tracing_handle| {
             exec_fs(

--- a/crates/dbt-sa-cli/tests/golden/hello_world/compile_strict_static_analysis_warns.stdout
+++ b/crates/dbt-sa-cli/tests/golden/hello_world/compile_strict_static_analysis_warns.stdout
@@ -1,4 +1,4 @@
-  dbt-core 
+   dbt-oss 
    Loading profiles.yml
    Parsing models/hello_world.sql
  Rendering models/hello_world.sql

--- a/crates/dbt-sa-cli/tests/golden/hello_world/parse_hello_world.stdout
+++ b/crates/dbt-sa-cli/tests/golden/hello_world/parse_hello_world.stdout
@@ -1,4 +1,4 @@
-  dbt-core 
+   dbt-oss 
    Loading profiles.yml
    Parsing models/hello_world.sql
 ==================== Execution Summary =====================

--- a/crates/dbt-sa-python/pyproject.toml
+++ b/crates/dbt-sa-python/pyproject.toml
@@ -3,13 +3,13 @@ requires = ["maturin>=1.0,<2.0"]
 build-backend = "maturin"
 
 [project]
-name = "dbt-core"
+name = "dbt-oss"
 requires-python = ">=3.11"
 dynamic = ["version"]
 dependencies = ["mashumaro[msgpack]>=3.14"]
 
 # The `dbt` CLI is served from this wheel's compiled extension (dbt._core), so
-# `pip install dbt-core` provides both the command line and the programmatic API.
+# `pip install dbt-oss` provides both the command line and the programmatic API.
 [project.scripts]
 dbt = "dbt.cli.main:cli"
 

--- a/crates/dbt-sa-python/src/lib.rs
+++ b/crates/dbt-sa-python/src/lib.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 
 /// This distribution's CLI surface.
 fn dbt_core_cli_parser() -> CliParser {
-    DefaultCliParserFactory.create("dbt-core", env!("CARGO_PKG_VERSION"))
+    DefaultCliParserFactory.create("dbt-oss", env!("CARGO_PKG_VERSION"))
 }
 
 /// This distribution's runtime configuration. Takes the invocation's tracing

--- a/crates/dbt-sa-python/uv.lock
+++ b/crates/dbt-sa-python/uv.lock
@@ -57,8 +57,11 @@ wheels = [
 ]
 
 [[package]]
-name = "dbt-core"
+name = "dbt-oss"
 source = { editable = "." }
+dependencies = [
+    { name = "mashumaro", extra = ["msgpack"] },
+]
 
 [package.dev-dependencies]
 lint = [
@@ -70,13 +73,14 @@ test = [
 ]
 
 [package.metadata]
+requires-dist = [{ name = "mashumaro", extras = ["msgpack"], specifier = ">=3.14" }]
 
 [package.metadata.requires-dev]
 lint = [
-    { name = "mypy", specifier = ">=1.11" },
-    { name = "ruff", specifier = ">=0.6" },
+    { name = "mypy", specifier = ">=2.3" },
+    { name = "ruff", specifier = ">=0.16" },
 ]
-test = [{ name = "pytest", specifier = ">=8" }]
+test = [{ name = "pytest", specifier = ">=9.1" }]
 
 [[package]]
 name = "iniconfig"
@@ -160,6 +164,108 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/99/6203ce619dee940d6bfbe099ec3fe4be00a68e9d60f70abf906cf124fe66/librt-0.13.0-cp314-cp314t-win32.whl", hash = "sha256:5fdcf34f86de8fb66d7dc7589f96ba91c4aa46671200d400e6fd6f109a483f18", size = 104357, upload-time = "2026-07-08T12:26:09.828Z" },
     { url = "https://files.pythonhosted.org/packages/52/dd/843b6314087c41657c7036d7914d8f294bdf9b580aa8513ea0588c8e9a3d/librt-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:260c33e92263fa629b4f6d3c51967a1c2158fe6c33237aaa3ebeac586b085259", size = 126998, upload-time = "2026-07-08T12:26:10.975Z" },
     { url = "https://files.pythonhosted.org/packages/5f/5d/3dcec2884ba1b0806d1408612555c38dd5d68e90156b59f75f6e36435c3a/librt-0.13.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2f281549a4c52ac7bb97997f14353f8bd0e53a34ca0dad1c905cfd0b4a58ae99", size = 110771, upload-time = "2026-07-08T12:26:12.303Z" },
+]
+
+[[package]]
+name = "mashumaro"
+version = "3.22"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/e3/a06dcd2e6df094c5e294721926f1f76da30f50823e2ac233a9198e804891/mashumaro-3.22.tar.gz", hash = "sha256:64538cc365204402a060ebde683a86505b5a4344acf6870d79021e9fbfe57360", size = 197845, upload-time = "2026-05-26T14:39:21.859Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/1c/92fd926c2e7763535454683250dbdd8d10aa2f2c62f58d6abbcce4d8b3fc/mashumaro-3.22-py3-none-any.whl", hash = "sha256:17dc4d7294c33ef380a8b929dda0608577aa2141988c00a0c4932310108fe71d", size = 95916, upload-time = "2026-05-26T14:39:20.233Z" },
+]
+
+[package.optional-dependencies]
+msgpack = [
+    { name = "msgpack" },
+]
+
+[[package]]
+name = "msgpack"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/44/ea2100ec54d30c46ee9dba10a3bfb79b655e96c6df237238a3234c75869b/msgpack-1.2.2.tar.gz", hash = "sha256:9eb0b0e602064527a045ea28c4f174ed69383587e29cebe28947e3b84106eb2a", size = 187025, upload-time = "2026-08-27T10:03:47.793Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/fd/a05ba8f84c5951c9aec2a19c1c81f6c4a67b8bec80af604ac5b23ccfa019/msgpack-1.2.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:9d7fb25b4442fae0cb2590272d06ab4f6caa526ee36a994edb81e946b874813e", size = 83498, upload-time = "2026-08-27T10:01:50.62Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/df/e20bcf5c149890545334743b212eb4b82e1a25fe0a34f99753a1755bfab5/msgpack-1.2.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7fe374ba76eb0ecca13a1703daa8fa85825a6ddddbb52d4c1a732fa524194683", size = 83896, upload-time = "2026-08-27T10:01:51.898Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/c3/00dcd902d66a641b9ba350783feb482ea5c1ca4a7ff6629db0c10c0ea982/msgpack-1.2.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b9b0c1f2aa7b0026b4bd50718100e8b04175e4f36e160aa852502377b5e572e7", size = 413259, upload-time = "2026-08-27T10:01:53.296Z" },
+    { url = "https://files.pythonhosted.org/packages/93/15/17374efe9793f5332c7d4727ab40539f95a1dc9df653531795daca8c4281/msgpack-1.2.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f11e09f10210a91c169e39c7a5a1f9090eaa73ad75555fafad5023c3053c47ba", size = 422907, upload-time = "2026-08-27T10:01:54.786Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/af/2b567d684f912fedcefe3f7c37de604716ffa99336bd432688f9f040df92/msgpack-1.2.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8b1415d02e9bf722672af8a90f90813265a0cd0b14163187261e54a5592bc949", size = 389248, upload-time = "2026-08-27T10:01:56.55Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fd/d8533fed473cc3e309a701e851d0e5fe36ada5552a3899025f5c69fbe877/msgpack-1.2.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:42fd9260416885b4815caca5bdd14dfd5dda6cdade732d6c09104ef8f6228761", size = 407099, upload-time = "2026-08-27T10:01:58.357Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/1b/57906337bfee0ead554571dc203ea17c3fad26d51e5eca6271ecd983f73b/msgpack-1.2.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:336525cc2688e43ea77dfb1a4ce012c8cde561835913801dbfcfdcf4111d8abb", size = 387201, upload-time = "2026-08-27T10:02:00.109Z" },
+    { url = "https://files.pythonhosted.org/packages/de/0f/5d1e6d68e516621697a9262b24917d678793e838cf3f331ed4656b3e959d/msgpack-1.2.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:cdb6cc6e1127d15879c47a8b3270716243da82d3e7feab1f5946872c75b3d60f", size = 420765, upload-time = "2026-08-27T10:02:01.573Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a6/07f9a4f3324d55c3567ab2a7e8d5325291bc95a31a374bb390a21b7c4e24/msgpack-1.2.2-cp311-cp311-win32.whl", hash = "sha256:cf66fb38703e61a486b01b56d43bb1f50698fbe99b6bd90feba10f24fab60b3b", size = 64785, upload-time = "2026-08-27T10:02:03.01Z" },
+    { url = "https://files.pythonhosted.org/packages/84/13/f748f0d59f355d196e71a0b32d48d386a9bd311f94d954e666cf7e5b2572/msgpack-1.2.2-cp311-cp311-win_amd64.whl", hash = "sha256:0883a1578168929fd1640fbbc4614773f1a130e419a8a817dc2918d9af1b651c", size = 71258, upload-time = "2026-08-27T10:02:04.375Z" },
+    { url = "https://files.pythonhosted.org/packages/46/a6/10d979c4e76b18a9b9ebbd6499ff863474ffe5955028ea27e09b66f6833c/msgpack-1.2.2-cp311-cp311-win_arm64.whl", hash = "sha256:4955accbd87f27beebef5f3ecc27503aa74cb016fb4f640868e749fd93194a35", size = 65860, upload-time = "2026-08-27T10:02:05.735Z" },
+    { url = "https://files.pythonhosted.org/packages/31/78/90c15bebb1a72667349ca62d4507e9d9369e7f8f76b95f490b823d3622e5/msgpack-1.2.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4a4348705be86e029d04e741cf9ed0dfe03e942d7d3b92e838fa80d3aa2c3ebc", size = 84275, upload-time = "2026-08-27T10:02:07.106Z" },
+    { url = "https://files.pythonhosted.org/packages/88/88/c2b6d8e81571da87aa232c0e34a3f3a0e618e6235892065ec82d1d81fc7a/msgpack-1.2.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0a652ceeededf71d3fa40c303a02a149d42338d310162367b91c539d4bd6e0a3", size = 83970, upload-time = "2026-08-27T10:02:08.488Z" },
+    { url = "https://files.pythonhosted.org/packages/da/c0/d3ede9f5d16acb4c05a9281859f1e99ef9f877a928eb78454c37f70db001/msgpack-1.2.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:90986cc9aab9d7d1d8f38bcbf65d3f7ac83bdd90c35765db7d691b4829698cba", size = 409401, upload-time = "2026-08-27T10:02:09.877Z" },
+    { url = "https://files.pythonhosted.org/packages/41/f0/29f591bea185616cf417645ac03bd3ad9b317483ad8572160e325f7fe777/msgpack-1.2.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:77c2e018417dc1d66f235e383877ee885b60ade9d29e494dd581e08af2cb1923", size = 420619, upload-time = "2026-08-27T10:02:11.526Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/8e/c70c8c9180c5ddf4440eb8658ebead98e22e7686fbf84f6b165031430750/msgpack-1.2.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0e91332144f69bc3018c91232fac26da580ef748fb8eaddd7914d4458001cc4f", size = 379747, upload-time = "2026-08-27T10:02:13.345Z" },
+    { url = "https://files.pythonhosted.org/packages/50/9a/f10ce11fa62700c9ab87a22e65b9ca272f7f673ddd31aeb2de6ae272ad35/msgpack-1.2.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3e915d390d7068b257ca8b62f3fc59fad135c8631d1017ab03b0b924b07c5367", size = 398944, upload-time = "2026-08-27T10:02:15.006Z" },
+    { url = "https://files.pythonhosted.org/packages/82/fe/d7be978456ff8552e69a8e270d882e7530e01513c096b293d83df03753ea/msgpack-1.2.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:c522420d78db2431887d45b518e304d86e27b9ad0b30f24e3806a6ad5d8bdbfc", size = 373979, upload-time = "2026-08-27T10:02:16.618Z" },
+    { url = "https://files.pythonhosted.org/packages/be/af/91b0d8d3fb3063e259daee3ea8515cea6282f68f4b0e5f0b6fea25762c6e/msgpack-1.2.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4b554d8164ebb526892194f71dcd96ef1fefe0c250087498785d3ffc04a80be3", size = 417781, upload-time = "2026-08-27T10:02:18.293Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3c/ce8e9efe1fd9e95c78b3705e4300ba7feba3dc6c00fb76259895db155518/msgpack-1.2.2-cp312-cp312-win32.whl", hash = "sha256:0e3315de5a4b2920ccef48d96b4448025e064a10d0f5a250f6584477d839c8d4", size = 65267, upload-time = "2026-08-27T10:02:19.869Z" },
+    { url = "https://files.pythonhosted.org/packages/85/98/a33b8b4af14e3476bb0da1b8c36ef7a0f28dcf95db1c5e68ff88cb89d591/msgpack-1.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:b68614fba0570349833b7dd999ff0aed4e5cc8d9eb6e3a7d4527be33c65e33d3", size = 72275, upload-time = "2026-08-27T10:02:21.141Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5e/2f323a33a6aba5bd4b2d8b430e4fab21d92cd91c093b49ee287bc166ee54/msgpack-1.2.2-cp312-cp312-win_arm64.whl", hash = "sha256:59d5b93efa45fd09f620d0c9ba81cde339a2c9937af3eea42ee9653094ce6640", size = 65488, upload-time = "2026-08-27T10:02:22.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/eb/42f31c5a48811787ff59a9869721f70a49654d65ab6c455f4463c39b044e/msgpack-1.2.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8b2a281b556f120a43e591ea39915741b7ad54d4727b9c4350a0a11692252533", size = 83911, upload-time = "2026-08-27T10:02:24.06Z" },
+    { url = "https://files.pythonhosted.org/packages/33/54/10c6c16ddba8a5112e3680176b838e3694e4aad7284f9daa6d6d70d98817/msgpack-1.2.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1e8cdd1f3e7cc52c751092a9bf740e81e6919ab109cd376ae2d965dad0bbae34", size = 83734, upload-time = "2026-08-27T10:02:25.613Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/75/35823e4419df8792191b2a17ae3fe71b41d02c162b2c491c94d1a87f0caa/msgpack-1.2.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1814f92306ae7862908e9ece7cfd90e0dc87ded3e89b6ae7ffdd1175d6376fdc", size = 405635, upload-time = "2026-08-27T10:02:27.012Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d3/6592e4064619b04f2dd0054c5fa13e37e3d55eb26044483d871fadb2f46b/msgpack-1.2.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d24b38a825bcca41bb956de50eb98451ef291304a8607fad99e619043d3e79b9", size = 417332, upload-time = "2026-08-27T10:02:28.776Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/a1/b21c6818a545e9a4a976ac954a5c250eecde9a02e0ec82f415473dab1324/msgpack-1.2.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:34e83e345194a2a51d8bd447dea9de2104f91e75b247f4735f14f04529f0746b", size = 374378, upload-time = "2026-08-27T10:02:30.678Z" },
+    { url = "https://files.pythonhosted.org/packages/03/8b/7ada15c7b64151d6dbb562d1b091520efb2c37acf2403b1d4ae13797b27d/msgpack-1.2.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:682804bf31e43d46e51a9a33bd575b51e839d715ce6bd5612c055f7b28ad637b", size = 395809, upload-time = "2026-08-27T10:02:32.322Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f7/96283e50f7020df4dfeacc55612b7a210c8cdf0dda48bc262f1f9b3e4c49/msgpack-1.2.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:9b659d77f8726fa5e7038967dda6b68d53cf34472c094cfa5b845454713b90d5", size = 373495, upload-time = "2026-08-27T10:02:33.832Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/fe/1548dede9d9ca482f2d424a2e110a9705d4e02627a16b8bc8d10ce0208a2/msgpack-1.2.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4d9a562aec0a92fe536da2e533d313b3d2a6b929157b1dec7ff623446dc0a8ab", size = 414360, upload-time = "2026-08-27T10:02:35.396Z" },
+    { url = "https://files.pythonhosted.org/packages/77/9d/4419b8f86c219174b1fb8bbd7faaf84a548935f7b1916d028401b9433417/msgpack-1.2.2-cp313-cp313-win32.whl", hash = "sha256:a4161eee7799863aee237c35c90427861f7b994416dd81ae829f560b0a81bdcd", size = 65196, upload-time = "2026-08-27T10:02:37.007Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f8/593f5caf0dacab41cde1564c5f0419e61af55ec9628006205e8fd5eb5e03/msgpack-1.2.2-cp313-cp313-win_amd64.whl", hash = "sha256:b07c03f0da7e5279170df7745ddc732d526c8a198208936ec1a95c11ed2b2d5f", size = 72203, upload-time = "2026-08-27T10:02:38.28Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/9e/c6ef92046b4a2bbb9d3aa0cb581cbf4a4051afccf6e5fb301a1bd3086f39/msgpack-1.2.2-cp313-cp313-win_arm64.whl", hash = "sha256:d13d07efbf655f9ae7a2352b630c52727b359005b21ba08a507585c9ac8c0896", size = 65435, upload-time = "2026-08-27T10:02:39.534Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/50/3e92c403346652cabd08cb8faceef847bae917ea3b3c81b64a5b6d09ed41/msgpack-1.2.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:e497ee34e8a3342bbde51b27c22d8db05a651df3361dd3daef5b3ab0d66f3e04", size = 84315, upload-time = "2026-08-27T10:02:41.181Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/dc/8efe6dd96a12ab043930cb4cffb40b6e7f061491d6ec7a3d2b75ef1fda42/msgpack-1.2.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0dd9173c5ebaf5ecc5ca86e7ae1db92934e1d57b856f3dd90698941431f4fd77", size = 84634, upload-time = "2026-08-27T10:02:42.621Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/89/996573095bf7b038c04dd65ddbc4f1a4d381b0f7a44ff9186f3c7b8325c2/msgpack-1.2.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8dc4487097571f7311188c3eca2a3e86cd1f1db4c37c7a017bcc3fd38486cbfe", size = 404194, upload-time = "2026-08-27T10:02:44.096Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/4e/46f5a5d949dbd054dab60cb15aac7ac6ae6774c134532893414689bf2f53/msgpack-1.2.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:73b0e05c32c3cfc3cd84994908e57430c0ebc6813abf905d3f18ff115d54df3f", size = 412343, upload-time = "2026-08-27T10:02:45.747Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e8/739a94197358a313307e6e9e7d8d22ef66add39222de911a44161aa96920/msgpack-1.2.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aa1120c653b76d8eafa50423b5eba06b5c9737f8692c74fa3afe03e84b8978ea", size = 372620, upload-time = "2026-08-27T10:02:47.578Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d4/09b92e1fcdccea9466bfae45455367ac52362ae445d96a602e51b7a8df73/msgpack-1.2.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ccfd880988f8438d1c91c77d7edc58e70f4d2012e999167bc154c64c6f06ea6b", size = 394603, upload-time = "2026-08-27T10:02:49.172Z" },
+    { url = "https://files.pythonhosted.org/packages/47/db/d11bd6f258a60703dcdc7a3772818ad0c2f602ee4c2acfb24088c6c3ebc3/msgpack-1.2.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:6195257a107bf25872ef84aab7295078271eea3ac6413f0506b631f6c9586ed5", size = 372666, upload-time = "2026-08-27T10:02:50.886Z" },
+    { url = "https://files.pythonhosted.org/packages/71/cf/fbbbac0c6e5fbb9d51abc23e3b5fe8620f5c01e0588797cf664a623bb9e1/msgpack-1.2.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b8dd6c71d20c28d2d0eb0c51e7cccf3584afde3b1364f6629596186c9025bd54", size = 410889, upload-time = "2026-08-27T10:02:52.51Z" },
+    { url = "https://files.pythonhosted.org/packages/94/60/8366558da954095e04e7fbc351f9387d87a682feaee9a235ceda966f794b/msgpack-1.2.2-cp314-cp314-win32.whl", hash = "sha256:d242f3c4ccf55b056e6cf901720dccde58f1df117898f2bbf3bcd6e38ec7c248", size = 66774, upload-time = "2026-08-27T10:02:53.984Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/3d/1ce873c8057c65e4fbb076ffe1c99c9ae39d90a00a2540d7b06c652a292f/msgpack-1.2.2-cp314-cp314-win_amd64.whl", hash = "sha256:1510f24612d4b983dff6935d9273e02c320cfd525727fbcb58836a75f589fdbc", size = 73424, upload-time = "2026-08-27T10:02:55.277Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/55/e36f2a33e38657f33850d74e0bf256838a0d45802c298cc501a32bffcc08/msgpack-1.2.2-cp314-cp314-win_arm64.whl", hash = "sha256:7826f16edc763e768404f55605ef85dfcf5857e729c1ed29e0d7c180be4fe6d8", size = 67657, upload-time = "2026-08-27T10:02:56.493Z" },
+    { url = "https://files.pythonhosted.org/packages/64/58/7e764b957bae80ae281a9cb28761068c8bae8d5c6ac0873e43cc69d176c7/msgpack-1.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:f466049b8e1ec0854287bbe9a074316826fe0e08dcf707245f98b1ae49e92650", size = 86594, upload-time = "2026-08-27T10:02:57.796Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/f0/250f5985b6ee533e60d357571a808aaae03c54118294dc3db7158e27feb1/msgpack-1.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1f6b6f8deb07d49090e1808c6ef9cb7d23ca17bef3aa6ed3e5e03df16606e60c", size = 87374, upload-time = "2026-08-27T10:02:59.256Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/2c/126ec8f187877c5f688631c543d1d3a3d75b2e66b83fb9de3ed7c13a39b6/msgpack-1.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b542ffc0a5c531eedc40419f291f1bd659aa8d4223408a5b51c88a2796083fd3", size = 428157, upload-time = "2026-08-27T10:03:00.9Z" },
+    { url = "https://files.pythonhosted.org/packages/95/21/d2d81d50aaedb14147d01f22094185794db3ad8a8791b60afacba0627c89/msgpack-1.2.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d095df2627e5dd59ac7b0c5ad627a671c76e6020171e03cbe4621a61f0562c3", size = 426669, upload-time = "2026-08-27T10:03:02.457Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/fc/f7d484ee5b572719608e7ffad569bea22ff11309a96ca2fae85eec94226b/msgpack-1.2.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ffdd2f4950daf7815490f23087963e3420175b9609520b7ff5df64d351159c22", size = 380625, upload-time = "2026-08-27T10:03:04.244Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/c4/b924cbd5516676f4e612329f18602a833bd055ffbe27f808eeba0f01bfea/msgpack-1.2.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:652d1bf13d01bac8fd569def0fe76745e55bcda01e30aa6332d5947ea3788839", size = 411328, upload-time = "2026-08-27T10:03:05.869Z" },
+    { url = "https://files.pythonhosted.org/packages/27/9d/0c1d9683a951a80f270c3b7dac1022c18b9307617344dd44d904135d5e12/msgpack-1.2.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:9bf452ff4d4981f25a18e9476e002bcc9263e7928024aa4d7148e25f7be3f929", size = 377892, upload-time = "2026-08-27T10:03:07.37Z" },
+    { url = "https://files.pythonhosted.org/packages/06/bb/bf22338cdd22e0b40c8f28468cea5f3d9c320244c095d8303364bc012c41/msgpack-1.2.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:55faa6f8395e23b848c535ad5dcb96b3462f37f5e7f4ac500d500434f7345da7", size = 419426, upload-time = "2026-08-27T10:03:09Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/42/6d02c19a01abd8d7ce817c321d2ee6af1a8e24d584dca619d1b6576a83bf/msgpack-1.2.2-cp314-cp314t-win32.whl", hash = "sha256:419a45c67a5c04213172a14b1864657e014665b77d7081b107a51707923dd39e", size = 71810, upload-time = "2026-08-27T10:03:10.498Z" },
+    { url = "https://files.pythonhosted.org/packages/af/df/fda3a204415dab0a8c0db5461ef7205416ea52bd8581c5cafd361be07f3b/msgpack-1.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:935b1cfad9b908b0fa845010f4271df4c2f04e1cd26e3f18acd61a45f93c9e36", size = 78919, upload-time = "2026-08-27T10:03:12.016Z" },
+    { url = "https://files.pythonhosted.org/packages/63/d4/4b4b0ef25a86deca91feaf7252ca885ba4f2ada40461379120122a04fe96/msgpack-1.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11e8c421e117d1c36728b423d0402555cccbf0c6f53e288f0e75b6b12100d70f", size = 71925, upload-time = "2026-08-27T10:03:13.332Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/92/4b44bc8f3243ef8cf9cb5368c17a299d45b9df858f6dfdd98a0482dbbb37/msgpack-1.2.2-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:e1b99ad34613d5f8477fa5cf99bc4eaeaf27965588007c102370cd9a78fe9de5", size = 84293, upload-time = "2026-08-27T10:03:14.718Z" },
+    { url = "https://files.pythonhosted.org/packages/80/05/c992bb65744665a41b5bf531fc0e1619bae0901f57738228ded90023c151/msgpack-1.2.2-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:0fbc1bed8a535389b41882cfae66376e248cd1680eaa94fd83193c73e1d24986", size = 84490, upload-time = "2026-08-27T10:03:16.12Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/bf/7f53b9e6709a4df7f9b9b81dc65f9dfaa32caf65bee94986ec2cb8fa07f1/msgpack-1.2.2-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:06d95f61de7afe4f4ff908a6feebfcb070d0582ac87c9cf3cedf8551cf634516", size = 405332, upload-time = "2026-08-27T10:03:17.692Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/5a/305c4dca14b50d0b51fb88ef04ec125b8f0be3e2ce730dcc62dbaa651cc5/msgpack-1.2.2-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b5c696ae7cd7166b3657261adb855b461ff31f07823fdbae9de8bf80adfccc21", size = 416798, upload-time = "2026-08-27T10:03:19.389Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/df/a645102b4cdfd9a94201cac4e900e9c1429fc16d86aa311c06eef82528c9/msgpack-1.2.2-cp315-cp315-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0708afbf6a9587f0bfe479a9825c141d14d91e2f6a5c8103cf28bc96f4edb5d9", size = 377312, upload-time = "2026-08-27T10:03:20.928Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/26/c56d8d086d3fb1077bb48092b158b5ea2eee08b279e10c191275f13bc980/msgpack-1.2.2-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:226a62ffe99fe54c5c61d910ec64c3449b7766c3280bd286bf6c94838dde239a", size = 395182, upload-time = "2026-08-27T10:03:22.571Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/b5/3d46ba367a565e536d8d2a61eebcee71b1dc803da3ce74a22313b573d6fa/msgpack-1.2.2-cp315-cp315-musllinux_1_2_riscv64.whl", hash = "sha256:9fd7f32e2f0fb334e7ecc5adb5cf0458785bd3a9d9d86f950e1715f101cebce5", size = 377945, upload-time = "2026-08-27T10:03:24.151Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/2c/d5d2df273ed5306357da25b69400fd8d7a53c4d87d8976604b677484d61c/msgpack-1.2.2-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:9db1ba1c1e6a84245a9dd866265b56b8a1e9461549cc72ed296d8cbfbd32961b", size = 413341, upload-time = "2026-08-27T10:03:25.85Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/fb/32613bced3cad47b40b1b73dd04d687121349d83f748efc2575929121903/msgpack-1.2.2-cp315-cp315-win32.whl", hash = "sha256:e2eb7ea0ac3911a7aac9d8aaa36d40f216d99455b3274cd3fac38181bcd910cf", size = 66730, upload-time = "2026-08-27T10:03:27.294Z" },
+    { url = "https://files.pythonhosted.org/packages/74/56/d86171f7251015e9312e5a7f9fdd4cf89752fc2114b88fed453d2a040c66/msgpack-1.2.2-cp315-cp315-win_amd64.whl", hash = "sha256:9352e6cdb510a7b1a5d3ccaccec730e82e50cf3484a3af7bdaab19e23b9589ff", size = 73477, upload-time = "2026-08-27T10:03:28.615Z" },
+    { url = "https://files.pythonhosted.org/packages/13/1a/56b90f6defef61700b86baca3637c15f62ac0f9b21ab0f16613ab9d1f101/msgpack-1.2.2-cp315-cp315-win_arm64.whl", hash = "sha256:29cc2d5291711a52956a79a51f41c732329df39ad727c886bd8f0b5b9237a808", size = 67660, upload-time = "2026-08-27T10:03:29.895Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/20/12751ca0d8ec874701b54c392c2b19f51af8dd1de40a92a10e356f0aaf58/msgpack-1.2.2-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:d886baa46b2532135e7320067e6a44edb09ba5883a6096b0f9c044533984b8a8", size = 86462, upload-time = "2026-08-27T10:03:31.348Z" },
+    { url = "https://files.pythonhosted.org/packages/91/4c/cf6d12a3d709fe5f9771dd917c35e6ebcd55597a5b792287382fde056c95/msgpack-1.2.2-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:53679573c75cce5f82359e0bd4e6a97809a6b9a9b7a48fd1ba592f4a82cddc84", size = 87412, upload-time = "2026-08-27T10:03:32.74Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/0d/0aac5752d1708dcb458f8754db34a4999514db3df2d2b798b9381293f638/msgpack-1.2.2-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d3c247d457ae9079974c7ce3c665396754a6d2baff7eaa51332212a8a5a3f13b", size = 422057, upload-time = "2026-08-27T10:03:34.124Z" },
+    { url = "https://files.pythonhosted.org/packages/81/30/70f281a3685b04aaf235a5237da11b978a02a865a5a479186205177ad676/msgpack-1.2.2-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:352ed831042549cca8be23780e1fe7c9177e65ff02bf183509c4b4d33f671782", size = 422696, upload-time = "2026-08-27T10:03:35.862Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/6d/f76e8425efb0aa38988cd778ae290bfa120491d80d26872d88bb52fedb3f/msgpack-1.2.2-cp315-cp315t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f80361592c13d7226b4379c8941529b63fe1a9d0e05d2de8f3306b70e522b53f", size = 376495, upload-time = "2026-08-27T10:03:37.339Z" },
+    { url = "https://files.pythonhosted.org/packages/95/77/0809aa9b52b2868f7d01862dc14073708f0440421a65197b48453480034c/msgpack-1.2.2-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:68df2947921d449f6dcfeafd86cb2cdde13327a8b447534bbe4ee5aaf32a5695", size = 404683, upload-time = "2026-08-27T10:03:38.87Z" },
+    { url = "https://files.pythonhosted.org/packages/02/d2/4e5ac915ba120172d210ef00165c5e6276c8a65db3a4a5cf36e946b83e23/msgpack-1.2.2-cp315-cp315t-musllinux_1_2_riscv64.whl", hash = "sha256:51dd39d23cfdea0400ed3ff2d29d1e83bd951d3aea79dc89be5b701a09edfe23", size = 375087, upload-time = "2026-08-27T10:03:40.486Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e3/8051d53e5495c87c6cf27eb42fb680361017037f87f322bdaf525f71e4a2/msgpack-1.2.2-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:b13b59e66f107cca1ba708dd5307179870ca1b15b19fcee7ccf722e5308d9212", size = 414421, upload-time = "2026-08-27T10:03:42.308Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/4e/13783aa7c17414d7186c72c49bc718366f75e49f0ea58d4f81cb63ac3187/msgpack-1.2.2-cp315-cp315t-win32.whl", hash = "sha256:8c6321a414f8b4a8dc43976b2fa8349156434ca9adedd9a187b796f7e1d3d3fc", size = 71790, upload-time = "2026-08-27T10:03:43.715Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/9d/1d02994c7ae2603c98100984428ff0f67443572133bc18eca6058f732c1b/msgpack-1.2.2-cp315-cp315t-win_amd64.whl", hash = "sha256:6f53285f20d592ed309ee19e509cc4c77a3bda1db02ad67e8a0949bb227a5a6d", size = 78766, upload-time = "2026-08-27T10:03:45.036Z" },
+    { url = "https://files.pythonhosted.org/packages/60/54/89ed16e6f966a050dc78b0e94a545025211b07ce9f4bdfe07dff70c03fc2/msgpack-1.2.2-cp315-cp315t-win_arm64.whl", hash = "sha256:a378e12ccc06d76efde115caf4073b7e5ff3cc18291d1341f9e65fb882e3f754", size = 71819, upload-time = "2026-08-27T10:03:46.375Z" },
 ]
 
 [[package]]

--- a/crates/dbt-tasks-sa/src/visitor.rs
+++ b/crates/dbt-tasks-sa/src/visitor.rs
@@ -352,7 +352,7 @@ fn task_graph_cycle_error(
     Box::new(FsError::new(
         ErrorCode::Unexpected,
         format!(
-            "Internal error: task graph has cycles. Node participating in the cycle: {cycle_node_unique_id}.\nPlease report a bug at: https://github.com/dbt-labs/dbt-fusion/issues"
+            "Internal error: task graph has cycles. Node participating in the cycle: {cycle_node_unique_id}.\nPlease report a bug at: https://github.com/dbt-labs/dbt-oss/issues"
         ),
     ))
 }
@@ -755,7 +755,7 @@ async fn visit(
         // Hard fail if there are unprocessed tasks
         return Err(fs_err!(
             ErrorCode::Unexpected,
-            "Internal error: {count} tasks were not processed.\nPlease report a bug at: https://github.com/dbt-labs/dbt-fusion/issues"
+            "Internal error: {count} tasks were not processed.\nPlease report a bug at: https://github.com/dbt-labs/dbt-oss/issues"
         ));
     }
 

--- a/crates/dbt-test-utils/src/task/utils.rs
+++ b/crates/dbt-test-utils/src/task/utils.rs
@@ -285,9 +285,9 @@ pub fn maybe_normalize_time(output: String) -> String {
 }
 
 /// Strip the version number out of the startup version banner, whose brand name
-/// varies per binary (`dbt-fusion`, `dbt-core`, `dbt-repl`).
+/// varies per binary (`dbt-fusion`, `dbt-oss`, `dbt-core`, `dbt-repl`).
 pub fn normalize_version(output: String) -> String {
-    const BRANDS: [&str; 3] = ["dbt-fusion", "dbt-core", "dbt-repl"];
+    const BRANDS: [&str; 4] = ["dbt-fusion", "dbt-oss", "dbt-core", "dbt-repl"];
 
     BRANDS.iter().fold(output, |acc, brand| {
         acc.replace(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "dbt-core"
+name = "dbt-oss"
 dynamic = ["version"]
 description = "Build analytics the way engineers build applications"
 authors = [{ name = "dbt Labs", email = "info@dbtlabs.com" }]
@@ -18,6 +18,6 @@ classifiers = [
 
 [project.urls]
 Homepage = "https://getdbt.com"
-Repository = "https://github.com/dbt-labs/dbt-core"
-Issues = "https://github.com/dbt-labs/dbt-core/issues"
+Repository = "https://github.com/dbt-labs/dbt-oss"
+Issues = "https://github.com/dbt-labs/dbt-oss/issues"
 Documentation = "https://docs.getdbt.com"


### PR DESCRIPTION
Completes the dbt-core -> dbt-oss rename: CLI `command_name` in the OSS distribution, `pyproject.toml` package name, and remaining doc/Dockerfile links.

Note: the CLI's `--format json --version` key changes from `core` to `oss` as a side effect (see changelog entry).