### PR TITLE
fix(databricks): emit only changed column-tag keys in SET TAGS diffs

### DIFF
--- a/.changes/unreleased/Fixes-20260908-195211.yaml
+++ b/.changes/unreleased/Fixes-20260908-195211.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Emit only changed Databricks column-tag keys in ALTER COLUMN SET TAGS diffs
+time: 2026-09-08T19:52:11.390613+05:30
+custom:
+    author: sd-db
+    issue: "16272"
+    project: dbt-core

--- a/crates/dbt-adapter/src/relation/databricks/config/components/column_tags.rs
+++ b/crates/dbt-adapter/src/relation/databricks/config/components/column_tags.rs
@@ -42,15 +42,25 @@ fn merge_tags_diff(
         .iter()
         .map(|(column_name, tags)| (column_name.to_lowercase(), tags))
         .collect::<IndexMap<_, _>>();
-    let changed = desired_state
-        .iter()
-        .filter(|(column_name, tags)| {
-            current_by_lower
-                .get(&column_name.to_lowercase())
-                .is_none_or(|current| current != tags)
-        })
-        .map(|(column_name, tags)| (column_name.clone(), tags.clone()))
-        .collect::<IndexMap<_, _>>();
+
+    let mut changed = IndexMap::new();
+    for (column_name, desired_tags) in desired_state {
+        match current_by_lower.get(&column_name.to_lowercase()) {
+            None => {
+                changed.insert(column_name.clone(), desired_tags.clone());
+            }
+            Some(current_tags) => {
+                let key_diff: IndexMap<_, _> = desired_tags
+                    .iter()
+                    .filter(|(key, value)| current_tags.get(*key) != Some(*value))
+                    .map(|(key, value)| (key.clone(), value.clone()))
+                    .collect();
+                if !key_diff.is_empty() {
+                    changed.insert(column_name.clone(), key_diff);
+                }
+            }
+        }
+    }
 
     if changed.is_empty() {
         None
@@ -213,6 +223,45 @@ mod tests {
             Some(IndexMap::from([(
                 "account_id".to_string(),
                 IndexMap::from([("pii".to_string(), "false".to_string())]),
+            )]))
+        );
+    }
+
+    #[test]
+    fn test_get_diff_omits_unchanged_keys_within_column() {
+        let desired = IndexMap::from([
+            (
+                "col1".to_string(),
+                IndexMap::from([
+                    ("stable".to_string(), "1".to_string()),
+                    ("moved".to_string(), "new".to_string()),
+                ]),
+            ),
+            (
+                "col2".to_string(),
+                IndexMap::from([("ok".to_string(), "yes".to_string())]),
+            ),
+        ]);
+        let existing = IndexMap::from([
+            (
+                "col1".to_string(),
+                IndexMap::from([
+                    ("stable".to_string(), "1".to_string()),
+                    ("moved".to_string(), "old".to_string()),
+                    ("remote_only".to_string(), "x".to_string()),
+                ]),
+            ),
+            (
+                "col2".to_string(),
+                IndexMap::from([("ok".to_string(), "yes".to_string())]),
+            ),
+        ]);
+
+        assert_eq!(
+            merge_tags_diff(&desired, &existing),
+            Some(IndexMap::from([(
+                "col1".to_string(),
+                IndexMap::from([("moved".to_string(), "new".to_string())]),
             )]))
         );
     }


### PR DESCRIPTION
## Summary

- Port [dbt-databricks#1668](https://github.com/databricks/dbt-databricks/pull/1668): for a column whose tags changed, `ALTER COLUMN … SET TAGS` now includes only new or updated keys, not that column's full desired map.
- Unchanged columns are still omitted. Newly tagged columns still receive the full desired map.
- Set-only semantics are unchanged: remote-only keys are never unset.
- Follow-up to [#16247](https://github.com/dbt-labs/dbt-core/pull/16247), which skips unchanged columns but still sends the full map for a changed column.

Fixes #16272

## Test plan

- [x] `cargo test -p dbt-adapter test_get_diff_` (including `test_get_diff_omits_unchanged_keys_within_column`)
- [ ] CI on this PR