### PR TITLE
fix: set Issue to N/A in changelog entry missing required custom field

### DIFF
--- a/.changes/unreleased/Fixes-20260907-120000.yaml
+++ b/.changes/unreleased/Fixes-20260907-120000.yaml
@@ -4,3 +4,4 @@ body: Validate that a resolved package installation path stays within the config
 time: 2026-09-07T12:00:00.000000+00:00
 custom:
     Author: ash2shukla
+    Issue: "N/A"


### PR DESCRIPTION
## Summary
Backport of #16231 to `1.13.latest`.

- `.changes/unreleased/Fixes-20260907-120000.yaml` (added by #16214) has no `Issue` custom field.
- `.changie.yaml`'s `changeFormat`/`footerFormat` templates call `splitList " " $.Custom.Issue`. When the `Issue` key is absent entirely, `$.Custom.Issue` is `nil` rather than an empty string, and `splitList` fails with `invalid value; expected string`.
- This broke the 1.11.15 release changelog generation job (`changie merge` failing with a template execution error) and would fail the same way for any release cut from this branch.
- Sets `Issue: "N/A"` on the entry, matching existing precedent for changes without an associated GitHub issue.

## Test plan
- [x] `changie batch <version> --dry-run` now renders this entry successfully instead of erroring.