### PR TITLE
chore: backfill interactive_table changelog entries into 2.0.0-rc.2

### DIFF
--- a/.changes/2.0.0-rc.2.md
+++ b/.changes/2.0.0-rc.2.md
@@ -6,6 +6,7 @@ Released September 08, 2026
 
 - [ClickHouse] dbt unit tests are supported; multi-statement SQL containing ClickHouse backslash escapes is now split correctly by the statement splitter ([#14585](https://github.com/dbt-labs/dbt-core/issues/14585))
 - [ClickHouse] `table` now compatible with MVs (mv_on_schema_change defaults to fail, repopulate_from_mvs_on_full_refresh replays the MV queries), `materialized_view` supports on_schema_change, in-place refresh-schedule updates (MODIFY REFRESH) with safe transition errors, multi-MV update/rename flows and refreshable: false, and projections accept the index form with up-front validation. ([#14585](https://github.com/dbt-labs/dbt-core/issues/14585))
+- Add beta support for the Snowflake interactive_table materialization, covering static and dynamic interactive tables and config-change detection for target_lag and warehouse settings ([#11798](https://github.com/dbt-labs/dbt-core/issues/11798))
 
 ### Fixes
 
@@ -13,7 +14,13 @@ Released September 08, 2026
 - Keep column metadata local to each column instead of inheriting parent resource metadata. ([#16097](https://github.com/dbt-labs/dbt-core/issues/16097))
 - Detect Databricks materialized view query changes and require full refresh when compiled SQL changes ([#16123](https://github.com/dbt-labs/dbt-core/issues/16123))
 - Skip Databricks get_relation_config tag and column-tag metadata queries when the model does not configure tags ([#16057](https://github.com/dbt-labs/dbt-core/issues/16057))
+- Fix state:modified missing a snowflake_interactive_warehouses-only config change, which could cause a --select state:modified run to skip a model whose interactive-warehouse attach/detach reconciliation needed to run
+- Fix blank or whitespace-only refresh_warehouse/snowflake_warehouse values being treated as configured, which could bypass interactive_table's target_lag warehouse validation and render an invalid warehouse = clause in generated DDL for both interactive and dynamic tables
+- Fix cluster_by change detection for Snowflake dynamic and interactive tables: strip the LINEAR type descriptor SHOW DYNAMIC TABLES wraps cluster_by in, and compare quoted identifiers case-sensitively instead of folding them
+- Strip double-quote delimiters from a warehouse name before comparing it case-insensitively during dynamic/interactive table configuration-change detection: SHOW never echoes the quotes back, so a quoted warehouse value never compared equal to its own readback and fired a spurious ALTER on every run
+- Treat a single-quoted string literal inside a clustering expression (e.g. to_char(ts, 'MON')) as case-sensitive data during configuration-change detection: the surrounding expression text was folded correctly, but a literal's exact case, and any )/, characters embedded inside it, previously corrupted the comparison and could cause an unnecessary full refresh on every run. Live-verified against Snowflake
 
 ### Contributors
+- [@itsnamangoyal](https://github.com/itsnamangoyal) ([#11798](https://github.com/dbt-labs/dbt-core/issues/11798))
 - [@koletzilla](https://github.com/koletzilla) ([#14585](https://github.com/dbt-labs/dbt-core/issues/14585), [#14585](https://github.com/dbt-labs/dbt-core/issues/14585))
 - [@sd-db](https://github.com/sd-db) ([#14359](https://github.com/dbt-labs/dbt-core/issues/14359), [#16097](https://github.com/dbt-labs/dbt-core/issues/16097), [#16123](https://github.com/dbt-labs/dbt-core/issues/16123), [#16057](https://github.com/dbt-labs/dbt-core/issues/16057))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Released September 08, 2026
 
 - [ClickHouse] dbt unit tests are supported; multi-statement SQL containing ClickHouse backslash escapes is now split correctly by the statement splitter ([#14585](https://github.com/dbt-labs/dbt-core/issues/14585))
 - [ClickHouse] `table` now compatible with MVs (mv_on_schema_change defaults to fail, repopulate_from_mvs_on_full_refresh replays the MV queries), `materialized_view` supports on_schema_change, in-place refresh-schedule updates (MODIFY REFRESH) with safe transition errors, multi-MV update/rename flows and refreshable: false, and projections accept the index form with up-front validation. ([#14585](https://github.com/dbt-labs/dbt-core/issues/14585))
+- Add beta support for the Snowflake interactive_table materialization, covering static and dynamic interactive tables and config-change detection for target_lag and warehouse settings ([#11798](https://github.com/dbt-labs/dbt-core/issues/11798))
 
 ### Fixes
 
@@ -23,8 +24,14 @@ Released September 08, 2026
 - Keep column metadata local to each column instead of inheriting parent resource metadata. ([#16097](https://github.com/dbt-labs/dbt-core/issues/16097))
 - Detect Databricks materialized view query changes and require full refresh when compiled SQL changes ([#16123](https://github.com/dbt-labs/dbt-core/issues/16123))
 - Skip Databricks get_relation_config tag and column-tag metadata queries when the model does not configure tags ([#16057](https://github.com/dbt-labs/dbt-core/issues/16057))
+- Fix state:modified missing a snowflake_interactive_warehouses-only config change, which could cause a --select state:modified run to skip a model whose interactive-warehouse attach/detach reconciliation needed to run
+- Fix blank or whitespace-only refresh_warehouse/snowflake_warehouse values being treated as configured, which could bypass interactive_table's target_lag warehouse validation and render an invalid warehouse = clause in generated DDL for both interactive and dynamic tables
+- Fix cluster_by change detection for Snowflake dynamic and interactive tables: strip the LINEAR type descriptor SHOW DYNAMIC TABLES wraps cluster_by in, and compare quoted identifiers case-sensitively instead of folding them
+- Strip double-quote delimiters from a warehouse name before comparing it case-insensitively during dynamic/interactive table configuration-change detection: SHOW never echoes the quotes back, so a quoted warehouse value never compared equal to its own readback and fired a spurious ALTER on every run
+- Treat a single-quoted string literal inside a clustering expression (e.g. to_char(ts, 'MON')) as case-sensitive data during configuration-change detection: the surrounding expression text was folded correctly, but a literal's exact case, and any )/, characters embedded inside it, previously corrupted the comparison and could cause an unnecessary full refresh on every run. Live-verified against Snowflake
 
 ### Contributors
+- [@itsnamangoyal](https://github.com/itsnamangoyal) ([#11798](https://github.com/dbt-labs/dbt-core/issues/11798))
 - [@koletzilla](https://github.com/koletzilla) ([#14585](https://github.com/dbt-labs/dbt-core/issues/14585), [#14585](https://github.com/dbt-labs/dbt-core/issues/14585))
 - [@sd-db](https://github.com/sd-db) ([#14359](https://github.com/dbt-labs/dbt-core/issues/14359), [#16097](https://github.com/dbt-labs/dbt-core/issues/16097), [#16123](https://github.com/dbt-labs/dbt-core/issues/16123), [#16057](https://github.com/dbt-labs/dbt-core/issues/16057))
 


### PR DESCRIPTION
## Summary
- PR dbt-labs/fs#12664's changie entries landed in fs's root .changes/unreleased instead of fs/sa/.changes/unreleased, so copybara never synced them to dbt-core and they were missing from the 2.0.0-rc.2 changelog batch.
- Backfills all 6 entries (the interactive_table feature + 5 related fixes) into .changes/2.0.0-rc.2.md and CHANGELOG.md, generated via `changie new` + `changie batch 2.0.0-rc.2 --force` + `changie merge`.

## Test plan
- [ ] Confirm .changes/2.0.0-rc.2.md and CHANGELOG.md rc.2 section match (diff is additive-only, 7 lines each)
- [ ] Confirm .changes/unreleased/ still has only the 6 unrelated pending entries for the next release