### PR TITLE
Fix statically_parse_unrendered_config stringifying list/dict config …

### DIFF
--- a/.changes/unreleased/Fixes-20260910-163300.yaml
+++ b/.changes/unreleased/Fixes-20260910-163300.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix `statically_parse_unrendered_config` stringifying list/dict config values, which caused false positives in `state:modified` comparisons across different dbt versions.
+time: 2026-09-10T16:33:00.000000+05:30
+custom:
+    Author: aagarg
+    Issue: "16133"

--- a/core/dbt/clients/jinja_static.py
+++ b/core/dbt/clients/jinja_static.py
@@ -259,19 +259,39 @@ def statically_parse_unrendered_config(string: str) -> Optional[Dict[str, Any]]:
     return unrendered_config
 
 
-def construct_static_kwarg_value(kwarg) -> str:
+def _try_evaluate_to_python(node: Any) -> Any:
+    """Evaluate a Jinja2 AST node to a native Python value when possible.
+
+    Handles literal types (Const, List, Dict, Tuple, Neg) recursively.
+    Falls back to a string representation via ``_reconstruct_node`` for complex
+    nodes such as Call, Name, Getattr, etc.
+
+    The *node* parameter is typed as ``Any`` because jinja2 AST node classes
+    define their fields dynamically, which mypy cannot resolve.
+    """
+    if isinstance(node, jinja2.nodes.Const):
+        return node.value  # type: ignore[attr-defined]
+    if isinstance(node, jinja2.nodes.List):
+        return [_try_evaluate_to_python(item) for item in node.items]  # type: ignore[attr-defined]
+    if isinstance(node, jinja2.nodes.Dict):
+        return {
+            _try_evaluate_to_python(pair.key): _try_evaluate_to_python(pair.value)
+            for pair in node.items  # type: ignore[attr-defined]
+        }
+    if isinstance(node, jinja2.nodes.Tuple):
+        return tuple(_try_evaluate_to_python(item) for item in node.items)  # type: ignore[attr-defined]
+    if isinstance(node, jinja2.nodes.Neg):
+        inner = _try_evaluate_to_python(node.node)  # type: ignore[attr-defined]
+        if isinstance(inner, (int, float)):
+            return -inner
+        return _reconstruct_node(node)
+    return _reconstruct_node(node)
+
+
+def construct_static_kwarg_value(kwarg) -> Any:
     try:
-        # jinja2 nodes define fields dynamically; kw typed Any to avoid attr errors.
         kw: Any = kwarg
-        kw_val: Any = kw.value
-        # If the final value is a plain string constant, return it without quotes.
-        # Nested string args (e.g. inside env_var) keep their repr() quoting.
-        if isinstance(kw_val, jinja2.nodes.Const):
-            # Re-bind to Any after narrowing so .value access stays untyped.
-            const_val: Any = kw_val
-            if isinstance(const_val.value, str):
-                return const_val.value
-        return _reconstruct_node(kw_val)
+        return _try_evaluate_to_python(kw.value)
     except Exception:
         # Sensitive codepath — fall back to the original AST repr on any error
         return str(kwarg)

--- a/tests/unit/clients/test_jinja_static.py
+++ b/tests/unit/clients/test_jinja_static.py
@@ -99,7 +99,7 @@ class TestStaticallyParseUnrenderedConfig:
                 "{{ config(materialized='view', enabled=True) }}",
                 {
                     "materialized": "view",
-                    "enabled": "True",
+                    "enabled": True,
                 },
             ),
             # macro call — string args keep repr() quoting
@@ -125,22 +125,22 @@ class TestStaticallyParseUnrenderedConfig:
             # integer constant
             (
                 "{{ config(hours_to_expiration=24) }}",
-                {"hours_to_expiration": "24"},
+                {"hours_to_expiration": 24},
             ),
             # None / Jinja2 `none`
             (
                 "{{ config(full_refresh=none) }}",
-                {"full_refresh": "None"},
+                {"full_refresh": None},
             ),
             # list literal
             (
                 "{{ config(tags=['t1', 't2']) }}",
-                {"tags": "['t1', 't2']"},
+                {"tags": ["t1", "t2"]},
             ),
             # dict literal
             (
                 "{{ config(meta={'owner': 'alice'}) }}",
-                {"meta": "{'owner': 'alice'}"},
+                {"meta": {"owner": "alice"}},
             ),
             # attribute access
             (
@@ -175,17 +175,17 @@ class TestStaticallyParseUnrenderedConfig:
             # False boolean
             (
                 "{{ config(enabled=false) }}",
-                {"enabled": "False"},
+                {"enabled": False},
             ),
             # float constant
             (
                 "{{ config(some_ratio=0.5) }}",
-                {"some_ratio": "0.5"},
+                {"some_ratio": 0.5},
             ),
             # negative number (Neg node)
             (
                 "{{ config(hours_to_expiration=-1) }}",
-                {"hours_to_expiration": "-1"},
+                {"hours_to_expiration": -1},
             ),
             # != comparison
             (
@@ -210,12 +210,22 @@ class TestStaticallyParseUnrenderedConfig:
             # list of dicts (BigQuery grants pattern)
             (
                 "{{ config(grant_access_to=[{'project': 'p', 'dataset': 'd'}]) }}",
-                {"grant_access_to": "[{'project': 'p', 'dataset': 'd'}]"},
+                {"grant_access_to": [{"project": "p", "dataset": "d"}]},
             ),
             # getitem access
             (
                 "{{ config(alias=var('aliases')['my_model']) }}",
                 {"alias": "var('aliases')['my_model']"},
+            ),
+            # list with a Jinja call — items evaluate independently
+            (
+                "{{ config(cluster_by=[var('col')]) }}",
+                {"cluster_by": ["var('col')"]},
+            ),
+            # mixed list — literal items stay native, calls become strings
+            (
+                "{{ config(tags=['t1', var('t2')]) }}",
+                {"tags": ["t1", "var('t2')"]},
             ),
         ],
     )


### PR DESCRIPTION
Resolves #16133

### Problem

`construct_static_kwarg_value` in `core/dbt/clients/jinja_static.py` is typed `-> str` and unconditionally stringifies all config values parsed from Jinja `{{ config(...) }}` calls. This means literal lists and dicts like `{{ config(cluster_by=['id']) }}` produce `unrendered_config['cluster_by'] == "['id']"` (a string) instead of the native `['id']` (a list).

When `upgrade_manifest_json_dbt_version` re-derives `unrendered_config` from `raw_code` for a manifest with a different `dbt_version`, the stringified values overwrite native types via `.update()`. Since `same_config` / `same_contents` compare `unrendered_config` values with plain `==`, this type mismatch causes `state:modified` to falsely flag models as changed — even when the SQL is identical.

This affects any model with a list/dict-valued config key declared inline (`cluster_by`, `partition_by`, `grants`, `labels`, `meta`, `unique_key` as a list, etc.) whenever `state:modified` compares manifests across different dbt versions.

### Solution

Added a `_try_evaluate_to_python` helper that recursively converts Jinja AST nodes to native Python values where possible:
- `Const` → native value (`str`, `int`, `float`, `bool`, `None`)
- `List` → Python `list` (items evaluated recursively)
- `Dict` → Python `dict` (keys and values evaluated recursively)
- `Tuple` → Python `tuple`
- `Neg` → negated numeric value
- Everything else (Call, Name, Getattr, etc.) → string via `_reconstruct_node` (same as before)

Updated `construct_static_kwarg_value` to use this helper and changed its return type from `-> str` to `-> Any`. This ensures both the fresh-parse path and the upgrade path produce the same native types for literal config values, eliminating the type mismatch.

No changes were needed to `_reconstruct_node`, `upgrade_unrendered_config`, or the comparison logic in `same_config` / `same_contents`.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.