### PR TITLE
fix: implement dbt-agate column value lookup

### DIFF
--- a/.changes/unreleased/Fixes-20260909-101903.yaml
+++ b/.changes/unreleased/Fixes-20260909-101903.yaml
@@ -1,7 +1,0 @@
-kind: Fixes
-body: Fix Fusion dbt-agate column index and count operations used by dbt_utils.get_query_results_as_dict
-time: 2026-09-09T10:19:03.248377+02:00
-custom:
-    author: Jules-G1
-    issue: "16263"
-    project: dbt-core

--- a/.changes/unreleased/Fixes-20260909-101903.yaml
+++ b/.changes/unreleased/Fixes-20260909-101903.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Fix Fusion dbt-agate column index and count operations used by dbt_utils.get_query_results_as_dict
+time: 2026-09-09T10:19:03.248377+02:00
+custom:
+    author: Jules-G1
+    issue: "16263"
+    project: dbt-core

--- a/.changes/unreleased/Fixes-20260909-103143.yaml
+++ b/.changes/unreleased/Fixes-20260909-103143.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Implement TableRepr methods index_of_value_in_column and count_occurrences_of_value_in_column to fix Fusion panic in dbt_utils.get_query_results_as_dict()
+time: 2026-09-09T10:31:43.792892+02:00
+custom:
+    author: jules-guillot
+    issue: "16263"
+    project: dbt-core

--- a/crates/dbt-agate/src/table.rs
+++ b/crates/dbt-agate/src/table.rs
@@ -240,14 +240,24 @@ impl TableRepr {
         todo!("column_without_nulls_sorted")
     }
 
-    pub fn count_occurrences_of_value_in_column(&self, _needle: &Value, col_idx: isize) -> usize {
-        let _col = self.single_column_table(col_idx).unwrap();
-        todo!("count_occurrences_of_value_in_column")
+    pub fn count_occurrences_of_value_in_column(&self, needle: &Value, col_idx: isize) -> usize {
+        let Some(col_idx) = self.adjusted_column_index(col_idx) else {
+            return 0;
+        };
+        (0..self.num_rows())
+            .filter(|&r| {
+                self.cell(r as isize, col_idx as isize)
+                    .is_some_and(|v| v == *needle)
+            })
+            .count()
     }
 
-    pub fn index_of_value_in_column(&self, _needle: &Value, col_idx: isize) -> Option<usize> {
-        let _col = self.single_column_table(col_idx).unwrap();
-        todo!("index_of_value_in_column")
+    pub fn index_of_value_in_column(&self, needle: &Value, col_idx: isize) -> Option<usize> {
+        let col_idx = self.adjusted_column_index(col_idx)?;
+        (0..self.num_rows()).find(|&r| {
+            self.cell(r as isize, col_idx as isize)
+                .is_some_and(|v| v == *needle)
+        })
     }
 
     fn with_renamed_columns(&self, renamed_columns: Vec<String>) -> Arc<Self> {
@@ -1660,6 +1670,53 @@ mod tests {
 
         let out_of_bounds = UInt64Array::new(vec![99].into(), None);
         assert!(table.repr.select_rows(&out_of_bounds, None).is_err());
+    }
+
+    #[test]
+    fn test_index_of_and_count_occurrences_in_column() {
+        let table = main_table(&[1, 2, 2, 3], &["one", "two", "two", "three"], &[None; 4]);
+
+        assert_eq!(
+            table.repr.index_of_value_in_column(&Value::from(2), 0),
+            Some(1)
+        );
+        assert_eq!(
+            table.repr.index_of_value_in_column(&Value::from(99), 0),
+            None
+        );
+        assert_eq!(
+            table.repr.index_of_value_in_column(&Value::from("two"), -2),
+            Some(1)
+        );
+
+        assert_eq!(
+            table
+                .repr
+                .count_occurrences_of_value_in_column(&Value::from(2), 0),
+            2
+        );
+        assert_eq!(
+            table
+                .repr
+                .count_occurrences_of_value_in_column(&Value::from("two"), -2),
+            2
+        );
+        assert_eq!(
+            table
+                .repr
+                .count_occurrences_of_value_in_column(&Value::from("missing"), 1),
+            0
+        );
+        assert_eq!(
+            table
+                .repr
+                .count_occurrences_of_value_in_column(&Value::from(2), 99),
+            0
+        );
+        assert_eq!(
+            table.repr.index_of_value_in_column(&Value::from(2), 99),
+            None
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Implement `TableRepr` column value counting and first-match lookup.
- Handle negative and out-of-range column indices without panicking.
- Add integer/string, missing-value, repeated-value, and bounds tests.
- Add the Fixes changelog entry.

Fixes #16263

The PR replaces the two unimplemented methods linked here: [the `todo!()` implementations](https://github.com/dbt-labs/dbt/blob/main/crates/dbt-agate/src/table.rs#L243-L250).

## Tests

- `cargo fmt -p dbt-agate -- --check`
- `cargo test -p dbt-agate --features minijinja-contrib/testing` (114 passed)
- `cargo build -p dbt-sa-cli --bin dbt`