### PR TITLE
docs: add v2 install banner to dbt-core PyPI description

### DIFF
--- a/.changes/unreleased/Under the Hood-20260909-063207.yaml
+++ b/.changes/unreleased/Under the Hood-20260909-063207.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: 'Add a banner to the `dbt-core` PyPI description pointing users to the v2 install docs'
+time: 2026-09-09T06:32:07.000000-07:00
+custom:
+    Author: tauhid621
+    Issue: ""

--- a/core/README.md
+++ b/core/README.md
@@ -1,3 +1,5 @@
+> **Note:** dbt v2 is now available and is the default for new installations. [See the install docs](https://docs.getdbt.com/docs/local/install-dbt?utm_source=dbt-cli) to get started.
+
 <p align="center">
   <img src="https://raw.githubusercontent.com/dbt-labs/dbt-core/fa1ea14ddfb1d5ae319d5141844910dd53ab2834/docs/images/dbt-core.svg" alt="dbt logo" width="750"/>
 </p>

--- a/core/README.md
+++ b/core/README.md
@@ -1,4 +1,11 @@
-> **Note:** dbt v2 is now available and is the default for new installations. [See the install docs](https://docs.getdbt.com/docs/local/install-dbt?utm_source=dbt-cli) to get started.
+> **Note:** v2 of the dbt engine is now available, and ships as two distributions:
+>
+> - `pip install dbt` (recommended) - installs the default distribution with the full feature set
+> - `pip install dbt-oss` - installs the subset distribution, with only Apache 2 open source code
+>
+> With v2, you no longer need to install adapters separately, so you can remove `pip install dbt-<adapter>` from your installation.
+>
+> Long term, the `dbt-core` PyPI namespace will be deprecated, so please update your install scripts to the appropriate v2 distribution moving forward. [See the install docs](https://docs.getdbt.com/docs/local/install-dbt?utm_source=dbt-cli) to get started.
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/dbt-labs/dbt-core/fa1ea14ddfb1d5ae319d5141844910dd53ab2834/docs/images/dbt-core.svg" alt="dbt logo" width="750"/>


### PR DESCRIPTION
## Summary
- Adds a plain-text (non-GitHub-alert) blockquote banner to the top of `core/README.md` pointing users to the v2 install docs, since this README is also rendered as the `dbt-core` PyPI long description.
- GitHub's `[!NOTE]` alert syntax was avoided since PyPI's renderer (comrak, semantic alert style) doesn't apply GitHub's styling for it — bold text renders consistently on both GitHub and PyPI.

## Test plan
- [ ] Confirm banner renders as expected on GitHub
- [ ] Confirm banner renders as expected on TestPyPI (e.g. via a manual `nightly-release.yml` or `release.yml` dispatch with `test_run: true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)