### PR TITLE
feat(databricks): merge tblproperties additively across config layers

### DIFF
--- a/.changes/unreleased/Features-20260910-190326.yaml
+++ b/.changes/unreleased/Features-20260910-190326.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Merge Databricks tblproperties additively across config hierarchy layers, matching dbt-databricks MergeBehavior.Update.
+time: 2026-09-10T19:03:26.546808+05:30
+custom:
+    author: sd-db
+    issue: "16278"
+    project: dbt-core

--- a/crates/dbt-adapter/src/adapter/mod.rs
+++ b/crates/dbt-adapter/src/adapter/mod.rs
@@ -2917,7 +2917,6 @@ impl Adapter {
                         .tblproperties
                         .clone()
                         .unwrap_or_default()
-                        .0
                         .into_iter()
                         .map(|(k, v)| (k, yml_value_to_minijinja(v)))
                         .collect(),

--- a/crates/dbt-adapter/src/relation/databricks/config/components/tbl_properties.rs
+++ b/crates/dbt-adapter/src/relation/databricks/config/components/tbl_properties.rs
@@ -109,7 +109,7 @@ fn from_local_config(
     if let Some(databricks_attr) = &model.__adapter_attr__.databricks_attr
         && let Some(props_map) = &databricks_attr.tblproperties
     {
-        for (key, value) in &props_map.0 {
+        for (key, value) in props_map {
             if let YmlValue::String(value_str, _) = value {
                 tblproperties.insert(key.clone(), value_str.clone());
             }

--- a/crates/dbt-adapter/src/relation/databricks/config/test_helpers.rs
+++ b/crates/dbt-adapter/src/relation/databricks/config/test_helpers.rs
@@ -98,12 +98,12 @@ pub(crate) fn create_mock_dbt_model(cfg: TestModelConfig) -> DbtModel {
     };
 
     let wh_config = WarehouseSpecificNodeConfig {
-        tblproperties: Some(TblProperties(
+        tblproperties: Some(
             cfg.tbl_properties
                 .into_iter()
                 .map(|(k, v)| (k, dbt_yaml::Value::from(v)))
                 .collect(),
-        )),
+        ),
         partition_by: Some(PartitionConfig::List(cfg.partition_by)),
         liquid_clustered_by: (!cfg.cluster_by.is_empty())
             .then_some(StringOrArrayOfStrings::ArrayOfStrings(cfg.cluster_by)),

--- a/crates/dbt-schemas/src/lib.rs
+++ b/crates/dbt-schemas/src/lib.rs
@@ -171,7 +171,7 @@ pub mod schemas {
         };
         pub use configs::common::{WarehouseSpecificNodeConfig, same_warehouse_config};
         pub use configs::config_keys::ConfigKeys;
-        pub use configs::config_merge::{DefaultTo, Packages, Tags, TblProperties};
+        pub use configs::config_merge::{DefaultTo, Packages, Tags};
         pub use configs::data_test_config::{
             DEFAULT_DATA_TEST_ERROR_IF, DEFAULT_DATA_TEST_FAIL_CALC, DEFAULT_DATA_TEST_SEVERITY,
             DEFAULT_DATA_TEST_WARN_IF, DataTestConfig, ProjectDataTestConfig,

--- a/crates/dbt-schemas/src/schemas/nodes.rs
+++ b/crates/dbt-schemas/src/schemas/nodes.rs
@@ -22,7 +22,7 @@ use crate::schemas::dbt_column::{DbtColumnRef, deserialize_dbt_columns, serializ
 use crate::schemas::manifest::GrantAccessToTarget;
 use crate::schemas::project::configs::common::log_state_mod_diff;
 use crate::schemas::project::configs::common::{grants_equal, tags_eq_vec};
-use crate::schemas::project::{TblProperties, WarehouseSpecificNodeConfig, same_warehouse_config};
+use crate::schemas::project::{WarehouseSpecificNodeConfig, same_warehouse_config};
 use crate::schemas::relations::default_dbt_quoting_for;
 use crate::schemas::serde::{PartitionsConfig, QueryTag, StringOrArrayOfStrings};
 use crate::schemas::{
@@ -6301,7 +6301,7 @@ pub struct DatabricksAttr {
     pub file_format: Option<String>,
     pub location_root: Option<String>,
     pub use_uniform: Option<bool>,
-    pub tblproperties: Option<TblProperties>,
+    pub tblproperties: Option<IndexMap<String, YmlValue>>,
     pub include_full_name_in_path: Option<bool>,
     pub liquid_clustered_by: Option<StringOrArrayOfStrings>,
     pub auto_liquid_cluster: Option<bool>,

--- a/crates/dbt-schemas/src/schemas/project/configs/README_OMISSIBLE.md
+++ b/crates/dbt-schemas/src/schemas/project/configs/README_OMISSIBLE.md
@@ -35,7 +35,6 @@ Each field type implements `inherit_from` with its own merge semantics:
 | `Option<DbtQuoting>` | Deep-merge: each sub-field inherits from parent when unset |
 | `Option<DocsConfig>` | Deep-merge: `node_color` falls back to parent |
 | `Option<IndexMap<String, YmlValue>>` | Union-merge: child keys win, missing keys fall back to parent |
-| `Option<TblProperties>` | Replace-if-none while preserving mapping insertion order |
 | `Option<BTreeMap<Spanned<String>, String>>` | Union-merge: parent keys fill missing child keys |
 | `OmissibleGrantConfig` | DictKeyAppend: `+key` extends, plain key clobbers |
 | `Verbatim<Option<Hooks>>` | Append: parent hooks prepended to child hooks |

--- a/crates/dbt-schemas/src/schemas/project/configs/common.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/common.rs
@@ -16,7 +16,6 @@ use dbt_telemetry::StateModifiedDiff;
 use crate::schemas::common::{ClusterConfig, DocsConfig, Schedule};
 use crate::schemas::common::{PartitionConfig, RowFilterConfig};
 use crate::schemas::manifest::GrantAccessToTarget;
-use crate::schemas::project::configs::config_merge::TblProperties;
 use crate::schemas::project::configs::model_config::DataLakeObjectCategory;
 use crate::schemas::project::dbt_project::{ResolvableConfig, ResolvedConfig};
 use crate::schemas::serde::PartitionsConfig;
@@ -149,7 +148,7 @@ pub struct WarehouseSpecificNodeConfig {
     pub location_root: Option<String>,
     #[serde(default, deserialize_with = "bool_or_string_bool")]
     pub use_uniform: Option<bool>,
-    pub tblproperties: Option<TblProperties>,
+    pub tblproperties: Option<IndexMap<String, YmlValue>>,
     // this config is introduced here https://github.com/databricks/dbt-databricks/pull/823
     #[serde(default, deserialize_with = "bool_or_string_bool")]
     pub include_full_name_in_path: Option<bool>,

--- a/crates/dbt-schemas/src/schemas/project/configs/config_merge.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/config_merge.rs
@@ -12,7 +12,6 @@ use dbt_proc_macros::StringOrArrayNewtype;
 use dbt_yaml::{Spanned, Verbatim};
 use indexmap::IndexMap;
 use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 
 use crate::schemas::common::{DbtQuoting, DocsConfig, Hooks, merge_meta, merge_tags, merge_vec};
 use crate::schemas::properties::model_properties::{DataTestState, ModelState};
@@ -182,14 +181,6 @@ impl DefaultTo for Option<IndexMap<String, YmlValue>> {
         *self = merge_meta(parent.clone(), self.take());
     }
 }
-
-/// Insertion-ordered `tblproperties` map.
-///
-/// Newtype over `IndexMap` so this field can implement `ReplaceIfNone`. A bare
-/// `Option<IndexMap<String, YmlValue>>` already uses union-merge (`meta`).
-#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
-#[serde(transparent)]
-pub struct TblProperties(pub IndexMap<String, YmlValue>);
 
 // `#[derive(StringOrArrayNewtype)]` (defined in `dbt-proc-macros`) generates the
 // `AsStringOrArrayOfStrings` impl and shared accessors for newtypes wrapping
@@ -365,8 +356,6 @@ impl ReplaceIfNone for YmlValue {}
 // BTreeMap<String, YmlValue> is distinct from BTreeMap<Spanned<String>, String>
 // (column_types, handled by a special DefaultTo impl).
 impl ReplaceIfNone for BTreeMap<String, YmlValue> {}
-// See TblProperties: cannot use IndexMap<String, YmlValue> here (that type is meta).
-impl ReplaceIfNone for TblProperties {}
 impl<T: Clone> ReplaceIfNone for Vec<T> {}
 // IndexMap<String, String> for labels/resource_tags (replace-if-none).
 // IndexMap<String, YmlValue> for meta uses a custom merge — do NOT add ReplaceIfNone for it.

--- a/crates/dbt-schemas/src/schemas/project/configs/data_test_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/data_test_config.rs
@@ -20,7 +20,7 @@ use crate::schemas::manifest::GrantAccessToTarget;
 use crate::schemas::project::configs::common::{
     WarehouseSpecificNodeConfig, take_databricks_catalog_alias,
 };
-use crate::schemas::project::configs::config_merge::{Tags, TblProperties};
+use crate::schemas::project::configs::config_merge::Tags;
 use crate::schemas::properties::DataTestState;
 use dbt_proc_macros::DefaultTo;
 use dbt_proc_macros::Resolvable;
@@ -222,7 +222,7 @@ pub struct ProjectDataTestConfig {
     #[serde(rename = "+location_root")]
     pub location_root: Option<String>,
     #[serde(rename = "+tblproperties")]
-    pub tblproperties: Option<TblProperties>,
+    pub tblproperties: Option<IndexMap<String, YmlValue>>,
     #[serde(
         default,
         rename = "+include_full_name_in_path",

--- a/crates/dbt-schemas/src/schemas/project/configs/model_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/model_config.rs
@@ -36,7 +36,7 @@ use crate::schemas::project::configs::common::{
     WarehouseSpecificNodeConfig, access_eq, docs_eq, grants_equal, meta_eq, omissible_option_eq,
     same_warehouse_config, take_databricks_catalog_alias,
 };
-use crate::schemas::project::configs::config_merge::{Classifiers, Packages, Tags, TblProperties};
+use crate::schemas::project::configs::config_merge::{Classifiers, Packages, Tags};
 use crate::schemas::project::dbt_project::ResolvableConfig;
 use crate::schemas::project::dbt_project::TypedRecursiveConfig;
 use crate::schemas::properties::model_properties::ModelConstraint;
@@ -534,7 +534,7 @@ pub struct ProjectModelConfig {
     #[serde(rename = "+target_file_size")]
     pub target_file_size: Option<String>,
     #[serde(rename = "+tblproperties")]
-    pub tblproperties: Option<TblProperties>,
+    pub tblproperties: Option<IndexMap<String, YmlValue>>,
     #[serde(rename = "+tmp_relation_type")]
     pub tmp_relation_type: Option<String>,
     #[serde(
@@ -2153,7 +2153,6 @@ __additional_properties__: {}
             .tblproperties
             .as_ref()
             .expect("tblproperties should parse")
-            .0
             .keys()
             .map(String::as_str)
             .collect::<Vec<_>>();
@@ -2162,39 +2161,37 @@ __additional_properties__: {}
     }
 
     #[test]
-    fn test_tblproperties_default_to_clobbers_or_inherits_without_reordering() {
-        use crate::schemas::project::dbt_project::ResolvableConfig;
-
+    fn test_tblproperties_default_to_merges() {
         let parent: ModelConfig = dbt_yaml::from_str(
             r#"
 __warehouse_specific_config__:
   tblproperties:
-    parent_zeta: last
-    parent_alpha: first
-"#,
-        )
-        .unwrap();
-        let mut configured_child: ModelConfig = dbt_yaml::from_str(
-            r#"
-__warehouse_specific_config__:
-  tblproperties:
-    child_zeta: last
-    child_alpha: first
+    parent_only: keep
+    shared: parent
 "#,
         )
         .unwrap();
 
+        let mut configured_child: ModelConfig = dbt_yaml::from_str(
+            r#"
+__warehouse_specific_config__:
+  tblproperties:
+    shared: child
+    child_only: new
+"#,
+        )
+        .unwrap();
         configured_child.default_to(&parent);
-        let configured_keys = configured_child
+        let merged = configured_child
             .__warehouse_specific_config__
             .tblproperties
             .as_ref()
-            .expect("configured child should retain tblproperties")
-            .0
-            .keys()
-            .map(String::as_str)
-            .collect::<Vec<_>>();
-        assert_eq!(configured_keys, ["child_zeta", "child_alpha"]);
+            .expect("configured child should retain tblproperties");
+        assert_eq!(
+            merged.keys().map(String::as_str).collect::<Vec<_>>(),
+            ["parent_only", "shared", "child_only"]
+        );
+        assert_eq!(merged.get("shared").and_then(|v| v.as_str()), Some("child"));
 
         let mut empty_child: ModelConfig = dbt_yaml::from_str(
             r#"
@@ -2208,15 +2205,11 @@ __warehouse_specific_config__:
             .__warehouse_specific_config__
             .tblproperties
             .as_ref()
-            .expect("empty tblproperties should remain Some, not inherit")
-            .0
+            .expect("empty tblproperties should remain Some")
             .keys()
             .map(String::as_str)
             .collect::<Vec<_>>();
-        assert!(
-            empty_keys.is_empty(),
-            "empty tblproperties should clobber parent, got {empty_keys:?}"
-        );
+        assert_eq!(empty_keys, ["parent_only", "shared"]);
 
         let mut unset_child = ModelConfig::default();
         unset_child.default_to(&parent);
@@ -2225,11 +2218,10 @@ __warehouse_specific_config__:
             .tblproperties
             .as_ref()
             .expect("unset child should inherit tblproperties")
-            .0
             .keys()
             .map(String::as_str)
             .collect::<Vec<_>>();
-        assert_eq!(inherited_keys, ["parent_zeta", "parent_alpha"]);
+        assert_eq!(inherited_keys, ["parent_only", "shared"]);
     }
 
     #[test]

--- a/crates/dbt-schemas/src/schemas/project/configs/seed_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/seed_config.rs
@@ -32,7 +32,7 @@ use crate::schemas::project::TypedRecursiveConfig;
 use crate::schemas::project::configs::common::{
     WarehouseSpecificNodeConfig, take_databricks_catalog_alias,
 };
-use crate::schemas::project::configs::config_merge::{Tags, TblProperties};
+use crate::schemas::project::configs::config_merge::Tags;
 use crate::schemas::serde::PartitionsConfig;
 use crate::schemas::serde::StringOrArrayOfStrings;
 use crate::schemas::serde::bool_or_string_bool;
@@ -218,7 +218,7 @@ pub struct ProjectSeedConfig {
     #[serde(rename = "+location_root")]
     pub location_root: Option<String>,
     #[serde(rename = "+tblproperties")]
-    pub tblproperties: Option<TblProperties>,
+    pub tblproperties: Option<IndexMap<String, YmlValue>>,
     #[serde(
         default,
         rename = "+include_full_name_in_path",

--- a/crates/dbt-schemas/src/schemas/project/configs/snapshot_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/snapshot_config.rs
@@ -35,7 +35,7 @@ use crate::schemas::project::TypedRecursiveConfig;
 use crate::schemas::project::configs::common::{
     WarehouseSpecificNodeConfig, take_databricks_catalog_alias,
 };
-use crate::schemas::project::configs::config_merge::{Tags, TblProperties};
+use crate::schemas::project::configs::config_merge::Tags;
 use crate::schemas::properties::ModelState;
 use crate::schemas::serde::PartitionsConfig;
 use crate::schemas::serde::StringOrArrayOfStrings;
@@ -341,7 +341,7 @@ pub struct ProjectSnapshotConfig {
     #[serde(rename = "+target_alias")]
     pub target_alias: Option<String>,
     #[serde(rename = "+tblproperties")]
-    pub tblproperties: Option<TblProperties>,
+    pub tblproperties: Option<IndexMap<String, YmlValue>>,
     // Adapter-specific fields (Redshift)
     #[serde(default, rename = "+bind", deserialize_with = "bool_or_string_bool")]
     pub bind: Option<bool>,

--- a/crates/dbt-schemas/src/schemas/project/configs/source_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/source_config.rs
@@ -17,7 +17,7 @@ use crate::schemas::common::{
 };
 use crate::schemas::manifest::GrantAccessToTarget;
 use crate::schemas::project::configs::common::WarehouseSpecificNodeConfig;
-use crate::schemas::project::configs::config_merge::{Tags, TblProperties};
+use crate::schemas::project::configs::config_merge::Tags;
 use crate::schemas::project::{ResolvableConfig, TypedRecursiveConfig};
 use crate::schemas::serde::{
     IndexesConfig, PartitionsConfig, PrimaryKeyConfig, StringOrArrayOfStrings, StringOrInteger,
@@ -121,7 +121,7 @@ pub struct ProjectSourceConfig {
     #[serde(rename = "+location_root")]
     pub location_root: Option<String>,
     #[serde(rename = "+tblproperties")]
-    pub tblproperties: Option<TblProperties>,
+    pub tblproperties: Option<IndexMap<String, YmlValue>>,
     #[serde(
         default,
         rename = "+include_full_name_in_path",

--- a/crates/dbt-schemas/src/schemas/project/configs/unit_test_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/unit_test_config.rs
@@ -17,9 +17,7 @@ use crate::schemas::{
     project::{
         ResolvableConfig, TypedRecursiveConfig,
         configs::{
-            common::WarehouseSpecificNodeConfig,
-            config_keys::ConfigKeys,
-            config_merge::{Tags, TblProperties},
+            common::WarehouseSpecificNodeConfig, config_keys::ConfigKeys, config_merge::Tags,
         },
     },
     serde::{
@@ -174,7 +172,7 @@ pub struct ProjectUnitTestConfig {
     #[serde(rename = "+location_root")]
     pub location_root: Option<String>,
     #[serde(rename = "+tblproperties")]
-    pub tblproperties: Option<TblProperties>,
+    pub tblproperties: Option<IndexMap<String, YmlValue>>,
     #[serde(
         default,
         rename = "+include_full_name_in_path",


### PR DESCRIPTION
Resolves #16278

Port of [databricks/dbt-databricks#1353](https://github.com/databricks/dbt-databricks/pull/1353) (`feat: tblproperties merge behavior`). Upstream request: [databricks/dbt-databricks#1340](https://github.com/databricks/dbt-databricks/issues/1340).


**Note:** [#16077](https://github.com/dbt-labs/dbt-core/pull/16077) recently added the `TblProperties` newtype so Fusion matched then-current v1 behavior (declaration-order `IndexMap` with replace-if-none / clobber-or-inherit). dbt-databricks#1353 then changed that v1 contract to additive merge hence this PR.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.