### PR TITLE
fix: copy config.group onto source and singular tests

### DIFF
--- a/.changes/unreleased/Fixes-20260909-105051.yaml
+++ b/.changes/unreleased/Fixes-20260909-105051.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Copy config.group onto the top-level group for source and singular tests, matching dbt-core
+time: 2026-09-09T10:50:51.671558+02:00
+custom:
+    author: larspettermadsstuen
+    issue: "15930"
+    project: dbt-core

--- a/crates/dbt-parser/src/resolve/resolve_tests/resolve_data_tests.rs
+++ b/crates/dbt-parser/src/resolve/resolve_tests/resolve_data_tests.rs
@@ -810,10 +810,18 @@ pub async fn resolve_data_tests(
                 unrendered_config,
             },
             __test_attr__: {
-                let group = attached_node
-                    .as_deref()
-                    .and_then(|id| models.get(id))
-                    .and_then(|m| m.__model_attr__.group.clone());
+                let group = if attached_node.is_some() {
+                    // Generic tests on models/seeds/snapshots inherit the parent's group
+                    // (which may be None even if an explicit config.group is set).
+                    attached_node
+                        .as_deref()
+                        .and_then(|id| models.get(id))
+                        .and_then(|m| m.__model_attr__.group.clone())
+                } else {
+                    // Source tests and singular tests have no attached node; fall back to
+                    // the explicit config.group, matching dbt-core 1.x behavior.
+                    test_config.group.clone()
+                };
                 DbtTestAttr {
                     column_name: test_asset.and_then(|ta| ta.column_name.clone()),
                     attached_node,


### PR DESCRIPTION
Resolves #15930

@waterWang already fixed this in #15940. That PR is still open, but it looks stuck: CLA unsigned, no changelog, and it's gone dirty against main. I asked there whether they were going to finish it; no movement, and other people still want the fix. Opening a fresh PR so this can actually land.

The code change is theirs — I reapplied it on current main and added the changelog. Credit for the diagnosis and the patch goes to them.

### Problem

On Fusion, source tests and singular tests never get a top-level `group`, even when you set `config.group`. Core 1.x copies that config onto `group`. Selectors like `group:…`, `state:modified`, and group notifications all look at the top-level field, so those tests quietly drop out of group-based workflows.

Generic tests on models are already fine — they inherit the parent model's group, and we should leave that alone (including the case where the parent has no group).

### Solution

If the test has no `attached_node`, use `config.group`. If it does (model/seed/snapshot), keep inheriting the parent.

#15940 doesn't include a repro. The parse setup and how to check `config.group` vs `group` are in #15930 — I ran that on a local build of this branch and the three bug rows now get `group=test_group`.

No new unit test — the check that matters is parse + the manifest field.

### Checklist

- [x] I have read the contributing guide and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.

Made with [Cursor](https://cursor.com)