### PR TITLE
fix(databricks): emit only changed keys in relation-tag SET TAGS diffs

### DIFF
--- a/.changes/unreleased/Fixes-20260908-191405.yaml
+++ b/.changes/unreleased/Fixes-20260908-191405.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Emit only changed keys in Databricks relation-tag SET TAGS diffs
+time: 2026-09-08T19:14:05.44393+05:30
+custom:
+    author: sd-db
+    issue: ""
+    project: dbt-core

--- a/.changes/unreleased/Fixes-20260908-191405.yaml
+++ b/.changes/unreleased/Fixes-20260908-191405.yaml
@@ -3,5 +3,5 @@ body: Emit only changed keys in Databricks relation-tag SET TAGS diffs
 time: 2026-09-08T19:14:05.44393+05:30
 custom:
     author: sd-db
-    issue: ""
+    issue: "16248"
     project: dbt-core

--- a/crates/dbt-adapter/src/relation/databricks/config/components/relation_tags.rs
+++ b/crates/dbt-adapter/src/relation/databricks/config/components/relation_tags.rs
@@ -23,15 +23,14 @@ fn set_only_diff(
     desired_state: &IndexMap<String, String>,
     current_state: &IndexMap<String, String>,
 ) -> Option<IndexMap<String, String>> {
-    let has_diff = desired_state
+    // Tags are now "set only" - we never unset tags, only add or update them
+    let diff: IndexMap<String, String> = desired_state
         .iter()
-        .any(|(name, value)| current_state.get(name) != Some(value));
+        .filter(|(name, value)| current_state.get(*name) != Some(*value))
+        .map(|(name, value)| (name.clone(), value.clone()))
+        .collect();
 
-    if has_diff {
-        Some(desired_state.clone())
-    } else {
-        None
-    }
+    if diff.is_empty() { None } else { Some(diff) }
 }
 
 fn to_jinja(v: &IndexMap<String, String>) -> Value {
@@ -132,6 +131,28 @@ mod tests {
 
         assert_eq!(diff.value.get("b"), Some(&"3".to_string()));
         assert_eq!(diff.value.get("c"), Some(&"4".to_string()));
+        assert!(!diff.value.contains_key("a"));
+    }
+
+    #[test]
+    fn test_get_diff_omits_unchanged_desired_keys() {
+        let old_config = new_component(IndexMap::from([
+            ("stable".to_string(), "1".to_string()),
+            ("moved".to_string(), "old".to_string()),
+            ("remote_only".to_string(), "x".to_string()),
+        ]));
+        let new_config = new_component(IndexMap::from([
+            ("stable".to_string(), "1".to_string()),
+            ("moved".to_string(), "new".to_string()),
+        ]));
+
+        let diff = RelationTags::diff_from(&new_config, Some(&old_config)).unwrap();
+        let diff = diff.as_any().downcast_ref::<RelationTags>().unwrap();
+
+        assert_eq!(
+            diff.value,
+            IndexMap::from([("moved".to_string(), "new".to_string())])
+        );
     }
 
     #[test]

--- a/crates/dbt-adapter/src/relation/databricks/config/components/relation_tags.rs
+++ b/crates/dbt-adapter/src/relation/databricks/config/components/relation_tags.rs
@@ -23,7 +23,6 @@ fn set_only_diff(
     desired_state: &IndexMap<String, String>,
     current_state: &IndexMap<String, String>,
 ) -> Option<IndexMap<String, String>> {
-    // Tags are now "set only" - we never unset tags, only add or update them
     let diff: IndexMap<String, String> = desired_state
         .iter()
         .filter(|(name, value)| current_state.get(*name) != Some(*value))
@@ -165,6 +164,14 @@ mod tests {
         let diff = RelationTags::diff_from(&config, Some(&config));
 
         assert!(diff.is_none());
+    }
+
+    #[test]
+    fn test_get_diff_empty_desired_does_not_unset_remote_tags() {
+        let desired = new_component(IndexMap::new());
+        let existing = new_component(IndexMap::from([("tag".to_string(), "value".to_string())]));
+
+        assert!(RelationTags::diff_from(&desired, Some(&existing)).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Port of [databricks/dbt-databricks#1667](https://github.com/databricks/dbt-databricks/pull/1667) ([dbt-core#16248](https://github.com/dbt-labs/dbt-core/issues/16248)).
- Databricks relation-tag diffs stay set-only (no UNSET of remote-only keys) but now emit only desired keys whose values differ, instead of cloning the full desired map into `ALTER … SET TAGS`.
- Adds a unit test that empty desired tags against a populated remote is a no-op.

## Test plan
- [x] `cargo test --offline -p dbt-adapter --lib test_get_diff` (relation_tags cases, including empty desired)
- [ ] Reviewer: confirm this is Databricks-only (`set_only_diff` is not shared with BigQuery tags/labels or Snowflake table tags)