### PR TITLE
fix: move docker base image from bullseye to bookworm

### DIFF
--- a/.changes/unreleased/Under the Hood-20260908-164755.yaml
+++ b/.changes/unreleased/Under the Hood-20260908-164755.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Move base docker image to bookworm
+time: 2026-09-08T16:47:55.841513+05:30
+custom:
+    Author: ash2shukla
+    Issue: NA

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,16 +1,21 @@
-ARG py_version=3.11.16
+ARG py_version=3.11.2
 
-FROM python:$py_version-slim-bookworm AS base
+FROM python:$py_version-slim-bullseye AS base
 
 RUN apt-get update \
+  # bullseye-security is past standard support and its InRelease metadata
+  # periodically ages out past its Valid-Until window without being refreshed,
+  # intermittently hard-failing apt-get update; tolerate that staleness here
+  # (signature verification is unaffected)
+  -o Acquire::Check-Valid-Until=false \
   # Install version-pinned packages for reproducible builds
   && apt-get install -y --no-install-recommends \
     build-essential=12.9 \
-    ca-certificates=20250419~deb12u1 \
-    libpq-dev=15.19-0+deb12u1 \
+    ca-certificates=20250419~deb12u1~deb11u1 \
+    libpq-dev=13.23-0+deb11u4 \
     make=4.3-4.1 \
-    openssh-client=1:9.2p1-2+deb12u10 \
-    software-properties-common=0.99.30-4.1~deb12u1 \
+    openssh-client=1:8.4p1-5+deb11u7 \
+    software-properties-common=0.96.20.2-2.1 \
   # Prevent dist-upgrade from changing pinned package versions
   && apt-mark hold \
     build-essential \
@@ -28,7 +33,7 @@ RUN apt-get update \
     libexpat1-dev \
     libssl-dev \
     zlib1g-dev \
-  # Build and install git from source to get 2.50.1 since debian only ships with 2.39 for now
+  # Build and install git from source to get 2.50.1 since debian only ships with 2.47 for now
   && wget https://github.com/git/git/archive/refs/tags/v2.50.1.tar.gz \
   && tar -xf v2.50.1.tar.gz \
   && cd git-2.50.1 \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,8 +6,8 @@ RUN apt-get update \
   # Install version-pinned packages for reproducible builds
   && apt-get install -y --no-install-recommends \
     build-essential=12.9 \
-    ca-certificates=20230311+deb12u1 \
-    libpq-dev=15.18-0+deb12u1 \
+    ca-certificates=20250419~deb12u1 \
+    libpq-dev=15.19-0+deb12u1 \
     make=4.3-4.1 \
     openssh-client=1:9.2p1-2+deb12u10 \
     software-properties-common=0.99.30-4.1~deb12u1 \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,21 +1,16 @@
-ARG py_version=3.11.2
+ARG py_version=3.11.16
 
-FROM python:$py_version-slim-bullseye AS base
+FROM python:$py_version-slim-bookworm AS base
 
 RUN apt-get update \
-  # bullseye-security is past standard support and its InRelease metadata
-  # periodically ages out past its Valid-Until window without being refreshed,
-  # intermittently hard-failing apt-get update; tolerate that staleness here
-  # (signature verification is unaffected)
-  -o Acquire::Check-Valid-Until=false \
   # Install version-pinned packages for reproducible builds
   && apt-get install -y --no-install-recommends \
     build-essential=12.9 \
-    ca-certificates=20250419~deb12u1~deb11u1 \
-    libpq-dev=13.23-0+deb11u4 \
+    ca-certificates=20250419~deb12u1 \
+    libpq-dev=15.19-0+deb12u1 \
     make=4.3-4.1 \
-    openssh-client=1:8.4p1-5+deb11u7 \
-    software-properties-common=0.96.20.2-2.1 \
+    openssh-client=1:9.2p1-2+deb12u10 \
+    software-properties-common=0.99.30-4.1~deb12u1 \
   # Prevent dist-upgrade from changing pinned package versions
   && apt-mark hold \
     build-essential \
@@ -26,14 +21,17 @@ RUN apt-get update \
     software-properties-common \
   # Apply security updates to non-pinned base image packages
   && apt-get dist-upgrade -y \
-  # Install temporary dependencies for building git from source (removed later)
+  # Install temporary dependencies for building git from source (removed later).
+  # libssl-dev is intentionally excluded from removal below: libpq-dev (held,
+  # above) has a hard Depends on it in bookworm, so removing it would leave
+  # libpq-dev's dependency unsatisfied and break dpkg's resolver.
   && apt-get install -y --no-install-recommends \
     wget \
     libcurl4-gnutls-dev \
     libexpat1-dev \
     libssl-dev \
     zlib1g-dev \
-  # Build and install git from source to get 2.50.1 since debian only ships with 2.47 for now
+  # Build and install git from source to get 2.50.1 since debian only ships with 2.39 for now
   && wget https://github.com/git/git/archive/refs/tags/v2.50.1.tar.gz \
   && tar -xf v2.50.1.tar.gz \
   && cd git-2.50.1 \
@@ -41,11 +39,10 @@ RUN apt-get update \
   && make prefix=/usr/local NO_TCLTK=1 NO_GETTEXT=1 install \
   && cd .. \
   && rm -rf git-2.50.1 v2.50.1.tar.gz \
-  # Remove build dependencies to keep image slim
+  # Remove build dependencies to keep image slim (libssl-dev kept, see above)
   && apt-get remove -y \
     libcurl4-gnutls-dev \
     libexpat1-dev \
-    libssl-dev \
     wget \
     zlib1g-dev \
   && apt-get autoremove -y \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,21 +1,16 @@
-ARG py_version=3.11.2
+ARG py_version=3.11.16
 
-FROM python:$py_version-slim-bullseye AS base
+FROM python:$py_version-slim-bookworm AS base
 
 RUN apt-get update \
-  # bullseye-security is past standard support and its InRelease metadata
-  # periodically ages out past its Valid-Until window without being refreshed,
-  # intermittently hard-failing apt-get update; tolerate that staleness here
-  # (signature verification is unaffected)
-  -o Acquire::Check-Valid-Until=false \
   # Install version-pinned packages for reproducible builds
   && apt-get install -y --no-install-recommends \
     build-essential=12.9 \
-    ca-certificates=20250419~deb12u1~deb11u1 \
-    libpq-dev=13.23-0+deb11u4 \
+    ca-certificates=20230311+deb12u1 \
+    libpq-dev=15.18-0+deb12u1 \
     make=4.3-4.1 \
-    openssh-client=1:8.4p1-5+deb11u7 \
-    software-properties-common=0.96.20.2-2.1 \
+    openssh-client=1:9.2p1-2+deb12u10 \
+    software-properties-common=0.99.30-4.1~deb12u1 \
   # Prevent dist-upgrade from changing pinned package versions
   && apt-mark hold \
     build-essential \
@@ -33,7 +28,7 @@ RUN apt-get update \
     libexpat1-dev \
     libssl-dev \
     zlib1g-dev \
-  # Build and install git from source to get 2.50.1 since debian only ships with 2.47 for now
+  # Build and install git from source to get 2.50.1 since debian only ships with 2.39 for now
   && wget https://github.com/git/git/archive/refs/tags/v2.50.1.tar.gz \
   && tar -xf v2.50.1.tar.gz \
   && cd git-2.50.1 \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,6 +3,11 @@ ARG py_version=3.11.2
 FROM python:$py_version-slim-bullseye AS base
 
 RUN apt-get update \
+  # bullseye-security is past standard support and its InRelease metadata
+  # periodically ages out past its Valid-Until window without being refreshed,
+  # intermittently hard-failing apt-get update; tolerate that staleness here
+  # (signature verification is unaffected)
+  -o Acquire::Check-Valid-Until=false \
   # Install version-pinned packages for reproducible builds
   && apt-get install -y --no-install-recommends \
     build-essential=12.9 \


### PR DESCRIPTION
## Summary
- The `Docker Release` workflow run [34194577485](https://github.com/dbt-labs/dbt-core/actions/runs/34194577485/job/101963834992) failed building `dbt-core==1.11.15` with:
  ```
  E: Release file for http://deb.debian.org/debian-security/dists/bullseye-security/InRelease is expired (invalid since 9h 32min 11s). Updates for this repository will not be applied.
  ERROR: process "/bin/sh -c apt-get update && apt-get install -y ..." did not complete successfully: exit code: 100
  ```
- Root cause: `bullseye` (Debian 11) is past standard Debian security support, so `bullseye-security`'s `InRelease` metadata is no longer refreshed on a reliable cadence and periodically ages past its `Valid-Until` window, intermittently hard-failing `apt-get update`. This isn't a one-off mirror hiccup — it'll keep recurring on an EOL base image, so this PR migrates the base image to bookworm rather than papering over the staleness check.

## What changed
- Base image: `python:3.11.2-slim-bullseye` → `python:3.11.16-slim-bookworm`.
- Pinned package versions updated to their bookworm equivalents (computed as the actual apt candidate — the highest version across `main` + `updates` + `security`, not just `main`):
  - `ca-certificates`: `20250419~deb12u1`
  - `libpq-dev`: `15.19-0+deb12u1`
  - `openssh-client`: `1:9.2p1-2+deb12u10`
  - `software-properties-common`: `0.99.30-4.1~deb12u1`
  - `build-essential` / `make`: unchanged (`12.9` / `4.3-4.1`, same in both suites)
- Kept `libssl-dev` installed instead of removing it with the other temporary git-build dependencies. In bookworm, `libpq-dev` (held/pinned) has a hard `Depends: libssl-dev`; removing it broke dpkg's resolver with `E: Error, pkgProblemResolver::Resolve generated breaks, this may be caused by held packages.` This wasn't an issue on bullseye.
- Corrected a stale comment: bookworm ships git `1:2.39.5-0+deb12u3`, not 2.47, so the from-source git 2.50.1 build is still needed for the same reason, just a different current version.

## How this was found and verified
Two earlier attempts at this migration failed in CI (see PR history) with two different apt dependency errors. Rather than keep iterating against the live release workflow, I reproduced the build locally (via a local Docker daemon) and iterated there:
- `held broken packages` → traced to `ca-certificates`/`libpq-dev` pins being taken from bookworm's `main` component only, when apt's real candidate (combining `main`+`updates`+`security`) was higher.
- `pkgProblemResolver::Resolve generated breaks` → traced to `libpq-dev`'s new hard dependency on `libssl-dev` in bookworm, broken by the temp-dependency cleanup step.
- After both fixes, verified locally end-to-end:
  - `docker build --target base` completes cleanly
  - `docker build --target dbt-core --build-arg commit_ref=1.latest` completes cleanly
  - `docker run dbt-core-test --version` → reports dbt version correctly
  - `docker run --entrypoint git dbt-core-test --version` → `git version 2.50.1`
- Note: `dbt-postgres` target currently fails on `1.latest` for an unrelated, pre-existing reason (`plugins/postgres` no longer contains a `pyproject.toml`/`setup.py` — looks like the postgres adapter moved out of this repo). Not related to this change; flagging separately rather than fixing here.

## Test plan
- [ ] CI Docker build/test workflow passes on this branch
- [ ] Re-run the release workflow and confirm the Docker build/push step succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)