### PR TITLE
fix: null dbt_project.yml keys cause state:modified to over-select siblings

### DIFF
--- a/.changes/unreleased/Fixes-20260911-214018.yaml
+++ b/.changes/unreleased/Fixes-20260911-214018.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix state:modified selecting sibling models when a null-valued key in dbt_project.yml is changed
+time: 2026-09-11T21:40:18.859025-04:00
+custom:
+    Author: wilu222
+    Issue: "16290"

--- a/core/dbt/context/context_config.py
+++ b/core/dbt/context/context_config.py
@@ -133,7 +133,9 @@ class BaseContextConfigGenerator(Generic[T]):
             for key, value in level_config.items():
                 if key.startswith("+"):
                     result[key[1:].strip()] = deepcopy(value)
-                elif not isinstance(value, dict):
+                # Skip null hierarchy placeholders (e.g. `beta:` with no children).
+                # None is not a dict, but it is also not a legacy bare config value.
+                elif value is not None and not isinstance(value, dict):
                     result[key] = deepcopy(value)
 
             yield result

--- a/tests/unit/context/test_context_config.py
+++ b/tests/unit/context/test_context_config.py
@@ -1,0 +1,115 @@
+from typing import Any, Dict, List
+from unittest import mock
+
+from dbt.context.context_config import BaseContextConfigGenerator
+from dbt.node_types import NodeType
+
+
+def _project_config_levels(model_configs: Dict[str, Any], fqn: List[str]) -> List[Dict[str, Any]]:
+    """Run the real `_project_configs` extractor against a fake project tree."""
+    src = mock.MagicMock()
+    src.get_config_dict.return_value = model_configs
+    generator = mock.MagicMock()
+    generator.get_config_source.return_value = src
+    project = mock.MagicMock()
+    return list(
+        BaseContextConfigGenerator._project_configs(generator, project, fqn, NodeType.Model)
+    )
+
+
+class TestProjectConfigsNullFolderKeys:
+    """Regression for #16290: null dbt_project.yml keys are hierarchy placeholders,
+    not legacy bare config values. Treating them as config made every sibling under
+    the parent appear state:modified when the null key was populated or deleted.
+    """
+
+    def test_null_sibling_key_is_not_copied_into_config(self):
+        model_configs = {
+            "repro": {
+                "parent": {
+                    "alpha": {"+tags": ["alpha"]},
+                    "beta": None,
+                    "gamma": {"+tags": ["gamma"]},
+                }
+            }
+        }
+        levels = _project_config_levels(model_configs, ["repro", "parent", "alpha", "a1"])
+
+        # levels: models root, repro, parent, alpha
+        parent_level = levels[2]
+        assert "beta" not in parent_level
+        assert parent_level == {}
+
+        alpha_level = levels[3]
+        assert alpha_level == {"tags": ["alpha"]}
+
+    def test_parent_level_unchanged_when_null_key_is_populated(self):
+        before = {
+            "repro": {
+                "parent": {
+                    "alpha": {"+tags": ["alpha"]},
+                    "beta": None,
+                    "gamma": {"+tags": ["gamma"]},
+                }
+            }
+        }
+        after = {
+            "repro": {
+                "parent": {
+                    "alpha": {"+tags": ["alpha"]},
+                    "beta": {"b1": {"+tags": ["added"]}},
+                    "gamma": {"+tags": ["gamma"]},
+                }
+            }
+        }
+        fqn = ["repro", "parent", "alpha", "a1"]
+        before_parent = _project_config_levels(before, fqn)[2]
+        after_parent = _project_config_levels(after, fqn)[2]
+        assert before_parent == after_parent == {}
+
+    def test_parent_level_unchanged_when_null_key_is_deleted(self):
+        before = {
+            "repro": {
+                "parent": {
+                    "alpha": {"+tags": ["alpha"]},
+                    "beta": None,
+                    "gamma": {"+tags": ["gamma"]},
+                }
+            }
+        }
+        after = {
+            "repro": {
+                "parent": {
+                    "alpha": {"+tags": ["alpha"]},
+                    "gamma": {"+tags": ["gamma"]},
+                }
+            }
+        }
+        fqn = ["repro", "parent", "gamma", "g1"]
+        before_parent = _project_config_levels(before, fqn)[2]
+        after_parent = _project_config_levels(after, fqn)[2]
+        assert before_parent == after_parent == {}
+
+    def test_legacy_bare_scalar_config_still_extracted(self):
+        model_configs = {
+            "repro": {
+                "parent": {
+                    "materialized": "view",
+                    "alpha": {"+tags": ["alpha"]},
+                }
+            }
+        }
+        levels = _project_config_levels(model_configs, ["repro", "parent", "alpha", "a1"])
+        assert levels[2] == {"materialized": "view"}
+
+    def test_plus_prefixed_null_config_still_extracted(self):
+        model_configs = {
+            "repro": {
+                "parent": {
+                    "+enabled": None,
+                    "alpha": {},
+                }
+            }
+        }
+        levels = _project_config_levels(model_configs, ["repro", "parent", "alpha", "a1"])
+        assert levels[2] == {"enabled": None}


### PR DESCRIPTION
Resolves #16290

### Problem

If a key in the `dbt_project.yml` model tree has a null value (e.g. `beta:` with no children or configs), any change to that key caused `state:modified` to select every model beneath the parent block, including unrelated siblings.

Root cause: `_project_configs` treated any non-dict value as a legacy bare config. YAML null parses as `None`, which is not a dict, so the placeholder key was copied into every sibling's `unrendered_config` and then compared by `same_contents`.

### Solution

Skip `None` values in the legacy bare-config branch so null hierarchy placeholders are not treated as config, while still supporting bare scalars (`materialized: view`) and `+`-prefixed explicit nulls (`+enabled: null`).

Adds unit regression coverage in `tests/unit/context/test_context_config.py`.

### Checklist

- [x] I have read the contributing guide and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes type annotations for new and modified functions.