### PR TITLE
ci: sync winget PAT fork with upstream before submit

### DIFF
--- a/.changes/unreleased/Under the Hood-20260908-200914.yaml
+++ b/.changes/unreleased/Under the Hood-20260908-200914.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Sync winget PAT fork with upstream before submitting to avoid opaque wingetcreate submit failures on fork drift
+time: 2026-09-08T20:09:14.094423+05:30
+custom:
+    author: "itsnamangoyal"
+    issue: ""
+    project: dbt-core

--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -142,7 +142,11 @@ jobs:
           GH_TOKEN: ${{ secrets.WINGET_PUBLISH_PAT }}
         run: |
           fork_owner=$(gh api user --jq .login)
-          gh repo sync "${fork_owner}/winget-pkgs" --source microsoft/winget-pkgs --force
+          if gh repo view "${fork_owner}/winget-pkgs" >/dev/null 2>&1; then
+            gh repo sync "${fork_owner}/winget-pkgs" --source microsoft/winget-pkgs --force
+          else
+            gh repo fork microsoft/winget-pkgs --clone=false --default-branch-only
+          fi
 
       - name: Submit to microsoft/winget-pkgs
         if: ${{ !inputs.dry_run && steps.published.outputs.exists != 'true' }}

--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -135,6 +135,15 @@ jobs:
             *) echo "::error::Unexpected HTTP $code checking winget-pkgs for ${VERSION}"; exit 1 ;;
           esac
 
+      - name: Sync fork with upstream
+        if: ${{ !inputs.dry_run && steps.published.outputs.exists != 'true' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.WINGET_PUBLISH_PAT }}
+        run: |
+          fork_owner=$(gh api user --jq .login)
+          gh repo sync "${fork_owner}/winget-pkgs" --source microsoft/winget-pkgs --force
+
       - name: Submit to microsoft/winget-pkgs
         if: ${{ !inputs.dry_run && steps.published.outputs.exists != 'true' }}
         id: submit


### PR DESCRIPTION
## Summary
`wingetcreate --submit` runs an implicit auto-sync of the PAT fork's default branch before pushing; when the fork has drifted this fails with `The forked repository could not be synced with the upstream commits. Sync your fork manually and try again.`, surfacing as an opaque `wingetcreate submit failed (exit 1)`. This adds an explicit "Sync fork with upstream" step before submit so the common drift case is fixed outright and any residual failure surfaces at a clearly-named step.

Jira: CORE-933

## Test plan
- [ ] Dry-run (`dry_run: true`) dispatch confirms the sync step is skipped
- [ ] Workflow YAML parses